### PR TITLE
HTTP respose status code after validation check.

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -3817,6 +3817,11 @@ void ndpi_parse_packet_line_info(struct ndpi_detection_module_struct *ndpi_struc
 	    packet->http_response.len = packet->line[0].len - NDPI_STATICSTRING_LEN("HTTP/1.1 ");
 	    packet->http_num_headers++;
 
+	    /* Set server HTTP response code */
+	    strncpy((char*)flow->http.response_status_code, (char*)packet->http_response.ptr, 3);
+	    flow->http.response_status_code[4]='\0';
+
+
 	    NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG,
 		  "ndpi_parse_packet_line_info: HTTP response parsed: \"%.*s\"\n",
 		   packet->http_response.len, packet->http_response.ptr);

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -826,12 +826,6 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
     ndpi_parse_packet_line_info(ndpi_struct, flow);
     check_content_type_and_change_protocol(ndpi_struct, flow);
 
-    /* Set server HTTP response code, if available */
-    if(packet->http_response.len>=3){
-      strncpy((char*)flow->http.response_status_code, (char*)packet->http_response.ptr, 3);
-      flow->http.response_status_code[4]='\0';
-    }
-
     if(packet->packet_direction == 1 /* server -> client */){
         flow->http.num_response_headers += packet->http_num_headers; /* flow structs are initialized with zeros */
     }


### PR DESCRIPTION
Hi all,

In this pull the HTTP response status code is caught inside a prior existent response validation check. This change was needed to ensure that the code exists and is valid, i.e., in interval [000,699].

This solves a bug which may occur in some cases. Below is the relevant code fragment.

```c
if(packet->parsed_lines == 0 && packet->line[0].len >= NDPI_STATICSTRING_LEN("HTTP/1.X 200 ") &&
	     memcmp(packet->line[0].ptr, "HTTP/1.", NDPI_STATICSTRING_LEN("HTTP/1.")) == 0 &&
	     packet->line[0].ptr[NDPI_STATICSTRING_LEN("HTTP/1.X ")] > '0' && /* response code between 000 and 699 */
	     packet->line[0].ptr[NDPI_STATICSTRING_LEN("HTTP/1.X ")] < '6') {

	    packet->http_response.ptr = &packet->line[0].ptr[NDPI_STATICSTRING_LEN("HTTP/1.1 ")];
	    packet->http_response.len = packet->line[0].len - NDPI_STATICSTRING_LEN("HTTP/1.1 ");
	    packet->http_num_headers++;

	    /* Set server HTTP response code */ <==== THESE THREE LINES WERE INSERTED
	    strncpy((char*)flow->http.response_status_code, (char*)packet->http_response.ptr, 3);
	    flow->http.response_status_code[4]='\0';


	    NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG,
		  "ndpi_parse_packet_line_info: HTTP response parsed: \"%.*s\"\n",
		   packet->http_response.len, packet->http_response.ptr);
      }
```

regards,

Paulo Angelo