### PR TITLE
ndpi_search_dns: fix potential buffer overflow

### DIFF
--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -250,7 +250,7 @@ void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	char a_buf[32];
 	int i;
 
-	for(i=0; i<num_a_records; i++) {
+	for(i=0; j < sizeof(flow->host_server_name)-1 && i < num_a_records; i++) {
 	  j += snprintf((char*)&flow->host_server_name[j], sizeof(flow->host_server_name)-1-j, "%s%s",
 			(i == 0) ? "@" : ";",
 			ndpi_intoa_v4(a_record[i], a_buf, sizeof(a_buf)));

--- a/src/lib/protocols/mail_smtp.c
+++ b/src/lib/protocols/mail_smtp.c
@@ -117,10 +117,10 @@ void ndpi_search_mail_smtp_tcp(struct ndpi_detection_module_struct
 	    && (packet->line[a].ptr[1] == 'T' || packet->line[a].ptr[1] == 't')
 	    && (packet->line[a].ptr[2] == 'A' || packet->line[a].ptr[2] == 'a')
 	    && (packet->line[a].ptr[3] == 'R' || packet->line[a].ptr[3] == 'r')
-	    && (packet->line[a].ptr[4] == 'T' || packet->line[a].ptr[0] == 't')
-	    && (packet->line[a].ptr[5] == 'T' || packet->line[a].ptr[1] == 't')
-	    && (packet->line[a].ptr[6] == 'L' || packet->line[a].ptr[2] == 'l')
-	    && (packet->line[a].ptr[7] == 'S' || packet->line[a].ptr[3] == 's')) {
+	    && (packet->line[a].ptr[4] == 'T' || packet->line[a].ptr[4] == 't')
+	    && (packet->line[a].ptr[5] == 'T' || packet->line[a].ptr[5] == 't')
+	    && (packet->line[a].ptr[6] == 'L' || packet->line[a].ptr[6] == 'l')
+	    && (packet->line[a].ptr[7] == 'S' || packet->line[a].ptr[7] == 's')) {
 	  flow->l4.tcp.smtp_command_bitmask |= SMTP_BIT_STARTTLS;
 	}
       }


### PR DESCRIPTION
If j == sizeof(flow->host_server_name) then snprintf() generates the warning that the size is greater MAX_INT.
