### PR TITLE
Checking for libdl vs. libc during configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,11 @@ if test -f $PCAP_HOME/libpcap/libpcap.a; then :
 
      AC_CHECK_LIB([rt], [clock_gettime],   [PCAP_LIB="$PCAP_LIB -lrt"])
      AC_CHECK_LIB([nl], [nl_handle_alloc], [PCAP_LIB="$PCAP_LIB -lnl"])
+     # The dlopen() function is in libdl on GLIBC-based systems
+     # and in the C library for *BSD systems
+     AC_CHECK_LIB([dl], [dlopen, dlsym],   [DL_LIB="-ldl"],
+                  [AC_CHECK_LIB([c], [dlopen, dlsym], [DL_LIB="-lc"],
+                                [AC_MSG_ERROR([unable to find the dlopen(), dlsym() functions]) ]) ])
 else
     AC_CHECK_LIB([pcap], [pcap_open_live], [PCAP_LIB="-lpcap"])
 
@@ -94,6 +99,7 @@ AC_SUBST(SVN_DATE)
 AC_SUBST(JSON_C_LIB)
 AC_SUBST(PCAP_INC)
 AC_SUBST(PCAP_LIB)
+AC_SUBST(DL_LIB)
 AC_SUBST(HAVE_PTHREAD_SETAFFINITY_NP)
 
 AC_OUTPUT

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -4,7 +4,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src/include @PCAP_INC@
 AM_CFLAGS = @PTHREAD_CFLAGS@
 
 LDADD = $(top_builddir)/src/lib/libndpi.la @JSON_C_LIB@ @PTHREAD_LIBS@ @PCAP_LIB@
-AM_LDFLAGS = -static -ldl
+AM_LDFLAGS = -static @DL_LIB@
 
 ndpiReader_SOURCES = ndpiReader.c ndpi_util.c ndpi_util.h
 


### PR DESCRIPTION
Please take a look at the changes whether they are ok or not.
ndpiReader fails to link on BSD systems