### PR TITLE
Allow Host IP based subprotocols to be added in protos.txt

### DIFF
--- a/example/protos.txt
+++ b/example/protos.txt
@@ -14,5 +14,11 @@ host:"googlesyndacation.com"@Google
 host:"venere.com"@Venere
 host:"kataweb.it",host:"repubblica.it"@Repubblica
 
+#  IP based Subprotocols
+#  Format:
+#  ip:"<value>",ip:"<value>",.....@<subproto>
+
+ip:213.75.170.11@CustomProtocol
+
 
 

--- a/example/protos.txt
+++ b/example/protos.txt
@@ -16,7 +16,7 @@ host:"kataweb.it",host:"repubblica.it"@Repubblica
 
 #  IP based Subprotocols
 #  Format:
-#  ip:"<value>",ip:"<value>",.....@<subproto>
+#  ip:<value>,ip:<value>,.....@<subproto>
 
 ip:213.75.170.11@CustomProtocol
 


### PR DESCRIPTION
These changes allow to dynamically add new subprotocols that depend on the
host IP, similarly to the host-name based subprotocols.
```
#  IP based Subprotocols
#  Format:
#  ip:<value>,ip:<value>,.....@<subproto>

ip:213.75.170.11@CustomProtocolName
```