### PR TITLE
unified HTTPDownload name with other HTTP protocols (as HTTP_Download)

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -187,7 +187,7 @@ static void ndpi_tdestroy_recurse(ndpi_node* root, void (*free_action)(void *))
 void ndpi_tdestroy(void *vrootp, void (*freefct)(void *))
 {
   ndpi_node *root = (ndpi_node *) vrootp;
-  
+
   if(root != NULL)
     ndpi_tdestroy_recurse(root, freefct);
 }
@@ -338,7 +338,7 @@ void ndpi_flow_free(void *ptr) { if(_ndpi_flow_free) _ndpi_flow_free(ptr); else 
 void * ndpi_realloc(void *ptr, size_t old_size, size_t new_size)
 {
   void *ret = ndpi_malloc(new_size);
-  
+
   if(!ret)
     return(ret);
   else {
@@ -477,9 +477,9 @@ static int ndpi_default_ports_tree_node_t_cmp(const void *a, const void *b)
 {
   ndpi_default_ports_tree_node_t *fa = (ndpi_default_ports_tree_node_t*)a;
   ndpi_default_ports_tree_node_t *fb = (ndpi_default_ports_tree_node_t*)b;
-  
+
   //printf("[NDPI] %s(%d, %d)\n", __FUNCTION__, fa->default_port, fb->default_port);
-  
+
   return((fa->default_port == fb->default_port) ? 0 : ((fa->default_port < fb->default_port) ? -1 : 1));
 }
 
@@ -488,7 +488,7 @@ static int ndpi_default_ports_tree_node_t_cmp(const void *a, const void *b)
 void ndpi_default_ports_tree_node_t_walker(const void *node, const ndpi_VISIT which, const int depth)
 {
   ndpi_default_ports_tree_node_t *f = *(ndpi_default_ports_tree_node_t **)node;
-  
+
 
   printf("<%d>Walk on node %s (%u)\n",
 	 depth,
@@ -1016,7 +1016,7 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
 			    ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
     ndpi_set_proto_defaults(ndpi_mod, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_HTTP_DOWNLOAD,
 			    no_master,
-			    no_master, "HTTPDownload", NDPI_PROTOCOL_CATEGORY_FILE_TRANSFER,
+			    no_master, "HTTP_Download", NDPI_PROTOCOL_CATEGORY_FILE_TRANSFER,
 			    ndpi_build_default_ports(ports_a, 0, 0, 0, 0, 0) /* TCP */,
 			    ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
     ndpi_set_proto_defaults(ndpi_mod, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_QQLIVE,
@@ -3281,8 +3281,8 @@ void check_ndpi_tcp_flow_func(struct ndpi_detection_module_struct *ndpi_struct,
 	   && NDPI_BITMASK_COMPARE(ndpi_struct->callback_buffer_tcp_payload[a].detection_bitmask,
 				   detection_bitmask) != 0) {
 	  ndpi_struct->callback_buffer_tcp_payload[a].func(ndpi_struct, flow);
-	  
-	  
+
+
 	  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN)
 	    break; /* Stop after detecting the first protocol */
 	}
@@ -3347,7 +3347,7 @@ ndpi_protocol ndpi_detection_giveup(struct ndpi_detection_module_struct *ndpi_st
 
     if(flow->protos.ssl.client_certificate[0] != '\0') {
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SSL, NDPI_PROTOCOL_UNKNOWN);
-    } else {    
+    } else {
       if((flow->guessed_protocol_id == NDPI_PROTOCOL_UNKNOWN)
 	 && (flow->packet.l4_protocol == IPPROTO_TCP)
 	 && (flow->l4.tcp.ssl_stage > 1))
@@ -3485,9 +3485,9 @@ ndpi_protocol ndpi_detection_process_packet(struct ndpi_detection_module_struct 
 
     /* guess protocol */
     flow->guessed_protocol_id = (int16_t) ndpi_guess_protocol_id(ndpi_struct, protocol, sport, dport, &user_defined_proto);
-    
+
     if(user_defined_proto && flow->guessed_protocol_id != NDPI_PROTOCOL_UNKNOWN) {
-      
+
       if(flow->packet.iph) {
 	/* guess host protocol */
 	flow->guessed_host_protocol_id = ndpi_network_ptree_match(ndpi_struct, (struct in_addr *)&flow->packet.iph->saddr);
@@ -3496,7 +3496,7 @@ ndpi_protocol ndpi_detection_process_packet(struct ndpi_detection_module_struct 
 	if(flow->guessed_host_protocol_id != NDPI_PROTOCOL_UNKNOWN)
 	  /* ret.master_protocol = flow->guessed_protocol_id , ret.app_protocol = flow->guessed_host_protocol_id; /\* ****** *\/ */
 	  ret = ndpi_detection_giveup(ndpi_struct, flow);
-	
+
 	return(ret);
       }
     } else {
@@ -3508,7 +3508,7 @@ ndpi_protocol ndpi_detection_process_packet(struct ndpi_detection_module_struct 
       }
     }
   }
-  
+
   check_ndpi_flow_func(ndpi_struct, flow, &ndpi_selection_packet);
 
   a = flow->packet.detected_protocol_stack[0];
@@ -4111,7 +4111,7 @@ void ndpi_int_change_protocol(struct ndpi_detection_module_struct *ndpi_struct,
 /*     flow->packet.detected_protocol_stack[0] = flow->guessed_host_protocol_id; */
 /*     /\* master proto for packet *\/ */
 /*     flow->packet.detected_protocol_stack[1] = flow->guessed_protocol_id; */
-    
+
 /*   } */
 /* } */
 
@@ -4346,7 +4346,7 @@ ndpi_protocol ndpi_guess_undetected_protocol(struct ndpi_detection_module_struct
     if(rc != NDPI_PROTOCOL_UNKNOWN) {
       ret.app_protocol = rc,
 	ret.master_protocol = ndpi_guess_protocol_id(ndpi_struct, proto, sport, dport, &user_defined_proto);
-      
+
       if(ret.app_protocol == ret.master_protocol)
 	ret.master_protocol = NDPI_PROTOCOL_UNKNOWN;
 

--- a/tests/result/starcraft_battle.pcap.out
+++ b/tests/result/starcraft_battle.pcap.out
@@ -1,7 +1,7 @@
 DNS	26	2848	7
 HTTP	271	160676	18
 SSDP	11	4984	1
-HTTPDownload	179	134204	1
+HTTP_Download	179	134204	1
 WorldOfWarcraft	9	880	1
 IGMP	2	120	1
 SSL	38	2548	11
@@ -40,7 +40,7 @@ Starcraft	236	51494	6
 	28	TCP 80.239.186.26:443 <-> 192.168.1.100:3476 [proto: 91/SSL][1 pkts/60 bytes]
 	29	TCP 80.239.186.40:443 <-> 192.168.1.100:3478 [proto: 91/SSL][1 pkts/60 bytes]
 	30	TCP 192.168.1.100:2759 <-> 64.233.184.188:5228 [proto: 126/Google][2 pkts/121 bytes]
-	31	TCP 192.168.1.100:3508 <-> 87.248.221.254:80 [proto: 7.60/HTTP.HTTPDownload][179 pkts/134204 bytes][Host: llnw.blizzard.com]
+	31	TCP 192.168.1.100:3508 <-> 87.248.221.254:80 [proto: 7.60/HTTP.HTTP_Download][179 pkts/134204 bytes][Host: llnw.blizzard.com]
 	32	UDP 173.194.40.22:443 <-> 192.168.1.100:53568 [proto: 188/QUIC][6 pkts/475 bytes]
 	33	UDP 192.168.1.100:55468 <-> 192.168.1.254:53 [proto: 5/DNS][4 pkts/556 bytes][Host: bnetcmsus-a.akamaihd.net]
 	34	UDP 192.168.1.100:58818 <-> 192.168.1.254:53 [proto: 5/DNS][4 pkts/432 bytes][Host: 91.252.30.192.in-addr.arpa]

--- a/tests/result/waze.pcap.out
+++ b/tests/result/waze.pcap.out
@@ -1,7 +1,7 @@
 Unknown	10	786	1
 HTTP	28	1572	7
 NTP	2	180	1
-HTTPDownload	37	63205	1
+HTTP_Download	37	63205	1
 SSL_No_Cert	13	2142	1
 SSL	8	432	2
 Waze	484	289335	19
@@ -27,7 +27,7 @@ WhatsApp	15	1341	1
 	18	TCP 10.8.0.1:45546 <-> 54.230.227.172:80 [proto: 7.135/HTTP.Waze][14 pkts/1328 bytes][Host: cres.waze.com]
 	19	TCP 10.8.0.1:45552 <-> 54.230.227.172:80 [proto: 7.135/HTTP.Waze][14 pkts/1323 bytes][Host: cres.waze.com]
 	20	TCP 10.8.0.1:45554 <-> 54.230.227.172:80 [proto: 7.135/HTTP.Waze][14 pkts/1319 bytes][Host: cres.waze.com]
-	21	TCP 10.8.0.1:54915 <-> 65.39.128.135:80 [proto: 7.60/HTTP.HTTPDownload][37 pkts/63205 bytes][Host: xtra1.gpsonextra.net]
+	21	TCP 10.8.0.1:54915 <-> 65.39.128.135:80 [proto: 7.60/HTTP.HTTP_Download][37 pkts/63205 bytes][Host: xtra1.gpsonextra.net]
 	22	TCP 10.8.0.1:36585 <-> 173.194.118.48:443 [proto: 64/SSL_No_Cert][13 pkts/2142 bytes]
 	23	TCP 10.8.0.1:43089 <-> 200.160.4.198:443 [proto: 91/SSL][4 pkts/216 bytes]
 	24	TCP 10.8.0.1:51049 <-> 176.34.103.105:443 [proto: 91.135/SSL.Waze][23 pkts/7823 bytes][server: *.waze.com]


### PR DESCRIPTION
Currently, the HTTP protocols available are: HTTP_Proxy, HTTP_Connect, HTTP and HTTPDownload. As you can see, there is some inconsistency in the naming of these protocols. Because of this, this request changes the name HTTPDownload to HTTP_Download.