### PR TITLE
ndpi_main(.c): fix unused function 'tor_ptree_match' [-Werror,-Wunuse…

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -1668,9 +1668,11 @@ u_int16_t ndpi_network_ptree_match(struct ndpi_detection_module_struct *ndpi_str
 
 /* ******************************************* */
 
+#if 0
 static u_int8_t tor_ptree_match(struct ndpi_detection_module_struct *ndpi_struct, struct in_addr *pin) {
   return((ndpi_network_ptree_match(ndpi_struct, pin) == NDPI_PROTOCOL_TOR) ? 1 : 0);
 }
+#endif
 
 /* ******************************************* */
 


### PR DESCRIPTION
…d-function]