### PR TITLE
SMPP: fix comparison of unsigned expression >= 0 is always true [-Wer…

### DIFF
--- a/src/lib/protocols/smpp.c
+++ b/src/lib/protocols/smpp.c
@@ -100,7 +100,7 @@ void ndpi_search_smpp_tcp(struct ndpi_detection_module_struct* ndpi_struct,
     // remove 0x80, get request type pdu
     u_int32_t pdu_req = pdu_type & 0x00FFFFFF;
     // list of known PDU types
-    if((pdu_req >= 0x00000000 && pdu_req <= 0x00000009) ||
+    if((pdu_req >  0x00000000 && pdu_req <= 0x00000009) ||
        (pdu_req == 0x0000000B || pdu_req == 0x00000015  ||
         pdu_req == 0x00000021 || pdu_req == 0x00000102  ||
         pdu_req == 0x00000103)){


### PR DESCRIPTION
…ror,-Wtautological-compare]