### PR TITLE
ndpi_main: fix Value stored to 'saddr'/'daddr' is never read

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -3281,16 +3281,6 @@ ndpi_protocol ndpi_l4_detection_process_packet(struct ndpi_detection_module_stru
 
     flow->protocol_id_already_guessed = 1;
 
-#ifdef NDPI_DETECTION_SUPPORT_IPV6
-    if(flow->packet.iphv6 != NULL) {
-      saddr = 0, daddr = 0;
-    } else
-#endif
-    {
-      saddr = ntohl(flow->packet.iph->saddr);
-      daddr = ntohl(flow->packet.iph->daddr);
-    }
-
     flow->guessed_protocol_id = (int16_t)ndpi_guess_protocol_id(ndpi_struct, l4_proto, sport, dport);
 
     if(flow->packet.iph) {


### PR DESCRIPTION
ndpi_main.c:3286:7: warning: Value stored to 'saddr' is never read
ndpi_main.c:3290:7: warning: Value stored to 'saddr' is never read
ndpi_main.c:3291:7: warning: Value stored to 'daddr' is never read
