### PR TITLE
Backported CSGO/DOTA2 protocol.

### DIFF
--- a/src/include/ndpi_protocol_ids.h
+++ b/src/include/ndpi_protocol_ids.h
@@ -272,9 +272,10 @@
 #define NDPI_PROTOCOL_PASTEBIN              232 /* Paulo Angelo <pa@pauloangelo.com> */
 #define NDPI_PROTOCOL_LINKEDIN              233 /* Paulo Angelo <pa@pauloangelo.com> */
 #define NDPI_PROTOCOL_SOUNDCLOUD            234
+#define NDPI_PROTOCOL_CSGO                  235 /* Counter-Strike Global Offensive, Dota 2 */
 
 /* UPDATE UPDATE UPDATE UPDATE UPDATE UPDATE UPDATE UPDATE UPDATE */
-#define NDPI_LAST_IMPLEMENTED_PROTOCOL              NDPI_PROTOCOL_SOUNDCLOUD
+#define NDPI_LAST_IMPLEMENTED_PROTOCOL              NDPI_PROTOCOL_CSGO
 
 #define NDPI_MAX_SUPPORTED_PROTOCOLS                (NDPI_LAST_IMPLEMENTED_PROTOCOL + 1)
 #define NDPI_MAX_NUM_CUSTOM_PROTOCOLS               (NDPI_NUM_BITS-NDPI_LAST_IMPLEMENTED_PROTOCOL)

--- a/src/include/ndpi_protocols.h
+++ b/src/include/ndpi_protocols.h
@@ -198,6 +198,7 @@ void ndpi_search_bjnp(struct ndpi_detection_module_struct *ndpi_struct, struct n
 void ndpi_search_smpp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow);
 void ndpi_search_tinc(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow);
 void ndpi_search_fix(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow);
+void ndpi_search_csgo(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow);
 /* --- INIT FUNCTIONS --- */
 void init_afp_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask);
 void init_aimini_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask);
@@ -344,5 +345,6 @@ void init_smpp_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int
 void init_tinc_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask);
 void init_fix_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask);
 void init_nintendo_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask);
