### PR TITLE
Fix warning when use -Wdocumentation (Clang CFLAG)

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -149,11 +149,11 @@ static struct reader_thread ndpi_thread_info[MAX_NUM_READER_THREADS];
  * @brief ID tracking
  */
 typedef struct ndpi_id {
-  u_int8_t ip[4];				//< Ip address
-  struct ndpi_id_struct *ndpi_id;		//< nDpi worker structure
+  u_int8_t ip[4];				// Ip address
+  struct ndpi_id_struct *ndpi_id;		// nDpi worker structure
 } ndpi_id_t;
 
-static u_int32_t size_id_struct = 0;		//< ID tracking structure size
+static u_int32_t size_id_struct = 0;		// ID tracking structure size
 
 #ifndef ETH_P_IP
 #define ETH_P_IP 0x0800

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -70,7 +70,7 @@ extern "C" {
   /**
    * This function returns a new initialized detection module.
    * @param ticks_per_second the timestamp resolution per second (like 1000 for millisecond resolution)
-   * @param ndpi_malloc function pointer to a memory allocator
+   * @param __ndpi_malloc function pointer to a memory allocator
    * @param ndpi_debug_printf a function pointer to a debug output function, use NULL in productive envionments
    * @return the initialized detection module
    */
@@ -88,8 +88,8 @@ extern "C" {
 
   /**
    * This function enables cache support in nDPI used for some protocol such as Skype
-   * @param cache host name
-   * @param cache port
+   * @param host host name
+   * @param port port number
    */
   void ndpi_enable_cache(struct ndpi_detection_module_struct *ndpi_mod, char* host, u_int port);
 


### PR DESCRIPTION
src/include/ndpi_api.h:73:13: error: parameter 'ndpi_malloc' not found in the function declaration [-Werror,-Wdocumentation]
src/include/ndpi_api.h:91:13: error: parameter 'cache' not found in the function declaration [-Werror,-Wdocumentation]
src/include/ndpi_api.h:92:13: error: parameter 'cache' not found in the function declaration [-Werror,-Wdocumentation]
ndpiReader.c:152:22: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
ndpiReader.c:153:36: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
ndpiReader.c:156:39: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
