### PR TITLE
Remove unused variable and clarify operator precedence in ndpi_util.c

### DIFF
--- a/example/ndpi_util.c
+++ b/example/ndpi_util.c
@@ -887,7 +887,7 @@ static uint32_t crc32_for_byte(uint32_t r) {
   int j;
 
   for(j = 0; j < 8; ++j)
-    r = (r & 1? 0: (uint32_t)0xEDB88320L) ^ r >> 1;
+    r = ((r & 1) ? 0 : ((uint32_t)0xEDB88320L) ^ r >> 1);
   return r ^ (uint32_t)0xFF000000L;
 }
 
@@ -912,7 +912,7 @@ static void init_tables(uint32_t* table, uint32_t* wtable) {
 void ethernet_crc32(const void* data, size_t n_bytes, uint32_t* crc) {
   static uint32_t table[0x100], wtable[0x100*sizeof(accum_t)];
   size_t n_accum = n_bytes/sizeof(accum_t);
-  size_t i, k, j;
+  size_t i, j;
 
   if(!*table)
     init_tables(table, wtable);


### PR DESCRIPTION
Remove unused variable k from function ethernet_crc32() in ndpi_util.c .
Use some parentheses to clarify operator precedence in crc32_for_byte() in ndpi_util.c .