### PR TITLE
Updated ndpi_l4_detection_process_packet

### DIFF
--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -224,6 +224,52 @@ extern "C" {
 					      struct ndpi_id_struct *src,
 					      struct ndpi_id_struct *dst);
 
+
+  /**
+   * Processes one packet of L4 and returns the ID of the detected protocol.
+   * L3 and L4 packet headers are passed in the arguments while payload
+   * points to the L4 body.
+   * This function mimics ndpi_detection_process_packet behaviour.
+   *
+   * @par    ndpi_struct           = the detection module
+   * @par    flow                  = pointer to the connection state machine
+   * @par    iph                   = IP packet header for IPv4 or NULL
+   * @par    iph6                  = IP packet header for IPv6 or NULL
+   * @par    tcp                   = TCP packet header for TCP or NULL
+   * @par    udp                   = UDP packet header for UDP or NULL
+   * @par    src_to_dst_direction  = order of src/dst state machines in a flow.
+   * @par    l4_proto              = L4 protocol of the packet.
+   * @par    src                   = pointer to the source subscriber state machine
+   * @par    dst                   = pointer to the destination subscriber state machine
+   * @par    sport                 = source port of L4 packet, used for protocol guessing.
+   * @par    dport                 = destination port of L4 packet, used for protocol guessing.
+   * @par    current_tick_l        = the current timestamp for the packet
+   * @par    payload               = unsigned char pointer to the Layer 4 (TCP/UDP body)
+   * @par    payload_len           = the length of the payload
+   * @return the detected ID of the protocol
+   *
+   * NOTE: in a current implementation flow->src and flow->dst are swapped with
+   * the src_to_dst_direction flag while ndpi_detection_process_packet does not swap
+   * these values.
+   *
+   */
+
+ndpi_protocol ndpi_l4_detection_process_packet(struct ndpi_detection_module_struct *ndpi_struct,
+					       struct ndpi_flow_struct *flow,
+					       const struct ndpi_iphdr *iph,
+					       struct ndpi_ipv6hdr *iph6,
+					       struct ndpi_tcphdr *tcp,
+					       struct ndpi_udphdr *udp,
+					       u_int8_t src_to_dst_direction,
+					       u_int8_t l4_proto,
+					       struct ndpi_id_struct *src,
+					       u_int16_t sport,
+					       struct ndpi_id_struct *dst,
+					       u_int16_t dport,
+					       const u_int64_t current_tick_l,
+					       u_int8_t *payload, u_int16_t payload_len);
+
+
   
   /**
    * Get the main protocol of the passed flows for the detected module

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -112,10 +112,8 @@ void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, struct nd
     ret_code = (is_query == 0) ? 0 : (dns_header.flags & 0x0F);
     int j = 0;
     int off = sizeof(struct ndpi_dns_packet_header) + 1;
-    while((flow->packet.payload[off] != '\0'))
+    while(flow->packet.payload[off] != '\0' && off < flow->packet.payload_packet_len)
     {
-      if(off < flow->packet.payload_packet_len)
-      {
 	flow->host_server_name[j] = flow->packet.payload[off];
 	if(j < strlen((char*)flow->host_server_name)) {
 	  if(flow->host_server_name[j] < ' ')
@@ -123,7 +121,6 @@ void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	  j++;
 	}
 	off++;
-      }
     }
     flow->host_server_name[j] = '\0';
 


### PR DESCRIPTION
**Rationale**
Usually nDPI accepts L3 packet and deals with IP and TCP headers itself. Sometimes software handles IP and TCP on its own (custom IP or TCP reassemblers, flow control) and only needs to pass to nDPI a L4 payload.

**Patch content**
This patch updates a `ndpi_l4_detection_process_packet` function and synchronizes it with the main `ndpi_detection_process_packet` function. Patch was tested for a few weeks of a heavy traffic load.

It should be noted that `src_to_dst_direction` parameter works in a different way than in  `ndpi_detection_process_packet`. I think it should not be used for setting `flow->src` to be consistent with  the other function.
