### PR TITLE
Add Ubiquity AirControl 2 protocol detector

### DIFF
--- a/libndpi.sym
+++ b/libndpi.sym
@@ -31,3 +31,6 @@ ndpi_guess_protocol_id
 ndpi_protocol2name
 ndpi_get_lower_proto
 ndpi_is_proto
+ndpi_malloc
+ndpi_calloc
+ndpi_set_detected_protocol

--- a/src/include/ndpi_protocol_ids.h
+++ b/src/include/ndpi_protocol_ids.h
@@ -202,6 +202,7 @@
 #define NDPI_PROTOCOL_STARCRAFT 			        213 /* Matteo Bracci <matteobracci1@gmail.com> */
 #define NDPI_PROTOCOL_TEREDO 			                214
 #define NDPI_PROTOCOL_HEP 			                216 /* Sipcapture.org QXIP BV */
+#define NDPI_PROTOCOL_UBNTAC2							217 /* Ubiquity UBNT AirControl 2 - Thomas Fjellstrom <thomas+ndpi@fjellstrom.ca> */
 
 #define NDPI_CONTENT_AVI				39
 #define NDPI_CONTENT_FLASH				40
@@ -264,7 +265,7 @@
 #define NDPI_SERVICE_HOTSPOT_SHIELD                     215
 
 /* UPDATE UPDATE UPDATE UPDATE UPDATE UPDATE UPDATE UPDATE UPDATE */
-#define NDPI_LAST_IMPLEMENTED_PROTOCOL			NDPI_PROTOCOL_HEP
+#define NDPI_LAST_IMPLEMENTED_PROTOCOL			NDPI_PROTOCOL_UBNTAC2
 
 #define NDPI_MAX_SUPPORTED_PROTOCOLS                    (NDPI_LAST_IMPLEMENTED_PROTOCOL + 1)
 #define NDPI_MAX_NUM_CUSTOM_PROTOCOLS                   (NDPI_NUM_BITS-NDPI_LAST_IMPLEMENTED_PROTOCOL)

--- a/src/include/ndpi_protocols.h
+++ b/src/include/ndpi_protocols.h
@@ -196,6 +196,7 @@ void ndpi_search_eaq(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 void ndpi_search_kakaotalk_voice(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow);
 void ndpi_search_mpegts(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow);
 void ndpi_search_starcraft(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow);
+void ndpi_search_ubntac2(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow);
 
 
 /* --- INIT FUNCTIONS --- */
@@ -334,5 +335,6 @@ void init_yahoo_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_in
 void init_zattoo_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask);
 void init_zmq_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask);
 void init_stracraft_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask);
+void init_ubntac2_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask);
 
 #endif /* __NDPI_PROTOCOLS_INCLUDE_FILE__ */

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -140,6 +140,7 @@ libndpi_la_SOURCES = ndpi_content_match.c.inc \
 		     protocols/tvants.c \
 		     protocols/tvuplayer.c \
 		     protocols/twitter.c \
+		     protocols/ubntac2.c \
 		     protocols/usenet.c \
 		     protocols/veohtv.c \
 		     protocols/viber.c \

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -1627,7 +1627,12 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
 			    no_master, "Starcraft",
 			    ndpi_build_default_ports(ports_a, 1119, 0, 0, 0, 0),	/* TCP */
 			    ndpi_build_default_ports(ports_b, 1119, 0, 0, 0, 0));	/* UDP */
-    
+	 ndpi_set_proto_defaults(ndpi_mod, NDPI_PROTOCOL_SAFE, NDPI_PROTOCOL_UBNTAC2,
+			    no_master, 
+			    no_master, "UBNTAC2",
+			    ndpi_build_default_ports(ports_a, 0, 0, 0, 0, 0),	/* TCP */
+			    ndpi_build_default_ports(ports_b, 10001, 0, 0, 0, 0));	/* UDP */
+	 
     /* calling function for host and content matched protocols */
     init_string_based_protocols(ndpi_mod);
 
