### PR TITLE
Using autoconfigured variable for libdl linkage

### DIFF
--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -3,8 +3,8 @@ bin_PROGRAMS = ndpiReader
 AM_CPPFLAGS = -I$(top_srcdir)/src/include @PCAP_INC@
 AM_CFLAGS = @PTHREAD_CFLAGS@ # --coverage
 
-LDADD = $(top_builddir)/src/lib/libndpi.la @JSON_C_LIB@ @PTHREAD_LIBS@ @PCAP_LIB@ -ldl
-AM_LDFLAGS = -static @DL_LIB@
+LDADD = $(top_builddir)/src/lib/libndpi.la @JSON_C_LIB@ @PTHREAD_LIBS@ @PCAP_LIB@ @DL_LIB@
+AM_LDFLAGS = -static
 
 ndpiReader_SOURCES = ndpiReader.c ndpi_util.c ndpi_util.h
 


### PR DESCRIPTION
Hi,
-ldl has been explicitly reintroduced at some point after my previous pull-request.
Was there any case skipped by configure which does not properly substitute DL_LIB in makefiles?
Should not that be the case, please pull this change in.
Or can you give me some details where the autoconfigured DL_LIB variable fails so I can check?
Thanks