### PR TITLE
Introduced incremental versioning from git tag and -r option to ndpiReader to print revision

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,32 +10,31 @@ AC_PROG_CC
 AX_PTHREAD
 
 if test -d ".git"; then :
-GIT_TAG=`git rev-parse HEAD`
-GIT_DATE=`date +%Y%m%d`
-GIT_RELEASE="${PACKAGE_VERSION} (${GIT_TAG}:${GIT_DATE})"
+     GIT_TAG=`git log -1 --format=%H`
+     GIT_DATE=`git log -1 --format=%cd`
+     GIT_RELEASE=`git describe --tags --long --dirty --always`
 else
-GIT_RELEASE="${PACKAGE_VERSION}"
-SVN_DATE=`date`
+     GIT_RELEASE="${PACKAGE_VERSION}"
+     GIT_DATE=`date`
 fi
 
-AC_DEFINE_UNQUOTED(NDPI_GIT_RELEASE, "r${GIT_RELEASE}", [SVN Release])
-AC_DEFINE_UNQUOTED(NDPI_SVN_DATE, "${SVN_DATE}", [Last SVN change])
+AC_DEFINE_UNQUOTED(NDPI_GIT_RELEASE, "${GIT_RELEASE}", [GIT Release])
+AC_DEFINE_UNQUOTED(NDPI_GIT_DATE, "${GIT_DATE}", [Last GIT change])
 
 AC_CHECK_HEADERS([netinet/in.h stdint.h stdlib.h string.h unistd.h])
 
 PCAP_HOME=$HOME/PF_RING/userland
 
 if test -d $PCAP_HOME; then :
-   echo -n ""
+     echo -n ""
 else
-   PCAP_HOME=`pwd`/../../PF_RING/userland
+     PCAP_HOME=`pwd`/../../PF_RING/userland
 fi
-
 SHORT_MACHINE=`uname -m | cut -b1-3`
 if test $SHORT_MACHINE = "arm"; then
-LIBNUMA=""
+     LIBNUMA=""
 else
-LIBNUMA="-lnuma"
+     LIBNUMA="-lnuma"
 fi
 
 if test -f $PCAP_HOME/libpcap/libpcap.a; then :
@@ -57,11 +56,11 @@ else
 fi
 
 if test -d /usr/local/include/json-c/; then :
-   CFLAGS="$CFLAGS -I/usr/local/include/json-c/"
-   LDFLAGS="$LDFLAGS -L/usr/local/lib -ljson-c"
+     CFLAGS="$CFLAGS -I/usr/local/include/json-c/"
+     LDFLAGS="$LDFLAGS -L/usr/local/lib -ljson-c"
 else
-  CFLAGS="$CFLAGS $(pkg-config --cflags json-c)"
-  LDFLAGS="$LDFLAGS $(pkg-config --libs json-c)"
+     CFLAGS="$CFLAGS $(pkg-config --cflags json-c)"
+     LDFLAGS="$LDFLAGS $(pkg-config --libs json-c)"
 fi
 
 OLD_LIBS=$LIBS

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -160,7 +160,7 @@ static u_int32_t size_id_struct = 0;		//< ID tracking structure size
 #endif
 
 // flow tracking
