### PR TITLE
Easing OpenBSD build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 LT_INIT
 
 AC_PROG_CC
+AM_PROG_CC_C_O
 AX_PTHREAD
 
 if test -d ".git"; then :

--- a/example/ndpi_util.c
+++ b/example/ndpi_util.c
@@ -650,10 +650,12 @@ void ndpi_workflow_process_packet (struct ndpi_workflow * workflow,
     break;
 
     /* Linux Cooked Capture - 113 */
+#ifdef __linux__
   case DLT_LINUX_SLL :
     type = (packet[eth_offset+14] << 8) + packet[eth_offset+15];
     ip_offset = 16 + eth_offset;
     break;
+#endif
 
     /* Radiotap link-layer - 127 */
   case DLT_IEEE802_11_RADIO :


### PR DESCRIPTION
Addedd macro `AM_PROG_CC_C_O` in `configure.ac`, needed to have `autogen.sh`
manage the error:

    C objects in subdir but `AM_PROG_CC_C_O' not in `configure.ac'

Modified case instance in `example/ndpi_util.c`, since `DLT_LINUX_SLL`
isn't defined in OpenBSD `pcap.h`.