@@ -2630,6 +2635,8 @@ void ndpi_set_protocol_detection_bitmask2(struct ndpi_detection_module_struct *n
   /* MPEGTS */
   init_mpegts_dissector(ndpi_struct, &a, detection_bitmask);
   
+  /* UBNTAC2 */
+  init_ubntac2_dissector(ndpi_struct, &a, detection_bitmask);
 
   /* ----------------------------------------------------------------- */
 

--- a/src/lib/protocols/ubntac2.c
+++ b/src/lib/protocols/ubntac2.c
@@ -1,5 +1,5 @@
 /*
- * dhcp.c
+ * ubntac2.c
  *
  * Copyright (C) 2009-2011 by ipoque GmbH
  * Copyright (C) 2011-15 - ntop.org
@@ -40,11 +40,8 @@ void ndpi_search_ubntac2(struct ndpi_detection_module_struct *ndpi_struct, struc
 //      struct ndpi_id_struct         *src=ndpi_struct->src;
 //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
-	/* this detection also works for asymmetric dhcp traffic */
-
 	NDPI_LOG(NDPI_PROTOCOL_UBNTAC2, ndpi_struct, NDPI_LOG_TRACE, "UBNTAC2 detection... plen:%i %i:%i\n", packet->payload_packet_len, ntohs(packet->udp->source), ntohs(packet->udp->dest));
 	
-	/*check standard DHCP 0.0.0.0:68 -> 255.255.255.255:67 */
 	if (packet->payload_packet_len >= 135 &&
 		(packet->udp->source == htons(10001) || packet->udp->dest == htons(10001)) &&
 		memcmp(&(packet->payload[36]), "UBNT", 4) == 0) {

--- a/src/lib/protocols/ubntac2.c
+++ b/src/lib/protocols/ubntac2.c
@@ -1,0 +1,73 @@
+/*
+ * dhcp.c
+ *
+ * Copyright (C) 2009-2011 by ipoque GmbH
+ * Copyright (C) 2011-15 - ntop.org
+ *
+ * This file is part of nDPI, an open source deep packet inspection
+ * library based on the OpenDPI and PACE technology by ipoque GmbH
+ *
+ * nDPI is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * nDPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+
+#include "ndpi_protocols.h"
+
+#ifdef NDPI_PROTOCOL_UBNTAC2
+
+static void ndpi_int_ubntac2_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
+{
+  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_UBNTAC2, NDPI_PROTOCOL_UNKNOWN);
+}
+
+
+void ndpi_search_ubntac2(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
+{
+	struct ndpi_packet_struct *packet = &flow->packet;
+	
+//      struct ndpi_id_struct         *src=ndpi_struct->src;
+//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+
+	/* this detection also works for asymmetric dhcp traffic */
+
+	NDPI_LOG(NDPI_PROTOCOL_UBNTAC2, ndpi_struct, NDPI_LOG_TRACE, "UBNTAC2 detection... plen:%i %i:%i\n", packet->payload_packet_len, ntohs(packet->udp->source), ntohs(packet->udp->dest));
+	
+	/*check standard DHCP 0.0.0.0:68 -> 255.255.255.255:67 */
+	if (packet->payload_packet_len >= 135 &&
+		(packet->udp->source == htons(10001) || packet->udp->dest == htons(10001)) &&
+		memcmp(&(packet->payload[36]), "UBNT", 4) == 0) {
+
+		NDPI_LOG(NDPI_PROTOCOL_UBNTAC2, ndpi_struct, NDPI_LOG_DEBUG, "UBNT AirControl 2 request\n");
+
+		ndpi_int_ubntac2_add_connection(ndpi_struct, flow);
+		return;
+	}
+
+	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_UBNTAC2);
+}
+
+
+void init_ubntac2_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask)
+{
+  ndpi_set_bitmask_protocol_detection("UBNTAC2", ndpi_struct, detection_bitmask, *id,
+				      NDPI_PROTOCOL_UBNTAC2,
+				      ndpi_search_ubntac2,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
+				      ADD_TO_DETECTION_BITMASK);
+  *id += 1;
+}
+
+#endif


### PR DESCRIPTION
Supports detecting AirControl 2 (at the very least, no specs for any of the ubiquity protocols that I could find, and I only have dumps for one specific announce/broadcast packet) packets.