-typedef struct ndpi_flow {  
+typedef struct ndpi_flow {
   u_int32_t lower_ip;
   u_int32_t upper_ip;
   u_int16_t lower_port;
@@ -304,7 +304,7 @@ static void parseOptions(int argc, char **argv) {
     case 'q':
     quiet_mode = 1;
     break;
-    
+
   default:
     help(0);
       break;
@@ -637,7 +637,7 @@ static void node_idle_scan_walker(const void *node, ndpi_VISIT which, int depth,
 
       if (flow->detected_protocol == 0 /* UNKNOWN */ && !undetected_flows_deleted)
         undetected_flows_deleted = 1;
- 
+
       free_ndpi_flow(flow);
       ndpi_thread_info[thread_id].stats.ndpi_flow_count--;
 
@@ -866,7 +866,7 @@ static struct ndpi_flow *get_ndpi_flow6(u_int16_t thread_id,
 
   if(iph.protocol == 0x3C /* IPv6 destination option */) {
     u_int8_t *options = (u_int8_t*)iph6 + sizeof(const struct ndpi_ip6_hdr);
-    
+
     iph.protocol = options[0];
   }
 
@@ -884,7 +884,7 @@ static void setupDetection(u_int16_t thread_id) {
   memset(&ndpi_thread_info[thread_id], 0, sizeof(ndpi_thread_info[thread_id]));
 
   // init global detection structure
-  ndpi_thread_info[thread_id].ndpi_struct = ndpi_init_detection_module(detection_tick_resolution, 
+  ndpi_thread_info[thread_id].ndpi_struct = ndpi_init_detection_module(detection_tick_resolution,
 								       malloc_wrapper, free_wrapper, debug_printf);
   if(ndpi_thread_info[thread_id].ndpi_struct == NULL) {
     printf("ERROR: global structure initialization failed\n");
@@ -978,14 +978,14 @@ static unsigned int packet_processing(u_int16_t thread_id,
     }
 
     if((
-	(flow->detected_protocol == NDPI_PROTOCOL_HTTP) 
+	(flow->detected_protocol == NDPI_PROTOCOL_HTTP)
 	|| (flow->detected_protocol == NDPI_SERVICE_FACEBOOK)
 	)
        && full_http_dissection) {
       char *method;
 
       printf("[URL] %s\n", ndpi_get_http_url(ndpi_thread_info[thread_id].ndpi_struct, ndpi_flow));
-      printf("[Content-Type] %s\n", ndpi_get_http_content_type(ndpi_thread_info[thread_id].ndpi_struct, ndpi_flow));     
+      printf("[Content-Type] %s\n", ndpi_get_http_content_type(ndpi_thread_info[thread_id].ndpi_struct, ndpi_flow));
 
       switch(ndpi_get_http_method(ndpi_thread_info[thread_id].ndpi_struct, ndpi_flow)) {
       case HTTP_METHOD_OPTIONS: method = "HTTP_METHOD_OPTIONS"; break;
@@ -1271,7 +1271,7 @@ static void printResults(u_int64_t tot_usec) {
 		ndpi_get_proto_name(ndpi_thread_info[0].ndpi_struct, i),
 		(long long unsigned int)cumulative_stats.protocol_counter[i],
 		(long long unsigned int)cumulative_stats.protocol_counter_bytes[i],
-		cumulative_stats.protocol_flows[i]);	 
+		cumulative_stats.protocol_flows[i]);
 
       if((!json_flag) && (!quiet_mode)) {
 	printf("\t%-20s packets: %-13llu bytes: %-13llu "
@@ -1594,7 +1594,7 @@ static void pcap_packet_callback(u_char *args, const struct pcap_pkthdr *header,
 
     if(proto == 0x3C /* IPv6 destination option */) {
       u_int8_t *options = (u_int8_t*)&packet[ip_offset+ip_len];
-      
+
       proto = options[0];
       ip_len += 8 * (options[1] + 1);
     }

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -208,6 +208,7 @@ static void help(u_int long_help) {
 	 "  -d                        | Disable protocol guess and use only DPI\n"
 	 "  -q                        | Quiet mode\n"
 	 "  -t                        | Dissect GTP tunnels\n"
+	 "  -r                        | Print nDPI version and git revision\n"
 	 "  -w <path>                 | Write test output on the specified file. This is useful for\n"
 	 "                            | testing purposes in order to compare results across runs\n"
 	 "  -h                        | This help\n"
@@ -232,7 +233,7 @@ static void parseOptions(int argc, char **argv) {
   u_int num_cores = sysconf(_SC_NPROCESSORS_ONLN);
 #endif
 
-  while ((opt = getopt(argc, argv, "df:g:i:hp:l:s:tv:V:n:j:w:q")) != EOF) {
+  while ((opt = getopt(argc, argv, "df:g:i:hp:l:s:tv:V:n:j:rp:w:q")) != EOF) {
     switch (opt) {
     case 'd':
       enable_protocol_guess = 0;
@@ -270,6 +271,10 @@ static void parseOptions(int argc, char **argv) {
     case 't':
       decode_tunnels = 1;
       break;
+
+    case 'r':
+      printf("ndpiReader, nDPI (%s)\n\n", ndpi_revision());
+      exit(0);
 
     case 'v':
       verbose = atoi(optarg);


### PR DESCRIPTION
Version is now extracted using `git describe --tags --long --dirty --always` this uses the last git tag as version then an incremental number that reflects the number of commits (like svn revision) plus the commit hash:

```
1.5.2-43-gb3a292d-dirty
^     ^  ^        ^
|     |  |        |
|     |  |        if there are uncommitted changes
|     |  SHA of HEAD
|     number of commits since last tag
last tag
```
This allows to have incremental versioning changing at each build like it was before with svn.

Also added a `-r` to print ndpiReader / nDPI version and revision.
(I would have rather preferred `-V` or `--version` that is standard but I didn't want to change too much the code) 

```
ntop@bs-ndpi:~/target/bin$ ./ndpiReader -r
ndpiReader, nDPI (1.5.2-45-gb3b0ce7)
```