### PR TITLE
Avoid c99 complains about function prototypes

### DIFF
--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -122,7 +122,7 @@ extern "C" {
    * @return  the initialized detection module
    *
    */
-  struct ndpi_detection_module_struct *ndpi_init_detection_module();
+  struct ndpi_detection_module_struct *ndpi_init_detection_module(void);
   
   /**
    * Frees the memory allocated in the specified flow
@@ -588,7 +588,7 @@ ndpi_protocol ndpi_l4_detection_process_packet(struct ndpi_detection_module_stru
    * @return  The requested automata, or NULL if an error occurred
    * 
    */
-  void* ndpi_init_automa();
+  void* ndpi_init_automa(void);
 
 
   /**

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -1716,7 +1716,7 @@ void set_ndpi_debug_function(struct ndpi_detection_module_struct *ndpi_str, ndpi
 
 /* ******************************************************************** */
 
-struct ndpi_detection_module_struct *ndpi_init_detection_module() {
+struct ndpi_detection_module_struct *ndpi_init_detection_module(void) {
   struct ndpi_detection_module_struct *ndpi_str = ndpi_malloc(sizeof(struct ndpi_detection_module_struct));
 
   if(ndpi_str == NULL) {
@@ -1771,7 +1771,7 @@ struct ndpi_detection_module_struct *ndpi_init_detection_module() {
 /* *********************************************** */
 
 /* Wrappers */
-void* ndpi_init_automa() {
+void* ndpi_init_automa(void) {
   return(ac_automata_init(ac_match_handler));
 }
 


### PR DESCRIPTION
Please, can you merge these changes? They can simplify libndpi usage by 3rd parties applications.
Compiling with -Wstrict-prototypes -Werror flags generates error because of missing void in function prototypes (functions with no arguments).
