### PR TITLE
Scan build

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -2888,11 +2888,11 @@ static int ndpi_init_packet_header(struct ndpi_detection_module_struct *ndpi_str
   }
 #endif							/* NDPI_DETECTION_SUPPORT_IPV6 */
 
-  if(decaps_iph->version == 4 && decaps_iph->ihl >= 5) {
+  if(decaps_iph && decaps_iph->version == 4 && decaps_iph->ihl >= 5) {
     NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG, "ipv4 header\n");
   }
 #ifdef NDPI_DETECTION_SUPPORT_IPV6
-  else if(decaps_iph->version == 6 && l3len >= sizeof(struct ndpi_ipv6hdr) &&
+  else if(decaps_iph && decaps_iph->version == 6 && l3len >= sizeof(struct ndpi_ipv6hdr) &&
 	  (ndpi_struct->ip_version_limit & NDPI_DETECTION_ONLY_IPV4) == 0) {
     NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG, "ipv6 header\n");
     flow->packet.iphv6 = (struct ndpi_ipv6hdr *)flow->packet.iph;

--- a/src/lib/protocols/coap.c
+++ b/src/lib/protocols/coap.c
@@ -115,7 +115,7 @@ void ndpi_search_coap (struct ndpi_detection_module_struct *ndpi_struct,
     u_int16_t s_port = ntohs(flow->packet.udp->source);
     u_int16_t d_port = ntohs(flow->packet.udp->dest);
 
-    if((!isCoAPport(s_port) && !isCoAPport(s_port))
+    if((!isCoAPport(s_port) && !isCoAPport(d_port))
        || (packet->payload_packet_len < 4) // header too short
        ) {
       NDPI_LOG(NDPI_PROTOCOL_COAP, ndpi_struct, NDPI_LOG_DEBUG, "excluding Coap\n");

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -164,7 +164,7 @@ static void setHttpUserAgent(struct ndpi_flow_struct *flow, char *ua) {
 
 static void parseHttpSubprotocol(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   // int i = 0;
-  struct ndpi_packet_struct *packet = &flow->packet;
+  //struct ndpi_packet_struct *packet = &flow->packet;
 
   if((flow->l4.tcp.http_stage == 0)
      || (flow->http.url && flow->http_detected)) {


### PR DESCRIPTION
Fix last warning found by Scan build (Clang Analyzer)

There is also this warning but false positive i think  :
ndpiReader.c:993:5: warning: Function call argument is an uninitialized value