### PR TITLE
Fix undefined behavior (detected by gcc):

### DIFF
--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -215,9 +215,9 @@
 #define howmanybits(x, y)   (((x)+((y)-1))/(y))
 
 
-#define NDPI_SET(p, n)    ((p)->fds_bits[(n)/NDPI_BITS] |= (1 << (((u_int32_t)n) % NDPI_BITS)))
-#define NDPI_CLR(p, n)    ((p)->fds_bits[(n)/NDPI_BITS] &= ~(1 << (((u_int32_t)n) % NDPI_BITS)))
-#define NDPI_ISSET(p, n)  ((p)->fds_bits[(n)/NDPI_BITS] & (1 << (((u_int32_t)n) % NDPI_BITS)))
+#define NDPI_SET(p, n)    ((p)->fds_bits[(n)/NDPI_BITS] |=  (1ul << (((u_int32_t)n) % NDPI_BITS)))
+#define NDPI_CLR(p, n)    ((p)->fds_bits[(n)/NDPI_BITS] &= ~(1ul << (((u_int32_t)n) % NDPI_BITS)))
+#define NDPI_ISSET(p, n)  ((p)->fds_bits[(n)/NDPI_BITS] &   (1ul << (((u_int32_t)n) % NDPI_BITS)))
 #define NDPI_ZERO(p)      memset((char *)(p), 0, sizeof(*(p)))
 #define NDPI_ONE(p)       memset((char *)(p), 0xFF, sizeof(*(p)))
 

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -360,9 +360,11 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
     strncpy((char*)flow->host_server_name, (char*)packet->host_line.ptr, len);
     flow->host_server_name[len] = '\0', flow->server_id = flow->dst;
 
-    len = ndpi_min(packet->forwarded_line.len, sizeof(flow->protos.http.nat_ip)-1);
-    strncpy((char*)flow->protos.http.nat_ip, (char*)packet->forwarded_line.ptr, len);
-    flow->protos.http.nat_ip[len] = '\0';
+    if(packet->forwarded_line.ptr) {
+        len = ndpi_min(packet->forwarded_line.len, sizeof(flow->protos.http.nat_ip)-1);
+        strncpy((char*)flow->protos.http.nat_ip, (char*)packet->forwarded_line.ptr, len);
+        flow->protos.http.nat_ip[len] = '\0';
+    }
 
     if(ndpi_struct->http_dont_dissect_response)
       parseHttpSubprotocol(ndpi_struct, flow);

--- a/src/lib/third_party/src/ndpi_patricia.c
+++ b/src/lib/third_party/src/ndpi_patricia.c
@@ -74,14 +74,14 @@ ndpi_prefix_tochar (prefix_t * prefix)
 }
 
 int ndpi_comp_with_mask (void *addr, void *dest, u_int mask) {
-  if( /* mask/8 == 0 || */ memcmp (addr, dest, mask / 8) == 0) {
-    int n = mask / 8;
-    int m = ((-1) << (8 - (mask % 8)));
-
-    if(mask % 8 == 0 || (((u_char *)addr)[n] & m) == (((u_char *)dest)[n] & m))
-      return (1);
-  }
-  return (0);
+  uint32_t *pa = addr;
+  uint32_t *pd = dest;
+  uint32_t m;
+  for(;mask >= 32; mask -= 32, pa++,pd++)
+        if(*pa != *pd) return 0;
+  if(!mask) return 1;
+  m = htonl((~0u) << (32-mask));
+  return (*pa & m) == (*pd &m);
 }
 
 /* this allows incomplete prefix */


### PR DESCRIPTION
ndpi_define.h.in:218: Macros NDPI_SET(), NDPI_CLR(), NDPI_ISSET()
  runtime error: left shift of 1 by 31 places cannot be represented in type 'int'

http.c:364: strncpy((char*)flow->protos.http.nat_ip,(char*)packet->forwarded_line.ptr,len);
 runtime error: null pointer passed as argument 2, which is declared to never be null

ndpi_patricia.c:ndpi_comp_with_mask(): int m = ((-1) << (8 - (mask % 8)));
  runtime error: left shift of negative value -1

Original function ndpi_comp_with_mask() is unreadable and slow.
We have only 2 type of address: 32 bit and 128 bit. The optimized version works 6 times faster (IPv4).