### PR TITLE
Add symbols needed by ntopng to the shared library export list.

### DIFF
--- a/libndpi.sym
+++ b/libndpi.sym
@@ -1,4 +1,6 @@
 ndpi_dump_protocols
+ndpi_strnstr
+ndpi_detection_giveup
 ndpi_get_proto_name
 ndpi_free
 ndpi_guess_undetected_protocol


### PR DESCRIPTION
The export list for the shared library seems to lack a pair of function names which are actually used by ntopng.

This fixes compiling ntopng to use ndpi as a shared library.

Also looks like this is the underlying cause for issues ntop/ntopng#528 and ntop/ntopng#540.
