### PR TITLE
Made ndpi memory allocator type compatible with C++ on x686 platforms

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -407,7 +407,7 @@ static void debug_printf(u_int32_t protocol, void *id_struct,
 
 /* ***************************************************** */
 
-static void *malloc_wrapper(unsigned long size) {
+static void *malloc_wrapper(size_t size) {
   current_ndpi_memory += size;
 
   if(current_ndpi_memory > max_ndpi_memory)

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -45,8 +45,8 @@ extern "C" {
   u_int32_t ndpi_detection_get_sizeof_ndpi_id_struct(void);
 
   /* Public malloc/free */
-  void* ndpi_malloc(unsigned long size);
-  void* ndpi_calloc(unsigned long count, unsigned long size);
+  void* ndpi_malloc(size_t size);
+  void* ndpi_calloc(unsigned long count, size_t size);
   void  ndpi_free(void *ptr);
   void *ndpi_realloc(void *ptr, size_t old_size, size_t new_size);
   char *ndpi_strdup(const char *s);
@@ -75,7 +75,7 @@ extern "C" {
    * @return the initialized detection module
    */
   struct ndpi_detection_module_struct *ndpi_init_detection_module(u_int32_t ticks_per_second,
-								  void* (*__ndpi_malloc)(unsigned long size),
+								  void* (*__ndpi_malloc)(size_t size),
 								  void  (*__ndpi_free)(void *ptr),
 								  ndpi_debug_function_ptr ndpi_debug_printf);
 

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -196,7 +196,7 @@ u_int8_t ndpi_ips_match(u_int32_t src, u_int32_t dst,
 
 /* ****************************************** */
 
-static void *(*_ndpi_malloc)(unsigned long size);
+static void *(*_ndpi_malloc)(size_t size);
 static void  (*_ndpi_free)(void *ptr);
 
 /* ****************************************** */
@@ -290,12 +290,12 @@ static int removeDefaultPort(ndpi_port_range *range,
 
 /* ****************************************** */
 
-void* ndpi_malloc(unsigned long size) { return(_ndpi_malloc(size)); }
+void* ndpi_malloc(size_t size) { return(_ndpi_malloc(size)); }
 
 /* ****************************************** */
 
-void* ndpi_calloc(unsigned long count, unsigned long size) {
-  unsigned long len = count*size;
+void* ndpi_calloc(unsigned long count, size_t size) {
+  size_t len = count*size;
   void *p = ndpi_malloc(len);
 
   if(p)
@@ -1638,7 +1638,7 @@ static int ndpi_add_host_ip_subprotocol(struct ndpi_detection_module_struct *ndp
 /* ******************************************************************** */
 
 struct ndpi_detection_module_struct *ndpi_init_detection_module(u_int32_t ticks_per_second,
-								void* (*__ndpi_malloc)(unsigned long size),
+								void* (*__ndpi_malloc)(size_t size),
 								void  (*__ndpi_free)(void *ptr),
 								ndpi_debug_function_ptr ndpi_debug_printf)
 {


### PR DESCRIPTION
Hello!

nDPI uses unsigned long as allocation functions parameter. It's not recommended way because it's not platform independent. ISO / C++ standard uses size_t for this case.

So I decided to change all "unsigned long" to size_t. 

For C++ case it could help critical error about type mismatch on 32 bit platforms (because we could not use 8 byte counter here):

``` bash

g++ ndpi_example.cpp  -I/opt/ndpi/include/libndpi-1.7.1  -L/opt/ndpi/lib -lndpi  
ndpi_example.cpp: In function ‘ndpi_detection_module_struct* init_ndpi()’:
ndpi_example.cpp:40:89: error: invalid conversion from ‘void* (*)(size_t)throw () {aka void* (*)(unsigned int)throw ()}’ to ‘void* (*)(long unsigned int)’ [-fpermissive]
In file included from ndpi_example.cpp:3:0:
/opt/ndpi/include/libndpi-1.7.1/libndpi/ndpi_api.h:77:40: error:   initializing argument 2 of ‘ndpi_detection_module_struct* ndpi_init_detection_module(u_int32_t, void* (*)(long unsigned int), void (*)(void*), ndpi_debug_function_ptr)’ [-fpermissive]
```

Thanks!
