### PR TITLE
Fix out-of-bounds heap read

### DIFF
--- a/example/ndpi_util.c
+++ b/example/ndpi_util.c
@@ -908,7 +908,7 @@ struct ndpi_proto ndpi_workflow_process_packet (struct ndpi_workflow * workflow,
 
   /* process the packet */
   return(packet_processing(workflow, time, vlan_id, iph, iph6,
-			   ip_offset, header->len - ip_offset, header->len));
+			   ip_offset, header->caplen - ip_offset, header->caplen));
 }
 
 /* ********************************************************** */


### PR DESCRIPTION
Fix out-of-bounds heap read caused by using header->len instead of he…ader->caplen (as provided in pcap_loop).

It also might be a good idea to increase the capture length passed to pcap_open_live (in the example, at least) since in some systems IP fragmentation/defragmentation offloading causes (sometimes both outgoing and incoming) Ethernet frames to be significantly larger than the MTU of the network interface used. It seems that these artificial Ethernet frames can be as large as the largest possible IP frame, which is 65535 bytes.

I've observed this behavior on an Ubuntu 16.04 virtual machine, and it causes crashes in the protocol detectors. In addition, this error is also displayed by valgrind.