### PR TITLE
Fixed multiple buffer overflows

### DIFF
--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -32,6 +32,9 @@
 #include "ndpi_protocols.h"
 #include "ndpi_api.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 void *ndpi_tdelete(const void * __restrict, void ** __restrict,
 		   int (*)(const void *, const void *));
@@ -105,6 +108,21 @@ extern int ndpi_get_protocol_id_master_proto(struct ndpi_detection_module_struct
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
 void ndpi_debug_get_last_log_function_line(struct ndpi_detection_module_struct *ndpi_struct,
 					   const char **file, const char **func, u_int32_t * line);
+#endif
+
+/** Checks when the @p payload starts with the string literal @p str.
+* When the string is larger than the payload, check fails.
+* @return non-zero if check succeeded
+*/
+int ndpi_match_prefix(const u_int8_t *payload, size_t payload_len,
+                           const char *str, size_t str_len);
+
+/* version of ndpi_match_prefix with string literal */
+#define ndpi_match_strprefix(payload, payload_len, str) \
+  ndpi_match_prefix((payload), (payload_len), (str), (sizeof(str)-1))
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif	/* __NDPI_MAIN_H__ */

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4339,6 +4339,16 @@ char* ndpi_strnstr(const char *s, const char *find, size_t slen) {
 
 /* ****************************************************** */
 
+int ndpi_match_prefix(const u_int8_t *payload, size_t payload_len,
+    const char *str, size_t str_len)
+{
+  return str_len <= payload_len
+          ? memcmp(payload, str, str_len) == 0
+          : 0;
+}
+
+/* ****************************************************** */
+
 int ndpi_match_string_subprotocol(struct ndpi_detection_module_struct *ndpi_struct,
 				  char *string_to_match, u_int string_to_match_len,
 				  u_int8_t is_host_match) {

--- a/src/lib/protocols/dcerpc.c
+++ b/src/lib/protocols/dcerpc.c
@@ -36,13 +36,11 @@ void ndpi_search_dcerpc(struct ndpi_detection_module_struct *ndpi_struct, struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-	u_int16_t len_packet = (packet->payload[9]<<8) | packet->payload[8];
-
   if((packet->tcp != NULL)
      && (packet->payload_packet_len >= 64)
      && (packet->payload[0] == 0x05) /* version 5 */
      && (packet->payload[2] < 16) /* Packet type */
-		 && (len_packet == packet->payload_packet_len) /* Packet Length */
+		 && (((packet->payload[9]<<8) | packet->payload[8]) == packet->payload_packet_len) /* Packet Length */
      ) {
     NDPI_LOG(NDPI_PROTOCOL_DCERPC, ndpi_struct, NDPI_LOG_DEBUG, "DCERPC match\n");
     ndpi_int_dcerpc_add_connection(ndpi_struct, flow);

--- a/src/lib/protocols/ftp_control.c
+++ b/src/lib/protocols/ftp_control.c
@@ -30,904 +30,904 @@ static void ndpi_int_ftp_control_add_connection(struct ndpi_detection_module_str
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_FTP_CONTROL, NDPI_PROTOCOL_UNKNOWN);
 }
 
-static int ndpi_ftp_control_check_request(const u_int8_t *payload) {
+static int ndpi_ftp_control_check_request(const u_int8_t *payload, size_t payload_len) {
   
-  if (match_first_bytes(payload, "ABOR")) {
+  if (ndpi_match_strprefix(payload, payload_len, "ABOR")) {
     return 1;
   }
       
-  if (match_first_bytes(payload, "ACCT")) {
+  if (ndpi_match_strprefix(payload, payload_len, "ACCT")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "ADAT")) {
+  if (ndpi_match_strprefix(payload, payload_len, "ADAT")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "ALLO")) {
+  if (ndpi_match_strprefix(payload, payload_len, "ALLO")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "APPE")) {
+  if (ndpi_match_strprefix(payload, payload_len, "APPE")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "AUTH")) {
+  if (ndpi_match_strprefix(payload, payload_len, "AUTH")) {
     return 1;
   }
-  if (match_first_bytes(payload, "CCC")) {
+  if (ndpi_match_strprefix(payload, payload_len, "CCC")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "CDUP")) {
+  if (ndpi_match_strprefix(payload, payload_len, "CDUP")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "CONF")) {
+  if (ndpi_match_strprefix(payload, payload_len, "CONF")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "CWD")) {
+  if (ndpi_match_strprefix(payload, payload_len, "CWD")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "DELE")) {
+  if (ndpi_match_strprefix(payload, payload_len, "DELE")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "ENC")) {
+  if (ndpi_match_strprefix(payload, payload_len, "ENC")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "EPRT")) {
+  if (ndpi_match_strprefix(payload, payload_len, "EPRT")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "EPSV")) {
+  if (ndpi_match_strprefix(payload, payload_len, "EPSV")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "FEAT")) {
+  if (ndpi_match_strprefix(payload, payload_len, "FEAT")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "HELP")) {
+  if (ndpi_match_strprefix(payload, payload_len, "HELP")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "LANG")) {
+  if (ndpi_match_strprefix(payload, payload_len, "LANG")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "LIST")) {
+  if (ndpi_match_strprefix(payload, payload_len, "LIST")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "LPRT")) {
+  if (ndpi_match_strprefix(payload, payload_len, "LPRT")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "LPSV")) {
+  if (ndpi_match_strprefix(payload, payload_len, "LPSV")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "MDTM")) {
+  if (ndpi_match_strprefix(payload, payload_len, "MDTM")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "MIC")) {
+  if (ndpi_match_strprefix(payload, payload_len, "MIC")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "MKD")) {
+  if (ndpi_match_strprefix(payload, payload_len, "MKD")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "MLSD")) {
+  if (ndpi_match_strprefix(payload, payload_len, "MLSD")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "MLST")) {
+  if (ndpi_match_strprefix(payload, payload_len, "MLST")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "MODE")) {
+  if (ndpi_match_strprefix(payload, payload_len, "MODE")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "NLST")) {
+  if (ndpi_match_strprefix(payload, payload_len, "NLST")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "NOOP")) {
+  if (ndpi_match_strprefix(payload, payload_len, "NOOP")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "OPTS")) {
+  if (ndpi_match_strprefix(payload, payload_len, "OPTS")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "PASS")) {
+  if (ndpi_match_strprefix(payload, payload_len, "PASS")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "PASV")) {
+  if (ndpi_match_strprefix(payload, payload_len, "PASV")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "PBSZ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "PBSZ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "PORT")) {
+  if (ndpi_match_strprefix(payload, payload_len, "PORT")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "PROT")) {
+  if (ndpi_match_strprefix(payload, payload_len, "PROT")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "PWD")) {
+  if (ndpi_match_strprefix(payload, payload_len, "PWD")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "QUIT")) {
+  if (ndpi_match_strprefix(payload, payload_len, "QUIT")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "REIN")) {
+  if (ndpi_match_strprefix(payload, payload_len, "REIN")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "REST")) {
+  if (ndpi_match_strprefix(payload, payload_len, "REST")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "RETR")) {
+  if (ndpi_match_strprefix(payload, payload_len, "RETR")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "RMD")) {
+  if (ndpi_match_strprefix(payload, payload_len, "RMD")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "RNFR")) {
+  if (ndpi_match_strprefix(payload, payload_len, "RNFR")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "RNTO")) {
+  if (ndpi_match_strprefix(payload, payload_len, "RNTO")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "SITE")) {
+  if (ndpi_match_strprefix(payload, payload_len, "SITE")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "SIZE")) {
+  if (ndpi_match_strprefix(payload, payload_len, "SIZE")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "SMNT")) {
+  if (ndpi_match_strprefix(payload, payload_len, "SMNT")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "STAT")) {
+  if (ndpi_match_strprefix(payload, payload_len, "STAT")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "STOR")) {
+  if (ndpi_match_strprefix(payload, payload_len, "STOR")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "STOU")) {
+  if (ndpi_match_strprefix(payload, payload_len, "STOU")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "STRU")) {
+  if (ndpi_match_strprefix(payload, payload_len, "STRU")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "SYST")) {
+  if (ndpi_match_strprefix(payload, payload_len, "SYST")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "TYPE")) {
+  if (ndpi_match_strprefix(payload, payload_len, "TYPE")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "USER")) {
+  if (ndpi_match_strprefix(payload, payload_len, "USER")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "XCUP")) {
+  if (ndpi_match_strprefix(payload, payload_len, "XCUP")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "XMKD")) {
+  if (ndpi_match_strprefix(payload, payload_len, "XMKD")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "XPWD")) {
+  if (ndpi_match_strprefix(payload, payload_len, "XPWD")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "XRCP")) {
+  if (ndpi_match_strprefix(payload, payload_len, "XRCP")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "XRMD")) {
+  if (ndpi_match_strprefix(payload, payload_len, "XRMD")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "XRSQ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "XRSQ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "XSEM")) {
+  if (ndpi_match_strprefix(payload, payload_len, "XSEM")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "XSEN")) {
+  if (ndpi_match_strprefix(payload, payload_len, "XSEN")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "HOST")) {
+  if (ndpi_match_strprefix(payload, payload_len, "HOST")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "abor")) {
+  if (ndpi_match_strprefix(payload, payload_len, "abor")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "acct")) {
+  if (ndpi_match_strprefix(payload, payload_len, "acct")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "adat")) {
+  if (ndpi_match_strprefix(payload, payload_len, "adat")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "allo")) {
+  if (ndpi_match_strprefix(payload, payload_len, "allo")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "appe")) {
+  if (ndpi_match_strprefix(payload, payload_len, "appe")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "auth")) {
+  if (ndpi_match_strprefix(payload, payload_len, "auth")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "ccc")) {
+  if (ndpi_match_strprefix(payload, payload_len, "ccc")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "cdup")) {
+  if (ndpi_match_strprefix(payload, payload_len, "cdup")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "conf")) {
+  if (ndpi_match_strprefix(payload, payload_len, "conf")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "cwd")) {
+  if (ndpi_match_strprefix(payload, payload_len, "cwd")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "dele")) {
+  if (ndpi_match_strprefix(payload, payload_len, "dele")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "enc")) {
+  if (ndpi_match_strprefix(payload, payload_len, "enc")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "eprt")) {
+  if (ndpi_match_strprefix(payload, payload_len, "eprt")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "epsv")) {
+  if (ndpi_match_strprefix(payload, payload_len, "epsv")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "feat")) {
+  if (ndpi_match_strprefix(payload, payload_len, "feat")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "help")) {
+  if (ndpi_match_strprefix(payload, payload_len, "help")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "lang")) {
+  if (ndpi_match_strprefix(payload, payload_len, "lang")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "list")) {
+  if (ndpi_match_strprefix(payload, payload_len, "list")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "lprt")) {
+  if (ndpi_match_strprefix(payload, payload_len, "lprt")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "lpsv")) {
+  if (ndpi_match_strprefix(payload, payload_len, "lpsv")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "mdtm")) {
+  if (ndpi_match_strprefix(payload, payload_len, "mdtm")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "mic")) {
+  if (ndpi_match_strprefix(payload, payload_len, "mic")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "mkd")) {
+  if (ndpi_match_strprefix(payload, payload_len, "mkd")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "mlsd")) {
+  if (ndpi_match_strprefix(payload, payload_len, "mlsd")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "mlst")) {
+  if (ndpi_match_strprefix(payload, payload_len, "mlst")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "mode")) {
+  if (ndpi_match_strprefix(payload, payload_len, "mode")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "nlst")) {
+  if (ndpi_match_strprefix(payload, payload_len, "nlst")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "noop")) {
+  if (ndpi_match_strprefix(payload, payload_len, "noop")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "opts")) {
+  if (ndpi_match_strprefix(payload, payload_len, "opts")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "pass")) {
+  if (ndpi_match_strprefix(payload, payload_len, "pass")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "pasv")) {
+  if (ndpi_match_strprefix(payload, payload_len, "pasv")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "pbsz")) {
+  if (ndpi_match_strprefix(payload, payload_len, "pbsz")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "port")) {
+  if (ndpi_match_strprefix(payload, payload_len, "port")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "prot")) {
+  if (ndpi_match_strprefix(payload, payload_len, "prot")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "pwd")) {
+  if (ndpi_match_strprefix(payload, payload_len, "pwd")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "quit")) {
+  if (ndpi_match_strprefix(payload, payload_len, "quit")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "rein")) {
+  if (ndpi_match_strprefix(payload, payload_len, "rein")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "rest")) {
+  if (ndpi_match_strprefix(payload, payload_len, "rest")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "retr")) {
+  if (ndpi_match_strprefix(payload, payload_len, "retr")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "rmd")) {
+  if (ndpi_match_strprefix(payload, payload_len, "rmd")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "rnfr")) {
+  if (ndpi_match_strprefix(payload, payload_len, "rnfr")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "rnto")) {
+  if (ndpi_match_strprefix(payload, payload_len, "rnto")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "site")) {
+  if (ndpi_match_strprefix(payload, payload_len, "site")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "size")) {
+  if (ndpi_match_strprefix(payload, payload_len, "size")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "smnt")) {
+  if (ndpi_match_strprefix(payload, payload_len, "smnt")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "stat")) {
+  if (ndpi_match_strprefix(payload, payload_len, "stat")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "stor")) {
+  if (ndpi_match_strprefix(payload, payload_len, "stor")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "stou")) {
+  if (ndpi_match_strprefix(payload, payload_len, "stou")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "stru")) {
+  if (ndpi_match_strprefix(payload, payload_len, "stru")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "syst")) {
+  if (ndpi_match_strprefix(payload, payload_len, "syst")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "type")) {
+  if (ndpi_match_strprefix(payload, payload_len, "type")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "user")) {
+  if (ndpi_match_strprefix(payload, payload_len, "user")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "xcup")) {
+  if (ndpi_match_strprefix(payload, payload_len, "xcup")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "xmkd")) {
+  if (ndpi_match_strprefix(payload, payload_len, "xmkd")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "xpwd")) {
+  if (ndpi_match_strprefix(payload, payload_len, "xpwd")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "xrcp")) {
+  if (ndpi_match_strprefix(payload, payload_len, "xrcp")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "xrmd")) {
+  if (ndpi_match_strprefix(payload, payload_len, "xrmd")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "xrsq")) {
+  if (ndpi_match_strprefix(payload, payload_len, "xrsq")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "xsem")) {
+  if (ndpi_match_strprefix(payload, payload_len, "xsem")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "xsen")) {
+  if (ndpi_match_strprefix(payload, payload_len, "xsen")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "host")) {
+  if (ndpi_match_strprefix(payload, payload_len, "host")) {
     return 1;
   }
   
   return 0;
 }
 
-static int ndpi_ftp_control_check_response(const u_int8_t *payload) {
+static int ndpi_ftp_control_check_response(const u_int8_t *payload, size_t payload_len) {
   
-  if (match_first_bytes(payload, "110-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "110-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "120-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "120-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "125-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "125-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "150-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "150-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "202-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "202-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "211-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "211-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "212-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "212-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "213-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "213-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "214-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "214-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "215-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "215-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "220-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "220-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "221-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "221-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "225-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "225-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "226-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "226-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "227-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "227-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "228-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "228-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "229-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "229-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "230-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "230-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "231-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "231-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "232-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "232-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "250-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "250-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "257-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "257-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "331-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "331-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "332-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "332-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "350-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "350-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "421-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "421-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "425-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "425-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "426-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "426-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "430-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "430-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "434-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "434-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "450-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "450-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "451-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "451-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "452-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "452-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "501-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "501-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "502-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "502-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "503-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "503-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "504-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "504-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "530-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "530-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "532-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "532-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "550-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "550-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "551-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "551-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "552-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "552-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "553-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "553-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "631-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "631-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "632-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "632-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "633-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "633-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "10054-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "10054-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "10060-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "10060-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "10061-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "10061-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "10066-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "10066-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "10068-")) {
+  if (ndpi_match_strprefix(payload, payload_len, "10068-")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "110 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "110 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "120 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "120 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "125 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "125 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "150 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "150 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "202 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "202 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "211 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "211 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "212 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "212 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "213 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "213 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "214 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "214 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "215 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "215 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "220 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "220 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "221 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "221 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "225 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "225 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "226 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "226 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "227 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "227 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "228 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "228 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "229 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "229 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "230 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "230 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "231 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "231 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "232 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "232 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "250 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "250 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "257 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "257 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "331 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "331 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "332 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "332 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "350 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "350 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "421 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "421 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "425 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "425 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "426 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "426 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "430 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "430 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "434 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "434 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "450 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "450 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "451 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "451 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "452 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "452 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "501 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "501 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "502 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "502 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "503 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "503 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "504 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "504 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "530 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "530 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "532 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "532 ")) {
     return 1;
   }
-  if (match_first_bytes(payload, "550 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "550 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "551 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "551 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "552 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "552 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "553 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "553 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "631 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "631 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "632 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "632 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "633 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "633 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "10054 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "10054 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "10060 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "10060 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "10061 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "10061 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "10066 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "10066 ")) {
     return 1;
   }
 
-  if (match_first_bytes(payload, "10068 ")) {
+  if (ndpi_match_strprefix(payload, payload_len, "10068 ")) {
     return 1;
   }
 
@@ -956,7 +956,7 @@ static void ndpi_check_ftp_control(struct ndpi_detection_module_struct *ndpi_str
   if (flow->ftp_control_stage == 0) {
      NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "FTP_CONTROL stage 0: \n");
      
-     if ((payload_len > 0) && ndpi_ftp_control_check_request(packet->payload)) {
+     if ((payload_len > 0) && ndpi_ftp_control_check_request(packet->payload, payload_len)) {
        NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "Possible FTP_CONTROL request detected, we will look further for the response...\n");
        
        /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -972,7 +972,7 @@ static void ndpi_check_ftp_control(struct ndpi_detection_module_struct *ndpi_str
     }
     
     /* This is a packet in another direction. Check if we find the proper response. */
-    if ((payload_len > 0) && ndpi_ftp_control_check_response(packet->payload)) {
+    if ((payload_len > 0) && ndpi_ftp_control_check_response(packet->payload, payload_len)) {
       NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "Found FTP_CONTROL.\n");
       ndpi_int_ftp_control_add_connection(ndpi_struct, flow);
     } else {

--- a/src/lib/protocols/ftp_data.c
+++ b/src/lib/protocols/ftp_data.c
@@ -60,13 +60,14 @@ static int ndpi_match_ftp_data_directory(struct ndpi_detection_module_struct *nd
 
 static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &flow->packet;
+  u_int32_t payload_len = packet->payload_packet_len;
 
   /* A FTP packet is pretty long so 256 is a bit consrvative but it should be OK */
   if(packet->payload_packet_len < 256)
     return 0;
 
   /* RIFF is a meta-format for storing AVI and WAV files */
-  if(match_first_bytes(packet->payload, "RIFF"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "RIFF"))
     return 1;
 
   /* MZ is a .exe file */
@@ -74,7 +75,7 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
     return 1;
 
   /* Ogg files */
-  if(match_first_bytes(packet->payload, "OggS"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "OggS"))
     return 1;
 
   /* ZIP files */
@@ -86,7 +87,7 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
     return 1;
 
   /* RAR files */
-  if(match_first_bytes(packet->payload, "Rar!"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "Rar!"))
     return 1;
 
   /* EBML */
@@ -98,7 +99,7 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
     return 1;
 
   /* GIF */
-  if(match_first_bytes(packet->payload, "GIF8"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "GIF8"))
     return 1;
 
   /* PHP scripts */
@@ -110,7 +111,7 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
     return 1;
 
   /* PDFs */
-  if(match_first_bytes(packet->payload, "%PDF"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "%PDF"))
     return 1;
 
   /* PNG */
@@ -118,7 +119,7 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
     return 1;
 
   /* HTML */
-  if(match_first_bytes(packet->payload, "<htm"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "<htm"))
     return 1;
   if((packet->payload[0] == 0x0a) && (packet->payload[1] == '<') && (packet->payload[2] == '!') && (packet->payload[3] == 'D'))
     return 1;
@@ -132,17 +133,17 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
     return 1;
 
   /* XML */
-  if(match_first_bytes(packet->payload, "<!DO"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "<!DO"))
     return 1;
 
   /* FLAC */
-  if(match_first_bytes(packet->payload, "fLaC"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "fLaC"))
     return 1;
 
   /* MP3 */
   if((packet->payload[0] == 'I') && (packet->payload[1] == 'D') && (packet->payload[2] == '3') && (packet->payload[3] == 0x03))
     return 1;
-  if(match_first_bytes(packet->payload, "\xff\xfb\x90\xc0"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "\xff\xfb\x90\xc0"))
     return 1;
 
   /* RPM */
@@ -150,7 +151,7 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
     return 1;
 
   /* Wz Patch */
-  if(match_first_bytes(packet->payload, "WzPa"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "WzPa"))
     return 1;
 
   /* Flash Video */
@@ -158,7 +159,7 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
     return 1;
 
   /* .BKF (Microsoft Tape Format) */
-  if(match_first_bytes(packet->payload, "TAPE"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "TAPE"))
     return 1;
 
   /* MS Office Doc file - this is unpleasantly geeky */
@@ -174,23 +175,23 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
     return 1;
 
   /* ar archive, typically .deb files */
-  if(match_first_bytes(packet->payload, "!<ar"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "!<ar"))
     return 1;
 
   /* Raw XML (skip jabber-like traffic as this is not FTP but unencrypted jabber) */
-  if((match_first_bytes(packet->payload, "<?xm"))
+  if((ndpi_match_strprefix(packet->payload, payload_len, "<?xm"))
      && (ndpi_strnstr((const char *)packet->payload, "jabber", packet->payload_packet_len) == NULL))
     return 1;
 
-  if(match_first_bytes(packet->payload, "<iq "))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "<iq "))
     return 1;
 
   /* SPF */
-  if(match_first_bytes(packet->payload, "SPFI"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "SPFI"))
     return 1;
 
   /* ABIF - Applied Biosystems */
-  if(match_first_bytes(packet->payload, "ABIF"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, "ABIF"))
     return 1;
 
   /* bzip2 - other digits are also possible instead of 9 */
@@ -203,11 +204,11 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
     return 1;
   if((packet->payload[0] == '<') && (packet->payload[1] == 'C') && (packet->payload[2] == 'F'))
     return 1;
-  if(match_first_bytes(packet->payload, ".tem"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, ".tem"))
     return 1;
-  if(match_first_bytes(packet->payload, ".ite"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, ".ite"))
     return 1;
-  if(match_first_bytes(packet->payload, ".lef"))
+  if(ndpi_match_strprefix(packet->payload, payload_len, ".lef"))
     return 1;
 
   return 0;

--- a/src/lib/protocols/gnutella.c
+++ b/src/lib/protocols/gnutella.c
@@ -294,7 +294,7 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
       return;
     }
 
-    if (memcmp(packet->payload, "GND", 3) == 0) {
+    if (packet->payload_packet_len >= 3 && memcmp(packet->payload, "GND", 3) == 0) {
       if ((packet->payload_packet_len == 8 && (memcmp(&packet->payload[6], "\x01\x00", 2) == 0))
 	  || (packet->payload_packet_len == 11 && (memcmp(&packet->payload[6], "\x01\x01\x08\x50\x49", 5)
 						   == 0)) || (packet->payload_packet_len == 17

--- a/src/lib/protocols/h323.c
+++ b/src/lib/protocols/h323.c
@@ -27,7 +27,8 @@ void ndpi_search_h323(struct ndpi_detection_module_struct *ndpi_struct, struct n
     NDPI_LOG(NDPI_PROTOCOL_H323, ndpi_struct, NDPI_LOG_DEBUG, "calculated dport over tcp.\n");
 
     /* H323  */
-    if((packet->payload[0] == 0x03)
+    if(packet->payload_packet_len >= 3
+       && (packet->payload[0] == 0x03)
        && (packet->payload[1] == 0x00)
        && (packet->payload[2] == 0x00)) {
 	struct tpkt *t = (struct tpkt*)packet->payload;
@@ -63,7 +64,8 @@ void ndpi_search_h323(struct ndpi_detection_module_struct *ndpi_struct, struct n
     sport = ntohs(packet->udp->source), dport = ntohs(packet->udp->dest);
     NDPI_LOG(NDPI_PROTOCOL_H323, ndpi_struct, NDPI_LOG_DEBUG, "calculated dport over udp.\n");
 
-    if(packet->payload[0] == 0x80 && packet->payload[1] == 0x08 && (packet->payload[2] == 0xe7 || packet->payload[2] == 0x26) &&
+    if(packet->payload_packet_len >= 5 && packet->payload[0] == 0x80 && packet->payload[1] == 0x08 &&
+       (packet->payload[2] == 0xe7 || packet->payload[2] == 0x26) &&
        packet->payload[4] == 0x00 && packet->payload[5] == 0x00)
       {
 	NDPI_LOG(NDPI_PROTOCOL_H323, ndpi_struct, NDPI_LOG_DEBUG, "found H323 broadcast.\n");

--- a/src/lib/protocols/kakaotalk_voice.c
+++ b/src/lib/protocols/kakaotalk_voice.c
@@ -33,7 +33,7 @@ void ndpi_search_kakaotalk_voice(struct ndpi_detection_module_struct *ndpi_struc
   
   if(packet->iph
      && packet->udp
-     && (packet->payload_packet_len > 0)
+     && (packet->payload_packet_len >= 4)
      ) {
     if((packet->payload[0] == 0x81)
        || (packet->payload[1] == 0xC8)

--- a/src/lib/protocols/msn.c
+++ b/src/lib/protocols/msn.c
@@ -130,7 +130,7 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
       if (get_u_int8_t(packet->payload, packet->payload_packet_len - 2) == 0x0d
 	  && get_u_int8_t(packet->payload, packet->payload_packet_len - 1) == 0x0a) {
 	/* The MSNP string is used in XBOX clients. */
-	if (memcmp(packet->payload, "VER ", 4) == 0) {
+	if (ndpi_match_strprefix(packet->payload, packet->payload_packet_len, "VER ")) {
 
 	  if (memcmp(&packet->payload[packet->payload_packet_len - 6], "CVR",
 		     3) == 0 || memcmp(&packet->payload[packet->payload_packet_len - 8], "MSNP", 4) == 0) {
@@ -139,7 +139,7 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	    ndpi_int_msn_add_connection(ndpi_struct, flow);
 	    return;
 	  }
-	  if (memcmp(&packet->payload[4], "MSNFT", 5) == 0) {
+	  if (ndpi_match_strprefix(&packet->payload[4], packet->payload_packet_len-4, "MSNFT")) {
 	    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
 		     "found MSN FT by pattern VER MSNFT...0d0a.\n");
 	    ndpi_int_msn_add_connection(ndpi_struct, flow);
@@ -153,8 +153,8 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 #ifdef NDPI_PROTOCOL_HTTP
 	packet->detected_protocol_stack[0] == NDPI_PROTOCOL_HTTP ||
 #endif
-	memcmp(packet->payload, "GET ", NDPI_STATICSTRING_LEN("GET ")) == 0 ||
-	memcmp(packet->payload, "POST ", NDPI_STATICSTRING_LEN("POST ")) == 0) {
+	ndpi_match_strprefix(packet->payload, packet->payload_packet_len, "GET ") ||
+	ndpi_match_strprefix(packet->payload, packet->payload_packet_len, "POST ")) {
       ndpi_parse_packet_line_info(ndpi_struct, flow);
       if (packet->user_agent_line.ptr != NULL &&
 	  packet->user_agent_line.len > NDPI_STATICSTRING_LEN("Messenger/") &&
@@ -277,8 +277,8 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 #ifdef NDPI_PROTOCOL_HTTP
 	  packet->detected_protocol_stack[0] == NDPI_PROTOCOL_HTTP ||
 #endif
-	  (memcmp(packet->payload, "HTTP/1.0 200 OK", 15) == 0) ||
-	  (memcmp(packet->payload, "HTTP/1.1 200 OK", 15) == 0)
+	  ndpi_match_strprefix(packet->payload, packet->payload_packet_len, "HTTP/1.0 200 OK") ||
+	  ndpi_match_strprefix(packet->payload, packet->payload_packet_len, "HTTP/1.1 200 OK")
 	  ) {
 
 	ndpi_parse_packet_line_info(ndpi_struct, flow);

--- a/src/lib/protocols/pando.c
+++ b/src/lib/protocols/pando.c
@@ -34,7 +34,7 @@ static void ndpi_check_pando_tcp(struct ndpi_detection_module_struct *ndpi_struc
 	struct ndpi_packet_struct *packet = &flow->packet;
 	u_int32_t payload_len = packet->payload_packet_len;
 
-	if ((payload_len > 0) && match_first_bytes(packet->payload, "\x0ePan")) {
+	if (ndpi_match_strprefix(packet->payload, payload_len, "\x0ePan")) {
 	    NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Found PANDO.\n");
 	    ndpi_int_pando_add_connection(ndpi_struct, flow);
 	}
@@ -56,7 +56,7 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 			return;
 		}
 
-		if ((payload_len > 0) && match_first_bytes(packet->payload, "UDPA")) {
+		if (ndpi_match_strprefix(packet->payload, payload_len, "UDPA")) {
 			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Possible PANDO request detected, we will look further for the response...\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -64,7 +64,7 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 			return;
 		}
 
-		if ((payload_len > 0) && (match_first_bytes(packet->payload, "UDPR") || match_first_bytes(packet->payload, "UDPE"))) {
+		if (ndpi_match_strprefix(packet->payload, payload_len, "UDPR") || ndpi_match_strprefix(packet->payload, payload_len, "UDPE")) {
 			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Possible PANDO request detected, we will look further for the response...\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -98,7 +98,7 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 		}
 
 		/* This is a packet in another direction. Check if we find the proper response. */
-		if ((payload_len == 0) || match_first_bytes(packet->payload, "UDPR") || match_first_bytes(packet->payload, "UDPE")) {
+		if ((payload_len == 0) || (ndpi_match_strprefix(packet->payload, payload_len, "UDPR") || ndpi_match_strprefix(packet->payload, payload_len, "UDPE"))) {
 			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Found PANDO.\n");
 			ndpi_int_pando_add_connection(ndpi_struct, flow);
 		} else {
@@ -115,7 +115,7 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 		}
 
 		/* This is a packet in another direction. Check if we find the proper response. */
-		if ((payload_len > 0) && match_first_bytes(packet->payload, "UDPA")) {
+		if (ndpi_match_strprefix(packet->payload, payload_len, "UDPA")) {
 			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Found PANDO.\n");
 			ndpi_int_pando_add_connection(ndpi_struct, flow);
 		} else {

--- a/src/lib/protocols/pplive.c
+++ b/src/lib/protocols/pplive.c
@@ -39,7 +39,7 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 	if (flow->pplive_stage1 == 0) {
 		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE stage 0: \n");
 		
-		if ((payload_len > 0) && match_first_bytes(packet->payload, "\xe9\x03\x41\x01")) {
+		if (ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x41\x01")) {
 			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Possible PPLIVE request detected, we will look further for the response...\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -47,7 +47,7 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 			return;
 		}
 		
-		if ((payload_len > 0) && match_first_bytes(packet->payload, "\xe9\x03\x42\x01")) {
+		if (ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x42\x01")) {
 			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Possible PPLIVE request detected, we will look further for the response...\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -55,7 +55,7 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 			return;
 		}
 		
-		if ((payload_len > 0) && match_first_bytes(packet->payload, "\x1c\x1c\x32\x01")) {
+		if (ndpi_match_strprefix(packet->payload, payload_len, "\x1c\x1c\x32\x01")) {
 			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Possible PPLIVE request detected, we will look further for the response...\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -72,7 +72,7 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 		}
 
 		/* This is a packet in another direction. Check if we find the proper response. */
-		if ((payload_len > 0) && (match_first_bytes(packet->payload, "\xe9\x03\x42\x01") || match_first_bytes(packet->payload, "\xe9\x03\x41\x01"))) {
+		if (ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x42\x01") || ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x41\x01")) {
 			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Found PPLIVE.\n");
 			ndpi_int_pplive_add_connection(ndpi_struct, flow);
 		} else {
@@ -89,7 +89,7 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 		}
 
 		/* This is a packet in another direction. Check if we find the proper response. */
-		if ((payload_len > 0) && match_first_bytes(packet->payload, "\xe9\x03\x41\x01")) {
+		if (ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x41\x01")) {
 			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Found PPLIVE.\n");
 			ndpi_int_pplive_add_connection(ndpi_struct, flow);
 		} else {
@@ -105,7 +105,7 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 		}
 
 		/* This is a packet in another direction. Check if we find the proper response. */
-		if ((payload_len > 0) && match_first_bytes(packet->payload, "\x1c\x1c\x32\x01")) {
+		if (ndpi_match_strprefix(packet->payload, payload_len, "\x1c\x1c\x32\x01")) {
 			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Found PPLIVE.\n");
 			ndpi_int_pplive_add_connection(ndpi_struct, flow);
 		} else {
@@ -124,7 +124,7 @@ static void ndpi_check_pplive_udp2(struct ndpi_detection_module_struct *ndpi_str
 	if (flow->pplive_stage2 == 0) {
 		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE stage 0: \n");
 		
-		if ((payload_len == 57) && match_first_bytes(packet->payload, "\xe9\x03\x41\x01")) {
+		if ((payload_len == 57) && ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x41\x01")) {
 			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Possible PPLIVE request detected, we will look further for the response...\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */

--- a/src/lib/protocols/radius.c
+++ b/src/lib/protocols/radius.c
@@ -37,12 +37,11 @@ static void ndpi_check_radius(struct ndpi_detection_module_struct *ndpi_struct, 
 
   if(packet->udp != NULL) {
     struct radius_header *h = (struct radius_header*)packet->payload;
-    u_int len = ntohs(h->len);
 
     if((payload_len > sizeof(struct radius_header))
        && (h->code > 0)
        && (h->code <= 5)
-       && (len == payload_len)) {
+       && (ntohs(h->len) == payload_len)) {
       NDPI_LOG(NDPI_PROTOCOL_RADIUS, ndpi_struct, NDPI_LOG_DEBUG, "Found radius.\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_RADIUS, NDPI_PROTOCOL_UNKNOWN);
 

--- a/src/lib/protocols/rtcp.c
+++ b/src/lib/protocols/rtcp.c
@@ -38,7 +38,7 @@ void ndpi_search_rtcp(struct ndpi_detection_module_struct *ndpi_struct, struct n
     /* Let's check first the RTCP packet length */
     u_int16_t len, offset = 0, rtcp_section_len;
     
-    while(offset < packet->payload_packet_len) {
+    while(offset + 3 < packet->payload_packet_len) {
       len = packet->payload[2+offset] * 256 + packet->payload[2+offset+1];
       rtcp_section_len = (len + 1) * 4;
       
@@ -50,9 +50,10 @@ void ndpi_search_rtcp(struct ndpi_detection_module_struct *ndpi_struct, struct n
     
     sport = ntohs(packet->udp->source), dport = ntohs(packet->udp->dest);
     NDPI_LOG(NDPI_PROTOCOL_RTCP, ndpi_struct, NDPI_LOG_DEBUG, "calculating dport over udp.\n");
-    if(((packet->payload_packet_len >= 28 || packet->payload_packet_len <= 1200) &&
+    /* TODO changed a pair of length condition to the && from ||. Is it correct? */
+    if(((packet->payload_packet_len >= 28 && packet->payload_packet_len <= 1200) &&
 	((packet->payload[0] == 0x80) && ((packet->payload[1] == 0xc8) || (packet->payload[1] == 0xc9)) && (packet->payload[2] == 0x00)))
-       || (((packet->payload[0] == 0x81) && ((packet->payload[1] == 0xc8) || (packet->payload[1] == 0xc9))
+       || (packet->payload_packet_len >= 3 && ((packet->payload[0] == 0x81) && ((packet->payload[1] == 0xc8) || (packet->payload[1] == 0xc9))
 	    && (packet->payload[2] == 0x00)))) {
       NDPI_LOG(NDPI_PROTOCOL_RTCP, ndpi_struct, NDPI_LOG_DEBUG, "found rtcp.\n");
       ndpi_int_rtcp_add_connection(ndpi_struct, flow);

--- a/src/lib/protocols/rtp.c
+++ b/src/lib/protocols/rtp.c
@@ -73,6 +73,8 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
 			    struct ndpi_flow_struct *flow,
 			    const u_int8_t * payload, const u_int16_t payload_len)
 {
+  if (payload_len < 2)
+    return;
   //struct ndpi_packet_struct *packet = &flow->packet;
   u_int8_t payloadType, payload_type = payload[1] & 0x7F;
   u_int32_t *ssid = (u_int32_t*)&payload[8];

--- a/src/lib/protocols/spotify.c
+++ b/src/lib/protocols/spotify.c
@@ -54,7 +54,7 @@ static void ndpi_check_spotify(struct ndpi_detection_module_struct *ndpi_struct,
     }
   } else if(packet->tcp != NULL) {
 
-     if(packet->payload[0] == 0x00 && packet->payload[1] == 0x04 &&
+     if(payload_len >= 8 && packet->payload[0] == 0x00 && packet->payload[1] == 0x04 &&
        packet->payload[2] == 0x00 && packet->payload[3] == 0x00&&
        packet->payload[6] == 0x52 && packet->payload[7] == 0x0e &&
        packet->payload[8] == 0x50 ) {

--- a/src/lib/protocols/ssl.c
+++ b/src/lib/protocols/ssl.c
@@ -223,64 +223,67 @@ int getSSLcertificate(struct ndpi_detection_module_struct *ndpi_struct,
 	}
       } else if(handshake_protocol == 0x01 /* Client Hello */) {
 	u_int offset, base_offset = 43;
-	u_int16_t session_id_len = packet->payload[base_offset];
+	if (base_offset + 2 <= packet->payload_packet_len)
+	{
+	  u_int16_t session_id_len = packet->payload[base_offset];
 
-	if((session_id_len+base_offset+2) <= total_len) {
-	  u_int16_t cypher_len =  packet->payload[session_id_len+base_offset+2] + (packet->payload[session_id_len+base_offset+1] << 8);
-	  offset = base_offset + session_id_len + cypher_len + 2;
+	  if((session_id_len+base_offset+2) <= total_len) {
+	    u_int16_t cypher_len =  packet->payload[session_id_len+base_offset+2] + (packet->payload[session_id_len+base_offset+1] << 8);
+	    offset = base_offset + session_id_len + cypher_len + 2;
 
-	  flow->l4.tcp.ssl_seen_client_cert = 1;
-
-	  if(offset < total_len) {
-	    u_int16_t compression_len;
-	    u_int16_t extensions_len;
-
-	    compression_len = packet->payload[offset+1];
-	    offset += compression_len + 3;
+	    flow->l4.tcp.ssl_seen_client_cert = 1;
 
 	    if(offset < total_len) {
-	      extensions_len = packet->payload[offset];
+	      u_int16_t compression_len;
+	      u_int16_t extensions_len;
 
-	      if((extensions_len+offset) < total_len) {
-		u_int16_t extension_offset = 1; /* Move to the first extension */
+	      compression_len = packet->payload[offset+1];
+	      offset += compression_len + 3;
 
-		while(extension_offset < extensions_len) {
-		  u_int16_t extension_id, extension_len;
+	      if(offset < total_len) {
+		extensions_len = packet->payload[offset];
 
-		  memcpy(&extension_id, &packet->payload[offset+extension_offset], 2);
-		  extension_offset += 2;
+		if((extensions_len+offset) < total_len) {
+		  u_int16_t extension_offset = 1; /* Move to the first extension */
 
-		  memcpy(&extension_len, &packet->payload[offset+extension_offset], 2);
-		  extension_offset += 2;
+		  while(extension_offset < extensions_len) {
+		    u_int16_t extension_id, extension_len;
 
-		  extension_id = ntohs(extension_id), extension_len = ntohs(extension_len);
+		    memcpy(&extension_id, &packet->payload[offset+extension_offset], 2);
+		    extension_offset += 2;
 
-		  if(extension_id == 0) {
-		    u_int begin = 0,len;
-		    char *server_name = (char*)&packet->payload[offset+extension_offset];
+		    memcpy(&extension_len, &packet->payload[offset+extension_offset], 2);
+		    extension_offset += 2;
 
-		    while(begin < extension_len) {
-		      if((!ndpi_isprint(server_name[begin]))
-			 || ndpi_ispunct(server_name[begin])
-			 || ndpi_isspace(server_name[begin]))
-			begin++;
-		      else
-			break;
+		    extension_id = ntohs(extension_id), extension_len = ntohs(extension_len);
+
+		    if(extension_id == 0) {
+		      u_int begin = 0,len;
+		      char *server_name = (char*)&packet->payload[offset+extension_offset];
+
+		      while(begin < extension_len) {
+			if((!ndpi_isprint(server_name[begin]))
+			   || ndpi_ispunct(server_name[begin])
+			   || ndpi_isspace(server_name[begin]))
+			  begin++;
+			else
+			  break;
+		      }
+
+		      len = (u_int)ndpi_min(extension_len-begin, buffer_len-1);
+		      strncpy(buffer, &server_name[begin], len);
+		      buffer[len] = '\0';
+		      stripCertificateTrailer(buffer, buffer_len);
+
+		      snprintf(flow->protos.ssl.client_certificate,
+			       sizeof(flow->protos.ssl.client_certificate), "%s", buffer);
+
+		      /* We're happy now */
+		      return(2 /* Client Certificate */);
 		    }
 
-		    len = (u_int)ndpi_min(extension_len-begin, buffer_len-1);
-		    strncpy(buffer, &server_name[begin], len);
-		    buffer[len] = '\0';
-		    stripCertificateTrailer(buffer, buffer_len);
-
-		    snprintf(flow->protos.ssl.client_certificate,
-			     sizeof(flow->protos.ssl.client_certificate), "%s", buffer);
-
-		    /* We're happy now */
-		    return(2 /* Client Certificate */);
+		    extension_offset += extension_len;
 		  }
-
-		  extension_offset += extension_len;
 		}
 	      }
 	    }

--- a/src/lib/protocols/starcraft.c
+++ b/src/lib/protocols/starcraft.c
@@ -49,9 +49,8 @@ u_int8_t ndpi_check_starcraft_tcp(struct ndpi_detection_module_struct* ndpi_stru
 {
   if (sc2_match_logon_ip(&flow->packet)
       && flow->packet.tcp->dest == htons(1119)	//bnetgame port
-      && flow->packet.payload_packet_len >= 10
-      && (match_first_bytes(flow->packet.payload, "\x4a\x00\x00\x0a\x66\x02\x0a\xed\x2d\x66") 
-	  || match_first_bytes(flow->packet.payload, "\x49\x00\x00\x0a\x66\x02\x0a\xed\x2d\x66")))
+      && (ndpi_match_strprefix(flow->packet.payload, flow->packet.payload_packet_len, "\x4a\x00\x00\x0a\x66\x02\x0a\xed\x2d\x66") 
+	  || ndpi_match_strprefix(flow->packet.payload, flow->packet.payload_packet_len, "\x49\x00\x00\x0a\x66\x02\x0a\xed\x2d\x66")))
     return 1;
   else
     return -1;

--- a/src/lib/protocols/steam.c
+++ b/src/lib/protocols/steam.c
@@ -50,7 +50,7 @@ static void ndpi_check_steam_tcp(struct ndpi_detection_module_struct *ndpi_struc
   if (flow->steam_stage == 0) {
     NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage 0: \n");
 	    
-    if (((payload_len == 1) || (payload_len == 4) || (payload_len == 5)) && match_first_bytes(packet->payload, "\x01\x00\x00\x00")) {
+    if ((payload_len == 1 && packet->payload[0] == 0x01) || ((payload_len == 4 || payload_len == 5) && ndpi_match_strprefix(packet->payload, payload_len, "\x01\x00\x00\x00"))) {
       NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -58,7 +58,7 @@ static void ndpi_check_steam_tcp(struct ndpi_detection_module_struct *ndpi_struc
       return;
     }
 		
-    if (((payload_len == 1) || (payload_len == 4) || (payload_len == 5)) && (packet->payload[0] == 0x00) && (packet->payload[1] == 0x00) && (packet->payload[2] == 0x00)) {
+    if ((payload_len == 1 && packet->payload[0] == 0x00) || ((payload_len == 4 || payload_len == 5) && ndpi_match_strprefix(packet->payload, payload_len, "\x00\x00\x00"))) {
       NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -74,7 +74,7 @@ static void ndpi_check_steam_tcp(struct ndpi_detection_module_struct *ndpi_struc
     }
 
     /* This is a packet in another direction. Check if we find the proper response. */
-    if (((payload_len == 1) || (payload_len == 4) || (payload_len == 5)) && (packet->payload[0] == 0x00) && (packet->payload[1] == 0x00) && (packet->payload[2] == 0x00)) {
+    if ((payload_len == 1 && packet->payload[0] == 0x00) || ((payload_len == 4 || payload_len == 5) && ndpi_match_strprefix(packet->payload, payload_len, "\x00\x00\x00"))) {
       NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {
@@ -90,7 +90,7 @@ static void ndpi_check_steam_tcp(struct ndpi_detection_module_struct *ndpi_struc
     }
 
     /* This is a packet in another direction. Check if we find the proper response. */
-    if (((payload_len == 1) || (payload_len == 4) || (payload_len == 5)) && match_first_bytes(packet->payload, "\x01\x00\x00\x00")) {
+    if ((payload_len == 1 && packet->payload[0] == 0x01) || ((payload_len == 4 || payload_len == 5) && ndpi_match_strprefix(packet->payload, payload_len, "\x01\x00\x00\x00"))) {
       NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {
@@ -104,7 +104,7 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 	
-  if ((payload_len > 0) && match_first_bytes(packet->payload, "VS01")) {
+  if (ndpi_match_strprefix(packet->payload, payload_len, "VS01")) {
     NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
     ndpi_int_steam_add_connection(ndpi_struct, flow);
     return;
@@ -114,7 +114,7 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
   if (flow->steam_stage1 == 0) {
     NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage 0: \n");
 		
-    if ((payload_len > 0) && match_first_bytes(packet->payload, "\x31\xff\x30\x2e")) {
+    if (ndpi_match_strprefix(packet->payload, payload_len, "\x31\xff\x30\x2e")) {
       NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -122,7 +122,7 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
       return;
     }
 		
-    if ((payload_len > 0) && match_first_bytes(packet->payload, "\xff\xff\xff\xff")) {
+    if (ndpi_match_strprefix(packet->payload, payload_len, "\xff\xff\xff\xff")) {
       NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -139,7 +139,7 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
     }
 
     /* This is a packet in another direction. Check if we find the proper response. */
-    if ((payload_len > 0) && match_first_bytes(packet->payload, "\xff\xff\xff\xff")) {
+    if (ndpi_match_strprefix(packet->payload, payload_len, "\xff\xff\xff\xff")) {
       NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {
@@ -156,7 +156,7 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
     }
 
     /* This is a packet in another direction. Check if we find the proper response. */
-    if ((payload_len > 0) && match_first_bytes(packet->payload, "\x31\xff\x30\x2e")) {
+    if (ndpi_match_strprefix(packet->payload, payload_len, "\x31\xff\x30\x2e")) {
       NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {
@@ -175,7 +175,7 @@ static void ndpi_check_steam_udp2(struct ndpi_detection_module_struct *ndpi_stru
   if (flow->steam_stage2 == 0) {
     NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage 0: \n");
 		
-    if ((payload_len == 25) && match_first_bytes(packet->payload, "\xff\xff\xff\xff")) {
+    if ((payload_len == 25) && ndpi_match_strprefix(packet->payload, payload_len, "\xff\xff\xff\xff")) {
       NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
@@ -191,7 +191,7 @@ static void ndpi_check_steam_udp2(struct ndpi_detection_module_struct *ndpi_stru
     }
 
     /* This is a packet in another direction. Check if we find the proper response. */
-    if ((payload_len == 0) || match_first_bytes(packet->payload, "\xff\xff\xff\xff")) {
+    if ((payload_len == 0) || ndpi_match_strprefix(packet->payload, payload_len, "\xff\xff\xff\xff")) {
       NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {


### PR DESCRIPTION
We had encountered a lot of small packets at the traffic and nDPI often crashed with them because there are few places where packet length is not checked. I tried to fix it by checking packet length and by introducing a helper function ndpi_match_prefix with a length check (it has zero overhead because string length is checked at compile time!).

It is based on ntop/nDPI#172, address sanitizer and a fuzzy tester.
