### PR TITLE
Added ndpi_flow_ free/malloc and set_ functions:

### DIFF
--- a/example/ndpi_util.c
+++ b/example/ndpi_util.c
@@ -62,16 +62,13 @@
 #define GTP_U_V1_PORT                   2152
 #define TZSP_PORT                      37008
 
-#define SIZEOF_ID_STRUCT (sizeof(struct ndpi_id_struct))
-#define SIZEOF_FLOW_STRUCT (sizeof(struct ndpi_flow_struct))
-
 #include "ndpi_main.h"
 #include "ndpi_util.h"
 
 /* ***************************************************** */
 
 void ndpi_free_flow_info_half(struct ndpi_flow_info *flow) {
-  if(flow->ndpi_flow) { ndpi_free_flow(flow->ndpi_flow); flow->ndpi_flow = NULL; }
+  if(flow->ndpi_flow) { ndpi_flow_free(flow->ndpi_flow); flow->ndpi_flow = NULL; }
   if(flow->src_id)    { ndpi_free(flow->src_id); flow->src_id = NULL; }
   if(flow->dst_id)    { ndpi_free(flow->dst_id); flow->dst_id = NULL; }
 }
@@ -106,6 +103,7 @@ static void free_wrapper(void *freeable) {
 struct ndpi_workflow * ndpi_workflow_init(const struct ndpi_workflow_prefs * prefs, pcap_t * pcap_handle) {
 
   set_ndpi_malloc(malloc_wrapper), set_ndpi_free(free_wrapper);
+  set_ndpi_flow_malloc(NULL), set_ndpi_flow_free(NULL);
   /* TODO: just needed here to init ndpi malloc wrapper */
   struct ndpi_detection_module_struct * module = ndpi_init_detection_module();
 
@@ -356,7 +354,7 @@ static struct ndpi_flow_info *get_ndpi_flow_info(struct ndpi_workflow * workflow
 	patchIPv6Address(newflow->lower_name), patchIPv6Address(newflow->upper_name);
       }
 
-      if((newflow->ndpi_flow = ndpi_malloc(SIZEOF_FLOW_STRUCT)) == NULL) {
+      if((newflow->ndpi_flow = ndpi_flow_malloc(SIZEOF_FLOW_STRUCT)) == NULL) {
 	NDPI_LOG(0, workflow->ndpi_struct, NDPI_LOG_ERROR, "[NDPI] %s(2): not enough memory\n", __FUNCTION__);
 	free(newflow);
 	return(NULL);

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -31,6 +31,9 @@
 extern "C" {
 #endif
 
+#define SIZEOF_ID_STRUCT (sizeof(struct ndpi_id_struct))
+#define SIZEOF_FLOW_STRUCT (sizeof(struct ndpi_flow_struct))
+
 #define NDPI_DETECTION_ONLY_IPV4              ( 1 << 0 )
 #define NDPI_DETECTION_ONLY_IPV6              ( 1 << 1 )
 
@@ -79,8 +82,9 @@ extern "C" {
   void * ndpi_realloc(void *ptr, size_t old_size, size_t new_size);
   char * ndpi_strdup(const char *s);
   void   ndpi_free(void *ptr);
+  void * ndpi_flow_malloc(size_t size);
+  void   ndpi_flow_free(void *ptr);
 
-  
   /**
    * Search the first occurrence of substring -find- in -s-
    * The search is limited to the first -slen- characters of the string
@@ -591,6 +595,8 @@ extern "C" {
   /* Utility functions to set ndpi malloc/free/print wrappers */
   void set_ndpi_malloc(void* (*__ndpi_malloc)(size_t size));
   void set_ndpi_free(void  (*__ndpi_free)(void *ptr));
+  void set_ndpi_flow_malloc(void* (*__ndpi_flow_malloc)(size_t size));
+  void set_ndpi_flow_free(void  (*__ndpi_flow_free)(void *ptr));
   void set_ndpi_debug_function(struct ndpi_detection_module_struct *ndpi_str, ndpi_debug_function_ptr ndpi_debug_printf);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Ideally these two new functions will provide more flexibility
in regards of application that want to use specific allocation
approaches, for example storage queues for this structures
from where the application can pop and release the data it
needs.
Semantically they can be set up as the other ndpi_malloc and ndpi_free
functions, that is via the set_ndpi_flow_malloc and set_ndpi_flow_free.
In case a NULL parameter is passed to the above functions the old
approach will be used, that means that the ndpi_malloc will be used as
the ndpi_flow_malloc function and ndpi_free_flow as the ndpi_flow_free one.

Application that use the old functions will be not affected by this change,
and the ndpi_free_flow can be deprecated in the future and made private.