### PR TITLE
Fixed double version bug for ndpiReader -r

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,8 +17,7 @@ if test -d ".git"; then :
      # 
      #
      GIT_NUM=`git log --pretty=oneline | wc -l | tr -d '[[:space:]]'`
-     GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-     GIT_RELEASE="${PACKAGE_VERSION}-${GIT_BRANCH}-${GIT_NUM}-${GIT_TAG}"
+     GIT_RELEASE="${PACKAGE_VERSION}-${GIT_NUM}-${GIT_TAG}"
 else
      GIT_RELEASE="${PACKAGE_VERSION}"
      GIT_DATE=`date`


### PR DESCRIPTION
Removed the branch name from the ndpiReader version otherwise this is what happen if you build from branch 1.6-stable:

ntop@bs-ndpi:~$ ndpiReader -r
ndpiReader - nDPI (1.6.0-1.6-stable-62-a31b0a3)

now it's:
ntop@bs-ndpi:~$ ndpiReader -r
ndpiReader - nDPI (1.6.0-63-7943e6e)

This is also e problem for buildsystems that checkout a specific commit not the whole branch, this is what happens:

root@e-30-ndpi:~# ndpiReader -r
ndpiReader - nDPI (1.6.0-HEAD-63-7943e6e)

Differently from 1.6-stable branch there was a conflict that I resolved already.

Conflicts:
    configure.ac