+void init_csgo_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask);
 
 #endif /* __NDPI_PROTOCOLS_H__ */

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1081,6 +1081,10 @@ struct ndpi_flow_struct {
   u_int8_t tinc_state;
   struct tinc_cache_entry tinc_cache_entry;
 #endif
+#ifdef NDPI_PROTOCOL_CSGO
+  u_int8_t csgo_strid[18],csgo_state,csgo_s2;
+  u_int32_t csgo_id2;
+#endif
 
   /* internal structures to save functions calls */
   struct ndpi_packet_struct packet;

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -32,6 +32,7 @@ libndpi_la_SOURCES = ndpi_content_match.c.inc \
 		     protocols/collectd.c \
 		     protocols/corba.c \
 		     protocols/crossfire.c \
+		     protocols/csgo.c \
 		     protocols/dcerpc.c \
 		     protocols/dhcp.c \
 		     protocols/dhcpv6.c \

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -1616,7 +1616,12 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
 			    no_master, "Nintendo", NDPI_PROTOCOL_CATEGORY_GAME,
 			    ndpi_build_default_ports(ports_a, 0, 0, 0, 0, 0) /* TCP */,
 			    ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
-   
+    ndpi_set_proto_defaults(ndpi_mod, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_CSGO,
+			    no_master,
+			    no_master, "CSGO", NDPI_PROTOCOL_CATEGORY_GAME,
+			    ndpi_build_default_ports(ports_a, 0, 0, 0, 0, 0) /* TCP */,
+			    ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
+
     /* calling function for host and content matched protocols */
     init_string_based_protocols(ndpi_mod);
 
@@ -2712,7 +2717,7 @@ void ndpi_set_protocol_detection_bitmask2(struct ndpi_detection_module_struct *n
 
   /* FIX */
   init_fix_dissector(ndpi_struct, &a, detection_bitmask);
-  
+
   /* NINTENDO */
   init_nintendo_dissector(ndpi_struct, &a, detection_bitmask);
 
@@ -2726,6 +2731,9 @@ void ndpi_set_protocol_detection_bitmask2(struct ndpi_detection_module_struct *n
 
   /* AMQP */
   init_amqp_dissector(ndpi_struct, &a, detection_bitmask);
+
+  /* CSGO */
+  init_csgo_dissector(ndpi_struct, &a, detection_bitmask);
 
   /* ----------------------------------------------------------------- */
 

--- a/src/lib/protocols/csgo.c
+++ b/src/lib/protocols/csgo.c
@@ -1,0 +1,124 @@
+/*
+ * csgo.c
+ *
+ * Copyright (C) 2016-2017 Vitaly Lavrov <vel21ripn@gmail.com>
+ *
+ * This file is part of nDPI, an open source deep packet inspection
+ * library based on the OpenDPI and PACE technology by ipoque GmbH
+ *
+ * nDPI is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * nDPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#include "ndpi_api.h"
+
+#ifdef NDPI_PROTOCOL_CSGO
+
+void ndpi_search_csgo(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow) {
+  struct ndpi_packet_struct* packet = &flow->packet;
+
+  if (packet->udp != NULL) {
+    uint32_t w = htonl(get_u_int32_t(packet->payload, 0));
+    NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "CSGO: word %08x\n", w);
+
+    if (!flow->csgo_state && packet->payload_packet_len == 23 && w == 0xfffffffful) {
+      if (!memcmp(packet->payload + 5, "connect0x", 9)) {
+        NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo connect0x.\n");
+        flow->csgo_state++;
+        memcpy(flow->csgo_strid, packet->payload + 5, 18);
+        return;
+      }
+    }
+    if (flow->csgo_state == 1 && packet->payload_packet_len >= 42 && w == 0xfffffffful) {
+      if (!memcmp(packet->payload + 24, flow->csgo_strid, 18)) {
+        NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo connect0x reply.\n");
+        flow->csgo_state++;
+        ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
+        return;
+      }
+    }
+    if (packet->payload_packet_len == 8 && ( w == 0x3a180000 || w == 0x39180000) ) {
+      NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp 8b.\n");
+      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
+      return;
+    }
+    if (packet->payload_packet_len >= 36 && w == 0x56533031ul) {
+      NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp.\n");
+      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
+      return;
+    }
+    if (packet->payload_packet_len >= 36 && w == 0x01007364) {
+      uint32_t w2 = htonl(get_u_int32_t(packet->payload, 4));
+      if (w2 == 0x70696e67) {
+        NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp ping.\n");
+        ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
+        return;
+      }
+    }
+    if (flow->csgo_s2 < 3 && (w & 0xffff0000ul) == 0x0d1d0000) {
+      uint32_t w2 = get_u_int32_t(packet->payload, 2);
+      if (packet->payload_packet_len == 13) {
+        if (!flow->csgo_s2) {
+          flow->csgo_id2 = w2;
+          flow->csgo_s2 = 1;
+          NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp 0d1d step1.\n");
+          return;
+        }
+        if (flow->csgo_s2 == 1 && flow->csgo_id2 == w2) {
+          NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp 0d1d step1 DUP.\n");
+          return;
+        }
+        flow->csgo_s2 = 3;
+        return;
+      }
+      if (packet->payload_packet_len == 15) {
+        if (flow->csgo_s2 == 1 && flow->csgo_id2 == w2) {
+          NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp 0d1d.\n");
+          ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
+          return;
+        }
+      }
+      flow->csgo_s2 = 3;
+    }
+    if (packet->payload_packet_len >= 140 && (w == 0x02124c6c || w == 0x02125c6c) &&
+        !memcmp(&packet->payload[3], "lta\000mob\000tpc\000bhj\000bxd\000tae\000urg\000gkh\000", 32)) {
+          NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo dictionary udp.\n");
+          ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
+          return;
+    }
+    if (packet->payload_packet_len >= 33 && packet->iph && packet->iph->daddr == 0xffffffff &&
+        !memcmp(&packet->payload[17], "LanSearch", 9)) {
+          NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo LanSearch udp.\n");
+          ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
+          return;
+    }
+  }
+  if (flow->packet_counter > 20)
+    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_CSGO);
+}
+
+void init_csgo_dissector(struct ndpi_detection_module_struct *ndpi_struct,
+  u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask) {
+    ndpi_set_bitmask_protocol_detection("CSGO", ndpi_struct, detection_bitmask, *id,
+              NDPI_PROTOCOL_CSGO,
+              ndpi_search_csgo,
+              NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
+              ADD_TO_DETECTION_BITMASK);
+
+  *id += 1;
+}
+
+#endif


### PR DESCRIPTION
Backported from [ipt_ndpi ](https://github.com/vel21ripn/nDPI)fork Counter-Strike Global Offensive \ Dota 2 protocol. May be actually to name this protocol like [Valve Source](https://en.wikipedia.org/wiki/Source_(game_engine)), but I don't have pcaps from all games based on this engine.

The original author is [Vitaly Lavrov](https://github.com/vel21ripn).

Before:
```
Detected protocols:
	Unknown              packets: 2497          bytes: 490120        flows: 81           
	Steam                packets: 436426        bytes: 154149143     flows: 58           


Protocol statistics:
	Fun                      154149143 bytes
	Unrated                     490120 bytes
```

[csgo](https://yadi.sk/d/R3Uk-U0f3MLdwg):
```
Detected protocols:
	Steam                packets: 83004         bytes: 30560459      flows: 8            
	CSGO                 packets: 355919        bytes: 124078804     flows: 131          


Protocol statistics:
	Fun                      154639263 bytes
```