### PR TITLE
Remove wrong space on Whatsapp Voice protocol name

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -1241,7 +1241,7 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
 			    ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
     ndpi_set_proto_defaults(ndpi_mod, NDPI_PROTOCOL_ACCEPTABLE, NDPI_PROTOCOL_WHATSAPP_VOICE,
 			    no_master,
-			    no_master, "WhatsApp Voice",
+			    no_master, "WhatsAppVoice",
 			    ndpi_build_default_ports(ports_a, 0, 0, 0, 0, 0) /* TCP */,
 			    ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
 


### PR DESCRIPTION
Whitespace break iptables protocol name so you won't able to specify it as protocol since WhatsApp already exists.
