### PR TITLE
Fix 'IPVERSION undeclared' error on WIN32

### DIFF
--- a/src/include/ndpi_win32.h
+++ b/src/include/ndpi_win32.h
@@ -38,6 +38,8 @@
 
 #define _WS2TCPIP_H_ /* Avoid compilation problems */
 
+#define	IPVERSION	4 /* on *nix it is defined in netinet/ip.h */ 
+
 extern char* strsep(char **sp, const char *sep);
 
 typedef unsigned char  u_char;


### PR DESCRIPTION
Windows does not contain the `netinet/ip.h` header file so nDPI throws a `'IPVERSION': undeclared identifier` compilation error when compiled with Visual Studio.
This PR fixes that error.