### PR TITLE
Account for the skipping of the DNS RR CLASS field by progressing the…

### DIFF
--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -170,7 +170,7 @@ void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	i += 4;
 
 	if(header.answer_rrs > 0) {
-	  u_int16_t rsp_type /*, rsp_class */;
+	  u_int16_t rsp_type;
 	  u_int16_t num;
 
 	  for(num = 0; num < header.answer_rrs; num++) {
@@ -186,9 +186,9 @@ void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	      i += data_len;
 	
 	    rsp_type = get16(&i, packet->payload);
-	    // rsp_class = get16(&i, packet->payload);
 
-	    i += 4;
+	    // Skip past the CLASS (2 octets) and TTL (4 octets) fields.
+	    i += 6;
 	    data_len = get16(&i, packet->payload);
 
 	    if((data_len <= 1) || (data_len > (packet->payload_packet_len-i))) {


### PR DESCRIPTION
… payload index forward by an extra 2 octets. Remove commented code.
