### PR TITLE
Refactoring the debugging output.

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -77,7 +77,9 @@ static json_object *jArray_topStats;
 static u_int8_t live_capture = 0;
 static u_int8_t undetected_flows_deleted = 0;
 /** User preferences **/
-static u_int8_t enable_protocol_guess = 1, verbose = 0, nDPI_traceLevel = 0, json_flag = 0;
+static u_int8_t enable_protocol_guess = 1, verbose = 0, json_flag = 0;
+int nDPI_LogLevel = 0;
+char *_debug_protocols = NULL;
 static u_int8_t stats_flag = 0, bpf_filter_flag = 0;
 #ifdef HAVE_JSON_C
 static u_int8_t file_first_time = 1;
@@ -250,9 +252,12 @@ static void help(u_int long_help) {
 	 "                            | 1 = verbose\n"
 	 "                            | 2 = very verbose\n"
 	 "                            | 3 = port stats\n"
-         "  -b <file.json>            | Specify a file to write port based diagnose statistics\n"
-         "  -x <file.json>            | Produce bpf filters for specified diagnose file. Use\n"
-         "                            | this option only for .json files generated with -b flag.\n");
+	 "  -V <1-4>                  | nDPI logging level\n"
+	 "                            | 1 - trace, 2 - debug, 3 - full debug\n"
+	 "                            | >3 - full debug + dbg_proto = all\n"
+	 "  -b <file.json>            | Specify a file to write port based diagnose statistics\n"
+	 "  -x <file.json>            | Produce bpf filters for specified diagnose file. Use\n"
+	 "                            | this option only for .json files generated with -b flag.\n");
 
 
 #ifndef WIN32
@@ -266,6 +271,7 @@ static void help(u_int long_help) {
 	 "  --extcap-capture-filter\n"
 	 "  --fifo <path to file or pipe>\n"
 	 "  --debug\n"
+	 "  --dbg-proto proto|num[,...]\n"
 	 );
 #endif
 
@@ -289,7 +295,8 @@ static struct option longopts[] = {
   { "capture", no_argument, NULL, '5'},
   { "extcap-capture-filter", required_argument, NULL, '6'},
   { "fifo", required_argument, NULL, '7'},
-  { "debug", optional_argument, NULL, '8'},
+  { "debug", no_argument, NULL, '8'},
+  { "dbg-proto", required_argument, NULL, 257},
   { "ndpi-proto-filter", required_argument, NULL, '9'},
 
   /* ndpiReader options */
@@ -519,8 +526,12 @@ static void parseOptions(int argc, char **argv) {
       break;
 
     case 'V':
-      printf("%d\n",atoi(optarg) );
-      nDPI_traceLevel  = atoi(optarg);
+      nDPI_LogLevel  = atoi(optarg);
+      if(nDPI_LogLevel < 0) nDPI_LogLevel = 0;
+      if(nDPI_LogLevel > 3) {
+	 nDPI_LogLevel = 3;
+      	 _debug_protocols = strdup("all");
+      }
       break;
 
     case 'h':
@@ -546,6 +557,7 @@ static void parseOptions(int argc, char **argv) {
 
     case 'q':
       quiet_mode = 1;
+      nDPI_LogLevel = 0;
       break;
 
       /* Extcap */
@@ -574,11 +586,16 @@ static void parseOptions(int argc, char **argv) {
       break;
 
     case '8':
-      nDPI_traceLevel = 9;
+      nDPI_LogLevel = NDPI_LOG_DEBUG_EXTRA;
+      _debug_protocols = strdup("all");
       break;
 
     case '9':
       extcap_packet_filter = atoi(optarg);
+      break;
+    
+    case 257:
+      _debug_protocols = strdup(optarg);
       break;
 
     default:
@@ -985,7 +1002,6 @@ void updateTopIpAddress(u_int32_t addr, u_int8_t version, const char *proto,
   int min = count;
   int update = 0;
   int min_i = 0;
-  int r;
   int i;
 
   if(count == 0) return;
@@ -1117,6 +1133,7 @@ static struct receiver *cutBackTo(struct receiver **receivers, u_int32_t size, u
     HASH_DEL(*receivers, r);
     free(r);
   }
+  return NULL;
 }
 
 /* *********************************************** */
@@ -1381,7 +1398,7 @@ static void debug_printf(u_int32_t protocol, void *id_struct,
   struct tm result;
 #endif
 
-  if(log_level <= nDPI_traceLevel) {
+  if(log_level <= nDPI_LogLevel) {
     char buf[8192], out_buf[8192];
     char theDate[32];
     const char *extra_msg = "";

--- a/example/ndpi_util.c
+++ b/example/ndpi_util.c
@@ -105,6 +105,61 @@ static void free_wrapper(void *freeable) {
 
 /* ***************************************************** */
 
+static uint16_t ndpi_get_proto_id(struct ndpi_detection_module_struct *ndpi_mod, const char *name) {
+  uint16_t proto_id;
+  char *e;
+  unsigned long p = strtol(name,&e,0);
+  if(e && !*e) {
+	if(p < NDPI_MAX_SUPPORTED_PROTOCOLS+NDPI_MAX_NUM_CUSTOM_PROTOCOLS &&
+			ndpi_mod->proto_defaults[p].protoName) return (uint16_t)p;
+	return NDPI_PROTOCOL_UNKNOWN;
+  }
+  for(proto_id=NDPI_PROTOCOL_UNKNOWN; proto_id < NDPI_MAX_SUPPORTED_PROTOCOLS+NDPI_MAX_NUM_CUSTOM_PROTOCOLS; proto_id++) {
+	if(ndpi_mod->proto_defaults[proto_id].protoName &&
+			!strcasecmp(ndpi_mod->proto_defaults[proto_id].protoName,name))
+		return proto_id;
+  }
+  return NDPI_PROTOCOL_UNKNOWN;
+}
+static NDPI_PROTOCOL_BITMASK debug_bitmask;
+static char _proto_delim[] = " \t,:;";
+static int parse_debug_proto(struct ndpi_detection_module_struct *ndpi_mod, char *str) {
+char *n;
+uint16_t proto;
+char op=1;
+for(n = strtok(str,_proto_delim); n && *n; n = strtok(NULL,_proto_delim)) {
+	if(*n == '-') {
+		op = 0;
+		n++;
+	} else if(*n == '+') {
+		op = 1;
+		n++;
+	}
+	if(!strcmp(n,"all")) {
+		if(op)
+			NDPI_BITMASK_SET_ALL(debug_bitmask);
+		   else
+			NDPI_BITMASK_RESET(debug_bitmask);
+		continue;
+	}
+	proto = ndpi_get_proto_id(ndpi_mod, n);
+	if(proto == NDPI_PROTOCOL_UNKNOWN && strcmp(n,"unknown") && strcmp(n,"0")) {
+		fprintf(stderr,"Invalid protocol %s\n",n);
+		return 1;
+	}
+	if(op)
+		NDPI_BITMASK_ADD(debug_bitmask,proto);
+	  else
+		NDPI_BITMASK_DEL(debug_bitmask,proto);
+}
+return 0;
+}
+
+/* ***************************************************** */
+
+extern char *_debug_protocols;
+static int _debug_protocols_ok = 0;
+
 struct ndpi_workflow * ndpi_workflow_init(const struct ndpi_workflow_prefs * prefs, pcap_t * pcap_handle) {
   set_ndpi_malloc(malloc_wrapper), set_ndpi_free(free_wrapper);
   set_ndpi_flow_malloc(NULL), set_ndpi_flow_free(NULL);
@@ -121,7 +176,18 @@ struct ndpi_workflow * ndpi_workflow_init(const struct ndpi_workflow_prefs * pre
     NDPI_LOG(0, NULL, NDPI_LOG_ERROR, "global structure initialization failed\n");
     exit(-1);
   }
+  module->ndpi_log_level = nDPI_LogLevel;
 
+  if(_debug_protocols != NULL && ! _debug_protocols_ok) {
+	if(parse_debug_proto(module,_debug_protocols))
+		exit(-1);
+	_debug_protocols_ok = 1;
+  }
+#ifdef NDPI_ENABLE_DEBUG_MESSAGES
+  NDPI_BITMASK_RESET(module->debug_bitmask);
+  if(_debug_protocols_ok)
+	  module->debug_bitmask = debug_bitmask;
+#endif
   workflow->ndpi_flows_root = ndpi_calloc(workflow->prefs.num_roots, sizeof(void *));
   return workflow;
 }

--- a/example/ndpi_util.h
+++ b/example/ndpi_util.h
@@ -179,4 +179,7 @@ int ndpi_workflow_node_cmp(const void *a, const void *b);
 void process_ndpi_collected_info(struct ndpi_workflow * workflow, struct ndpi_flow_info *flow);
 u_int32_t ethernet_crc32(const void* data, size_t n_bytes);
 void ndpi_flow_info_freer(void *node);
+
+extern int nDPI_LogLevel;
+
 #endif

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -384,6 +384,20 @@ extern "C" {
 
 
   /**
+   * Exclude protocol from search
+   *
+   * @par    ndpi_struct         = the detection module
+   * @par    flow                = the flow where match the host
+   * @par    master_protocol_id  = value of the ID associated to the master protocol detected
+   *
+   */
+  void ndpi_exclude_protocol(struct ndpi_detection_module_struct *ndpi_struct,
+				  struct ndpi_flow_struct *flow,
+				  u_int16_t master_protocol_id,
+				  const char *_file, const char *_func,int _line);
+
+
+  /**
    * Check if the string -bigram_to_match- match with a bigram of -automa-
    *
    * @par     ndpi_mod         = the detection module

--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -180,23 +180,66 @@
 #define NDPI_SOULSEEK_CONNECTION_IP_TICK_TIMEOUT               600
 
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
-#define NDPI_LOG(proto, m, log_level, args...)		                                 \
+ #define NDPI_LOG(proto, m, log_level, args...)		                                 \
   {								                         \
     struct ndpi_detection_module_struct *mod = (struct ndpi_detection_module_struct*) m; \
-    if(mod != NULL) {						                         \
-      mod->ndpi_debug_print_file=__FILE__;                                               \
-      mod->ndpi_debug_print_function=__FUNCTION__;                                       \
-      mod->ndpi_debug_print_line=__LINE__;                                               \
-      (*(mod->ndpi_debug_printf))(proto, mod, log_level, args);                          \
-    }								                         \
+    if(mod != NULL && mod->ndpi_debug_printf != NULL)		                         \
+      (*(mod->ndpi_debug_printf))(proto, mod, log_level, __FILE__, __FUNCTION__, __LINE__, args); \
   }
-#else							/* NDPI_ENABLE_DEBUG_MESSAGES */
-#ifdef WIN32
-#define NDPI_LOG(...) {}
-#else
-#define NDPI_LOG(proto, mod, log_level, args...) {}
-#endif
+
+ /* We must define NDPI_CURRENT_PROTO before include ndpi_main.h !!! 
+  *
+  * #include "ndpi_protocol_ids.h"
+  * #define NDPI_CURRENT_PROTO NDPI_PROTOCOL_XXXX
+  * #include "ndpi_api.h"
+  *
+  */
+
+ #ifndef NDPI_CURRENT_PROTO
+ #define NDPI_CURRENT_PROTO NDPI_PROTO_UNKNOWN
+ #endif
+
+ #define NDPI_LOG__ERROR(mod, args...)		                                 \
+  if(mod && mod->ndpi_log_level >= NDPI_LOG_ERROR) {	                         \
+    if(mod != NULL && mod->ndpi_debug_printf != NULL)		                         \
+      (*(mod->ndpi_debug_printf))(NDPI_CURRENT_PROTO, mod, NDPI_LOG_ERROR , __FILE__, __FUNCTION__, __LINE__, args); \
+  }
+
+ #define NDPI_LOG__TRACE(mod, args...)		                                 \
+  if(mod && mod->ndpi_log_level >= NDPI_LOG_TRACE) {	                         \
+    if(mod != NULL && mod->ndpi_debug_printf != NULL)		                         \
+      (*(mod->ndpi_debug_printf))(NDPI_CURRENT_PROTO, mod, NDPI_LOG_TRACE , __FILE__, __FUNCTION__, __LINE__, args); \
+  }
+
+ #define NDPI_LOG__DEBUG(mod, args...)		                                 \
+  if(mod && mod->ndpi_log_level >= NDPI_LOG_DEBUG) {	                         \
+    if(mod != NULL && mod->ndpi_debug_printf != NULL)		                         \
+      (*(mod->ndpi_debug_printf))(NDPI_CURRENT_PROTO, mod, NDPI_LOG_DEBUG , __FILE__, __FUNCTION__, __LINE__, args); \
+  }
+
+ #define NDPI_LOG__DEBUG2(mod, args...)		                                 \
+  if(mod && mod->ndpi_log_level >= NDPI_LOG_DEBUG_EXTRA) {	                         \
+    if(mod != NULL && mod->ndpi_debug_printf != NULL)		                         \
+      (*(mod->ndpi_debug_printf))(NDPI_CURRENT_PROTO, mod, NDPI_LOG_DEBUG_EXTRA , __FILE__, __FUNCTION__, __LINE__, args); \
+  }
+
+#else							/* not defined NDPI_ENABLE_DEBUG_MESSAGES */
+# ifdef WIN32
+# define NDPI_LOG(...) {}
+# define NDPI_LOG__ERROR(...) {}
+# define NDPI_LOG__TRACE(...) {}
+# define NDPI_LOG__DEBUG(...) {}
+# define NDPI_LOG__DEBUG2(...) {}
+# else
+# define NDPI_LOG(proto, mod, log_level, args...) {}
+# define NDPI_LOG__ERROR(mod, args...) {}
+# define NDPI_LOG__TRACE(mod, args...) {}
+# define NDPI_LOG__DEBUG(mod,  args...) {}
+# define NDPI_LOG__DEBUG2(mod, args...) {}
+# endif
 #endif							/* NDPI_ENABLE_DEBUG_MESSAGES */
+
+#define NDPI_EXCLUDE_PROTO(mod,flow) ndpi_exclude_protocol(mod, flow, NDPI_CURRENT_PROTO, __FILE__, __FUNCTION__, __LINE__)
 
 /**
  * macro for getting the string len of a static string

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -36,7 +36,8 @@ typedef enum
   {
     NDPI_LOG_ERROR,
     NDPI_LOG_TRACE,
-    NDPI_LOG_DEBUG
+    NDPI_LOG_DEBUG,
+    NDPI_LOG_DEBUG_EXTRA
   } ndpi_log_level_t;
 
 /* NDPI_VISIT */
@@ -859,12 +860,14 @@ struct ndpi_detection_module_struct {
 
   ndpi_default_ports_tree_node_t *tcpRoot, *udpRoot;
 
+  ndpi_log_level_t ndpi_log_level; /* default error */
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
   /* debug callback, only set when debug is used */
   ndpi_debug_function_ptr ndpi_debug_printf;
   const char *ndpi_debug_print_file;
   const char *ndpi_debug_print_function;
   u_int32_t ndpi_debug_print_line;
+  NDPI_PROTOCOL_BITMASK debug_bitmask;
 #endif
 
   /* misc parameters */

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -24,6 +24,9 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "ahocorasick.h"
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_UNKNOWN
+
 #include "ndpi_api.h"
 #include "../../config.h"
 
@@ -36,6 +39,7 @@
 #include "third_party/include/ndpi_patricia.h"
 #include "third_party/src/ndpi_patricia.c"
 
+static int _ndpi_debug_callbacks = 0;
 
 /* implementation of the punycode check function */
 int check_punycode_string(char * buffer , int len)
@@ -301,10 +305,12 @@ int strncasecmp(s1, s2, n)
 /* ****************************************** */
 
 /* Forward */
-static void addDefaultPort(ndpi_port_range *range,
+static void addDefaultPort(struct ndpi_detection_module_struct *ndpi_mod,
+			   ndpi_port_range *range,
 			   ndpi_proto_defaults_t *def,
 			   u_int8_t customUserProto,
-			   ndpi_default_ports_tree_node_t **root);
+			   ndpi_default_ports_tree_node_t **root,
+			   const char *_func, int _line);
 
 static int removeDefaultPort(ndpi_port_range *range,
 			     ndpi_proto_defaults_t *def,
@@ -477,6 +483,27 @@ u_int8_t ndpi_is_subprotocol_informative(struct ndpi_detection_module_struct *nd
     return(0);
   }
 }
+/* ********************************************************************************** */
+
+void ndpi_exclude_protocol(struct ndpi_detection_module_struct *ndpi_struct,
+                                  struct ndpi_flow_struct *flow,
+                                  u_int16_t protocol_id,
+                                  const char *_file, const char *_func,int _line) {
+
+  if(protocol_id < NDPI_MAX_SUPPORTED_PROTOCOLS+NDPI_MAX_NUM_CUSTOM_PROTOCOLS) {
+#ifdef NDPI_ENABLE_DEBUG_MESSAGES
+	if ( ndpi_struct && 
+	     ndpi_struct->ndpi_log_level >= NDPI_LOG_DEBUG && 
+    	     ndpi_struct->ndpi_debug_printf != NULL) {
+
+		(*(ndpi_struct->ndpi_debug_printf))(protocol_id, ndpi_struct, NDPI_LOG_DEBUG,
+		 _file, _func, _line, "exclude %s\n",ndpi_get_proto_name(ndpi_struct, protocol_id));
+
+	}
+#endif
+	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, protocol_id);
+  }
+}
 
 /* ********************************************************************************** */
 
@@ -490,14 +517,14 @@ void ndpi_set_proto_defaults(struct ndpi_detection_module_struct *ndpi_mod,
 
   if(protoId >= NDPI_MAX_SUPPORTED_PROTOCOLS+NDPI_MAX_NUM_CUSTOM_PROTOCOLS) {
 #ifdef DEBUG
-    printf("[NDPI] %s(%s/protoId=%d): INTERNAL ERROR\n", __FUNCTION__, protoName, protoId);
+    NDPI_LOG__ERROR(ndpi_mod, "[NDPI] %s/protoId=%d: INTERNAL ERROR\n", protoName, protoId);
 #endif
     return;
   }
 
   if(ndpi_mod->proto_defaults[protoId].protoName != NULL) {
 #ifdef DEBUG
-    printf("[NDPI] %s(%s/protoId=%d): already initialized. Ignoring it\n", __FUNCTION__, protoName, protoId);
+    NDPI_LOG__ERROR(ndpi_mod, "[NDPI] %s/protoId=%d: already initialized. Ignoring it\n", protoName, protoId);
 #endif
     return;
   }
@@ -513,8 +540,8 @@ void ndpi_set_proto_defaults(struct ndpi_detection_module_struct *ndpi_mod,
   memcpy(&ndpi_mod->proto_defaults[protoId].master_udp_protoId, udp_master_protoId, 2*sizeof(u_int16_t));
 
   for(j=0; j<MAX_DEFAULT_PORTS; j++) {
-    if(udpDefPorts[j].port_low != 0) addDefaultPort(&udpDefPorts[j], &ndpi_mod->proto_defaults[protoId], 0, &ndpi_mod->udpRoot);
-    if(tcpDefPorts[j].port_low != 0) addDefaultPort(&tcpDefPorts[j], &ndpi_mod->proto_defaults[protoId], 0, &ndpi_mod->tcpRoot);
+    if(udpDefPorts[j].port_low != 0) addDefaultPort(ndpi_mod, &udpDefPorts[j], &ndpi_mod->proto_defaults[protoId], 0, &ndpi_mod->udpRoot, __FUNCTION__,__LINE__);
+    if(tcpDefPorts[j].port_low != 0) addDefaultPort(ndpi_mod, &tcpDefPorts[j], &ndpi_mod->proto_defaults[protoId], 0, &ndpi_mod->tcpRoot, __FUNCTION__,__LINE__);
   }
 }
 
@@ -536,7 +563,7 @@ void ndpi_default_ports_tree_node_t_walker(const void *node, const ndpi_VISIT wh
 {
   ndpi_default_ports_tree_node_t *f = *(ndpi_default_ports_tree_node_t **)node;
 
-
+#ifndef __KERNEL__
   printf("<%d>Walk on node %s (%u)\n",
 	 depth,
 	 which == ndpi_preorder?"ndpi_preorder":
@@ -544,14 +571,17 @@ void ndpi_default_ports_tree_node_t_walker(const void *node, const ndpi_VISIT wh
 	 which == ndpi_endorder?"ndpi_endorder":
 	 which == ndpi_leaf?"ndpi_leaf": "unknown",
 	 f->default_port);
+#endif
 }
 
 /* ******************************************************************** */
 
-static void addDefaultPort(ndpi_port_range *range,
+static void addDefaultPort(struct ndpi_detection_module_struct *ndpi_mod,
+			   ndpi_port_range *range,
 			   ndpi_proto_defaults_t *def,
 			   u_int8_t customUserProto,
-			   ndpi_default_ports_tree_node_t **root)
+			   ndpi_default_ports_tree_node_t **root,
+			   const char *_func, int _line)
 {
   ndpi_default_ports_tree_node_t *ret;
   u_int16_t port;
@@ -560,7 +590,7 @@ static void addDefaultPort(ndpi_port_range *range,
     ndpi_default_ports_tree_node_t *node = (ndpi_default_ports_tree_node_t*)ndpi_malloc(sizeof(ndpi_default_ports_tree_node_t));
 
     if(!node) {
-      printf("[NDPI] %s(): not enough memory\n", __FUNCTION__);
+      NDPI_LOG__ERROR(ndpi_mod, "%s:%d not enough memory\n", _func, _line);
       break;
     }
 
@@ -568,7 +598,8 @@ static void addDefaultPort(ndpi_port_range *range,
     ret = *(ndpi_default_ports_tree_node_t**)ndpi_tsearch(node, (void*)root, ndpi_default_ports_tree_node_t_cmp); /* Add it to the tree */
 
     if(ret != node) {
-      /* printf("[NDPI] %s(): found duplicate for port %u: overwriting it with new value\n", __FUNCTION__, port); */
+      NDPI_LOG__DEBUG(ndpi_mod, "[NDPI] %s:%d found duplicate for port %u: overwriting it with new value\n",
+		      _func, _line, port);
 
       ret->proto = def;
       ndpi_free(node);
@@ -616,7 +647,7 @@ static int ndpi_string_to_automa(struct ndpi_detection_module_struct *ndpi_struc
   AC_PATTERN_t ac_pattern;
 
   if(protocol_id >= (NDPI_MAX_SUPPORTED_PROTOCOLS+NDPI_MAX_NUM_CUSTOM_PROTOCOLS)) {
-    printf("[NDPI] %s(protoId=%d): INTERNAL ERROR\n", __FUNCTION__, protocol_id);
+    NDPI_LOG__ERROR(ndpi_struct, "[NDPI] protoId=%d: INTERNAL ERROR\n", protocol_id);
     return(-1);
   }
 
@@ -640,7 +671,7 @@ static int ndpi_add_host_url_subprotocol(struct ndpi_detection_module_struct *nd
 					 ndpi_protocol_breed_t breed)
 {
 #ifdef DEBUG
-  printf("[NDPI] Adding [%s][%d]\n", value, protocol_id);
+  NDPI_LOG_DEBUG2(ndpi_struct, "[NDPI] Adding [%s][%d]\n", value, protocol_id);
 #endif
 
   return(ndpi_string_to_automa(ndpi_struct, &ndpi_struct->host_automa,
@@ -668,7 +699,7 @@ int ndpi_add_content_subprotocol(struct ndpi_detection_module_struct *ndpi_struc
 static int ndpi_remove_host_url_subprotocol(struct ndpi_detection_module_struct *ndpi_struct,
 					    char *value, int protocol_id)
 {
-  printf("[NDPI] Missing implementation of %s()\n", __FUNCTION__);
+  NDPI_LOG__ERROR(ndpi_struct, "[NDPI] Missing implementation for proto %s/%d\n",value,protocol_id);
   return(-1);
 }
 
@@ -1686,9 +1717,8 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
       if((ndpi_mod->proto_defaults[i].protoName == NULL)
 	 || ((i != NDPI_PROTOCOL_UNKNOWN)
 	     && (ndpi_mod->proto_defaults[i].protoCategory == NDPI_PROTOCOL_CATEGORY_UNSPECIFIED))) {
-	printf("[NDPI] %s(missing protoId=%d/%s) INTERNAL ERROR: not all protocols have been initialized\n",
-	       __FUNCTION__, i,
-	       ndpi_mod->proto_defaults[i].protoName ? ndpi_mod->proto_defaults[i].protoName : "???");
+	NDPI_LOG__ERROR(ndpi_mod, "[NDPI] missing protoId=%d/%s: INTERNAL ERROR: not all protocols have been initialized\n",
+	       i, ndpi_mod->proto_defaults[i].protoName ? ndpi_mod->proto_defaults[i].protoName : "???");
       }
     }
 }
@@ -1837,22 +1867,26 @@ void set_ndpi_flow_malloc(void* (*__ndpi_flow_malloc)(size_t size)) { _ndpi_flow
 void set_ndpi_free(void  (*__ndpi_free)(void *ptr))       { _ndpi_free = __ndpi_free; }
 void set_ndpi_flow_free(void  (*__ndpi_flow_free)(void *ptr))       { _ndpi_flow_free = __ndpi_flow_free; }
 
-void ndpi_debug_printf(unsigned int proto, struct ndpi_detection_module_struct *ndpi_str, ndpi_log_level_t log_level, const char * format, ...)
+void ndpi_debug_printf(unsigned int proto, struct ndpi_detection_module_struct *ndpi_str, 
+		ndpi_log_level_t log_level, const char *file_name, const char *func_name, int line_number,
+		const char * format, ...)
 {
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
   va_list args;
 #define MAX_STR_LEN 120
   char str[MAX_STR_LEN];
+  if(ndpi_str != NULL && log_level > NDPI_LOG_ERROR  &&
+	proto > 0 && proto < NDPI_MAX_SUPPORTED_PROTOCOLS &&
+	!NDPI_ISSET(&ndpi_str->debug_bitmask,proto)) return;
   va_start(args, format);
   vsprintf(str, format, args);
   va_end(args);
 
   if (ndpi_str != NULL) {
-    char proto_name[64];
-    snprintf(proto_name, sizeof(proto_name), "%s", ndpi_get_proto_name(ndpi_str, proto));
-    printf("%s:%s:%u - Proto: %s, %s\n", ndpi_str->ndpi_debug_print_file, ndpi_str->ndpi_debug_print_function, ndpi_str->ndpi_debug_print_line, proto_name, str);
+    printf("%s:%s:%-3u - [%s]: %s", 
+	    file_name, func_name, line_number, ndpi_get_proto_name(ndpi_str, proto), str);
   } else {
-    printf("Proto: %u, %s\n", proto, str);
+    printf("Proto: %u, %s", proto, str);
   }
 #endif
 }
@@ -1871,7 +1905,7 @@ struct ndpi_detection_module_struct *ndpi_init_detection_module(void) {
   
   if(ndpi_str == NULL) {
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
-    NDPI_LOG(0, ndpi_str, NDPI_LOG_DEBUG, "ndpi_init_detection_module initial malloc failed for ndpi_str\n");
+    NDPI_LOG__ERROR(ndpi_str, "ndpi_init_detection_module initial malloc failed for ndpi_str\n");
 #endif /* NDPI_ENABLE_DEBUG_MESSAGES */
     return NULL;
   }
@@ -2166,7 +2200,7 @@ int ndpi_handle_rule(struct ndpi_detection_module_struct *ndpi_mod, char* rule, 
 
   at = strrchr(rule, '@');
   if(at == NULL) {
-    printf("Invalid rule '%s'\n", rule);
+    NDPI_LOG__ERROR(ndpi_mod, "Invalid rule '%s'\n", rule);
     return(-1);
   } else
     at[0] = 0, proto = &at[1];
@@ -2197,14 +2231,14 @@ int ndpi_handle_rule(struct ndpi_detection_module_struct *ndpi_mod, char* rule, 
   if(def == NULL) {
     if(!do_add) {
       /* We need to remove a rule */
-      printf("Unable to find protocol '%s': skipping rule '%s'\n", proto, rule);
+      NDPI_LOG__ERROR(ndpi_mod, "Unable to find protocol '%s': skipping rule '%s'\n", proto, rule);
       return(-3);
     } else {
       ndpi_port_range ports_a[MAX_DEFAULT_PORTS], ports_b[MAX_DEFAULT_PORTS];
       u_int16_t no_master[2] = { NDPI_PROTOCOL_NO_MASTER_PROTO, NDPI_PROTOCOL_NO_MASTER_PROTO };
 
       if(ndpi_mod->ndpi_num_custom_protocols >= (NDPI_MAX_NUM_CUSTOM_PROTOCOLS-1)) {
-	printf("Too many protocols defined (%u): skipping protocol %s\n",
+	NDPI_LOG__ERROR(ndpi_mod, "Too many protocols defined (%u): skipping protocol %s\n",
 	       ndpi_mod->ndpi_num_custom_protocols, proto);
 	return(-2);
       }
@@ -2245,7 +2279,7 @@ int ndpi_handle_rule(struct ndpi_detection_module_struct *ndpi_mod, char* rule, 
       if(sscanf(value, "%u-%u", (u_int32_t *)&range.port_low, (u_int32_t *)&range.port_high) != 2)
 	range.port_low = range.port_high = atoi(&elem[4]);
       if(do_add)
-	addDefaultPort(&range, def, 1 /* Custom user proto */, is_tcp ? &ndpi_mod->tcpRoot : &ndpi_mod->udpRoot);
+	addDefaultPort(ndpi_mod, &range, def, 1 /* Custom user proto */, is_tcp ? &ndpi_mod->tcpRoot : &ndpi_mod->udpRoot, __FUNCTION__,__LINE__);
       else
 	removeDefaultPort(&range, def, is_tcp ? &ndpi_mod->tcpRoot : &ndpi_mod->udpRoot);
     } else if(is_ip) {
@@ -2280,7 +2314,7 @@ int ndpi_load_protocols_file(struct ndpi_detection_module_struct *ndpi_mod, char
   int i;
 
   if(fd == NULL) {
-    printf("Unable to open file %s [%s]", path, strerror(errno));
+    NDPI_LOG__ERROR(ndpi_mod, "Unable to open file %s [%s]", path, strerror(errno));
     return(-1);
   }
 
@@ -2320,14 +2354,18 @@ void ndpi_set_bitmask_protocol_detection(char * label,
   */
   if(NDPI_COMPARE_PROTOCOL_TO_BITMASK(*detection_bitmask, ndpi_protocol_id) != 0) {
 #ifdef DEBUG
-    NDPI_LOG(0, ndpi_struct, NDPI_LOG_DEBUG,"[NDPI] ndpi_set_bitmask_protocol_detection: %s : [callback_buffer] idx= %u, [proto_defaults] protocol_id=%u\n", label, idx, ndpi_protocol_id);
+    NDPI_LOG__DEBUG2(ndpi_struct
+	"[NDPI] ndpi_set_bitmask_protocol_detection: %s : [callback_buffer] idx= %u, [proto_defaults] protocol_id=%u\n",
+	label, idx, ndpi_protocol_id);
 #endif
 
-    if(ndpi_struct->proto_defaults[ndpi_protocol_id].protoIdx != 0)
-      printf("[NDPI] Internal error: protocol %s/%u has been already registered\n", label, ndpi_protocol_id);
-    else {
+    if(ndpi_struct->proto_defaults[ndpi_protocol_id].protoIdx != 0) {
+      NDPI_LOG__DEBUG2(ndpi_struct,
+		"[NDPI] Internal error: protocol %s/%u has been already registered\n", label, ndpi_protocol_id);
 #ifdef DEBUG
-      printf("[NDPI] Adding %s with protocol id %d\n", label, ndpi_protocol_id);
+    } else {
+      NDPI_LOG__DEBUG2(ndpi_struct,
+		"[NDPI] Adding %s with protocol id %d\n", label, ndpi_protocol_id);
 #endif
     }
 
@@ -2810,7 +2848,7 @@ void ndpi_set_protocol_detection_bitmask2(struct ndpi_detection_module_struct *n
 
   ndpi_struct->callback_buffer_size = a;
 
-  NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG,
+  NDPI_LOG__DEBUG2(ndpi_struct,
 	   "callback_buffer_size is %u\n", ndpi_struct->callback_buffer_size);
 
   /* now build the specific buffer for tcp, udp and non_tcp_udp */
@@ -2821,7 +2859,7 @@ void ndpi_set_protocol_detection_bitmask2(struct ndpi_detection_module_struct *n
 	& (NDPI_SELECTION_BITMASK_PROTOCOL_INT_TCP |
 	   NDPI_SELECTION_BITMASK_PROTOCOL_INT_TCP_OR_UDP |
 	   NDPI_SELECTION_BITMASK_PROTOCOL_COMPLETE_TRAFFIC)) != 0) {
-      NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG,
+      if(_ndpi_debug_callbacks) NDPI_LOG__DEBUG2(ndpi_struct,
 	       "callback_buffer_tcp_payload, adding buffer %u as entry %u\n", a,
 	       ndpi_struct->callback_buffer_size_tcp_payload);
 
@@ -2831,7 +2869,7 @@ void ndpi_set_protocol_detection_bitmask2(struct ndpi_detection_module_struct *n
 
       if((ndpi_struct->
 	  callback_buffer[a].ndpi_selection_bitmask & NDPI_SELECTION_BITMASK_PROTOCOL_HAS_PAYLOAD) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG,
+	if(_ndpi_debug_callbacks) NDPI_LOG__DEBUG2(ndpi_struct,
 		 "\tcallback_buffer_tcp_no_payload, additional adding buffer %u to no_payload process\n", a);
 
 	memcpy(&ndpi_struct->callback_buffer_tcp_no_payload
@@ -2848,7 +2886,7 @@ void ndpi_set_protocol_detection_bitmask2(struct ndpi_detection_module_struct *n
 								  NDPI_SELECTION_BITMASK_PROTOCOL_INT_TCP_OR_UDP |
 								  NDPI_SELECTION_BITMASK_PROTOCOL_COMPLETE_TRAFFIC))
        != 0) {
-      NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG,
+      if(_ndpi_debug_callbacks) NDPI_LOG__DEBUG2(ndpi_struct,
 	       "callback_buffer_size_udp: adding buffer : %u as entry %u\n", a, ndpi_struct->callback_buffer_size_udp);
 
       memcpy(&ndpi_struct->callback_buffer_udp[ndpi_struct->callback_buffer_size_udp],
@@ -2865,7 +2903,7 @@ void ndpi_set_protocol_detection_bitmask2(struct ndpi_detection_module_struct *n
        == 0
        || (ndpi_struct->
 	   callback_buffer[a].ndpi_selection_bitmask & NDPI_SELECTION_BITMASK_PROTOCOL_COMPLETE_TRAFFIC) != 0) {
-      NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG,
+      if(_ndpi_debug_callbacks) NDPI_LOG__DEBUG2(ndpi_struct,
 	       "callback_buffer_non_tcp_udp: adding buffer : %u as entry %u\n", a, ndpi_struct->callback_buffer_size_non_tcp_udp);
 
       memcpy(&ndpi_struct->callback_buffer_non_tcp_udp[ndpi_struct->callback_buffer_size_non_tcp_udp],
@@ -2955,11 +2993,11 @@ static u_int8_t ndpi_detection_get_l4_internal(struct ndpi_detection_module_stru
   iph = (const struct ndpi_iphdr *) l3;
 
   if(iph->version == IPVERSION && iph->ihl >= 5) {
-    NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG, "ipv4 header\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "ipv4 header\n");
   }
 #ifdef NDPI_DETECTION_SUPPORT_IPV6
   else if(iph->version == 6 && l3_len >= sizeof(struct ndpi_ipv6hdr)) {
-    NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG, "ipv6 header\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "ipv6 header\n");
     iph_v6 = (const struct ndpi_ipv6hdr *) iph;
     iph = NULL;
   }
@@ -2969,12 +3007,12 @@ static u_int8_t ndpi_detection_get_l4_internal(struct ndpi_detection_module_stru
   }
 
   if((flags & NDPI_DETECTION_ONLY_IPV6) && iph != NULL) {
-    NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG, "ipv4 header found but excluded by flag\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "ipv4 header found but excluded by flag\n");
     return 1;
   }
 #ifdef NDPI_DETECTION_SUPPORT_IPV6
   else if((flags & NDPI_DETECTION_ONLY_IPV4) && iph_v6 != NULL) {
-    NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG, "ipv6 header found but excluded by flag\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "ipv6 header found but excluded by flag\n");
     return 1;
   }
 #endif
@@ -3073,12 +3111,12 @@ static int ndpi_init_packet_header(struct ndpi_detection_module_struct *ndpi_str
 #endif							/* NDPI_DETECTION_SUPPORT_IPV6 */
 
   if(decaps_iph && decaps_iph->version == IPVERSION && decaps_iph->ihl >= 5) {
-    NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG, "ipv4 header\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "ipv4 header\n");
   }
 #ifdef NDPI_DETECTION_SUPPORT_IPV6
   else if(decaps_iph && decaps_iph->version == 6 && l3len >= sizeof(struct ndpi_ipv6hdr) &&
 	  (ndpi_struct->ip_version_limit & NDPI_DETECTION_ONLY_IPV4) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG, "ipv6 header\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "ipv6 header\n");
     flow->packet.iphv6 = (struct ndpi_ipv6hdr *)flow->packet.iph;
     flow->packet.iph = NULL;
   }
@@ -3130,9 +3168,8 @@ static int ndpi_init_packet_header(struct ndpi_detection_module_struct *ndpi_str
 	 && flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) {
 	memset(flow, 0, sizeof(*(flow)));
 
-	NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct,
-		 NDPI_LOG_DEBUG,
-		 "%s:%u: tcp syn packet for unknown protocol, reset detection state\n", __FUNCTION__, __LINE__);
+	NDPI_LOG__DEBUG(ndpi_struct,
+		 "tcp syn packet for unknown protocol, reset detection state\n");
 
       }
     } else {
@@ -3351,11 +3388,11 @@ void check_ndpi_udp_flow_func(struct ndpi_detection_module_struct *ndpi_struct,
        && NDPI_BITMASK_COMPARE(ndpi_struct->callback_buffer_udp[a].detection_bitmask,
 			       detection_bitmask) != 0) {
       ndpi_struct->callback_buffer_udp[a].func(ndpi_struct, flow);
-      // NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG, "[UDP,CALL] dissector of protocol as callback_buffer idx =  %d\n",a);
+      // NDPI_LOG__DEBUG(ndpi_struct, "[UDP,CALL] dissector of protocol as callback_buffer idx =  %d\n",a);
       if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN)
 	break; /* Stop after detecting the first protocol */
     } else
-      NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG,
+      if(_ndpi_debug_callbacks) NDPI_LOG__DEBUG2(ndpi_struct,
 	       "[UDP,SKIP] dissector of protocol as callback_buffer idx =  %d\n",a);
   }
 }
@@ -3560,6 +3597,9 @@ ndpi_protocol ndpi_detection_process_packet(struct ndpi_detection_module_struct 
   u_int32_t a;
   ndpi_protocol ret = { NDPI_PROTOCOL_UNKNOWN, NDPI_PROTOCOL_UNKNOWN };
 
+  if(ndpi_struct->ndpi_log_level >= NDPI_LOG_TRACE)
+  	NDPI_LOG(flow ? flow->detected_protocol_stack[0]:NDPI_PROTOCOL_UNKNOWN,
+		  ndpi_struct, NDPI_LOG_TRACE, "START packet processing\n");
   if(flow == NULL)
     return(ret);
 
@@ -3911,7 +3951,7 @@ void ndpi_parse_packet_line_info(struct ndpi_detection_module_struct *ndpi_struc
 	    flow->http.response_status_code[4]='\0';
 
 
-	    NDPI_LOG(NDPI_PROTOCOL_UNKNOWN, ndpi_struct, NDPI_LOG_DEBUG,
+	    NDPI_LOG__DEBUG2(ndpi_struct,
 		  "ndpi_parse_packet_line_info: HTTP response parsed: \"%.*s\"\n",
 		   packet->http_response.len, packet->http_response.ptr);
       }
@@ -4138,13 +4178,13 @@ u_int16_t ndpi_check_for_email_address(struct ndpi_detection_module_struct *ndpi
 
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "called ndpi_check_for_email_address\n");
+  NDPI_LOG__DEBUG2(ndpi_struct, "called ndpi_check_for_email_address\n");
 
   if(packet->payload_packet_len > counter && ((packet->payload[counter] >= 'a' && packet->payload[counter] <= 'z')
 					      || (packet->payload[counter] >= 'A' && packet->payload[counter] <= 'Z')
 					      || (packet->payload[counter] >= '0' && packet->payload[counter] <= '9')
 					      || packet->payload[counter] == '-' || packet->payload[counter] == '_')) {
-    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "first letter\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "first letter\n");
     counter++;
     while (packet->payload_packet_len > counter
 	   && ((packet->payload[counter] >= 'a' && packet->payload[counter] <= 'z')
@@ -4152,44 +4192,44 @@ u_int16_t ndpi_check_for_email_address(struct ndpi_detection_module_struct *ndpi
 	       || (packet->payload[counter] >= '0' && packet->payload[counter] <= '9')
 	       || packet->payload[counter] == '-' || packet->payload[counter] == '_'
 	       || packet->payload[counter] == '.')) {
-      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "further letter\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "further letter\n");
       counter++;
       if(packet->payload_packet_len > counter && packet->payload[counter] == '@') {
-	NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "@\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "@\n");
 	counter++;
 	while (packet->payload_packet_len > counter
 	       && ((packet->payload[counter] >= 'a' && packet->payload[counter] <= 'z')
 		   || (packet->payload[counter] >= 'A' && packet->payload[counter] <= 'Z')
 		   || (packet->payload[counter] >= '0' && packet->payload[counter] <= '9')
 		   || packet->payload[counter] == '-' || packet->payload[counter] == '_')) {
-	  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "letter\n");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "letter\n");
 	  counter++;
 	  if(packet->payload_packet_len > counter && packet->payload[counter] == '.') {
-	    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, ".\n");
+	    NDPI_LOG__DEBUG2(ndpi_struct, ".\n");
 	    counter++;
 	    if(packet->payload_packet_len > counter + 1
 	       && ((packet->payload[counter] >= 'a' && packet->payload[counter] <= 'z')
 		   && (packet->payload[counter + 1] >= 'a' && packet->payload[counter + 1] <= 'z'))) {
-	      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "two letters\n");
+	      NDPI_LOG__DEBUG2(ndpi_struct, "two letters\n");
 	      counter += 2;
 	      if(packet->payload_packet_len > counter
 		 && (packet->payload[counter] == ' ' || packet->payload[counter] == ';')) {
-		NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "whitespace1\n");
+		NDPI_LOG__DEBUG2(ndpi_struct, "whitespace1\n");
 		return counter;
 	      } else if(packet->payload_packet_len > counter && packet->payload[counter] >= 'a'
 			&& packet->payload[counter] <= 'z') {
-		NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "one letter\n");
+		NDPI_LOG__DEBUG2(ndpi_struct, "one letter\n");
 		counter++;
 		if(packet->payload_packet_len > counter
 		   && (packet->payload[counter] == ' ' || packet->payload[counter] == ';')) {
-		  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "whitespace2\n");
+		  NDPI_LOG__DEBUG2(ndpi_struct, "whitespace2\n");
 		  return counter;
 		} else if(packet->payload_packet_len > counter && packet->payload[counter] >= 'a'
 			  && packet->payload[counter] <= 'z') {
 		  counter++;
 		  if(packet->payload_packet_len > counter
 		     && (packet->payload[counter] == ' ' || packet->payload[counter] == ';')) {
-		    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "whitespace3\n");
+		    NDPI_LOG__DEBUG2(ndpi_struct, "whitespace3\n");
 		    return counter;
 		  } else {
 		    return 0;
@@ -4835,9 +4875,10 @@ int ndpi_get_protocol_id(struct ndpi_detection_module_struct *ndpi_mod, char *pr
 
 void ndpi_dump_protocols(struct ndpi_detection_module_struct *ndpi_mod) {
   int i;
-
+#ifndef __KERNEL__
   for(i=0; i<(int)ndpi_mod->ndpi_num_supported_protocols; i++)
     printf("[%3d] %s\n", i, ndpi_mod->proto_defaults[i].protoName);
+#endif
 }
 
 /* ****************************************************** */
@@ -4941,7 +4982,7 @@ static int ndpi_automa_match_string_subprotocol(struct ndpi_detection_module_str
     strncpy(m, string_to_match, len);
     m[len] = '\0';
 
-    printf("[NDPI] ndpi_match_host_subprotocol(%s): %s\n",
+    NDPI_LOG__DEBUG2(ndpi_struct, "[NDPI] ndpi_match_host_subprotocol(%s): %s\n",
 	   m, ndpi_struct->proto_defaults[matching_protocol_id].protoName);
   }
 #endif
@@ -4959,7 +5000,7 @@ static int ndpi_automa_match_string_subprotocol(struct ndpi_detection_module_str
 
 #ifdef DEBUG
   string_to_match[string_to_match_len] = '\0';
-  printf("[NTOP] Unable to find a match for '%s'\n", string_to_match);
+  NDPI_LOG__DEBUG2(ndpi_struct, "[NTOP] Unable to find a match for '%s'\n", string_to_match);
 #endif
 
   return(NDPI_PROTOCOL_UNKNOWN);
@@ -5073,9 +5114,10 @@ int NDPI_BITMASK_IS_EMPTY(NDPI_PROTOCOL_BITMASK a) {
 
 void NDPI_DUMP_BITMASK(NDPI_PROTOCOL_BITMASK a) {
   int i;
-
+#ifndef __KERNEL__
   for(i=0; i<NDPI_NUM_FDS_BITS; i++)
     printf("[%d=%u]", i, a.fds_bits[i]);
 
   printf("\n");
+#endif
 }

--- a/src/lib/protocols/afp.c
+++ b/src/lib/protocols/afp.c
@@ -23,9 +23,13 @@
  * 
  */
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_AFP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_AFP
+
+#include "ndpi_api.h"
 
 struct afpHeader {
   u_int8_t flags, command;
@@ -42,6 +46,8 @@ static void ndpi_int_afp_add_connection(struct ndpi_detection_module_struct *ndp
 void ndpi_search_afp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search AFP\n");
 
   if (packet->payload_packet_len >= sizeof(struct afpHeader)) {
     struct afpHeader *h = (struct afpHeader*)packet->payload;
@@ -64,7 +70,7 @@ void ndpi_search_afp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	get_u_int32_t(packet->payload, 8) == htonl(packet->payload_packet_len - 16) &&
 	get_u_int32_t(packet->payload, 12) == 0 && get_u_int16_t(packet->payload, 16) == htons(0x0104)) {
 
-      NDPI_LOG(NDPI_PROTOCOL_AFP, ndpi_struct, NDPI_LOG_DEBUG, "AFP: DSI OpenSession detected.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found AFP: DSI OpenSession\n");
       ndpi_int_afp_add_connection(ndpi_struct, flow);
       return;
     }
@@ -73,14 +79,13 @@ void ndpi_search_afp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
        && ((h->command >= 1) && (h->command <= 8))
        && (h->reserved == 0)
        && (packet->payload_packet_len >= (sizeof(struct afpHeader)+ntohl(h->length)))) {
-      NDPI_LOG(NDPI_PROTOCOL_AFP, ndpi_struct, NDPI_LOG_DEBUG, "AFP: DSI detected.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found AFP: DSI\n");
       ndpi_int_afp_add_connection(ndpi_struct, flow);
       return;
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_AFP, ndpi_struct, NDPI_LOG_DEBUG, "AFP excluded.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_AFP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/aimini.c
+++ b/src/lib/protocols/aimini.c
@@ -23,9 +23,13 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_AIMINI
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_AIMINI
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_aimini_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow/* ,  */
@@ -50,43 +54,40 @@ static u_int8_t is_special_aimini_host(struct ndpi_int_one_line_struct host_line
 void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
-	//    struct ndpi_id_struct         *src=ndpi_struct->src;
-	//    struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
-
-	NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "search aimini.\n");
+	NDPI_LOG__DEBUG(ndpi_struct, "search aimini\n");
 
 	if (packet->udp != NULL) {
 		if (flow->l4.udp.aimini_stage == 0) {
 			if (packet->payload_packet_len == 64 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x010b) {
 				flow->l4.udp.aimini_stage = 1;
-				NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 1.\n");
+				NDPI_LOG__DEBUG2(ndpi_struct, "stage = 1\n");
 				return;
 			}
 			if (packet->payload_packet_len == 136
 				&& (ntohs(get_u_int16_t(packet->payload, 0)) == 0x01c9 || ntohs(get_u_int16_t(packet->payload, 0)) == 0x0165)) {
 				flow->l4.udp.aimini_stage = 4;
-				NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 4.\n");
+				NDPI_LOG__DEBUG2(ndpi_struct, "stage = 4\n");
 				return;
 			}
 			if (packet->payload_packet_len == 88 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x0101) {
 				flow->l4.udp.aimini_stage = 7;
-				NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 7.\n");
+				NDPI_LOG__DEBUG2(ndpi_struct, "stage = 7\n");
 				return;
 			}
 			if (packet->payload_packet_len == 104 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x0102) {
 				flow->l4.udp.aimini_stage = 10;
-				NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 10.\n");
+				NDPI_LOG__DEBUG2(ndpi_struct, "stage = 10\n");
 				return;
 			}
 			if (packet->payload_packet_len == 32 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x01ca) {
 				flow->l4.udp.aimini_stage = 13;
-				NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 13.\n");
+				NDPI_LOG__DEBUG2(ndpi_struct, "stage = 13\n");
 				return;
 			}
 			if (packet->payload_packet_len == 16 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x010c) {
 				flow->l4.udp.aimini_stage = 16;
-				NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 16.\n");
+				NDPI_LOG__DEBUG2(ndpi_struct, "stage = 16\n");
 				return;
 			}
 		}
@@ -96,7 +97,7 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 		if (flow->l4.udp.aimini_stage == 1 && packet->payload_packet_len > 100
 			&& ntohs(get_u_int16_t(packet->payload, 0)) == 0x0115) {
 			flow->l4.udp.aimini_stage = 2;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 2.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 2\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 2 &&
@@ -104,14 +105,14 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 			 (packet->payload_packet_len == 64 && get_u_int16_t(packet->payload, 0) == htons(0x010b)) ||
 			 (packet->payload_packet_len == 88 && get_u_int16_t(packet->payload, 0) == ntohs(0x0115)))) {
 			flow->l4.udp.aimini_stage = 3;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 3.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 3\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 3
 			&& ((packet->payload_packet_len == 16 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x010c)
 				|| (packet->payload_packet_len == 64 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x010b)
 				|| (packet->payload_packet_len > 100 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x0115))) {
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "found aimini (64, 0x010b), (>300, 0x0115), "
+			NDPI_LOG__TRACE(ndpi_struct, "found aimini (64, 0x010b), (>300, 0x0115), "
 					"(16, 0x010c || 64, 0x010b), (16, 0x010c || 64, 0x010b || >100, 0x0115).\n");
 			ndpi_int_aimini_add_connection(ndpi_struct, flow);
 			return;
@@ -122,14 +123,14 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 		if (flow->l4.udp.aimini_stage == 4 && packet->payload_packet_len == 136
 			&& (ntohs(get_u_int16_t(packet->payload, 0)) == 0x01c9 || ntohs(get_u_int16_t(packet->payload, 0)) == 0x0165)) {
 			flow->l4.udp.aimini_stage = 5;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 5.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 5\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 5 && (packet->payload_packet_len == 136
 											   && (ntohs(get_u_int16_t(packet->payload, 0)) == 0x01c9
 												   || ntohs(get_u_int16_t(packet->payload, 0)) == 0x0165))) {
 			flow->l4.udp.aimini_stage = 6;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 6.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 6\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 6 && ((packet->payload_packet_len == 136
@@ -137,7 +138,7 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 													|| ntohs(get_u_int16_t(packet->payload, 0)) == 0x01c9))
 											   || (packet->payload_packet_len == 32
 												   && ntohs(get_u_int16_t(packet->payload, 0)) == 0x01ca))) {
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG,
+			NDPI_LOG__TRACE(ndpi_struct,
 					"found aimini (136, 0x01c9), (136, 0x01c9)," "(136, 0x01c9),(136, 0x01c9 || 32, 0x01ca).\n");
 			ndpi_int_aimini_add_connection(ndpi_struct, flow);
 			return;
@@ -148,18 +149,18 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 		if (flow->l4.udp.aimini_stage == 7 && packet->payload_packet_len == 88
 			&& ntohs(get_u_int16_t(packet->payload, 0)) == 0x0101) {
 			flow->l4.udp.aimini_stage = 8;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 8.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 8\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 8
 			&& (packet->payload_packet_len == 88 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x0101)) {
 			flow->l4.udp.aimini_stage = 9;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 9.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 9\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 9
 			&& (packet->payload_packet_len == 88 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x0101)) {
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG,
+			NDPI_LOG__TRACE(ndpi_struct,
 					"found aimini (88, 0x0101), (88, 0x0101)," "(88, 0x0101),(88, 0x0101).\n");
 			ndpi_int_aimini_add_connection(ndpi_struct, flow);
 			return;
@@ -170,19 +171,19 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 		if (flow->l4.udp.aimini_stage == 10 && packet->payload_packet_len == 104
 			&& ntohs(get_u_int16_t(packet->payload, 0)) == 0x0102) {
 			flow->l4.udp.aimini_stage = 11;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 11.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 11\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 11
 			&& (packet->payload_packet_len == 104 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x0102)) {
 			flow->l4.udp.aimini_stage = 12;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 12.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 12\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 12
 			&& ((packet->payload_packet_len == 104 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x0102)
 				|| (packet->payload_packet_len == 32 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x01ca))) {
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG,
+			NDPI_LOG__TRACE(ndpi_struct,
 					"found aimini (104, 0x0102), (104, 0x0102), " "(104, 0x0102), (104, 0x0102).\n");
 			ndpi_int_aimini_add_connection(ndpi_struct, flow);
 			return;
@@ -193,20 +194,20 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 		if (flow->l4.udp.aimini_stage == 13 && packet->payload_packet_len == 32
 			&& ntohs(get_u_int16_t(packet->payload, 0)) == 0x01ca) {
 			flow->l4.udp.aimini_stage = 14;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 14.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 14\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 14
 			&& ((packet->payload_packet_len == 32 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x01ca)
 				|| (packet->payload_packet_len == 136 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x0166))) {
 			flow->l4.udp.aimini_stage = 15;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 15.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 15\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 15
 			&& ((packet->payload_packet_len == 136 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x0166)
 				|| (packet->payload_packet_len == 32 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x01ca))) {
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG,
+			NDPI_LOG__TRACE(ndpi_struct,
 					"found aimini (32,0x01ca), (32,0x01ca), (32,0x01ca), ((136, 0x0166)||(32,0x01ca)).\n");
 			ndpi_int_aimini_add_connection(ndpi_struct, flow);
 			return;
@@ -217,18 +218,18 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 		if (flow->l4.udp.aimini_stage == 16 && packet->payload_packet_len == 16
 			&& ntohs(get_u_int16_t(packet->payload, 0)) == 0x010c) {
 			flow->l4.udp.aimini_stage = 17;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 17.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 17\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 17
 			&& (packet->payload_packet_len == 16 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x010c)) {
 			flow->l4.udp.aimini_stage = 18;
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "stage = 18.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "stage = 18\n");
 			return;
 		}
 		if (flow->l4.udp.aimini_stage == 18
 			&& (packet->payload_packet_len == 16 && ntohs(get_u_int16_t(packet->payload, 0)) == 0x010c)) {
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG,
+			NDPI_LOG__TRACE(ndpi_struct,
 					"found aimini (16, 0x010c), (16, 0x010c), (16, 0x010c), (16, 0x010c).\n");
 			ndpi_int_aimini_add_connection(ndpi_struct, flow);
 			return;
@@ -238,11 +239,11 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 			 (memcmp(packet->payload, "GET /player/", NDPI_STATICSTRING_LEN("GET /player/")) == 0)) ||
 			(packet->payload_packet_len > NDPI_STATICSTRING_LEN("GET /play/?fid=") &&
 			 (memcmp(packet->payload, "GET /play/?fid=", NDPI_STATICSTRING_LEN("GET /play/?fid=")) == 0))) {
-			NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "HTTP packet detected.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "HTTP packet detected\n");
 			ndpi_parse_packet_line_info(ndpi_struct, flow);
 			if (packet->host_line.ptr != NULL && packet->host_line.len > 11
 				&& (memcmp(&packet->host_line.ptr[packet->host_line.len - 11], ".aimini.net", 11) == 0)) {
-				NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "AIMINI HTTP traffic detected.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found AIMINI HTTP traffic\n");
 				ndpi_int_aimini_add_connection(ndpi_struct, flow);
 				return;
 			}
@@ -255,8 +256,8 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 						   NDPI_STATICSTRING_LEN("download/")) == 0) {
 					ndpi_parse_packet_line_info(ndpi_struct, flow);
 					if (is_special_aimini_host(packet->host_line) == 1) {
-						NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG,
-								"AIMINI HTTP traffic detected.\n");
+						NDPI_LOG__TRACE(ndpi_struct,
+								"found AIMINI HTTP traffic\n");
 						ndpi_int_aimini_add_connection(ndpi_struct, flow);
 						return;
 					}
@@ -266,8 +267,8 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 						   NDPI_STATICSTRING_LEN("upload/")) == 0) {
 					ndpi_parse_packet_line_info(ndpi_struct, flow);
 					if (is_special_aimini_host(packet->host_line) == 1) {
-						NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG,
-								"AIMINI HTTP traffic detected.\n");
+						NDPI_LOG__TRACE(ndpi_struct,
+								"found AIMINI HTTP traffic detected.\n");
 						ndpi_int_aimini_add_connection(ndpi_struct, flow);
 						return;
 					}
@@ -276,8 +277,7 @@ void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct
 		}
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_AIMINI, ndpi_struct, NDPI_LOG_DEBUG, "exclude aimini.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_AIMINI);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 

--- a/src/lib/protocols/amqp.c
+++ b/src/lib/protocols/amqp.c
@@ -18,9 +18,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_AMQP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_AMQP
+
+#include "ndpi_api.h"
+
 
 PACK_ON
 struct amqp_header {
@@ -39,7 +44,7 @@ static void ndpi_int_amqp_add_connection(struct ndpi_detection_module_struct *nd
 void ndpi_search_amqp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
 	struct ndpi_packet_struct *packet = &flow->packet;
 
-	NDPI_LOG(NDPI_PROTOCOL_AMQP, ndpi_struct, NDPI_LOG_DEBUG, "search amqp.  \n");
+	NDPI_LOG__DEBUG(ndpi_struct, "search amqp\n");
 
 	if (packet->tcp != NULL) {
 		if(packet->payload_packet_len > sizeof(struct amqp_header)) {
@@ -57,7 +62,7 @@ void ndpi_search_amqp(struct ndpi_detection_module_struct *ndpi_struct, struct n
 						u_int16_t method = htons(h->method);
 
 						if(method <= 120 /* Method basic NACK */) {
-							NDPI_LOG(NDPI_PROTOCOL_AMQP, ndpi_struct, NDPI_LOG_DEBUG, "found amqp over tcp.  \n");
+							NDPI_LOG__TRACE(ndpi_struct, "found amqp over tcp\n");
 							ndpi_int_amqp_add_connection(ndpi_struct, flow);
 							return;
 						}
@@ -65,6 +70,8 @@ void ndpi_search_amqp(struct ndpi_detection_module_struct *ndpi_struct, struct n
 				}
 			}
 		}
+	} else {
+		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 	}
 }
 

--- a/src/lib/protocols/applejuice.c
+++ b/src/lib/protocols/applejuice.c
@@ -22,9 +22,13 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_APPLEJUICE
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_APPLEJUICE
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_applejuice_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
@@ -37,21 +41,18 @@ void ndpi_search_applejuice_tcp(struct ndpi_detection_module_struct *ndpi_struct
 				struct ndpi_flow_struct *flow)
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
-	NDPI_LOG(NDPI_PROTOCOL_APPLEJUICE, ndpi_struct, NDPI_LOG_DEBUG, "search applejuice.\n");
+	NDPI_LOG__DEBUG(ndpi_struct, "search applejuice\n");
 
 	if ((packet->payload_packet_len > 7) && (packet->payload[6] == 0x0d)
 		&& (packet->payload[7] == 0x0a)
 		&& (memcmp(packet->payload, "ajprot", 6) == 0)) {
-		NDPI_LOG(NDPI_PROTOCOL_APPLEJUICE, ndpi_struct, NDPI_LOG_DEBUG, "detected applejuice.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found applejuice\n");
 		ndpi_int_applejuice_add_connection(ndpi_struct, flow);
 		return;
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_APPLEJUICE, ndpi_struct, NDPI_LOG_DEBUG, "exclude applejuice.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_APPLEJUICE);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/armagetron.c
+++ b/src/lib/protocols/armagetron.c
@@ -22,27 +22,26 @@
  *
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_ARMAGETRON
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_ARMAGETRON
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_armagetron_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					       struct ndpi_flow_struct *flow)
 {
-
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ARMAGETRON, NDPI_PROTOCOL_UNKNOWN);
 }
 
 void ndpi_search_armagetron_udp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
-  NDPI_LOG(NDPI_PROTOCOL_ARMAGETRON, ndpi_struct, NDPI_LOG_DEBUG, "search armagetron.\n");
-
+  NDPI_LOG__DEBUG(ndpi_struct, "search armagetron\n");
 
   if (packet->payload_packet_len > 10) {
     /* login request */
@@ -52,7 +51,7 @@ void ndpi_search_armagetron_udp(struct ndpi_detection_module_struct *ndpi_struct
 	goto exclude;
       if (get_u_int16_t(packet->payload, 6) == htons(0x0008)
 	  && get_u_int16_t(packet->payload, packet->payload_packet_len - 2) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_ARMAGETRON, ndpi_struct, NDPI_LOG_DEBUG, "detected armagetron.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found armagetron\n");
 	ndpi_int_armagetron_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -65,7 +64,7 @@ void ndpi_search_armagetron_udp(struct ndpi_detection_module_struct *ndpi_struct
 	goto exclude;
       if (get_u_int32_t(packet->payload, 6) == htonl(0x00000500) && get_u_int32_t(packet->payload, 6 + 4) == htonl(0x00010000)
 	  && get_u_int16_t(packet->payload, packet->payload_packet_len - 2) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_ARMAGETRON, ndpi_struct, NDPI_LOG_DEBUG, "detected armagetron.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found armagetron\n");
 	ndpi_int_armagetron_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -85,7 +84,7 @@ void ndpi_search_armagetron_udp(struct ndpi_detection_module_struct *ndpi_struct
 	    && (get_u_int32_t(packet->payload, 6 + 10 + val) == htonl(0x00010000)
 		|| get_u_int32_t(packet->payload, 6 + 10 + val) == htonl(0x00000001))
 	    && get_u_int16_t(packet->payload, packet->payload_packet_len - 2) == 0) {
-	  NDPI_LOG(NDPI_PROTOCOL_ARMAGETRON, ndpi_struct, NDPI_LOG_DEBUG, "detected armagetron.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found armagetron\n");
 	  ndpi_int_armagetron_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -94,8 +93,7 @@ void ndpi_search_armagetron_udp(struct ndpi_detection_module_struct *ndpi_struct
   }
 
  exclude:
-  NDPI_LOG(NDPI_PROTOCOL_ARMAGETRON, ndpi_struct, NDPI_LOG_DEBUG, "exclude armagetron.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_ARMAGETRON);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/ayiya.c
+++ b/src/lib/protocols/ayiya.c
@@ -26,9 +26,13 @@
   http://tools.ietf.org/html/rfc4891
 */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_AYIYA
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_AYIYA
+
+#include "ndpi_api.h"
 
 struct ayiya {
   u_int8_t flags[3];
@@ -41,6 +45,8 @@ struct ayiya {
 void ndpi_search_ayiya(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search AYIYA\n");
 
   if(packet->udp && (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN)) {
     /* Ayiya is udp based, port 5072 */
@@ -55,13 +61,15 @@ void ndpi_search_ayiya(struct ndpi_detection_module_struct *ndpi_struct, struct 
 
       now = flow->packet.tick_timestamp;
 
-      if((epoch >= (now - fiveyears)) && (epoch <= (now+86400 /* 1 day */)))      
+      if((epoch >= (now - fiveyears)) && (epoch <= (now+86400 /* 1 day */))) {
+	NDPI_LOG__TRACE(ndpi_struct, "found AYIYA\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_AYIYA, NDPI_PROTOCOL_UNKNOWN);
+      }
 
       return;
     }
 
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_AYIYA);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/battlefield.c
+++ b/src/lib/protocols/battlefield.c
@@ -22,10 +22,13 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_BATTLEFIELD
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_BATTLEFIELD
+
+#include "ndpi_api.h"
 
 static void ndpi_int_battlefield_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -53,12 +56,12 @@ void ndpi_search_battlefield(struct ndpi_detection_module_struct *ndpi_struct, s
   if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_BATTLEFIELD) {
     if (src != NULL && ((u_int32_t)
 			(packet->tick_timestamp - src->battlefield_ts) < ndpi_struct->battlefield_timeout)) {
-      NDPI_LOG(NDPI_PROTOCOL_BATTLEFIELD, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG2(ndpi_struct,
 	       "battlefield : save src connection packet detected\n");
       src->battlefield_ts = packet->tick_timestamp;
     } else if (dst != NULL && ((u_int32_t)
 			       (packet->tick_timestamp - dst->battlefield_ts) < ndpi_struct->battlefield_timeout)) {
-      NDPI_LOG(NDPI_PROTOCOL_BATTLEFIELD, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG2(ndpi_struct,
 	       "battlefield : save dst connection packet detected\n");
       dst->battlefield_ts = packet->tick_timestamp;
     }
@@ -74,8 +77,7 @@ void ndpi_search_battlefield(struct ndpi_detection_module_struct *ndpi_struct, s
       }
     } else if (flow->l4.udp.battlefield_stage == 2 - packet->packet_direction) {
       if (packet->payload_packet_len > 8 && get_u_int32_t(packet->payload, 0) == flow->l4.udp.battlefield_msg_id) {
-	NDPI_LOG(NDPI_PROTOCOL_BATTLEFIELD, ndpi_struct,
-		 NDPI_LOG_DEBUG, "Battlefield message and reply detected.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found Battlefield message and reply detected\n");
 	ndpi_int_battlefield_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -91,28 +93,26 @@ void ndpi_search_battlefield(struct ndpi_detection_module_struct *ndpi_struct, s
   } else if (flow->l4.udp.battlefield_stage == 4 - packet->packet_direction) {
     if (packet->payload_packet_len == 7
 	&& (packet->payload[0] == 0x02 || packet->payload[packet->payload_packet_len - 1] == 0xe0)) {
-      NDPI_LOG(NDPI_PROTOCOL_BATTLEFIELD, ndpi_struct, NDPI_LOG_DEBUG,
-	       "Battlefield message and reply detected.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found Battlefield message and reply detected\n");
       ndpi_int_battlefield_add_connection(ndpi_struct, flow);
       return;
     }
   }
 
   if (packet->payload_packet_len == 18 && memcmp(&packet->payload[5], "battlefield2\x00", 13) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_BATTLEFIELD, ndpi_struct, NDPI_LOG_DEBUG, "Battlefield 2 hello packet detected.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found Battlefield 2 hello packet detected\n");
     ndpi_int_battlefield_add_connection(ndpi_struct, flow);
     return;
   } else if (packet->payload_packet_len > 10 &&
 	     (memcmp(packet->payload, "\x11\x20\x00\x01\x00\x00\x50\xb9\x10\x11", 10) == 0
 	      || memcmp(packet->payload, "\x11\x20\x00\x01\x00\x00\x30\xb9\x10\x11", 10) == 0
 	      || memcmp(packet->payload, "\x11\x20\x00\x01\x00\x00\xa0\x98\x00\x11", 10) == 0)) {
-    NDPI_LOG(NDPI_PROTOCOL_BATTLEFIELD, ndpi_struct, NDPI_LOG_DEBUG, "Battlefield safe pattern detected.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found Battlefield safe pattern detected\n");
     ndpi_int_battlefield_add_connection(ndpi_struct, flow);
     return;
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_BATTLEFIELD);
-  return;
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/bgp.c
+++ b/src/lib/protocols/bgp.c
@@ -20,15 +20,23 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_protocols.h"
+
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_BGP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_BGP
+
+#include "ndpi_api.h"
+
 
 /* this detection also works asymmetrically */
 void ndpi_search_bgp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int16_t bgp_port = htons(179);
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search BGP\n");
 
   if(packet->tcp) {
     if(packet->payload_packet_len > 18
@@ -38,13 +46,13 @@ void ndpi_search_bgp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
        && (get_u_int64_t(packet->payload, 8) == 0xffffffffffffffffULL)
        && (ntohs(get_u_int16_t(packet->payload, 16)) <= packet->payload_packet_len)) {
       
-      NDPI_LOG(NDPI_PROTOCOL_BGP, ndpi_struct, NDPI_LOG_DEBUG, "BGP detected.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found BGP\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_BGP, NDPI_PROTOCOL_UNKNOWN);
       return;
     } 
   }
-  /* exclude BGP */
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_BGP);
+
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -23,8 +23,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_BITTORRENT
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_BITTORRENT
+
+#include "ndpi_api.h"
+
 #define NDPI_PROTOCOL_UNSAFE_DETECTION 	 0
 #define NDPI_PROTOCOL_SAFE_DETECTION 	 1
 
@@ -87,10 +93,9 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
 
   if(flow->packet_counter == 2 && packet->payload_packet_len > 20) {
     if(memcmp(&packet->payload[0], "BitTorrent protocol", 19) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_BITTORRENT,
-	       ndpi_struct, NDPI_LOG_TRACE, "BT: plain BitTorrent protocol detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found BT: plain\n");
       ndpi_add_connection_as_bittorrent(ndpi_struct, flow, 19, 1,
-					NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
+			NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
       return 1;
     }
   }
@@ -99,19 +104,18 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
     /* test for match 0x13+"BitTorrent protocol" */
     if(packet->payload[0] == 0x13) {
       if(memcmp(&packet->payload[1], "BitTorrent protocol", 19) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct, NDPI_LOG_TRACE, "BT: plain BitTorrent protocol detected\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found BT: plain\n");
 	ndpi_add_connection_as_bittorrent(ndpi_struct, flow, 20, 1,
-					  NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
+			NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
 	return 1;
       }
     }
   }
 
   if(packet->payload_packet_len > 23 && memcmp(packet->payload, "GET /webseed?info_hash=", 23) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct,
-	     NDPI_LOG_TRACE, "BT: plain webseed BitTorrent protocol detected\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found BT: plain webseed\n");
     ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 1,
-				      NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_WEBSEED_DETECTION);
+			NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_WEBSEED_DETECTION);
     return 1;
   }
   /* seen Azureus as server for webseed, possibly other servers existing, to implement */
@@ -119,10 +123,9 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
   /* no asymmetric detection possible for answer of pattern "GET /data?fid=". */
   if(packet->payload_packet_len > 60
       && memcmp(packet->payload, "GET /data?fid=", 14) == 0 && memcmp(&packet->payload[54], "&size=", 6) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct,
-	     NDPI_LOG_TRACE, "BT: plain Bitcomet persistent seed protocol detected\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found BT: plain Bitcomet persistent seed\n");
     ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 1,
-				      NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_WEBSEED_DETECTION);
+			NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_WEBSEED_DETECTION);
     return 1;
   }
 
@@ -140,10 +143,9 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
 	&& ((packet->user_agent_line.len > 8 && memcmp(packet->user_agent_line.ptr, "Azureus ", 8) == 0)
 	    || (packet->user_agent_line.len >= 10 && memcmp(packet->user_agent_line.ptr, "BitTorrent", 10) == 0)
 	    || (packet->user_agent_line.len >= 11 && memcmp(packet->user_agent_line.ptr, "BTWebClient", 11) == 0))) {
-      NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct,
-	       NDPI_LOG_TRACE, "Azureus /Bittorrent user agent line detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found BT: Azureus /Bittorrent user agent\n");
       ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 1,
-					NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_WEBSEED_DETECTION);
+			NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_WEBSEED_DETECTION);
       return 1;
     }
 
@@ -151,10 +153,9 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
        && (packet->user_agent_line.len >= 9 && memcmp(packet->user_agent_line.ptr, "Shareaza ", 9) == 0)
        && (packet->parsed_lines > 8 && packet->line[8].ptr != 0
 	   && packet->line[8].len >= 9 && memcmp(packet->line[8].ptr, "X-Queue: ", 9) == 0)) {
-      NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct,
-	       NDPI_LOG_TRACE, "Bittorrent Shareaza detected.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found BT: Shareaza detected\n");
       ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 1,
-					NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_WEBSEED_DETECTION);
+			NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_WEBSEED_DETECTION);
       return 1;
     }
 
@@ -186,9 +187,9 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
 	&& packet->line[8].ptr != NULL
 	&& packet->line[8].len > 22 && memcmp(packet->line[8].ptr, "Cache-Control: no-cache", 23) == 0) {
 
-      NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct, NDPI_LOG_TRACE, "Bitcomet LTS detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found BT: Bitcomet LTS\n");
       ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 1,
-					NDPI_PROTOCOL_UNSAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
+			NDPI_PROTOCOL_UNSAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
       return 1;
     }
 
@@ -211,9 +212,9 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
 	&& packet->line[6].ptr != NULL
 	&& packet->line[6].len > 21 && memcmp(packet->line[6].ptr, "Connection: Keep-Alive", 22) == 0) {
 
-      NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct, NDPI_LOG_TRACE, "FlashGet detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found BT: FlashGet\n");
       ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 1,
-					NDPI_PROTOCOL_UNSAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
+			NDPI_PROTOCOL_UNSAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
       return 1;
     }
 
@@ -232,9 +233,9 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
 	&& packet->line[5].ptr != NULL
 	&& packet->line[5].len > 21 && memcmp(packet->line[5].ptr, "Connection: Keep-Alive", 22) == 0) {
 
-      NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct, NDPI_LOG_TRACE, "FlashGet detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found BT: FlashGet\n");
       ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 1,
-					NDPI_PROTOCOL_UNSAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
+			NDPI_PROTOCOL_UNSAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
       return 1;
     }
 
@@ -250,8 +251,7 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
       ptr++;
     }
 
-    NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct,
-	     NDPI_LOG_TRACE, " BT stat: tracker info hash found\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, " BT stat: tracker info hash found\n");
 
     /* len is > 50, so save operation here */
     len -= 10;
@@ -300,10 +300,9 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
       }
     }
 
-    NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct,
-	     NDPI_LOG_TRACE, " BT stat: tracker info hash parsed\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found BT: tracker info hash parsed\n");
     ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 1,
-				      NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
+			NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
     return 1;
   }
 
@@ -329,10 +328,9 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
     /* did not see this pattern anywhere */
     if((memcmp(&packet->payload[0], pattern_20_bytes, 20) == 0)
 	&& (memcmp(&packet->payload[52], pattern_12_bytes, 12) == 0)) {
-      NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct,
-	       NDPI_LOG_TRACE, "BT: Warez - Plain BitTorrent protocol detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found BT: Warez - Plain\n");
       ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 1,
-					NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
+			NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
       return 1;
     }
   }
@@ -344,11 +342,9 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
       /* haven't fount this pattern anywhere */
       if(packet->host_line.ptr != NULL
 	  && packet->host_line.len >= 9 && memcmp(packet->host_line.ptr, "ip2p.com:", 9) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_BITTORRENT,
-		 ndpi_struct, NDPI_LOG_TRACE,
-		 "BT: Warez - Plain BitTorrent protocol detected due to Host: ip2p.com: pattern\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found BT: Warez - Plain Host: ip2p.com: pattern\n");
 	ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 1,
-					  NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_WEBSEED_DETECTION);
+			NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_WEBSEED_DETECTION);
 	return 1;
       }
     }
@@ -370,13 +366,11 @@ static void ndpi_int_search_bittorrent_tcp(struct ndpi_detection_module_struct *
     /* exclude stage 0 detection from next run */
     flow->bittorrent_stage = 1;
     if(ndpi_int_search_bittorrent_tcp_zero(ndpi_struct, flow) != 0) {
-      NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct, NDPI_LOG_DEBUG,
-	       "stage 0 has detected something, returning\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "stage 0 has detected something, returning\n");
       return;
     }
 
-    NDPI_LOG(NDPI_PROTOCOL_BITTORRENT, ndpi_struct, NDPI_LOG_DEBUG,
-	     "stage 0 has no direct detection, fall through\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "stage 0 has no direct detection, fall through\n");
   }
   return;
 }
@@ -392,7 +386,7 @@ void ndpi_search_bittorrent(struct ndpi_detection_module_struct *ndpi_struct, st
 	 || (packet->udp
 	     && ((ntohs(packet->udp->source) == 3544) /* teredo.c */
 		 || (ntohs(packet->udp->dest) == 3544))))) {
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_BITTORRENT);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
@@ -481,18 +475,16 @@ void ndpi_search_bittorrent(struct ndpi_detection_module_struct *ndpi_struct, st
 	      if(bt_proto && (packet->payload_packet_len > 47))
 		memcpy(flow->protos.bittorrent.hash, &bt_proto[27], 20);
 
-	      NDPI_LOG(NDPI_PROTOCOL_BITTORRENT,
-		       ndpi_struct, NDPI_LOG_TRACE, "BT: plain BitTorrent protocol detected\n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found BT: plain\n");
 	      ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 0,
-						NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
+				NDPI_PROTOCOL_SAFE_DETECTION, NDPI_PROTOCOL_PLAIN_DETECTION);
 	      return;
 	    }
 	  }
 
 	return;
       }
-
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_BITTORRENT);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     }
   }
 }

--- a/src/lib/protocols/bjnp.c
+++ b/src/lib/protocols/bjnp.c
@@ -1,7 +1,10 @@
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_BJNP
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_BJNP
+
+#include "ndpi_api.h"
 
 static void ndpi_int_bjnp_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					    struct ndpi_flow_struct *flow,
@@ -23,22 +26,21 @@ static void ndpi_check_bjnp(struct ndpi_detection_module_struct *ndpi_struct, st
 	 || (memcmp((const char *)packet->payload, "BJNB", 4) == 0)
 	 || (memcmp((const char *)packet->payload, "MFNP", 4) == 0)
 	 ) {
-	    NDPI_LOG(NDPI_PROTOCOL_BJNP, ndpi_struct, NDPI_LOG_DEBUG, "Found bjnp.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found bjnp\n");
 	    ndpi_int_bjnp_add_connection(ndpi_struct, flow, 0);
 	    return;
 	  }
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_BJNP, ndpi_struct, NDPI_LOG_DEBUG, "exclude bjnp.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_BJNP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void ndpi_search_bjnp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_BJNP, ndpi_struct, NDPI_LOG_DEBUG, "bjnp detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search bjnp\n");
 
   /* skip marked packets */
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_BJNP) {

--- a/src/lib/protocols/btlib.c
+++ b/src/lib/protocols/btlib.c
@@ -89,6 +89,7 @@ static char *print_id_ip6_p(char *s,const struct bt_nodes6_data *b) {
   return print_ip6_p(s,(struct bt_ipv6p *)&b->ip,0);
 }
 
+#ifndef __KERNEL__
 
 void dump_bt_proto_struct(struct bt_parse_protocol *p) {
   char b20h[128];
@@ -181,8 +182,14 @@ static void _print_safe_str(char *msg,char *k,const u_int8_t *s,size_t l) {
 static void print_safe_str(char *msg,bt_parse_data_cb_t *cbd) {
   _print_safe_str(msg,cbd->buf,cbd->v.s.s,cbd->v.s.l);
 }
-
 #define DEBUG_TRACE(cmd) { if(bt_parse_debug) cmd; }
+#else
+
+#define DEBUG_TRACE(cmd)
+
+#endif
+
+
 #define STREQ(a,b) !strcmp(a,b)
 
 

--- a/src/lib/protocols/ciscovpn.c
+++ b/src/lib/protocols/ciscovpn.c
@@ -4,9 +4,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_CISCOVPN
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_CISCOVPN
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_ciscovpn_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -20,15 +25,15 @@ void ndpi_search_ciscovpn(struct ndpi_detection_module_struct *ndpi_struct, stru
   u_int16_t tdport = 0, tsport = 0;
 
 
-  NDPI_LOG(NDPI_PROTOCOL_CISCOVPN, ndpi_struct, NDPI_LOG_DEBUG, "search CISCOVPN.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search CISCOVPN\n");
 
   if(packet->tcp != NULL) {
     tsport = ntohs(packet->tcp->source), tdport = ntohs(packet->tcp->dest);
-    NDPI_LOG(NDPI_PROTOCOL_CISCOVPN, ndpi_struct, NDPI_LOG_DEBUG, "calculated CISCOVPN over tcp ports.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculated CISCOVPN over tcp ports\n");
   }
   if(packet->udp != NULL) {
     usport = ntohs(packet->udp->source), udport = ntohs(packet->udp->dest);
-    NDPI_LOG(NDPI_PROTOCOL_CISCOVPN, ndpi_struct, NDPI_LOG_DEBUG, "calculated CISCOVPN over udp ports.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculated CISCOVPN over udp ports\n");
   }
 
   if((tdport == 10000 && tsport == 10000) ||
@@ -42,8 +47,9 @@ void ndpi_search_ciscovpn(struct ndpi_detection_module_struct *ndpi_struct, stru
 
     {
       /* This is a good query  17010000*/
-      NDPI_LOG(NDPI_PROTOCOL_CISCOVPN, ndpi_struct, NDPI_LOG_DEBUG, "found CISCOVPN.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found CISCOVPN\n");
       ndpi_int_ciscovpn_add_connection(ndpi_struct, flow);
+      return;
     } 
   else if(
 	  (
@@ -59,11 +65,10 @@ void ndpi_search_ciscovpn(struct ndpi_detection_module_struct *ndpi_struct, stru
 
 
       /* This is a good query  fe577e2b */
-      NDPI_LOG(NDPI_PROTOCOL_CISCOVPN, ndpi_struct, NDPI_LOG_DEBUG, "found CISCOVPN.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found CISCOVPN\n");
       ndpi_int_ciscovpn_add_connection(ndpi_struct, flow);
     } else {
-    NDPI_LOG(NDPI_PROTOCOL_CISCOVPN, ndpi_struct, NDPI_LOG_DEBUG, "exclude CISCOVPN.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_CISCOVPN);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 
 }

--- a/src/lib/protocols/citrix.c
+++ b/src/lib/protocols/citrix.c
@@ -21,10 +21,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_CITRIX
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_CITRIX
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_CITRIX
 
 /* ************************************ */
 
@@ -45,26 +49,25 @@ static void ndpi_check_citrix(struct ndpi_detection_module_struct *ndpi_struct, 
 	char citrix_header[] = { 0x07, 0x07, 0x49, 0x43, 0x41, 0x00 };
 	
 	if(memcmp(packet->payload, citrix_header, sizeof(citrix_header)) == 0) {
-	  NDPI_LOG(NDPI_PROTOCOL_CITRIX, ndpi_struct, NDPI_LOG_DEBUG, "Found citrix.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found citrix\n");
 	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CITRIX, NDPI_PROTOCOL_UNKNOWN);
 	}
-
 	return;
       } else if(payload_len > 4) {
 	char citrix_header[] = { 0x1a, 0x43, 0x47, 0x50, 0x2f, 0x30, 0x31 };
 	
 	if((memcmp(packet->payload, citrix_header, sizeof(citrix_header)) == 0)
 	   || (ndpi_strnstr((const char *)packet->payload, "Citrix.TcpProxyService", payload_len) != NULL)) {
-	  NDPI_LOG(NDPI_PROTOCOL_CITRIX, ndpi_struct, NDPI_LOG_DEBUG, "Found citrix.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found citrix\n");
 	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CITRIX, NDPI_PROTOCOL_UNKNOWN);
 	}
-
 	return;	
       }
       
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_CITRIX);
-    } else if(flow->l4.tcp.citrix_packet_id > 3)
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_CITRIX);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    } else if(flow->l4.tcp.citrix_packet_id > 3) {
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    }
     
     return;
   }
@@ -74,7 +77,7 @@ void ndpi_search_citrix(struct ndpi_detection_module_struct *ndpi_struct, struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_CITRIX, ndpi_struct, NDPI_LOG_DEBUG, "citrix detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search citrix\n");
 
   /* skip marked packets */
   if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_CITRIX)

--- a/src/lib/protocols/coap.c
+++ b/src/lib/protocols/coap.c
@@ -21,9 +21,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_COAP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_COAP
+
+#include "ndpi_api.h"
+
 
 #define CON     0
 #define NO_CON  1
@@ -116,14 +121,12 @@ void ndpi_search_coap (struct ndpi_detection_module_struct *ndpi_struct,
     u_int16_t d_port = ntohs(flow->packet.udp->dest);
 
     if((!isCoAPport(s_port) && !isCoAPport(d_port))
-       || (packet->payload_packet_len < 4) // header too short
-       ) {
-      NDPI_LOG(NDPI_PROTOCOL_COAP, ndpi_struct, NDPI_LOG_DEBUG, "excluding Coap\n");
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_COAP);
+       || (packet->payload_packet_len < 4) ) {   // header too short
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
       return;
     }
 
-    NDPI_LOG(NDPI_PROTOCOL_COAP, ndpi_struct, NDPI_LOG_DEBUG, "calculating coap over udp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculating coap over udp\n");
 
     // check values in header
     if(h->version == 1) {
@@ -133,7 +136,7 @@ void ndpi_search_coap (struct ndpi_detection_module_struct *ndpi_struct,
 	     (h->code >= 128  && h->code <= 134) || (h->code >= 140 && h->code <= 143) ||
 	     (h->code >= 160 && h->code <= 165)) {
 
-	    NDPI_LOG(NDPI_PROTOCOL_COAP, ndpi_struct, NDPI_LOG_DEBUG, "Coap found...\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found Coap\n");
 	    ndpi_int_coap_add_connection(ndpi_struct,flow);
 	    return;
 	  }
@@ -142,8 +145,7 @@ void ndpi_search_coap (struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_COAP, ndpi_struct, NDPI_LOG_DEBUG, "Excluding Coap ...\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_COAP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   return;
 }
 

--- a/src/lib/protocols/collectd.c
+++ b/src/lib/protocols/collectd.c
@@ -19,16 +19,21 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_COLLECTD
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_COLLECTD
+
+#include "ndpi_api.h"
+
 
 void ndpi_search_collectd(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int len = 0;
 
-  NDPI_LOG(NDPI_PROTOCOL_COLLECTD, ndpi_struct, NDPI_LOG_DEBUG, "search collectd.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search collectd\n");
   
   if (packet->udp == NULL) return;
 
@@ -43,11 +48,10 @@ void ndpi_search_collectd(struct ndpi_detection_module_struct *ndpi_struct, stru
   }
 
   if(len == packet->payload_packet_len) {
-    NDPI_LOG(NDPI_PROTOCOL_COLLECTD, ndpi_struct, NDPI_LOG_DEBUG, "found COLLECTD.\n");      
+    NDPI_LOG__TRACE(ndpi_struct, "found COLLECTD\n");
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_COLLECTD, NDPI_PROTOCOL_UNKNOWN);
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_COLLECTD, ndpi_struct, NDPI_LOG_DEBUG, "exclude COLLECTD.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_COLLECTD);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/corba.c
+++ b/src/lib/protocols/corba.c
@@ -18,10 +18,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_CORBA
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_CORBA
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_CORBA
 static void ndpi_int_corba_add_connection(struct ndpi_detection_module_struct
 					  *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -31,18 +35,17 @@ void ndpi_search_corba(struct ndpi_detection_module_struct *ndpi_struct, struct 
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_CORBA, ndpi_struct, NDPI_LOG_DEBUG, "search for CORBA.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search for CORBA\n");
   if(packet->tcp != NULL) {
-    NDPI_LOG(NDPI_PROTOCOL_CORBA, ndpi_struct, NDPI_LOG_DEBUG, "calculating CORBA over tcp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculating CORBA over tcp\n");
     /* Corba General Inter-ORB Protocol -> GIOP */
     if ((packet->payload_packet_len >= 24 && packet->payload_packet_len <= 144) &&
         memcmp(packet->payload, "GIOP", 4) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_CORBA, ndpi_struct, NDPI_LOG_DEBUG, "found corba.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found corba\n");
       ndpi_int_corba_add_connection(ndpi_struct, flow);
     }
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_CORBA, ndpi_struct, NDPI_LOG_DEBUG, "exclude CORBA.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_CORBA);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/crossfire.c
+++ b/src/lib/protocols/crossfire.c
@@ -21,10 +21,13 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-/* include files */
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_CROSSFIRE
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_CROSSFIRE
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_crossfire_add_connection(struct ndpi_detection_module_struct *ndpi_struct, 
@@ -37,21 +40,17 @@ static void ndpi_int_crossfire_add_connection(struct ndpi_detection_module_struc
 void ndpi_search_crossfire_tcp_udp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
-	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
-	NDPI_LOG(NDPI_PROTOCOL_CROSSFIRE, ndpi_struct, NDPI_LOG_DEBUG, "search crossfire.\n");
-
+	NDPI_LOG__DEBUG(ndpi_struct, "search crossfire\n");
 
 	if (packet->udp != 0) {
-		if (packet->payload_packet_len == 25 && get_u_int32_t(packet->payload, 0) == ntohl(0xc7d91999)
+		if (packet->payload_packet_len == 25
+			&& get_u_int32_t(packet->payload, 0) == ntohl(0xc7d91999)
 			&& get_u_int16_t(packet->payload, 4) == ntohs(0x0200)
-			&& get_u_int16_t(packet->payload, 22) == ntohs(0x7d00)
-			) {
-			NDPI_LOG(NDPI_PROTOCOL_CROSSFIRE, ndpi_struct, NDPI_LOG_DEBUG, "Crossfire: found udp packet.\n");
-			ndpi_int_crossfire_add_connection(ndpi_struct, flow);
-			return;
+			&& get_u_int16_t(packet->payload, 22) == ntohs(0x7d00)) {
+		    NDPI_LOG__TRACE(ndpi_struct, "found Crossfire: udp packet\n");
+		    ndpi_int_crossfire_add_connection(ndpi_struct, flow);
+		    return;
 		}
 
 	} else if (packet->tcp != 0) {
@@ -67,16 +66,15 @@ void ndpi_search_crossfire_tcp_udp(struct ndpi_detection_module_struct *ndpi_str
 					&& (memcmp(packet->host_line.ptr, "crossfire", 9) == 0
 						|| memcmp(packet->host_line.ptr, "www.crossfire", 13) == 0))
 				) {
-				NDPI_LOG(NDPI_PROTOCOL_CROSSFIRE, ndpi_struct, NDPI_LOG_DEBUG, "Crossfire: found HTTP request.\n");
-				ndpi_int_crossfire_add_connection(ndpi_struct, flow);
-				return;
+			     NDPI_LOG__DEBUG(ndpi_struct, "found Crossfire: HTTP request\n");
+			     ndpi_int_crossfire_add_connection(ndpi_struct, flow);
+			     return;
 			}
 		}
 
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_CROSSFIRE, ndpi_struct, NDPI_LOG_DEBUG, "exclude crossfire.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_CROSSFIRE);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/csgo.c
+++ b/src/lib/protocols/csgo.c
@@ -20,49 +20,51 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
-
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_CSGO
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_CSGO
+
+#include "ndpi_api.h"
 
 void ndpi_search_csgo(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow) {
   struct ndpi_packet_struct* packet = &flow->packet;
 
   if (packet->udp != NULL) {
     uint32_t w = htonl(get_u_int32_t(packet->payload, 0));
-    NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "CSGO: word %08x\n", w);
+    NDPI_LOG__DEBUG2(ndpi_struct, "CSGO: word %08x\n", w);
 
     if (!flow->csgo_state && packet->payload_packet_len == 23 && w == 0xfffffffful) {
       if (!memcmp(packet->payload + 5, "connect0x", 9)) {
-        NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo connect0x.\n");
         flow->csgo_state++;
         memcpy(flow->csgo_strid, packet->payload + 5, 18);
+        NDPI_LOG__DEBUG2(ndpi_struct, "Found csgo connect0x\n");
         return;
       }
     }
     if (flow->csgo_state == 1 && packet->payload_packet_len >= 42 && w == 0xfffffffful) {
       if (!memcmp(packet->payload + 24, flow->csgo_strid, 18)) {
-        NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo connect0x reply.\n");
         flow->csgo_state++;
         ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
+        NDPI_LOG__TRACE( ndpi_struct, "found csgo connect0x reply\n");
         return;
       }
     }
     if (packet->payload_packet_len == 8 && ( w == 0x3a180000 || w == 0x39180000) ) {
-      NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp 8b.\n");
+      NDPI_LOG__TRACE( ndpi_struct, "found csgo udp 8b\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
       return;
     }
     if (packet->payload_packet_len >= 36 && w == 0x56533031ul) {
-      NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp.\n");
+      NDPI_LOG__TRACE( ndpi_struct, "found csgo udp\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
       return;
     }
     if (packet->payload_packet_len >= 36 && w == 0x01007364) {
       uint32_t w2 = htonl(get_u_int32_t(packet->payload, 4));
       if (w2 == 0x70696e67) {
-        NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp ping.\n");
+        NDPI_LOG__TRACE( ndpi_struct, "found csgo udp ping\n");
         ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
         return;
       }
@@ -73,11 +75,11 @@ void ndpi_search_csgo(struct ndpi_detection_module_struct* ndpi_struct, struct n
         if (!flow->csgo_s2) {
           flow->csgo_id2 = w2;
           flow->csgo_s2 = 1;
-          NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp 0d1d step1.\n");
+          NDPI_LOG__DEBUG2( ndpi_struct, "Found csgo udp 0d1d step1\n");
           return;
         }
         if (flow->csgo_s2 == 1 && flow->csgo_id2 == w2) {
-          NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp 0d1d step1 DUP.\n");
+          NDPI_LOG__DEBUG2( ndpi_struct, "Found csgo udp 0d1d step1 DUP\n");
           return;
         }
         flow->csgo_s2 = 3;
@@ -85,7 +87,7 @@ void ndpi_search_csgo(struct ndpi_detection_module_struct* ndpi_struct, struct n
       }
       if (packet->payload_packet_len == 15) {
         if (flow->csgo_s2 == 1 && flow->csgo_id2 == w2) {
-          NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo udp 0d1d.\n");
+          NDPI_LOG__TRACE( ndpi_struct, "found csgo udp 0d1d\n");
           ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
           return;
         }
@@ -94,23 +96,23 @@ void ndpi_search_csgo(struct ndpi_detection_module_struct* ndpi_struct, struct n
     }
     if (packet->payload_packet_len >= 140 && (w == 0x02124c6c || w == 0x02125c6c) &&
         !memcmp(&packet->payload[3], "lta\000mob\000tpc\000bhj\000bxd\000tae\000urg\000gkh\000", 32)) {
-          NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo dictionary udp.\n");
+          NDPI_LOG__TRACE( ndpi_struct, "found csgo dictionary udp\n");
           ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
           return;
     }
     if (packet->payload_packet_len >= 33 && packet->iph && packet->iph->daddr == 0xffffffff &&
         !memcmp(&packet->payload[17], "LanSearch", 9)) {
-          NDPI_LOG(NDPI_PROTOCOL_CSGO, ndpi_struct, NDPI_LOG_DEBUG, "Found csgo LanSearch udp.\n");
+          NDPI_LOG__TRACE( ndpi_struct, "found csgo LanSearch udp\n");
           ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CSGO, NDPI_PROTOCOL_UNKNOWN);
           return;
     }
   }
   if (flow->packet_counter > 20)
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_CSGO);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
-void init_csgo_dissector(struct ndpi_detection_module_struct *ndpi_struct,
-  u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask) {
+void init_csgo_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask)
+{
     ndpi_set_bitmask_protocol_detection("CSGO", ndpi_struct, detection_bitmask, *id,
               NDPI_PROTOCOL_CSGO,
               ndpi_search_csgo,

--- a/src/lib/protocols/dcerpc.c
+++ b/src/lib/protocols/dcerpc.c
@@ -21,10 +21,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_DCERPC
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_DCERPC
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_DCERPC
 
 static void ndpi_int_dcerpc_add_connection(struct ndpi_detection_module_struct
 					     *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -36,20 +40,21 @@ void ndpi_search_dcerpc(struct ndpi_detection_module_struct *ndpi_struct, struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search DCERPC\n");
+
   if((packet->tcp != NULL)
      && (packet->payload_packet_len >= 64)
      && (packet->payload[0] == 0x05) /* version 5 */
      && (packet->payload[2] < 16) /* Packet type */
 		 && (((packet->payload[9]<<8) | packet->payload[8]) == packet->payload_packet_len) /* Packet Length */
      ) {
-    NDPI_LOG(NDPI_PROTOCOL_DCERPC, ndpi_struct, NDPI_LOG_DEBUG, "DCERPC match\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found DCERPC\n");
     ndpi_int_dcerpc_add_connection(ndpi_struct, flow);
     return;
   }
 
-	if(packet->payload_packet_len>1){
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_DCERPC);
-  }
+  if(packet->payload_packet_len>1)
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/dhcp.c
+++ b/src/lib/protocols/dhcp.c
@@ -18,10 +18,17 @@
  *
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_DHCP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_DHCP
+
+#include "ndpi_api.h"
+
+#ifdef __KERNEL__
+#undef DHCP_DEBUG
+#endif
 
 /* freeradius/src/lib/dhcp.c */
 #define DHCP_CHADDR_LEN	16
@@ -61,8 +68,7 @@ void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struct, stru
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+  NDPI_LOG__DEBUG(ndpi_struct, "search DHCP\n");
 
   /* this detection also works for asymmetric dhcp traffic */
 
@@ -87,7 +93,7 @@ void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struct, stru
 	  if(len == 0) break;
 
 #ifdef DHCP_DEBUG
-	  printf("[DHCP] Id=%d [len=%d]\n", id, len);
+	  NDPI_LOG__DEBUG2(ndpi_struct, "[DHCP] Id=%d [len=%d]\n", id, len);
 #endif
 
 	  if(id == 53 /* DHCP Message Type */) {
@@ -95,8 +101,7 @@ void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struct, stru
 
 	    if(msg_type <= 8) foundValidMsgType = 1;
 	  } else if(id == 55 /* Parameter Request List / Fingerprint */) {
-	    u_int idx, offset = 0,
-	      hex_len = ndpi_min(len * 2, sizeof(flow->protos.dhcp.fingerprint));
+	    u_int idx, offset = 0;
 
 	    for(idx=0; idx<len; idx++) {
 	      snprintf((char*)&flow->protos.dhcp.fingerprint[offset],
@@ -109,9 +114,8 @@ void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struct, stru
 	    int j = 0;
 
 #ifdef DHCP_DEBUG
-	    printf("[DHCP] ");
-	    while(j < len) { printf("%c", name[j]); j++; }
-	    printf("\n");
+	    NDPI_LOG__DEBUG2(ndpi_struct, "[DHCP] '%.*s'\n",name,len);
+//	    while(j < len) { printf( "%c", name[j]); j++; }; printf("\n");
 #endif
 	    j = ndpi_min(len, sizeof(flow->host_server_name)-1);
 	    strncpy((char*)flow->host_server_name, name, j);
@@ -125,14 +129,14 @@ void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struct, stru
       //get_u_int16_t(packet->payload, 240) == htons(0x3501)) {
 
       if(foundValidMsgType) {
-	NDPI_LOG(NDPI_PROTOCOL_DHCP, ndpi_struct, NDPI_LOG_DEBUG, "DHCP found\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found DHCP\n");
 	ndpi_int_dhcp_add_connection(ndpi_struct, flow);
       }
       return;
     }
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_DHCP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/dhcpv6.c
+++ b/src/lib/protocols/dhcpv6.c
@@ -22,12 +22,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-
-/* include files */
-
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_DHCPV6
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_DHCPV6
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_dhcpv6_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					   struct ndpi_flow_struct *flow)
@@ -40,21 +42,19 @@ void ndpi_search_dhcpv6_udp(struct ndpi_detection_module_struct *ndpi_struct, st
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//  struct ndpi_id_struct         *src=ndpi_struct->src;
-//  struct ndpi_id_struct         *dst=ndpi_struct->dst;
+	NDPI_LOG__DEBUG(ndpi_struct, "search DHCPv6\n");
 
 	if (packet->payload_packet_len >= 4 &&
 		(packet->udp->source == htons(546) || packet->udp->source == htons(547)) &&
 		(packet->udp->dest == htons(546) || packet->udp->dest == htons(547)) &&
 		packet->payload[0] >= 1 && packet->payload[0] <= 13) {
 
-		NDPI_LOG(NDPI_PROTOCOL_DHCPV6, ndpi_struct, NDPI_LOG_DEBUG, "DHCPv6 detected.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found DHCPv6\n");
 		ndpi_int_dhcpv6_add_connection(ndpi_struct, flow);
 		return;
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_DHCPV6, ndpi_struct, NDPI_LOG_DEBUG, "DHCPv6 excluded.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_DHCPV6);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/directconnect.c
+++ b/src/lib/protocols/directconnect.c
@@ -23,8 +23,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_DIRECTCONNECT
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_DIRECTCONNECT
+
+#include "ndpi_api.h"
+
 
 //#define NDPI_DEBUG_DIRECTCONNECT
 //#define NDPI_DIRECTCONNECT_PORT_DEBUG
@@ -58,9 +64,7 @@ static u_int16_t parse_binf_message(struct ndpi_detection_module_struct
       if (memcmp(&payload[i], "DCTM", 4) == 0) {
 	if (memcmp(&payload[i + 15], "ADCS", 4) == 0) {
 	  ssl_port = ntohs_ndpi_bytestream_to_number(&payload[i + 25], 5, &bytes_read);
-	  NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		   NDPI_LOG_DEBUG, "directconnect ssl port parsed %d", ssl_port);
-
+	  NDPI_LOG__DEBUG2(ndpi_struct, "DC ssl port parsed %d\n", ssl_port);
 	}
       }
     } else {
@@ -89,13 +93,11 @@ static void ndpi_int_directconnect_add_connection(struct ndpi_detection_module_s
       if (packet->tcp != NULL
 	  && flow->setup_packet_direction != packet->packet_direction && src->detected_directconnect_port == 0) {
 	src->detected_directconnect_port = packet->tcp->source;
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "directconnect tcp PORT %u for src\n", ntohs(src->detected_directconnect_port));
+	NDPI_LOG__DEBUG2(ndpi_struct, "DC tcp PORT %u for src\n", ntohs(src->detected_directconnect_port));
       }
       if (packet->udp != NULL && src->detected_directconnect_udp_port == 0) {
 	src->detected_directconnect_udp_port = packet->udp->source;
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "directconnect udp PORT %u for src\n", ntohs(src->detected_directconnect_port));
+	NDPI_LOG__DEBUG2(ndpi_struct, "DC udp PORT %u for src\n", ntohs(src->detected_directconnect_port));
 
       }
     }
@@ -113,9 +115,9 @@ static void ndpi_int_directconnect_add_connection(struct ndpi_detection_module_s
 
 	/*
 	  dst->detected_directconnect_port = packet->tcp->dest;
-	  NDPI_LOG (NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-	  NDPI_LOG_DEBUG, "directconnect tcp PORT %u for dst\n",
-	  ntohs (dst->detected_directconnect_port));
+	  NDPI_LOG__DEBUG2(ndpi_struct,
+	  	"DC tcp PORT %u for dst\n",
+		ntohs (dst->detected_directconnect_port));
 	*/
       }
     }
@@ -148,14 +150,12 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
       if (dst != NULL) {
 	dst->detected_directconnect_ssl_port =
 	  ntohs_ndpi_bytestream_to_number(&packet->payload[25], 5, &bytes_read);
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "directconnect ssl port parsed %d", ntohs(dst->detected_directconnect_ssl_port));
+	NDPI_LOG__DEBUG2(ndpi_struct, "DC ssl port parsed %d\n", ntohs(dst->detected_directconnect_ssl_port));
       }
       if (src != NULL) {
 	src->detected_directconnect_ssl_port =
 	  ntohs_ndpi_bytestream_to_number(&packet->payload[25], 5, &bytes_read);
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "directconnect ssl port parsed %d", ntohs(src->detected_directconnect_ssl_port));
+	NDPI_LOG__DEBUG2(ndpi_struct, "DC ssl port parsed %d\n", ntohs(src->detected_directconnect_ssl_port));
       }
 
 
@@ -168,15 +168,13 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
       if ((u_int32_t)
 	  (packet->tick_timestamp -
 	   src->directconnect_last_safe_access_time) < ndpi_struct->directconnect_connection_ip_tick_timeout) {
-	ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
 	src->directconnect_last_safe_access_time = packet->tick_timestamp;
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "marking using dc port\n %d", ntohs(src->detected_directconnect_port));
+	NDPI_LOG__TRACE(ndpi_struct, "found DC using port %d\n", ntohs(src->detected_directconnect_port));
+	ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
 	return;
       } else {
 	src->detected_directconnect_port = 0;
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "resetting src port due to timeout");
+	NDPI_LOG__DEBUG2(ndpi_struct, "resetting src port due to timeout\n");
 	return;
       }
     }
@@ -184,15 +182,13 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
       if ((u_int32_t)
 	  (packet->tick_timestamp -
 	   src->directconnect_last_safe_access_time) < ndpi_struct->directconnect_connection_ip_tick_timeout) {
-	ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
 	src->directconnect_last_safe_access_time = packet->tick_timestamp;
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "marking using dc port\n %d", ntohs(src->detected_directconnect_ssl_port));
+	NDPI_LOG__TRACE(ndpi_struct, "found DC using port %d\n", ntohs(src->detected_directconnect_ssl_port));
+	ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
 	return;
       } else {
 	src->detected_directconnect_ssl_port = 0;
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "resetting src port due to timeout");
+	NDPI_LOG__DEBUG2(ndpi_struct, "resetting src port due to timeout\n");
 	return;
       }
     }
@@ -204,15 +200,13 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
       if ((u_int32_t)
 	  (packet->tick_timestamp -
 	   dst->directconnect_last_safe_access_time) < ndpi_struct->directconnect_connection_ip_tick_timeout) {
-	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
 	dst->directconnect_last_safe_access_time = packet->tick_timestamp;
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "marking using dc port\n %d", ntohs(dst->detected_directconnect_port));
+	NDPI_LOG__TRACE(ndpi_struct, "found DC using port %d\n", ntohs(dst->detected_directconnect_port));
+	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
 	return;
       } else {
 	dst->detected_directconnect_port = 0;
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "resetting dst port due to timeout");
+	NDPI_LOG__DEBUG(ndpi_struct, "resetting dst port due to timeout\n");
 	return;
       }
     }
@@ -220,16 +214,13 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
       if ((u_int32_t)
 	  (packet->tick_timestamp -
 	   dst->directconnect_last_safe_access_time) < ndpi_struct->directconnect_connection_ip_tick_timeout) {
-	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
 	dst->directconnect_last_safe_access_time = packet->tick_timestamp;
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "marking using dc port\n %d", ntohs(dst->detected_directconnect_ssl_port));
-
+	NDPI_LOG__DEBUG(ndpi_struct, "found DC using port %d\n", ntohs(dst->detected_directconnect_ssl_port));
+	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
 	return;
       } else {
 	dst->detected_directconnect_ssl_port = 0;
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "resetting dst port due to timeout");
+	NDPI_LOG__DEBUG2(ndpi_struct, "resetting dst port due to timeout\n");
 	return;
       }
     }
@@ -242,8 +233,7 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
       if (packet->payload[0] == '$'
 	  && packet->payload[packet->payload_packet_len - 1] == '|'
 	  && (memcmp(&packet->payload[1], "Lock ", 5) == 0)) {
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "maybe first dc connect to hub  detected\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "maybe first dc connect to hub  detected\n");
 	flow->directconnect_stage = 1;
 	return;
       }
@@ -251,8 +241,7 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
 	  && packet->payload[0] == '$'
 	  && packet->payload[packet->payload_packet_len - 1] == '|'
 	  && (memcmp(&packet->payload[1], "MyNick ", 7) == 0)) {
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "maybe first dc connect between peers  detected\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "maybe first dc connect between peers  detected\n");
 	flow->directconnect_stage = 2;
 	return;
       }
@@ -262,15 +251,13 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
       /* did not see this pattern in any trace */
       if (memcmp(&packet->payload[0], "HSUP ADBAS0", 11) == 0
 	  || memcmp(&packet->payload[0], "HSUP ADBASE", 11) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found directconnect HSUP ADBAS0 E\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found DC HSUP ADBAS0 E\n");
 	ndpi_int_directconnect_add_connection(ndpi_struct, flow, DIRECT_CONNECT_TYPE_HUB);
 	return;
 	/* did not see this pattern in any trace */
       } else if (memcmp(&packet->payload[0], "CSUP ADBAS0", 11) == 0 ||
 		 memcmp(&packet->payload[0], "CSUP ADBASE", 11) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found directconnect CSUP ADBAS0 E\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found DC CSUP ADBAS0 E\n");
 	ndpi_int_directconnect_add_connection(ndpi_struct, flow, DIRECT_CONNECT_ADC_PEER);
 	return;
 
@@ -283,19 +270,14 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
       /* did not see this pattern in any trace */
       if (memcmp(&packet->payload[0], "HSUP ADBAS0", 11) == 0
 	  || memcmp(&packet->payload[0], "HSUP ADBASE", 11) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found directconnect HSUP ADBAS E in second packet\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found DC HSUP ADBAS E in second packet\n");
 	ndpi_int_directconnect_add_connection(ndpi_struct, flow, DIRECT_CONNECT_TYPE_HUB);
-
 	return;
 	/* did not see this pattern in any trace */
       } else if (memcmp(&packet->payload[0], "CSUP ADBAS0", 11) == 0 ||
 		 memcmp(&packet->payload[0], "CSUP ADBASE", 11) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found directconnect HSUP ADBAS0 E in second packet\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found DC HSUP ADBAS0 E in second packet\n");
 	ndpi_int_directconnect_add_connection(ndpi_struct, flow, DIRECT_CONNECT_ADC_PEER);
-
-
 	return;
 
       }
@@ -304,12 +286,11 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
     if (packet->payload_packet_len > 6) {
       if ((packet->payload[0] == '$' || packet->payload[0] == '<')
 	  && packet->payload[packet->payload_packet_len - 1] == '|') {
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct, NDPI_LOG_DEBUG, "second dc detected\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found DC second\n");
 	ndpi_int_directconnect_add_connection(ndpi_struct, flow, DIRECT_CONNECT_TYPE_HUB);
-
 	return;
       } else {
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct, NDPI_LOG_DEBUG, "second dc not detected\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "second dc not detected\n");
       }
 
     }
@@ -317,23 +298,17 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
     /* get client hello answer or server message */
     if (packet->payload_packet_len > 6) {
       if (packet->payload[0] == '$' && packet->payload[packet->payload_packet_len - 1] == '|') {
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "second dc between peers detected\n");
-
-
+	NDPI_LOG__TRACE(ndpi_struct, "found DC between peers\n");
 	ndpi_int_directconnect_add_connection(ndpi_struct, flow, DIRECT_CONNECT_TYPE_PEER);
-
 	return;
       } else {
-	NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "second dc between peers not detected\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "second dc between peers not detected\n");
       }
     }
 
   }
 
-
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_DIRECTCONNECT);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 
@@ -352,15 +327,13 @@ static void ndpi_search_directconnect_udp(struct ndpi_detection_module_struct
 	(packet->tick_timestamp -
 	 dst->directconnect_last_safe_access_time) < ndpi_struct->directconnect_connection_ip_tick_timeout) {
 
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
       dst->directconnect_last_safe_access_time = packet->tick_timestamp;
-      NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-	       NDPI_LOG_DEBUG, "marking using dc udp port\n %d", ntohs(dst->detected_directconnect_udp_port));
+      NDPI_LOG__TRACE(ndpi_struct, "found DC using udp port %d\n", ntohs(dst->detected_directconnect_udp_port));
+      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
       return;
     } else {
       dst->detected_directconnect_udp_port = 0;
-      NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-	       NDPI_LOG_DEBUG, "resetting dst udp  port due to timeout");
+      NDPI_LOG__DEBUG2(ndpi_struct, "resetting dst udp  port due to timeout\n");
       return;
     }
   }
@@ -380,20 +353,15 @@ static void ndpi_search_directconnect_udp(struct ndpi_detection_module_struct
 	  if (packet->payload[pos] == '(') {
 	    pos = pos - 44;
 	    if (pos > 2 && memcmp(&packet->payload[pos], "TTH:", 4) == 0) {
-	      NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct, NDPI_LOG_DEBUG, "dc udp detected\n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found DC udp\n");
 	      ndpi_int_directconnect_add_connection(ndpi_struct, flow, DIRECT_CONNECT_TYPE_PEER);
 	      return;
 	    }
 	  }
 	}
 	flow->directconnect_stage++;
-
-	if (flow->directconnect_stage < 3) {
-
-
+	if (flow->directconnect_stage < 3) 
 	  return;
-	}
-
       }
 
     }
@@ -411,7 +379,7 @@ static void ndpi_search_directconnect_udp(struct ndpi_detection_module_struct
 	  if (packet->payload[pos] == '(') {
 	    pos = pos - 44;
 	    if (pos > 2 && memcmp(&packet->payload[pos], "TTH:", 4) == 0) {
-	      NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct, NDPI_LOG_DEBUG, "dc udp detected\n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found DC udp\n");
 	      ndpi_int_directconnect_add_connection(ndpi_struct, flow, DIRECT_CONNECT_TYPE_PEER);
 	      return;
 	    }
@@ -420,15 +388,11 @@ static void ndpi_search_directconnect_udp(struct ndpi_detection_module_struct
 	flow->directconnect_stage++;
 	if (flow->directconnect_stage < 3)
 	  return;
-
       }
     }
 
   }
-  NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct, NDPI_LOG_DEBUG,
-	   "excluded at stage %d \n", flow->directconnect_stage);
-
-
+  NDPI_LOG__DEBUG(ndpi_struct, "excluded DC at stage %d \n", flow->directconnect_stage);
 
   NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_DIRECTCONNECT);
 
@@ -442,7 +406,7 @@ void ndpi_search_directconnect(struct ndpi_detection_module_struct
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
 
-
+  NDPI_LOG__DEBUG(ndpi_struct, "search DC\n");
 
   if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_DIRECTCONNECT) {
     if (src != NULL && ((u_int32_t)
@@ -458,8 +422,7 @@ void ndpi_search_directconnect(struct ndpi_detection_module_struct
       dst->directconnect_last_safe_access_time = packet->tick_timestamp;
     } else {
       packet->detected_protocol_stack[0] = NDPI_PROTOCOL_UNKNOWN;
-      NDPI_LOG(NDPI_PROTOCOL_DIRECTCONNECT, ndpi_struct,
-	       NDPI_LOG_DEBUG, "directconnect: skipping as unknown due to timeout\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "skipping as unknown due to timeout\n");
     }
     return;
   }

--- a/src/lib/protocols/directdownloadlink.c
+++ b/src/lib/protocols/directdownloadlink.c
@@ -23,8 +23,13 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK
+
+#include "ndpi_api.h"
 
 
 #ifdef NDPI_DEBUG_DIRECT_DOWNLOAD_LINK
@@ -52,15 +57,12 @@ static void ndpi_int_direct_download_link_add_connection(struct ndpi_detection_m
 u_int8_t search_ddl_domains(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
   u_int16_t filename_start = 0;
   u_int8_t i = 1;
   u_int16_t host_line_len_without_port;
 
   if (packet->payload_packet_len < 100) {
-    NDPI_LOG(NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, ndpi_struct, NDPI_LOG_DEBUG, "DDL: Packet too small.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "DDL: Packet too small\n");
     goto end_ddl_nothing_found;
   }
 
@@ -68,10 +70,10 @@ u_int8_t search_ddl_domains(struct ndpi_detection_module_struct *ndpi_struct, st
 
   if (memcmp(packet->payload, "POST ", 5) == 0) {
     filename_start = 5;		// POST
-    NDPI_LOG(NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, ndpi_struct, NDPI_LOG_DEBUG, "DDL: POST FOUND\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "DDL: POST FOUND\n");
   } else if (memcmp(packet->payload, "GET ", 4) == 0) {
     filename_start = 4;		// GET
-    NDPI_LOG(NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, ndpi_struct, NDPI_LOG_DEBUG, "DDL: GET FOUND\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "DDL: GET FOUND\n");
   } else {
     goto end_ddl_nothing_found;
   }
@@ -79,16 +81,15 @@ u_int8_t search_ddl_domains(struct ndpi_detection_module_struct *ndpi_struct, st
   ndpi_parse_packet_line_info(ndpi_struct, flow);
 
   if (packet->host_line.ptr == NULL) {
-    NDPI_LOG(NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, ndpi_struct, NDPI_LOG_DEBUG, "DDL: NO HOST FOUND\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "DDL: NO HOST FOUND\n");
     goto end_ddl_nothing_found;
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, ndpi_struct, NDPI_LOG_DEBUG, "DDL: Host: found\n");
+  NDPI_LOG__DEBUG2(ndpi_struct, "DDL: Host: found\n");
 
   if (packet->line[0].len < 9 + filename_start
       || memcmp(&packet->line[0].ptr[packet->line[0].len - 9], " HTTP/1.", 8) != 0) {
-    NDPI_LOG(NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, ndpi_struct,
-	     NDPI_LOG_DEBUG, "DDL: PACKET NOT HTTP CONFORM.\nXXX%.*sXXX\n",
+    NDPI_LOG__DEBUG2(ndpi_struct, "DDL: PACKET NOT HTTP CONFORM.\nXXX%.*sXXX\n",
 	     8, &packet->line[0].ptr[packet->line[0].len - 9]);
     goto end_ddl_nothing_found;
   }
@@ -100,11 +101,11 @@ u_int8_t search_ddl_domains(struct ndpi_detection_module_struct *ndpi_struct, st
     i = 2;
     while (host_line_len_without_port >= i && packet->host_line.ptr[host_line_len_without_port - i] >= '0'
 	   && packet->host_line.ptr[host_line_len_without_port - i] <= '9') {
-      NDPI_LOG(NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, ndpi_struct, NDPI_LOG_DEBUG, "DDL: number found\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "DDL: number found\n");
       i++;
     }
     if (host_line_len_without_port >= i && packet->host_line.ptr[host_line_len_without_port - i] == ':') {
-      NDPI_LOG(NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, ndpi_struct, NDPI_LOG_DEBUG, "DDL: ':' found\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "DDL: ':' found\n");
       host_line_len_without_port = host_line_len_without_port - i;
     }
   }
@@ -694,12 +695,12 @@ u_int8_t search_ddl_domains(struct ndpi_detection_module_struct *ndpi_struct, st
   */
 
  end_ddl_nothing_found:
-  NDPI_LOG(NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, ndpi_struct, NDPI_LOG_DEBUG,
+  NDPI_LOG__DEBUG2(ndpi_struct,
 	   "Nothing Found\n");
   return 0;
 
  end_ddl_found:
-  NDPI_LOG(NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, ndpi_struct, NDPI_LOG_DEBUG, "DDL: DIRECT DOWNLOAD LINK FOUND\n");
+  NDPI_LOG__TRACE(ndpi_struct, "found DIRECT DOWNLOAD LINK\n");
   ndpi_int_direct_download_link_add_connection(ndpi_struct, flow);
   return 1;
 }
@@ -709,15 +710,12 @@ void ndpi_search_direct_download_link_tcp(struct ndpi_detection_module_struct *n
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  /* struct ndpi_id_struct         *src=ndpi_struct->src; */
-  /* struct ndpi_id_struct         *dst=ndpi_struct->dst; */
-
   /* do not detect again if it is already ddl */
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK) {
     if (search_ddl_domains(ndpi_struct, flow) != 0) {
       return;
     }
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 
 }

--- a/src/lib/protocols/dofus.c
+++ b/src/lib/protocols/dofus.c
@@ -22,76 +22,68 @@
  *
  */
 
-
-
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_DOFUS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_DOFUS
+
+#include "ndpi_api.h"
 
 static void ndpi_dofus_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DOFUS, NDPI_PROTOCOL_UNKNOWN);
+  NDPI_LOG__TRACE(ndpi_struct, "found dofus\n");
 }
 
 void ndpi_search_dofus(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;       
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+  struct ndpi_packet_struct *packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search dofus\n");
 
   /* Dofus v 1.x.x */
   if (packet->payload_packet_len == 13 && get_u_int16_t(packet->payload, 1) == ntohs(0x0508)
       && get_u_int16_t(packet->payload, 5) == ntohs(0x04a0)
       && get_u_int16_t(packet->payload, packet->payload_packet_len - 2) == ntohs(0x0194)) {
-    NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "found dofus.\n");
     ndpi_dofus_add_connection(ndpi_struct, flow);
     return;
   }
-  if (flow->l4.tcp.dofus_stage == 0 && packet->payload_packet_len == 3 && memcmp(packet->payload, "HG", 2) == 0
-      && packet->payload[packet->payload_packet_len - 1] == 0) {
-    flow->l4.tcp.dofus_stage = 1;
-    NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "maybe dofus.\n");
-    return;
+  if (flow->l4.tcp.dofus_stage == 0) {
+    if (packet->payload_packet_len == 3 && memcmp(packet->payload, "HG", 2) == 0
+        && packet->payload[packet->payload_packet_len - 1] == 0)
+      goto maybe_dofus;
+
+    if (packet->payload_packet_len == 12 && memcmp(packet->payload, "Af", 2) == 0
+        && packet->payload[packet->payload_packet_len - 1] == 0)
+      goto maybe_dofus;
+
+    if (packet->payload_packet_len == 35 && memcmp(packet->payload, "HC", 2) == 0
+        && packet->payload[packet->payload_packet_len - 1] == 0)
+      goto maybe_dofus;
+
+    if (packet->payload_packet_len > 2 && packet->payload[0] == 'A'
+        && (packet->payload[1] == 'x' || packet->payload[1] == 'X')
+        && packet->payload[packet->payload_packet_len - 1] == 0) 
+      goto maybe_dofus;
+
+    if (packet->payload_packet_len > 2 && memcmp(packet->payload, "Ad", 2)
+        && packet->payload[packet->payload_packet_len - 1] == 0)
+      goto maybe_dofus;
+
   }
-  if (flow->l4.tcp.dofus_stage == 0 && packet->payload_packet_len == 35 && memcmp(packet->payload, "HC", 2) == 0
-      && packet->payload[packet->payload_packet_len - 1] == 0) {
-    flow->l4.tcp.dofus_stage = 1;
-    NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "maybe dofus.\n");
-    return;
-  }
-  if (flow->l4.tcp.dofus_stage == 0 && packet->payload_packet_len > 2 && packet->payload[0] == 'A'
-      && (packet->payload[1] == 'x' || packet->payload[1] == 'X')
-      && packet->payload[packet->payload_packet_len - 1] == 0) {
-    flow->l4.tcp.dofus_stage = 1;
-    NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "maybe dofus.\n");
-    return;
-  }
-  if (flow->l4.tcp.dofus_stage == 0 && packet->payload_packet_len == 12 && memcmp(packet->payload, "Af", 2) == 0
-      && packet->payload[packet->payload_packet_len - 1] == 0) {
-    flow->l4.tcp.dofus_stage = 1;
-    NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "maybe dofus.\n");
-    return;
-  }
-  if (flow->l4.tcp.dofus_stage == 0 && packet->payload_packet_len > 2 && memcmp(packet->payload, "Ad", 2)
-      && packet->payload[packet->payload_packet_len - 1] == 0) {
-    flow->l4.tcp.dofus_stage = 1;
-    NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "maybe dofus.\n");
-    return;
-  }
-  if (packet->payload_packet_len == 11 && memcmp(packet->payload, "AT", 2) == 0 && packet->payload[10] == 0x00) {
-    if (flow->l4.tcp.dofus_stage == 1) {
-      NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "found dofus.\n");
+  if (flow->l4.tcp.dofus_stage == 1) {
+    if (packet->payload_packet_len == 11 && memcmp(packet->payload, "AT", 2) == 0
+	&& packet->payload[10] == 0x00) {
       ndpi_dofus_add_connection(ndpi_struct, flow);
       return;
     }
-  }
-  if (flow->l4.tcp.dofus_stage == 1 && packet->payload_packet_len == 5
-      && packet->payload[0] == 'A' && packet->payload[4] == 0x00 && (packet->payload[1] == 'T'
-								     || packet->payload[1] == 'k')) {
-    NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "found dofus asym.\n");
-    ndpi_dofus_add_connection(ndpi_struct, flow);
-    return;
+    if (packet->payload_packet_len == 5
+        && packet->payload[0] == 'A' && packet->payload[4] == 0x00 
+	&& (packet->payload[1] == 'T' || packet->payload[1] == 'k')) {
+      ndpi_dofus_add_connection(ndpi_struct, flow);
+      return;
+    }
   }
   /* end Dofus 1.x.x */
 
@@ -109,7 +101,6 @@ void ndpi_search_dofus(struct ndpi_detection_module_struct *ndpi_struct, struct 
     if (packet->payload_packet_len == 49 && ntohs(get_u_int16_t(packet->payload, 15)) + 17 != packet->payload_packet_len) {
       goto exclude;
     }
-    NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "found dofus.\n");
     ndpi_dofus_add_connection(ndpi_struct, flow);
     return;
   }
@@ -120,7 +111,6 @@ void ndpi_search_dofus(struct ndpi_detection_module_struct *ndpi_struct, struct 
       goto exclude;
     len2 = ntohs(get_u_int16_t(packet->payload, 5 + len));
     if (5 + len + 2 + len2 == packet->payload_packet_len) {
-      NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "found dofus.\n");
       ndpi_dofus_add_connection(ndpi_struct, flow);
       return;
     }
@@ -135,16 +125,20 @@ void ndpi_search_dofus(struct ndpi_detection_module_struct *ndpi_struct, struct 
     if ((12 + len + 2 + len2 + 1) > packet->payload_packet_len)
       goto exclude;
     if (12 + len + 2 + len2 + 1 == packet->payload_packet_len && packet->payload[12 + len + 2 + len2] == 0x01) {
-      NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "found dofus.\n");
       ndpi_dofus_add_connection(ndpi_struct, flow);
       return;
     }
   }
- exclude:
-  NDPI_LOG(NDPI_PROTOCOL_DOFUS, ndpi_struct, NDPI_LOG_DEBUG, "exclude dofus.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_DOFUS);
-}
+exclude:
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  return;
 
+maybe_dofus:
+  flow->l4.tcp.dofus_stage = 1;
+  NDPI_LOG__DEBUG2(ndpi_struct, "maybe dofus\n");
+  return;
+
+}
 
 void init_dofus_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask)
 {

--- a/src/lib/protocols/drda.c
+++ b/src/lib/protocols/drda.c
@@ -17,9 +17,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_DRDA
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_DRDA
+
+#include "ndpi_api.h"
 
 struct ndpi_drda_hdr {
   u_int16_t length;
@@ -37,6 +41,8 @@ void ndpi_search_drda(struct ndpi_detection_module_struct *ndpi_struct,
   struct ndpi_packet_struct * packet = &flow->packet;
   u_int16_t payload_len = packet->payload_packet_len;
   u_int count = 0; // prevent integer overflow
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search DRDA\n");
   
   if(packet->tcp != NULL) {
 
@@ -71,15 +77,14 @@ void ndpi_search_drda(struct ndpi_detection_module_struct *ndpi_struct,
 	}
 	if(count != payload_len) goto no_drda;
       }
-      NDPI_LOG(NDPI_PROTOCOL_DRDA, ndpi_struct, NDPI_LOG_DEBUG, "found DRDA.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found DRDA\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DRDA, NDPI_PROTOCOL_UNKNOWN);
       return;
     }
   }
 
  no_drda:
-  NDPI_LOG(NDPI_PROTOCOL_DRDA, ndpi_struct, NDPI_LOG_DEBUG, "exclude DRDA.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_DRDA);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/dropbox.c
+++ b/src/lib/protocols/dropbox.c
@@ -21,10 +21,14 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_DROPBOX
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_DROPBOX
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_DROPBOX
 
 #define DB_LSP_PORT 17500
 
@@ -51,7 +55,7 @@ static void ndpi_check_dropbox(struct ndpi_detection_module_struct *ndpi_struct,
       if(payload_len > 2) {
 	if(strncmp((const char *)packet->payload, "{\"host_int\"", 11) == 0) {
 	  
-	  NDPI_LOG(NDPI_PROTOCOL_DROPBOX, ndpi_struct, NDPI_LOG_DEBUG, "Found dropbox.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found dropbox\n");
 	  ndpi_int_dropbox_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
@@ -59,15 +63,14 @@ static void ndpi_check_dropbox(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
   
-  NDPI_LOG(NDPI_PROTOCOL_DROPBOX, ndpi_struct, NDPI_LOG_DEBUG, "exclude dropbox.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_DROPBOX);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void ndpi_search_dropbox(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_DROPBOX, ndpi_struct, NDPI_LOG_DEBUG, "dropbox detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search dropbox\n");
 
   /* skip marked packets */
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_DROPBOX) {

--- a/src/lib/protocols/eaq.c
+++ b/src/lib/protocols/eaq.c
@@ -24,12 +24,18 @@
 
   http://www.brasilbandalarga.com.br
  */
+
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_EAQ
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_EAQ
+
 #include "ndpi_api.h"
 
 #define EAQ_DEFAULT_PORT   6000
 #define EAQ_DEFAULT_SIZE     16
 
-#ifdef NDPI_PROTOCOL_EAQ
 static void ndpi_int_eaq_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					struct ndpi_flow_struct *flow) {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_EAQ, NDPI_PROTOCOL_UNKNOWN);
@@ -40,33 +46,34 @@ void ndpi_search_eaq(struct ndpi_detection_module_struct *ndpi_struct, struct nd
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int16_t sport = ntohs(packet->udp->source), dport = ntohs(packet->udp->dest);
   
-  if((packet->payload_packet_len != EAQ_DEFAULT_SIZE)
-     || ((sport != EAQ_DEFAULT_PORT) && (dport != EAQ_DEFAULT_PORT))) {
-  exclude_eaq:
-    NDPI_LOG(NDPI_PROTOCOL_EAQ, ndpi_struct, NDPI_LOG_DEBUG, "Exclude eaq.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_EAQ);
-    return;
-  }
+  NDPI_LOG__DEBUG(ndpi_struct, "search eaq\n");
 
-  if(packet->udp != NULL) {
-    u_int32_t seq = (packet->payload[0] * 1000) + (packet->payload[1] * 100) + (packet->payload[2] * 10) + packet->payload[3];
-    
-    if(flow->l4.udp.eaq_pkt_id == 0)
-      flow->l4.udp.eaq_sequence = seq;
-    else {
-      if((flow->l4.udp.eaq_sequence == seq) || ((flow->l4.udp.eaq_sequence+1) == seq)) {
-	; /* Looks good */
-      } else
-	goto exclude_eaq;
-    }
+  do {
+    if( (packet->payload_packet_len != EAQ_DEFAULT_SIZE) ||
+        ((sport != EAQ_DEFAULT_PORT) && (dport != EAQ_DEFAULT_PORT)) )
+	    break;
+      
+    if(packet->udp != NULL) {
+      u_int32_t seq = (packet->payload[0] * 1000) + (packet->payload[1] * 100) + (packet->payload[2] * 10) + packet->payload[3];
+      
+      if(flow->l4.udp.eaq_pkt_id == 0)
+        flow->l4.udp.eaq_sequence = seq;
+      else {
+        if( (flow->l4.udp.eaq_sequence != seq) &&
+	    ((flow->l4.udp.eaq_sequence+1) != seq)) break;
+      }
 
-    if(++flow->l4.udp.eaq_pkt_id == 4) {
-      /* We have collected enough packets so we assume it's EAQ */
-      NDPI_LOG(NDPI_PROTOCOL_EAQ, ndpi_struct, NDPI_LOG_DEBUG, "found eaq.\n");
-      ndpi_int_eaq_add_connection(ndpi_struct, flow);
+      if(++flow->l4.udp.eaq_pkt_id == 4) {
+        /* We have collected enough packets so we assume it's EAQ */
+        NDPI_LOG__TRACE(ndpi_struct, "found eaq\n");
+        ndpi_int_eaq_add_connection(ndpi_struct, flow);
+        return;
+      }
     }
-  } else
-    goto exclude_eaq;
+  } while(0);
+
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+
 }
 
 

--- a/src/lib/protocols/edonkey.c
+++ b/src/lib/protocols/edonkey.c
@@ -23,10 +23,15 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_EDONKEY
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_EDONKEY
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_EDONKEY
+
 static void ndpi_int_edonkey_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_EDONKEY, NDPI_PROTOCOL_UNKNOWN);
 }
@@ -159,24 +164,23 @@ static void ndpi_check_edonkey(struct ndpi_detection_module_struct *ndpi_struct,
 
   /* Break after 20 packets. */
   if (flow->packet_counter > 20) {
-    NDPI_LOG(NDPI_PROTOCOL_EDONKEY, ndpi_struct, NDPI_LOG_DEBUG, "Exclude EDONKEY.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_EDONKEY);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
   /* Check if we so far detected the protocol in the request or not. */
   if (flow->edonkey_stage == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_EDONKEY, ndpi_struct, NDPI_LOG_DEBUG, "EDONKEY stage 0: \n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "EDONKEY stage 0: \n");
 
     if (ndpi_edonkey_payload_check(packet->payload, payload_len)) {
-      NDPI_LOG(NDPI_PROTOCOL_EDONKEY, ndpi_struct, NDPI_LOG_DEBUG, "Possible EDONKEY request detected, we will look further for the response...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "Possible EDONKEY request detected, we will look further for the response\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
       flow->edonkey_stage = packet->packet_direction + 1;
     }
 
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_EDONKEY, ndpi_struct, NDPI_LOG_DEBUG, "EDONKEY stage %u: \n", flow->edonkey_stage);
+    NDPI_LOG__DEBUG2(ndpi_struct, "EDONKEY stage %u: \n", flow->edonkey_stage);
 
     /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
     if ((flow->edonkey_stage - packet->packet_direction) == 1) {
@@ -185,10 +189,10 @@ static void ndpi_check_edonkey(struct ndpi_detection_module_struct *ndpi_struct,
 
     /* This is a packet in another direction. Check if we find the proper response. */
     if ((payload_len == 0) || (ndpi_edonkey_payload_check(packet->payload, payload_len))) {
-      NDPI_LOG(NDPI_PROTOCOL_EDONKEY, ndpi_struct, NDPI_LOG_DEBUG, "Found EDONKEY.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found EDONKEY\n");
       ndpi_int_edonkey_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_EDONKEY, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to EDONKEY, resetting the stage to 0...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to EDONKEY, resetting the stage to 0\n");
       flow->edonkey_stage = 0;
     }
 
@@ -198,7 +202,7 @@ static void ndpi_check_edonkey(struct ndpi_detection_module_struct *ndpi_struct,
 void ndpi_search_edonkey(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_EDONKEY, ndpi_struct, NDPI_LOG_DEBUG, "EDONKEY detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search EDONKEY\n");
 
   /* skip marked packets */
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_EDONKEY) {

--- a/src/lib/protocols/fasttrack.c
+++ b/src/lib/protocols/fasttrack.c
@@ -22,11 +22,13 @@
  *
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_FASTTRACK
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_FASTTRACK
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_fasttrack_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -39,13 +41,12 @@ void ndpi_search_fasttrack_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+	NDPI_LOG__DEBUG(ndpi_struct, "search FASTTRACK\n");
 
 	if ( (packet->payload != NULL)
 	     && (packet->payload_packet_len > 6)
 	     && (ntohs(get_u_int16_t(packet->payload, packet->payload_packet_len - 2)) == 0x0d0a)) {
-		NDPI_LOG(NDPI_PROTOCOL_FASTTRACK, ndpi_struct, NDPI_LOG_TRACE, "detected 0d0a at the end of the packet.\n");
+		NDPI_LOG__DEBUG2(ndpi_struct, "detected 0d0a at the end of the packet\n");
 
 		if (memcmp(packet->payload, "GIVE ", 5) == 0 && packet->payload_packet_len >= 8) {
 			u_int16_t i;
@@ -56,20 +57,20 @@ void ndpi_search_fasttrack_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 				}
 			}
 
-			NDPI_LOG(NDPI_PROTOCOL_FASTTRACK, ndpi_struct, NDPI_LOG_TRACE, "FASTTRACK GIVE DETECTED\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found FASTTRACK\n");
 			ndpi_int_fasttrack_add_connection(ndpi_struct, flow);
 			return;
 		}
 
 		if (packet->payload_packet_len > 50 && memcmp(packet->payload, "GET /", 5) == 0) {
 			u_int8_t a = 0;
-			NDPI_LOG(NDPI_PROTOCOL_FASTTRACK, ndpi_struct, NDPI_LOG_TRACE, "detected GET /. \n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "detected GET /. \n");
 			ndpi_parse_packet_line_info(ndpi_struct, flow);
 			for (a = 0; a < packet->parsed_lines; a++) {
 				if ((packet->line[a].len > 17 && memcmp(packet->line[a].ptr, "X-Kazaa-Username: ", 18) == 0)
 					|| (packet->line[a].len > 23 && memcmp(packet->line[a].ptr, "User-Agent: PeerEnabler/", 24) == 0)) {
-					NDPI_LOG(NDPI_PROTOCOL_FASTTRACK, ndpi_struct, NDPI_LOG_TRACE,
-							"detected X-Kazaa-Username: || User-Agent: PeerEnabler/\n");
+					NDPI_LOG__TRACE(ndpi_struct,
+							"found FASTTRACK X-Kazaa-Username: || User-Agent: PeerEnabler/\n");
 					ndpi_int_fasttrack_add_connection(ndpi_struct, flow);
 					return;
 				}
@@ -78,8 +79,7 @@ void ndpi_search_fasttrack_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	}
 
   exclude_fasttrack:
-	NDPI_LOG(NDPI_PROTOCOL_FASTTRACK, ndpi_struct, NDPI_LOG_TRACE, "fasttrack/kazaa excluded.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_FASTTRACK);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/fiesta.c
+++ b/src/lib/protocols/fiesta.c
@@ -22,9 +22,13 @@
  *
  */
 
-/* include files */
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_FIESTA
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_FIESTA
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_fiesta_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -35,18 +39,15 @@ static void ndpi_int_fiesta_add_connection(struct ndpi_detection_module_struct *
 void ndpi_search_fiesta(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
-	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
-	NDPI_LOG(NDPI_PROTOCOL_FIESTA, ndpi_struct, NDPI_LOG_DEBUG, "search fiesta.\n");
+	NDPI_LOG__DEBUG(ndpi_struct, "search fiesta\n");
 
 	if (flow->l4.tcp.fiesta_stage == 0 && packet->payload_packet_len == 5
 		&& get_u_int16_t(packet->payload, 0) == ntohs(0x0407)
 		&& (packet->payload[2] == 0x08)
 		&& (packet->payload[4] == 0x00 || packet->payload[4] == 0x01)) {
 
-		NDPI_LOG(NDPI_PROTOCOL_FIESTA, ndpi_struct, NDPI_LOG_DEBUG, "maybe fiesta symmetric, first packet.\n");
+		NDPI_LOG__DEBUG2(ndpi_struct, "maybe fiesta symmetric, first packet\n");
 		flow->l4.tcp.fiesta_stage = 1 + packet->packet_direction;
 		goto maybe_fiesta;
 	}
@@ -54,7 +55,7 @@ void ndpi_search_fiesta(struct ndpi_detection_module_struct *ndpi_struct, struct
 		&& ((packet->payload_packet_len > 1 && packet->payload_packet_len - 1 == packet->payload[0])
 			|| (packet->payload_packet_len > 3 && packet->payload[0] == 0
 				&& get_l16(packet->payload, 1) == packet->payload_packet_len - 3))) {
-		NDPI_LOG(NDPI_PROTOCOL_FIESTA, ndpi_struct, NDPI_LOG_DEBUG, "Maybe fiesta.\n");
+		NDPI_LOG__DEBUG2(ndpi_struct, "Maybe fiesta\n");
 		goto maybe_fiesta;
 	}
 	if (flow->l4.tcp.fiesta_stage == (1 + packet->packet_direction)) {
@@ -79,16 +80,15 @@ void ndpi_search_fiesta(struct ndpi_detection_module_struct *ndpi_struct, struct
 		}
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_FIESTA, ndpi_struct, NDPI_LOG_DEBUG, "exclude fiesta.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_FIESTA);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 	return;
 
   maybe_fiesta:
-	NDPI_LOG(NDPI_PROTOCOL_FIESTA, ndpi_struct, NDPI_LOG_DEBUG, "Stage is set to %d.\n", flow->l4.tcp.fiesta_stage);
+	NDPI_LOG__DEBUG2(ndpi_struct, "Stage is set to %d\n", flow->l4.tcp.fiesta_stage);
 	return;
 
   add_fiesta:
-	NDPI_LOG(NDPI_PROTOCOL_FIESTA, ndpi_struct, NDPI_LOG_DEBUG, "detected fiesta.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found fiesta\n");
 	ndpi_int_fiesta_add_connection(ndpi_struct, flow);
 	return;
 }

--- a/src/lib/protocols/filetopia.c
+++ b/src/lib/protocols/filetopia.c
@@ -22,9 +22,13 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_FILETOPIA
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_FILETOPIA
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_filetopia_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -36,14 +40,13 @@ void ndpi_search_filetopia_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+	NDPI_LOG__DEBUG(ndpi_struct, "search Filetopia\n");
 
 	if (flow->l4.tcp.filetopia_stage == 0) {
 		if (packet->payload_packet_len >= 50 && packet->payload_packet_len <= 70
 			&& packet->payload[0] == 0x03 && packet->payload[1] == 0x9a
 			&& packet->payload[3] == 0x22 && packet->payload[packet->payload_packet_len - 1] == 0x2b) {
-			NDPI_LOG(NDPI_PROTOCOL_FILETOPIA, ndpi_struct, NDPI_LOG_DEBUG, "Filetopia stage 1 detected\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Filetopia stage 1 detected\n");
 			flow->l4.tcp.filetopia_stage = 1;
 			return;
 		}
@@ -59,7 +62,7 @@ void ndpi_search_filetopia_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 				}
 			}
 
-			NDPI_LOG(NDPI_PROTOCOL_FILETOPIA, ndpi_struct, NDPI_LOG_DEBUG, "Filetopia stage 2 detected\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Filetopia stage 2 detected\n");
 			flow->l4.tcp.filetopia_stage = 2;
 			return;
 		}
@@ -69,7 +72,7 @@ void ndpi_search_filetopia_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 		if (packet->payload_packet_len >= 4 && packet->payload_packet_len <= 100
 			&& packet->payload[0] == 0x03 && packet->payload[1] == 0x9a
 			&& (packet->payload[3] == 0x22 || packet->payload[3] == 0x23)) {
-			NDPI_LOG(NDPI_PROTOCOL_FILETOPIA, ndpi_struct, NDPI_LOG_DEBUG, "Filetopia detected\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found Filetopia\n");
 			ndpi_int_filetopia_add_connection(ndpi_struct, flow);
 			return;
 		}
@@ -77,7 +80,7 @@ void ndpi_search_filetopia_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	}
 
   end_filetopia_nothing_found:
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_FILETOPIA);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/fix.c
+++ b/src/lib/protocols/fix.c
@@ -20,14 +20,21 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_protocols.h"
+
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_FIX
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_FIX
+
+#include "ndpi_api.h"
+
 
 void ndpi_search_fix(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search FIX\n");
   if(packet->tcp) {
     // 8=
     if(packet->payload[0] == 0x38 && packet->payload[1] == 0x3d) {
@@ -37,7 +44,7 @@ void ndpi_search_fix(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	 packet->payload[4] == 0x58 &&
 	 packet->payload[5] == 0x2e) {
 	
-	NDPI_LOG(NDPI_PROTOCOL_FIX, ndpi_struct, NDPI_LOG_DEBUG, "FIX detected.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found FIX\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_FIX, NDPI_PROTOCOL_UNKNOWN);
 	return;
       }
@@ -47,14 +54,14 @@ void ndpi_search_fix(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	 packet->payload[4] == 0x39 &&
 	 packet->payload[5] == 0x3d) {
 
-	NDPI_LOG(NDPI_PROTOCOL_FIX, ndpi_struct, NDPI_LOG_DEBUG, "FIX detected.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found FIX\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_FIX, NDPI_PROTOCOL_UNKNOWN);
 	return;
       }
     }
   }
-  /* exclude FIX */
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_FIX);
+
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/florensia.c
+++ b/src/lib/protocols/florensia.c
@@ -22,10 +22,13 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_FLORENSIA
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_FLORENSIA
+
+#include "ndpi_api.h"
 
 
 static void ndpi_florensia_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -37,44 +40,40 @@ void ndpi_search_florensia(struct ndpi_detection_module_struct *ndpi_struct, str
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-
-	NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "search florensia.\n");
+	NDPI_LOG__DEBUG(ndpi_struct, "search florensia\n");
 
 	if (packet->tcp != NULL) {
 		if (packet->payload_packet_len == 5 && get_l16(packet->payload, 0) == packet->payload_packet_len
 			&& packet->payload[2] == 0x65 && packet->payload[4] == 0xff) {
 			if (flow->florensia_stage == 1) {
-				NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "found florensia.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found florensia\n");
 				ndpi_florensia_add_connection(ndpi_struct, flow);
 				return;
 			}
-			NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "maybe florensia -> stage is set to 1.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "maybe florensia -> stage is set to 1\n");
 			flow->florensia_stage = 1;
 			return;
 		}
 		if (packet->payload_packet_len > 8 && get_l16(packet->payload, 0) == packet->payload_packet_len
 			&& get_u_int16_t(packet->payload, 2) == htons(0x0201) && get_u_int32_t(packet->payload, 4) == htonl(0xFFFFFFFF)) {
-			NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "maybe florensia -> stage is set to 1.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "maybe florensia -> stage is set to 1\n");
 			flow->florensia_stage = 1;
 			return;
 		}
 		if (packet->payload_packet_len == 406 && get_l16(packet->payload, 0) == packet->payload_packet_len
 			&& packet->payload[2] == 0x63) {
-			NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "maybe florensia -> stage is set to 1.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "maybe florensia -> stage is set to 1\n");
 			flow->florensia_stage = 1;
 			return;
 		}
 		if (packet->payload_packet_len == 12 && get_l16(packet->payload, 0) == packet->payload_packet_len
 			&& get_u_int16_t(packet->payload, 2) == htons(0x0301)) {
 			if (flow->florensia_stage == 1) {
-				NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "found florensia.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found florensia\n");
 				ndpi_florensia_add_connection(ndpi_struct, flow);
 				return;
 			}
-			NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "maybe florensia -> stage is set to 1.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "maybe florensia -> stage is set to 1\n");
 			flow->florensia_stage = 1;
 			return;
 		}
@@ -82,19 +81,19 @@ void ndpi_search_florensia(struct ndpi_detection_module_struct *ndpi_struct, str
 		if (flow->florensia_stage == 1) {
 			if (packet->payload_packet_len == 8 && get_l16(packet->payload, 0) == packet->payload_packet_len
 				&& get_u_int16_t(packet->payload, 2) == htons(0x0302) && get_u_int32_t(packet->payload, 4) == htonl(0xFFFFFFFF)) {
-				NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "found florensia asymmetrically.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found florensia asymmetrically\n");
 				ndpi_florensia_add_connection(ndpi_struct, flow);
 				return;
 			}
 			if (packet->payload_packet_len == 24 && get_l16(packet->payload, 0) == packet->payload_packet_len
 				&& get_u_int16_t(packet->payload, 2) == htons(0x0202)
 				&& get_u_int32_t(packet->payload, packet->payload_packet_len - 4) == htonl(0xFFFFFFFF)) {
-				NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "found florensia.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found florensia\n");
 				ndpi_florensia_add_connection(ndpi_struct, flow);
 				return;
 			}
 			if (flow->packet_counter < 10 && get_l16(packet->payload, 0) == packet->payload_packet_len) {
-				NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "maybe florensia.\n");
+				NDPI_LOG__DEBUG2(ndpi_struct, "maybe florensia\n");
 				return;
 			}
 		}
@@ -103,20 +102,19 @@ void ndpi_search_florensia(struct ndpi_detection_module_struct *ndpi_struct, str
 	if (packet->udp != NULL) {
 		if (flow->florensia_stage == 0 && packet->payload_packet_len == 6
 			&& get_u_int16_t(packet->payload, 0) == ntohs(0x0503) && get_u_int32_t(packet->payload, 2) == htonl(0xFFFF0000)) {
-			NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "maybe florensia -> stage is set to 1.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "maybe florensia -> stage is set to 1\n");
 			flow->florensia_stage = 1;
 			return;
 		}
 		if (flow->florensia_stage == 1 && packet->payload_packet_len == 8
 			&& get_u_int16_t(packet->payload, 0) == ntohs(0x0500) && get_u_int16_t(packet->payload, 4) == htons(0x4191)) {
-			NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "found florensia.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found florensia\n");
 			ndpi_florensia_add_connection(ndpi_struct, flow);
 			return;
 		}
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_FLORENSIA, ndpi_struct, NDPI_LOG_DEBUG, "exclude florensia.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_FLORENSIA);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/ftp_control.c
+++ b/src/lib/protocols/ftp_control.c
@@ -21,10 +21,14 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_FTP_CONTROL
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_FTP_CONTROL
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_FTP_CONTROL
 
 static void ndpi_int_ftp_control_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_FTP_CONTROL, NDPI_PROTOCOL_UNKNOWN);
@@ -944,31 +948,29 @@ static void ndpi_check_ftp_control(struct ndpi_detection_module_struct *ndpi_str
   
     /* Exclude SMTP, which uses similar commands. */
     if (packet->tcp->dest == htons(25) || packet->tcp->source == htons(25)) {
-      NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "Exclude FTP_CONTROL.\n");
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_FTP_CONTROL);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
       return;
     }
   
     /* Break after 20 packets. */
     if (flow->packet_counter > 20) {
-      NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "Exclude FTP_CONTROL.\n");
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_FTP_CONTROL);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
       return;
     }
   
     /* Check if we so far detected the protocol in the request or not. */
     if (flow->ftp_control_stage == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "FTP_CONTROL stage 0: \n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "FTP_CONTROL stage 0: \n");
      
       if ((payload_len > 0) && ndpi_ftp_control_check_request(packet->payload, payload_len)) {
-	NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "Possible FTP_CONTROL request detected, we will look further for the response...\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "Possible FTP_CONTROL request detected, we will look further for the response..\n");
        
 	/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
 	flow->ftp_control_stage = packet->packet_direction + 1;
       }
      
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "FTP_CONTROL stage %u: \n", flow->ftp_control_stage);
+      NDPI_LOG__DEBUG2(ndpi_struct, "FTP_CONTROL stage %u: \n", flow->ftp_control_stage);
     
       /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
       if ((flow->ftp_control_stage - packet->packet_direction) == 1) {
@@ -977,10 +979,10 @@ static void ndpi_check_ftp_control(struct ndpi_detection_module_struct *ndpi_str
     
       /* This is a packet in another direction. Check if we find the proper response. */
       if ((payload_len > 0) && ndpi_ftp_control_check_response(packet->payload, payload_len)) {
-	NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "Found FTP_CONTROL.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found FTP_CONTROL\n");
 	ndpi_int_ftp_control_add_connection(ndpi_struct, flow);
       } else {
-	NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to FTP_CONTROL, resetting the stage to 0...\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to FTP_CONTROL, resetting the stage to 0\n");
 	flow->ftp_control_stage = 0;
       }
     }
@@ -990,7 +992,7 @@ static void ndpi_check_ftp_control(struct ndpi_detection_module_struct *ndpi_str
 void ndpi_search_ftp_control(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_FTP_CONTROL, ndpi_struct, NDPI_LOG_DEBUG, "FTP_CONTROL detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search FTP_CONTROL\n");
 
   /* skip marked packets */
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_FTP_CONTROL) {

--- a/src/lib/protocols/ftp_data.c
+++ b/src/lib/protocols/ftp_data.c
@@ -23,9 +23,14 @@
  * 
  */
 
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_FTP_DATA
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_FTP_DATA
+
+#include "ndpi_api.h"
+
 static void ndpi_int_ftp_data_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_FTP_DATA, NDPI_PROTOCOL_UNKNOWN);
 }
@@ -223,22 +228,21 @@ static void ndpi_check_ftp_data(struct ndpi_detection_module_struct *ndpi_struct
 	 || ndpi_match_ftp_data_port(ndpi_struct, flow)
 	 )
      ) {
-    NDPI_LOG(NDPI_PROTOCOL_FTP_DATA, ndpi_struct, NDPI_LOG_DEBUG, "Possible FTP_DATA request detected...\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found FTP_DATA request\n");
     ndpi_int_ftp_data_add_connection(ndpi_struct, flow);
   } else
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_FTP_DATA);  
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void ndpi_search_ftp_data(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
 	
   /* Break after 20 packets. */
   if(flow->packet_counter > 20) {
-    NDPI_LOG(NDPI_PROTOCOL_FTP_DATA, ndpi_struct, NDPI_LOG_DEBUG, "Exclude FTP_DATA.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_FTP_DATA);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_FTP_DATA, ndpi_struct, NDPI_LOG_DEBUG, "FTP_DATA detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search FTP_DATA\n");
   ndpi_check_ftp_data(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/git.c
+++ b/src/lib/protocols/git.c
@@ -17,10 +17,16 @@
  * If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_GIT
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_GIT
+
 #include <stdlib.h>
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_GIT
 
 #define GIT_PORT 9418
 
@@ -28,6 +34,8 @@ void ndpi_search_git(struct ndpi_detection_module_struct *ndpi_struct,
 		     struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct * packet = &flow->packet;
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search Git\n");
 
   if((packet->tcp != NULL) && (packet->payload_packet_len > 4)) {
     if((ntohs(packet->tcp->source) == GIT_PORT)
@@ -52,15 +60,14 @@ void ndpi_search_git(struct ndpi_detection_module_struct *ndpi_struct,
       }
 
       if(found_git) {
-	NDPI_LOG(NDPI_PROTOCOL_GIT, ndpi_struct, NDPI_LOG_DEBUG, "found Git.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found Git\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_GIT, NDPI_PROTOCOL_UNKNOWN);
 	return;
       }
     }
   }
   
-  NDPI_LOG(NDPI_PROTOCOL_GIT, ndpi_struct, NDPI_LOG_DEBUG, "exclude Git.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_GIT);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/gnutella.c
+++ b/src/lib/protocols/gnutella.c
@@ -22,12 +22,14 @@
  * 
  */
 
-
-/* include files */
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_GNUTELLA
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_GNUTELLA
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_gnutella_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					     struct ndpi_flow_struct *flow/* , */
@@ -38,22 +40,21 @@ static void ndpi_int_gnutella_add_connection(struct ndpi_detection_module_struct
   struct ndpi_id_struct *dst = flow->dst;
 
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_GNUTELLA, NDPI_PROTOCOL_UNKNOWN);
+  NDPI_LOG__TRACE(ndpi_struct, "found GNUTELLA\n");
 
   if (src != NULL) {
     src->gnutella_ts = packet->tick_timestamp;
     if (packet->udp != NULL) {
       if (!src->detected_gnutella_udp_port1) {
 	src->detected_gnutella_udp_port1 = (packet->udp->source);
-	NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct,
-			  NDPI_LOG_DEBUG, "GNUTELLA UDP PORT1 DETECTED as %u\n",
-			  src->detected_gnutella_udp_port1);
+	NDPI_LOG__DEBUG2(ndpi_struct,
+		"GNUTELLA UDP PORT1 DETECTED as %u\n", src->detected_gnutella_udp_port1);
 
       } else if ((ntohs(packet->udp->source) != src->detected_gnutella_udp_port1)
 		 && !src->detected_gnutella_udp_port2) {
 	src->detected_gnutella_udp_port2 = (packet->udp->source);
-	NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct,
-			  NDPI_LOG_DEBUG, "GNUTELLA UDP PORT2 DETECTED as %u\n",
-			  src->detected_gnutella_udp_port2);
+	NDPI_LOG__DEBUG2(ndpi_struct,
+		"GNUTELLA UDP PORT2 DETECTED as %u\n", src->detected_gnutella_udp_port2);
 
       }
     }
@@ -71,16 +72,17 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
   struct ndpi_id_struct *dst = flow->dst;
 
   u_int16_t c;
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search GNUTELLA\n");
+
   if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_GNUTELLA) {
     if (src != NULL && ((u_int32_t)
 			(packet->tick_timestamp - src->gnutella_ts) < ndpi_struct->gnutella_timeout)) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct,
-			NDPI_LOG_DEBUG, "gnutella : save src connection packet detected\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "save src connection packet detected\n");
       src->gnutella_ts = packet->tick_timestamp;
     } else if (dst != NULL && ((u_int32_t)
 			       (packet->tick_timestamp - dst->gnutella_ts) < ndpi_struct->gnutella_timeout)) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct,
-			NDPI_LOG_DEBUG, "gnutella : save dst connection packet detected\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "save dst connection packet detected\n");
       dst->gnutella_ts = packet->tick_timestamp;
     }
     if (src != NULL && (packet->tick_timestamp - src->gnutella_ts) > ndpi_struct->gnutella_timeout) {
@@ -102,13 +104,11 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
   if (packet->tcp != NULL) {
     /* this case works asymmetrically */
     if (packet->payload_packet_len > 10 && memcmp(packet->payload, "GNUTELLA/", 9) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_TRACE, "GNUTELLA DETECTED\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
     /* this case works asymmetrically */
     if (packet->payload_packet_len > 17 && memcmp(packet->payload, "GNUTELLA CONNECT/", 17) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_TRACE, "GNUTELLA DETECTED\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
@@ -123,7 +123,6 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 	    || (packet->line[c].len > 7 && memcmp(packet->line[c].ptr, "X-Queue:", 8) == 0)
 	    || (packet->line[c].len > 36 && memcmp(packet->line[c].ptr,
 						   "Content-Type: application/x-gnutella-", 37) == 0)) {
-	  NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG, "DETECTED GNUTELLA GET.\n");
 	  ndpi_int_gnutella_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -135,7 +134,6 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 	   && memcmp(packet->user_agent_line.ptr, "BearShare Lite ", 15) == 0)
 	  || (packet->accept_line.ptr != NULL && packet->accept_line.len > 24
 	      && memcmp(packet->accept_line.ptr, "application n/x-gnutella", 24) == 0)) {
-	NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG, "DETECTED GNUTELLA GET.\n");
 	ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       }
 
@@ -151,8 +149,7 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
       }
 
       if (c < (packet->payload_packet_len - 9) && memcmp(&packet->payload[c], "urn:sha1:", 9) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_TRACE,
-		 "detected GET /get/ or GET /uri-res/.\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "detected GET /get/ or GET /uri-res/\n");
 	ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       }
 
@@ -161,14 +158,14 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
     /* answer to this packet is HTTP/1.1 ..... Content-Type: application/x-gnutella-packets,
      * it is searched in the upper paragraph. */
     if (packet->payload_packet_len > 30 && memcmp(packet->payload, "HEAD /gnutella/push-proxy?", 26) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_TRACE, "detected HEAD /gnutella/push-proxy?\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "detected HEAD /gnutella/push-proxy?\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
     /* haven't found any trace with this pattern */
     if (packet->payload_packet_len == 46
 	&& memcmp(packet->payload, "\x50\x55\x53\x48\x20\x67\x75\x69\x64\x3a", 10) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_TRACE,
+      NDPI_LOG__DEBUG2(ndpi_struct,
 	       "detected \x50\x55\x53\x48\x20\x67\x75\x69\x64\x3a\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
@@ -189,8 +186,7 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 			    44) == 0) || (end - c > 10 && memcmp(&packet->payload[c], "\r\nX-Queue:", 10) == 0)
 	      || (end - c > 13 && memcmp(&packet->payload[c], "\r\nX-Features:", 13) == 0)) {
 
-	    NDPI_LOG(NDPI_PROTOCOL_GNUTELLA,
-			      ndpi_struct, NDPI_LOG_TRACE, "FOXY :: GNUTELLA GET 2 DETECTED\n");
+	    NDPI_LOG__DEBUG2(ndpi_struct, "FOXY :: GNUTELLA GET 2 DETECTED\n");
 	    ndpi_int_gnutella_add_connection(ndpi_struct, flow);
 	    return;
 	  }
@@ -202,7 +198,7 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
     if (packet->payload_packet_len > 1 && packet->payload[packet->payload_packet_len - 1] == 0x0a
 	&& packet->payload[packet->payload_packet_len - 2] == 0x0a) {
       if (packet->payload_packet_len > 3 && memcmp(packet->payload, "GIV", 3) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_TRACE, "MORPHEUS GIV DETECTED\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "MORPHEUS GIV DETECTED\n");
 	/* Not Excluding the flow now.. We shall Check the next Packet too for Gnutella Patterns */
 	return;
       }
@@ -211,21 +207,21 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
     if (packet->payload_packet_len == 46 && get_u_int32_t(packet->payload, 0) == htonl(0x802c0103) &&
 	get_u_int32_t(packet->payload, 4) == htonl(0x01000300) && get_u_int32_t(packet->payload, 8) == htonl(0x00002000) &&
 	get_u_int16_t(packet->payload, 12) == htons(0x0034)) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_TRACE, "detected gnutella len == 46.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "detected gnutella len == 46\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
     if (packet->payload_packet_len == 49 &&
 	memcmp(packet->payload, "\x80\x2f\x01\x03\x01\x00\x06\x00\x00\x00\x20\x00\x00\x34\x00\x00\xff\x4d\x6c",
 	       19) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_TRACE, "detected gnutella len == 49.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "detected gnutella len == 49\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
     if (packet->payload_packet_len == 89 && memcmp(&packet->payload[43], "\x20\x4d\x6c", 3) == 0 &&
 	memcmp(packet->payload, "\x16\x03\x01\x00\x54\x01\x00\x00\x50\x03\x01\x4d\x6c", 13) == 0 &&
 	memcmp(&packet->payload[76], "\x00\x02\x00\x34\x01\x00\x00\x05", 8) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_TRACE,
+      NDPI_LOG__DEBUG2(ndpi_struct,
 	       "detected gnutella asymmetrically len == 388.\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
@@ -235,7 +231,7 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 	  && get_u_int16_t(packet->payload, 8) == htons(0x4903)
 	  && get_u_int16_t(packet->payload, 76) == htons(0x0002)
 	  && get_u_int32_t(packet->payload, 78) == htonl(0x00340100)) {
-	NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_TRACE, "detected len == 82.\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "detected len == 82\n");
 	ndpi_int_gnutella_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -244,7 +240,7 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
     if (src != NULL && (packet->udp->source == src->detected_gnutella_udp_port1 ||
 			packet->udp->source == src->detected_gnutella_udp_port2) &&
 	(packet->tick_timestamp - src->gnutella_ts) < ndpi_struct->gnutella_timeout) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG, "port based detection\n\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "port based detection\n\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
     }
     /* observations:
@@ -257,8 +253,7 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 	&& packet->payload[16] == 0x41 && packet->payload[17] == 0x01
 	&& packet->payload[18] == 0x00 && packet->payload[19] == 0x00
 	&& packet->payload[20] == 0x00 && packet->payload[21] == 0x00 && packet->payload[22] == 0x00) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG,
-			"detected gnutella udp, len = 23.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "detected gnutella udp, len = 23\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
 
       return;
@@ -267,29 +262,25 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 	&& packet->payload[26] == 0x50 && packet->payload[27] == 0x40
 	&& packet->payload[28] == 0x83 && packet->payload[29] == 0x53
 	&& packet->payload[30] == 0x43 && packet->payload[31] == 0x50 && packet->payload[32] == 0x41) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG,
-			"detected gnutella udp, len = 35.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "detected gnutella udp, len = 35\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
     if (packet->payload_packet_len == 32
 	&& (memcmp(&packet->payload[16], "\x31\x01\x00\x09\x00\x00\x00\x4c\x49\x4d\x45", 11) == 0)) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG,
-			"detected gnutella udp, len = 32.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "detected gnutella udp, len = 32\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
     if (packet->payload_packet_len == 34 && (memcmp(&packet->payload[25], "SCP@", 4) == 0)
 	&& (memcmp(&packet->payload[30], "DNA@", 4) == 0)) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG,
-			"detected gnutella udp, len = 34.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "detected gnutella udp, len = 34\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
     if ((packet->payload_packet_len == 73 || packet->payload_packet_len == 96)
 	&& memcmp(&packet->payload[32], "urn:sha1:", 9) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG,
-			"detected gnutella udp, len = 73,96.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "detected gnutella udp, len = 73,96\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
@@ -308,8 +299,7 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 	      && (memcmp(&packet->payload[6], "\x01\x01\x5c\x1b\x50\x55\x53\x48\x48\x10", 10) == 0))
 	  || (packet->payload_packet_len > 200 && packet->payload_packet_len < 300 && packet->payload[3] == 0x03)
 	  || (packet->payload_packet_len > 300 && (packet->payload[3] == 0x01 || packet->payload[3] == 0x03))) {
-	NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG,
-			  "detected gnutella udp, GND.\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "detected gnutella udp, GND\n");
 	ndpi_int_gnutella_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -317,15 +307,13 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 
     if ((packet->payload_packet_len == 32)
 	&& memcmp(&packet->payload[16], "\x31\x01\x00\x09\x00\x00\x00", 7) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG,
-			"detected gnutella udp, len = 32 ii.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "detected gnutella udp, len = 32 ii\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
     if ((packet->payload_packet_len == 23)
 	&& memcmp(&packet->payload[16], "\x00\x01\x00\x00\x00\x00\x00", 7) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct, NDPI_LOG_DEBUG,
-			"detected gnutella udp, len = 23 ii.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "detected gnutella udp, len = 23 ii\n");
       ndpi_int_gnutella_add_connection(ndpi_struct, flow);
       return;
     }
@@ -350,8 +338,7 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 	  && flow->l4.tcp.gnutella_msg_id[1] == packet->payload[2]
 	  && flow->l4.tcp.gnutella_msg_id[2] == packet->payload[4]
 	  && NDPI_SRC_OR_DST_HAS_PROTOCOL(src, dst, NDPI_PROTOCOL_GNUTELLA)) {
-	NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct,
-			  NDPI_LOG_TRACE, "GNUTELLA DETECTED due to message ID match (NEONet protocol)\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "GNUTELLA DETECTED due to message ID match (NEONet protocol)\n");
 	ndpi_int_gnutella_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -361,15 +348,14 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 	  && flow->l4.tcp.gnutella_msg_id[1] == packet->payload[2]
 	  && flow->l4.tcp.gnutella_msg_id[2] == packet->payload[4]
 	  && NDPI_SRC_OR_DST_HAS_PROTOCOL(src, dst, NDPI_PROTOCOL_GNUTELLA)) {
-	NDPI_LOG(NDPI_PROTOCOL_GNUTELLA, ndpi_struct,
-			  NDPI_LOG_TRACE, "GNUTELLA DETECTED due to message ID match (NEONet protocol)\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "GNUTELLA DETECTED due to message ID match (NEONet protocol)\n");
 	ndpi_int_gnutella_add_connection(ndpi_struct, flow);
 	return;
       }
     }
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_GNUTELLA);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/gtp.c
+++ b/src/lib/protocols/gtp.c
@@ -18,9 +18,13 @@
  *
  */
 
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_GTP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_GTP
+
+#include "ndpi_api.h"
 
 struct gtp_header_generic {
   u_int8_t flags, message_type;
@@ -50,7 +54,7 @@ static void ndpi_check_gtp(struct ndpi_detection_module_struct *ndpi_struct, str
 	u_int16_t message_len = ntohs(gtp->message_len);
 	
 	if(message_len <= (payload_len-sizeof(struct gtp_header_generic))) {
-	  NDPI_LOG(NDPI_PROTOCOL_GTP, ndpi_struct, NDPI_LOG_DEBUG, "Found gtp.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found gtp\n");
 	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_GTP, NDPI_PROTOCOL_UNKNOWN);
 	  return;
 	}
@@ -58,7 +62,7 @@ static void ndpi_check_gtp(struct ndpi_detection_module_struct *ndpi_struct, str
     }
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_GTP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   return;
 }
 
@@ -66,7 +70,7 @@ void ndpi_search_gtp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_GTP, ndpi_struct, NDPI_LOG_DEBUG, "gtp detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search gtp\n");
 
   /* skip marked packets */
   if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_GTP)

--- a/src/lib/protocols/guildwars.c
+++ b/src/lib/protocols/guildwars.c
@@ -22,9 +22,13 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_GUILDWARS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_GUILDWARS
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_guildwars_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -35,35 +39,31 @@ static void ndpi_int_guildwars_add_connection(struct ndpi_detection_module_struc
 void ndpi_search_guildwars_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
-	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
-	NDPI_LOG(NDPI_PROTOCOL_GUILDWARS, ndpi_struct, NDPI_LOG_DEBUG, "search guildwars.\n");
+	NDPI_LOG__DEBUG(ndpi_struct, "search guildwars\n");
 
 	if (packet->payload_packet_len == 64 && get_u_int16_t(packet->payload, 1) == ntohs(0x050c)
 		&& memcmp(&packet->payload[50], "@2&P", 4) == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_GUILDWARS, ndpi_struct, NDPI_LOG_DEBUG, "GuildWars version 29.350: found.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found GuildWars version 29.350\n");
 		ndpi_int_guildwars_add_connection(ndpi_struct, flow);
 		return;
 	}
 	if (packet->payload_packet_len == 16 && get_u_int16_t(packet->payload, 1) == ntohs(0x040c)
 		&& get_u_int16_t(packet->payload, 4) == ntohs(0xa672)
 		&& packet->payload[8] == 0x01 && packet->payload[12] == 0x04) {
-		NDPI_LOG(NDPI_PROTOCOL_GUILDWARS, ndpi_struct, NDPI_LOG_DEBUG, "GuildWars version 29.350: found.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found GuildWars version 29.350\n");
 		ndpi_int_guildwars_add_connection(ndpi_struct, flow);
 		return;
 	}
 	if (packet->payload_packet_len == 21 && get_u_int16_t(packet->payload, 0) == ntohs(0x0100)
 		&& get_u_int32_t(packet->payload, 5) == ntohl(0xf1001000)
 		&& packet->payload[9] == 0x01) {
-		NDPI_LOG(NDPI_PROTOCOL_GUILDWARS, ndpi_struct, NDPI_LOG_DEBUG, "GuildWars version 216.107.245.50: found.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found GuildWars version 216.107.245.50\n");
 		ndpi_int_guildwars_add_connection(ndpi_struct, flow);
 		return;
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_GUILDWARS, ndpi_struct, NDPI_LOG_DEBUG, "exclude guildwars.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_GUILDWARS);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/h323.c
+++ b/src/lib/protocols/h323.c
@@ -7,9 +7,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_H323
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_H323
+
+#include "ndpi_api.h"
+
 
 struct tpkt {
   u_int8_t version, reserved;
@@ -21,10 +26,10 @@ void ndpi_search_h323(struct ndpi_detection_module_struct *ndpi_struct, struct n
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int16_t dport = 0, sport = 0;
 
-  NDPI_LOG(NDPI_PROTOCOL_H323, ndpi_struct, NDPI_LOG_DEBUG, "search H323.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search H323\n");
 
   if(packet->tcp != NULL) {
-    NDPI_LOG(NDPI_PROTOCOL_H323, ndpi_struct, NDPI_LOG_DEBUG, "calculated dport over tcp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculated dport over tcp\n");
 
     /* H323  */
     if(packet->payload_packet_len >= 3
@@ -44,6 +49,7 @@ void ndpi_search_h323(struct ndpi_detection_module_struct *ndpi_struct, struct n
 	    /* ISO 8073/X.224 */
 	    if((packet->payload[5] == 0xE0 /* CC Connect Request */)
 	       || (packet->payload[5] == 0xD0 /* CC Connect Confirm */)) {
+	      NDPI_LOG__TRACE(ndpi_struct, "found RDP\n");
 	      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_RDP, NDPI_PROTOCOL_UNKNOWN);
 	      return;
 	    }
@@ -52,23 +58,24 @@ void ndpi_search_h323(struct ndpi_detection_module_struct *ndpi_struct, struct n
 	  flow->l4.tcp.h323_valid_packets++;
 
 	  if(flow->l4.tcp.h323_valid_packets >= 2) {
-	    NDPI_LOG(NDPI_PROTOCOL_H323, ndpi_struct, NDPI_LOG_DEBUG, "found H323 broadcast.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found H323 broadcast\n");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_H323, NDPI_PROTOCOL_UNKNOWN);
 	  }
 	} else {
 	  /* This is not H.323 */
-	  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_H323);
+	  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	  return;
 	}
       }    
   } else if(packet->udp != NULL) {
     sport = ntohs(packet->udp->source), dport = ntohs(packet->udp->dest);
-    NDPI_LOG(NDPI_PROTOCOL_H323, ndpi_struct, NDPI_LOG_DEBUG, "calculated dport over udp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculated dport over udp\n");
 
     if(packet->payload_packet_len >= 6 && packet->payload[0] == 0x80 && packet->payload[1] == 0x08 &&
        (packet->payload[2] == 0xe7 || packet->payload[2] == 0x26) &&
        packet->payload[4] == 0x00 && packet->payload[5] == 0x00)
       {
-	NDPI_LOG(NDPI_PROTOCOL_H323, ndpi_struct, NDPI_LOG_DEBUG, "found H323 broadcast.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found H323 broadcast\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_H323, NDPI_PROTOCOL_UNKNOWN);
 	return;
       }
@@ -77,19 +84,19 @@ void ndpi_search_h323(struct ndpi_detection_module_struct *ndpi_struct, struct n
       {
         if(packet->payload[0] == 0x16 && packet->payload[1] == 0x80 && packet->payload[4] == 0x06 && packet->payload[5] == 0x00)
 	  {
-	    NDPI_LOG(NDPI_PROTOCOL_H323, ndpi_struct, NDPI_LOG_DEBUG, "found H323 broadcast.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found H323 broadcast\n");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_H323, NDPI_PROTOCOL_UNKNOWN);
 	    return;
 	  }
         else if(packet->payload_packet_len >= 20 && packet->payload_packet_len <= 117)
 	  {
-	    NDPI_LOG(NDPI_PROTOCOL_H323, ndpi_struct, NDPI_LOG_DEBUG, "found H323 broadcast.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found H323 broadcast\n");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_H323, NDPI_PROTOCOL_UNKNOWN);
 	    return;
 	  }
         else
 	  {
-	    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_H323);
+	    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 	    return;
 	  }
       }

--- a/src/lib/protocols/halflife2_and_mods.c
+++ b/src/lib/protocols/halflife2_and_mods.c
@@ -23,8 +23,13 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_HALFLIFE2
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_HALFLIFE2
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_halflife2_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -36,15 +41,14 @@ void ndpi_search_halflife2(struct ndpi_detection_module_struct *ndpi_struct, str
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+	NDPI_LOG__DEBUG(ndpi_struct, "search halflife2\n");
 
 	if (flow->l4.udp.halflife2_stage == 0) {
 		if (packet->payload_packet_len >= 20
 			&& get_u_int32_t(packet->payload, 0) == 0xFFFFFFFF
 			&& get_u_int32_t(packet->payload, packet->payload_packet_len - 4) == htonl(0x30303000)) {
 			flow->l4.udp.halflife2_stage = 1 + packet->packet_direction;
-			NDPI_LOG(NDPI_PROTOCOL_HALFLIFE2, ndpi_struct, NDPI_LOG_DEBUG,
+			NDPI_LOG__DEBUG2(ndpi_struct,
 					"halflife2 client req detected, waiting for server reply\n");
 			return;
 		}
@@ -53,13 +57,12 @@ void ndpi_search_halflife2(struct ndpi_detection_module_struct *ndpi_struct, str
 			&& get_u_int32_t(packet->payload, 0) == 0xFFFFFFFF
 			&& get_u_int32_t(packet->payload, packet->payload_packet_len - 4) == htonl(0x30303000)) {
 			ndpi_int_halflife2_add_connection(ndpi_struct, flow);
-			NDPI_LOG(NDPI_PROTOCOL_HALFLIFE2, ndpi_struct, NDPI_LOG_DEBUG, "halflife2 server reply detected\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found halflife2\n");
 			return;
 		}
 	}
 
-
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_HALFLIFE2);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/hangout.c
+++ b/src/lib/protocols/hangout.c
@@ -17,9 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_api.h"
+
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_HANGOUT
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_HANGOUT
+
+#include "ndpi_api.h"
+
 
 /* https://support.google.com/a/answer/1279090?hl=en */
 #define HANGOUT_UDP_LOW_PORT  19302
@@ -73,19 +79,20 @@ void ndpi_search_hangout(struct ndpi_detection_module_struct *ndpi_struct,
 			 struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct * packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search Hangout\n");
+
   if((packet->payload_packet_len > 24) && is_google_flow(ndpi_struct, flow)) {
     if(
        ((packet->udp != NULL) && (isHangoutUDPPort(ntohs(packet->udp->source)) || isHangoutUDPPort(ntohs(packet->udp->dest))))
        ||
        ((packet->tcp != NULL) && (isHangoutTCPPort(ntohs(packet->tcp->source)) || isHangoutTCPPort(ntohs(packet->tcp->dest))))) {
-      NDPI_LOG(NDPI_PROTOCOL_HANGOUT, ndpi_struct, NDPI_LOG_DEBUG, "Found Hangout.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found Hangout\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_HANGOUT, NDPI_PROTOCOL_UNKNOWN);
       return;
     }
   }
   
-  NDPI_LOG(NDPI_PROTOCOL_HANGOUT, ndpi_struct, NDPI_LOG_DEBUG, "No Hangout.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_HANGOUT);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 /* ***************************************************************** */

--- a/src/lib/protocols/hep.c
+++ b/src/lib/protocols/hep.c
@@ -24,8 +24,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_HEP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_HEP
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_hep_add_connection(struct ndpi_detection_module_struct
 					*ndpi_struct, struct ndpi_flow_struct *flow)
@@ -39,17 +45,16 @@ void ndpi_search_hep(struct ndpi_detection_module_struct *ndpi_struct, struct nd
   const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
 
-    NDPI_LOG(NDPI_PROTOCOL_HEP, ndpi_struct, NDPI_LOG_DEBUG, "searching for HEP.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "searching HEP\n");
     if (payload_len > 10) {
 	    if (memcmp(packet_payload, "HEP3", 4) == 0) {
-	      NDPI_LOG(NDPI_PROTOCOL_HEP, ndpi_struct, NDPI_LOG_DEBUG, "found HEP3.\n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found HEP3\n");
 	      ndpi_int_hep_add_connection(ndpi_struct, flow);
 	      return;
 	    } 
     }
 
-    NDPI_LOG(NDPI_PROTOCOL_HEP, ndpi_struct, NDPI_LOG_DEBUG, "exclude HEP.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_HEP);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -20,9 +20,14 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_protocols.h"
+
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_HTTP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_HTTP
+
+#include "ndpi_api.h"
 
 
 /* global variables used for 1kxun protocol and iqiyi service */
@@ -63,7 +68,7 @@ static void flash_check_http_payload(struct ndpi_detection_module_struct
   if(memcmp(pos, "FLV", 3) == 0 && pos[3] == 0x01 && (pos[4] == 0x01 || pos[4] == 0x04 || pos[4] == 0x05)
      && pos[5] == 0x00 && pos[6] == 0x00 && pos[7] == 0x00 && pos[8] == 0x09) {
 
-    NDPI_LOG(NDPI_CONTENT_FLASH, ndpi_struct, NDPI_LOG_DEBUG, "Flash content in HTTP detected\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found Flash content in HTTP\n");
     ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_CONTENT_FLASH);
   }
 }
@@ -75,7 +80,7 @@ static void avi_check_http_payload(struct ndpi_detection_module_struct *ndpi_str
   struct ndpi_packet_struct *packet = &flow->packet;
 
 
-  NDPI_LOG(NDPI_CONTENT_AVI, ndpi_struct, NDPI_LOG_DEBUG, "called avi_check_http_payload: %u %u %u\n",
+  NDPI_LOG__DEBUG2(ndpi_struct, "called avi_check_http_payload: %u %u %u\n",
 	   packet->empty_line_position_set, flow->l4.tcp.http_empty_line_seen, packet->empty_line_position);
 
   if(packet->empty_line_position_set == 0 && flow->l4.tcp.http_empty_line_seen == 0)
@@ -90,7 +95,7 @@ static void avi_check_http_payload(struct ndpi_detection_module_struct *ndpi_str
   if(flow->l4.tcp.http_empty_line_seen == 1) {
     if(packet->payload_packet_len > 20 && memcmp(packet->payload, "RIFF", 4) == 0
        && memcmp(packet->payload + 8, "AVI LIST", 8) == 0) {
-      NDPI_LOG(NDPI_CONTENT_AVI, ndpi_struct, NDPI_LOG_DEBUG, "Avi content in HTTP detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found Avi content in HTTP\n");
       ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_CONTENT_AVI);
     }
     flow->l4.tcp.http_empty_line_seen = 0;
@@ -105,11 +110,11 @@ static void avi_check_http_payload(struct ndpi_detection_module_struct *ndpi_str
     u_int32_t p = packet->empty_line_position + 2;
 
     // check for avi header
-    NDPI_LOG(NDPI_CONTENT_AVI, ndpi_struct, NDPI_LOG_DEBUG, "p = %u\n", p);
+    NDPI_LOG__DEBUG2(ndpi_struct, "p = %u\n", p);
 
     if((p + 16) <= packet->payload_packet_len && memcmp(&packet->payload[p], "RIFF", 4) == 0
        && memcmp(&packet->payload[p + 8], "AVI LIST", 8) == 0) {
-      NDPI_LOG(NDPI_CONTENT_AVI, ndpi_struct, NDPI_LOG_DEBUG, "Avi content in HTTP detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found Avi content in HTTP\n");
       ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_CONTENT_AVI);
     }
   }
@@ -122,7 +127,7 @@ static void teamviewer_check_http_payload(struct ndpi_detection_module_struct *n
   struct ndpi_packet_struct *packet = &flow->packet;
   const u_int8_t *pos;
 
-  NDPI_LOG(NDPI_PROTOCOL_TEAMVIEWER, ndpi_struct, NDPI_LOG_DEBUG, "called teamviewer_check_http_payload: %u %u %u\n",
+  NDPI_LOG__DEBUG2(ndpi_struct, "called teamviewer_check_http_payload: %u %u %u\n",
 	   packet->empty_line_position_set, flow->l4.tcp.http_empty_line_seen, packet->empty_line_position);
 
   if(packet->empty_line_position_set == 0 || (packet->empty_line_position + 5) > (packet->payload_packet_len))
@@ -131,7 +136,7 @@ static void teamviewer_check_http_payload(struct ndpi_detection_module_struct *n
   pos = &packet->payload[packet->empty_line_position] + 2;
 
   if(pos[0] == 0x17 && pos[1] == 0x24) {
-    NDPI_LOG(NDPI_PROTOCOL_TEAMVIEWER, ndpi_struct, NDPI_LOG_DEBUG, "TeamViewer content in HTTP detected\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found TeamViewer content in HTTP\n");
     ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_TEAMVIEWER);
   }
 }
@@ -145,7 +150,7 @@ static void rtsp_parse_packet_acceptline(struct ndpi_detection_module_struct
   struct ndpi_packet_struct *packet = &flow->packet;
 
   if(packet->accept_line.len >= 28 && memcmp(packet->accept_line.ptr, "application/x-rtsp-tunnelled", 28) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_RTSP, ndpi_struct, NDPI_LOG_DEBUG, "RTSP accept line detected\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found RTSP accept line\n");
     ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_RTSP);
   }
 }
@@ -199,12 +204,12 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 #if defined(NDPI_PROTOCOL_1KXUN) || defined(NDPI_PROTOCOL_IQIYI)
   /* PPStream */
   if(flow->l4.tcp.ppstream_stage > 0 && flow->iqiyi_counter == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG, "PPStream found.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found PPStream\n");
     /* ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_PPSTREAM); */
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_PPSTREAM, NDPI_PROTOCOL_HTTP);
   }
   else if(flow->iqiyi_counter > 0) {
-    NDPI_LOG(NDPI_PROTOCOL_IQIYI, ndpi_struct, NDPI_LOG_DEBUG, "iQiyi found.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found iQiyi\n");
     /* ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_IQIYI); */
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_IQIYI, NDPI_PROTOCOL_HTTP);
   }
@@ -213,7 +218,7 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 #if defined(NDPI_PROTOCOL_1KXUN) || defined(NDPI_PROTOCOL_IQIYI)
   /* 1KXUN */
   if(flow->kxun_counter > 0) {
-    NDPI_LOG(NDPI_PROTOCOL_1KXUN, ndpi_struct, NDPI_LOG_DEBUG, "1kxun found.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found 1kxun\n");
     /* ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_1KXUN); */
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_1KXUN, NDPI_PROTOCOL_HTTP);
   }
@@ -330,12 +335,13 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 	}
       }
       else if(memcmp(ua, "netflix-ios-app", 15) == 0) {
+	NDPI_LOG__TRACE(ndpi_struct, "found netflix\n");
       	ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_NETFLIX);
       	return;
       }
     }
 
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "User Agent Type line found %.*s\n",
+    NDPI_LOG__DEBUG2(ndpi_struct, "User Agent Type line found %.*s\n",
 	     packet->user_agent_line.len, packet->user_agent_line.ptr);
   }
 
@@ -343,7 +349,7 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
   if(packet->host_line.ptr != NULL) {
     u_int len;
 
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HOST line found %.*s\n",
+    NDPI_LOG__DEBUG2(ndpi_struct, "HOST line found %.*s\n",
 	     packet->host_line.len, packet->host_line.ptr);
 
     /* call ndpi_match_host_subprotocol to see if there is a match with known-host HTTP subprotocol */
@@ -395,6 +401,8 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 
     if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
       if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_HTTP) {
+	NDPI_LOG__TRACE(ndpi_struct, "found HTTP/%s\n", 
+		    ndpi_get_proto_name(ndpi_struct, packet->detected_protocol_stack[0]));
 	ndpi_int_http_add_connection(ndpi_struct, flow, packet->detected_protocol_stack[0]);
 	return; /* We have identified a sub-protocol so we're done */
       }
@@ -409,7 +417,7 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 
   /* check for accept line */
   if(packet->accept_line.ptr != NULL) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "Accept line found %.*s\n",
+    NDPI_LOG__DEBUG2(ndpi_struct, "Accept line found %.*s\n",
 	     packet->accept_line.len, packet->accept_line.ptr);
 #ifdef NDPI_PROTOCOL_RTSP
     if(NDPI_COMPARE_PROTOCOL_TO_BITMASK(ndpi_struct->detection_bitmask, NDPI_PROTOCOL_RTSP) != 0) {
@@ -422,7 +430,7 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 #ifdef NDPI_CONTENT_MPEG
   for (a = 0; a < packet->parsed_lines; a++) {
     if(packet->line[a].len > 11 && memcmp(packet->line[a].ptr, "Icy-MetaData", 12) == 0) {
-      NDPI_LOG(NDPI_CONTENT_MPEG, ndpi_struct, NDPI_LOG_DEBUG, "MPEG: Icy-MetaData found.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found MPEG: Icy-MetaData\n");
       ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_CONTENT_MPEG);
       return;
     }
@@ -432,7 +440,7 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 #endif
 
   if(packet->content_line.ptr != NULL && packet->content_line.len != 0) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "Content Type line found %.*s\n",
+    NDPI_LOG__DEBUG2(ndpi_struct, "Content Type line found %.*s\n",
 	     packet->content_line.len, packet->content_line.ptr);
 
     if((ndpi_struct->http_dont_dissect_response) || flow->http_detected)
@@ -444,7 +452,7 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 
 static void check_http_payload(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "called check_http_payload.\n");
+  NDPI_LOG__DEBUG2(ndpi_struct, "called check_http_payload\n");
 
 #ifdef NDPI_CONTENT_FLASH
   if(NDPI_COMPARE_PROTOCOL_TO_BITMASK(ndpi_struct->detection_bitmask, NDPI_CONTENT_FLASH) != 0)
@@ -466,54 +474,55 @@ static void check_http_payload(struct ndpi_detection_module_struct *ndpi_struct,
  * @returnvalue 0 if no valid request has been found
  * @returnvalue >0 indicates start of filename but not necessarily in packet limit
  */
+
+#define STATIC_STRING_L(a) {.str=a, .len=sizeof(a)-1 }
+
+static struct l_string {
+	const char *str;
+	size_t     len;
+} http_methods[] = {
+	STATIC_STRING_L("GET "),
+	STATIC_STRING_L("POST "),
+	STATIC_STRING_L("OPTIONS "),
+	STATIC_STRING_L("HEAD "),
+	STATIC_STRING_L("PUT "),
+	STATIC_STRING_L("DELETE "),
+	STATIC_STRING_L("CONNECT "),
+	STATIC_STRING_L("PROPFIND "),
+	STATIC_STRING_L("REPORT ") };
+static const char *http_fs = "CDGHOPR";
+
+static inline uint8_t non_ctrl(uint8_t c) {
+	return c < 32 ? '.':c;
+}
+
 static u_int16_t http_request_url_offset(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
+  int i;
 
-  NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "====>>>> HTTP: %c%c%c%c [len: %u]\n",
-	   packet->payload[0], packet->payload[1], packet->payload[2], packet->payload[3],
+  NDPI_LOG__DEBUG2(ndpi_struct, "====>>>> HTTP: %c%c%c%c [len: %u]\n",
+	   non_ctrl(packet->payload[0]), non_ctrl(packet->payload[1]),
+	   non_ctrl(packet->payload[2]), non_ctrl(packet->payload[3]),
 	   packet->payload_packet_len);
 
+  /* Check first char */
+  if(!strchr(http_fs,packet->payload[0])) return 0;
   /**
      FIRST PAYLOAD PACKET FROM CLIENT
   **/
-
-  /* check if the packet starts with POST or GET */
-  if(packet->payload_packet_len >= 4 && memcmp(packet->payload, "GET ", 4) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP: GET FOUND\n");
-    return 4;
-  } else if(packet->payload_packet_len >= 5 && memcmp(packet->payload, "POST ", 5) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP: POST FOUND\n");
-    return 5;
-  } else if(packet->payload_packet_len >= 8 && memcmp(packet->payload, "OPTIONS ", 8) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP: OPTIONS FOUND\n");
-    return 8;
-  } else if(packet->payload_packet_len >= 5 && memcmp(packet->payload, "HEAD ", 5) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP: HEAD FOUND\n");
-    return 5;
-  } else if(packet->payload_packet_len >= 4 && memcmp(packet->payload, "PUT ", 4) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP: PUT FOUND\n");
-    return 4;
-  } else if(packet->payload_packet_len >= 7 && memcmp(packet->payload, "DELETE ", 7) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP: DELETE FOUND\n");
-    return 7;
-  } else if(packet->payload_packet_len >= 8 && memcmp(packet->payload, "CONNECT ", 8) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP: CONNECT FOUND\n");
-    return 8;
-  } else if(packet->payload_packet_len >= 9 && memcmp(packet->payload, "PROPFIND ", 9) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP: PROFIND FOUND\n");
-    return 9;
-  } else if(packet->payload_packet_len >= 7 && memcmp(packet->payload, "REPORT ", 7) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP: REPORT FOUND\n");
-    return 7;
+  for(i=0; i < sizeof(http_methods)/sizeof(http_methods[0]); i++) {
+	if(packet->payload_packet_len >= http_methods[i].len &&
+	   memcmp(packet->payload,http_methods[i].str,http_methods[i].len) == 0) {
+		NDPI_LOG__DEBUG2(ndpi_struct, "HTTP: %sFOUND\n",http_methods[i].str);
+		return http_methods[i].len;
+	}
   }
-
   return 0;
 }
 
-static void http_bitmask_exclude(struct ndpi_flow_struct *flow)
+static void http_bitmask_exclude_other(struct ndpi_flow_struct *flow)
 {
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_HTTP);
 #ifdef NDPI_CONTENT_MPEG
   NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_CONTENT_MPEG);
 #endif
@@ -554,18 +563,15 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
   if(flow->l4.tcp.http_stage == 0) { /* Expected a request */
     flow->http_detected = 0;
 
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP stage %d: \n",
-	     flow->l4.tcp.http_stage);
+    NDPI_LOG__DEBUG2(ndpi_struct, "HTTP stage %d: \n", flow->l4.tcp.http_stage);
 
     filename_start = http_request_url_offset(ndpi_struct, flow);
 
     if(filename_start == 0) { /* not a regular request. In the HTTP first stage, may be a truncated flow or other protocols */
-      NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
-	       "Filename HTTP not found, we look for possible truncate flow...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "Filename HTTP not found, we look for possible truncate flow..\n");
 
       if(packet->payload_packet_len >= 7 && memcmp(packet->payload, "HTTP/1.", 7) == 0) {
-        NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
-		 "HTTP response found (truncated flow ?)\n");
+        NDPI_LOG__TRACE(ndpi_struct, "found HTTP response\n");
         ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_HTTP);
         check_content_type_and_change_protocol(ndpi_struct, flow);
         return;
@@ -589,18 +595,18 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
         return;
       }
       
-      NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "Exclude HTTP\n");
-      http_bitmask_exclude(flow);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      http_bitmask_exclude_other(flow);
       return;
     }
 
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
 	     "Filename HTTP found: %d, we look for line info..\n", filename_start);
 
     ndpi_parse_packet_line_info(ndpi_struct, flow);
 
     if(packet->parsed_lines <= 1) {
-      NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG2(ndpi_struct,
 	       "Found just one line, we will look further for the next packet...\n");
 
       packet->http_method.ptr = packet->line[0].ptr;
@@ -611,7 +617,7 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
       return;
     }
 
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
 	     "Found more than one line, we look further for the next packet...\n");
 
     if(packet->line[0].len >= (9 + filename_start)
@@ -643,6 +649,7 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
       /* Check for additional field introduced by Steam */
       int x = 1;
       if((memcmp(packet->line[x].ptr, "x-steam-sid", 11)) == 0) {
+	    NDPI_LOG__TRACE(ndpi_struct, "found STEAM\n");
 	    ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_STEAM);
 	    check_content_type_and_change_protocol(ndpi_struct, flow);
 	    return;
@@ -652,6 +659,7 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
       x = 1;
       while(packet->line[x].len != 0) {
 	    if(packet->line[x].len >= 12 && (memcmp(packet->line[x].ptr, "X-FB-SIM-HNI", 12)) == 0) {
+	      NDPI_LOG__TRACE(ndpi_struct, "found FACEBOOK\n");
 	      ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_FACEBOOK);
 	      check_content_type_and_change_protocol(ndpi_struct, flow);
 	      return;
@@ -704,19 +712,19 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
       
       if((packet->http_url_name.len > 7)
           && (!strncmp((const char*) packet->http_url_name.ptr, "http://", 7))) {
-        NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP_PROXY Found.\n");
+        NDPI_LOG__TRACE(ndpi_struct, "found HTTP_PROXY\n");
         ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_HTTP_PROXY);
         check_content_type_and_change_protocol(ndpi_struct, flow);
       }
 
       if(filename_start == 8 && (memcmp(packet->payload, "CONNECT ", 8) == 0)) {
 	    /* nathan@getoffmalawn.com */
-        NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP_CONNECT Found.\n");
+        NDPI_LOG__TRACE(ndpi_struct, "found HTTP_CONNECT\n");
         ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_HTTP_CONNECT);
         check_content_type_and_change_protocol(ndpi_struct, flow);
       }
 
-      NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG2(ndpi_struct,
           "HTTP START Found, we will look for sub-protocols (content and host)...\n");
 
       if(packet->host_line.ptr != NULL) {
@@ -729,10 +737,11 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
 
         if(ndpi_struct->http_dont_dissect_response) {
           if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) /* No subprotocol found */
+	    NDPI_LOG__TRACE(ndpi_struct, "found HTTP\n");
             ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_HTTP);
         } else {
           flow->http_detected = 1;
-          NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
+          NDPI_LOG__DEBUG2(ndpi_struct,
                "HTTP START Found, we will look further for the response...\n");
           flow->l4.tcp.http_stage = packet->packet_direction + 1; // packet_direction 0: stage 1, packet_direction 1: stage 2
         }
@@ -742,13 +751,12 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
       }
     }
 
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP: REQUEST NOT HTTP CONFORM\n");
-    http_bitmask_exclude(flow);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    http_bitmask_exclude_other(flow);
 
   } else if((flow->l4.tcp.http_stage == 1) || (flow->l4.tcp.http_stage == 2)) {
 
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP stage %u: \n",
-	     flow->l4.tcp.http_stage);
+    NDPI_LOG__DEBUG2(ndpi_struct, "HTTP stage %u: \n", flow->l4.tcp.http_stage);
 
 
     if(flow->l4.tcp.http_stage == 1) {
@@ -769,7 +777,7 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
       if(flow->http_detected)
         return;
 
-      NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG2(ndpi_struct,
 	       " SECOND PAYLOAD TRAFFIC FROM CLIENT, FIRST PACKET MIGHT HAVE BEEN HTTP...UNKNOWN TRAFFIC, HERE FOR HTTP again.. \n");
 
       ndpi_parse_packet_line_info(ndpi_struct, flow);
@@ -780,14 +788,13 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
       if(packet->parsed_lines <= 1) {
         /* wait some packets in case request is split over more than 2 packets */
         if(flow->packet_counter < 5) {
-          NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
-		   "line still not finished, search next packet\n");
+          NDPI_LOG__DEBUG2(ndpi_struct, "line still not finished, search next packet\n");
           return;
         } else {
           /* stop parsing here */
-          NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
-		   "HTTP: PACKET DOES NOT HAVE A LINE STRUCTURE\n");
-          http_bitmask_exclude(flow);
+          NDPI_LOG__DEBUG2(ndpi_struct, "exclude HTTP: PACKET DOES NOT HAVE A LINE STRUCTURE\n");
+	  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+          http_bitmask_exclude_other(flow);
           return;
         }
       }
@@ -795,11 +802,11 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
       if(packet->line[0].len >= 9
           && memcmp(&packet->line[0].ptr[packet->line[0].len - 9], " HTTP/1.", 8) == 0) {
 
-        NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "Found HTTP.\n");
+        NDPI_LOG__TRACE(ndpi_struct, "found HTTP\n");
         ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_HTTP);
         check_content_type_and_change_protocol(ndpi_struct, flow);
 
-        NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG,
+        NDPI_LOG__DEBUG2(ndpi_struct,
 		 "HTTP START Found in 2. packet, we will look further for the response....\n");
         flow->http_detected = 1;
       }
@@ -817,15 +824,17 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
      */
     if((packet->parsed_lines == 1) && (packet->packet_direction == 1 /* server -> client */)) {
       /* In Apache if you do "GET /\n\n" the response comes without any header */
-      NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "Found HTTP. (apache)\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found HTTP. (apache)\n");
       ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_HTTP);
       check_content_type_and_change_protocol(ndpi_struct, flow);
       return;
     }
 
     /* If we already detected the HTTP request, we can add the connection and then check for the sub-protocol */
-    if(flow->http_detected)
+    if(flow->http_detected) {
+      NDPI_LOG__TRACE(ndpi_struct, "found HTTP\n");
       ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_HTTP);
+    }
 
     /* Parse packet line and we look for the subprotocols */
     ndpi_parse_packet_line_info(ndpi_struct, flow);
@@ -836,7 +845,7 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
     }
 
     if(packet->empty_line_position_set != 0 || flow->l4.tcp.http_empty_line_seen == 1) {
-      NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "empty line. check_http_payload.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "empty line. check_http_payload\n");
       check_http_payload(ndpi_struct, flow);
     }
 
@@ -852,8 +861,8 @@ void ndpi_search_http_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 
   /* Break after 20 packets. */
   if(flow->packet_counter > 20) {
-    NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "Exclude HTTP.\n");
-    http_bitmask_exclude(flow);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    http_bitmask_exclude_other(flow);
     return;
   }
 
@@ -861,7 +870,7 @@ void ndpi_search_http_tcp(struct ndpi_detection_module_struct *ndpi_struct,
      return;
    }
 
-  NDPI_LOG(NDPI_PROTOCOL_HTTP, ndpi_struct, NDPI_LOG_DEBUG, "HTTP detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search HTTP\n");
   ndpi_check_http_tcp(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/http_activesync.c
+++ b/src/lib/protocols/http_activesync.c
@@ -24,8 +24,14 @@
 
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_HTTP_APPLICATION_ACTIVESYNC
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_HTTP_APPLICATION_ACTIVESYNC
+
+#include "ndpi_api.h"
+
 static void ndpi_int_activesync_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_HTTP_APPLICATION_ACTIVESYNC, NDPI_PROTOCOL_HTTP);
@@ -35,20 +41,19 @@ void ndpi_search_activesync(struct ndpi_detection_module_struct *ndpi_struct, st
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
+	NDPI_LOG__DEBUG(ndpi_struct, "search activesync\n");
 	if (packet->tcp != NULL) {
 
 		if (packet->payload_packet_len > 150
 			&& ((memcmp(packet->payload, "OPTIONS /Microsoft-Server-ActiveSync?", 37) == 0)
 				|| (memcmp(packet->payload, "POST /Microsoft-Server-ActiveSync?", 34) == 0))) {
 			ndpi_int_activesync_add_connection(ndpi_struct, flow);
-			NDPI_LOG(NDPI_PROTOCOL_HTTP_APPLICATION_ACTIVESYNC, ndpi_struct, NDPI_LOG_DEBUG,
-					" flow marked as ActiveSync \n");
+			NDPI_LOG__TRACE(ndpi_struct, "found ActiveSync \n");
 			return;
 		}
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_HTTP_APPLICATION_ACTIVESYNC, ndpi_struct, NDPI_LOG_DEBUG, "exclude activesync\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_HTTP_APPLICATION_ACTIVESYNC);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 

--- a/src/lib/protocols/iax.c
+++ b/src/lib/protocols/iax.c
@@ -23,9 +23,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_IAX
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_IAX
+
+#include "ndpi_api.h"
+
 
 #define NDPI_IAX_MAX_INFORMATION_ELEMENTS 15
 
@@ -58,7 +63,7 @@ static void ndpi_search_setup_iax(struct ndpi_detection_module_struct *ndpi_stru
       && packet->payload[11] <= 15) {
 
     if (packet->payload_packet_len == 12) {
-      NDPI_LOG(NDPI_PROTOCOL_IAX, ndpi_struct, NDPI_LOG_DEBUG, "found IAX.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found IAX\n");
       ndpi_int_iax_add_connection(ndpi_struct, flow);
       return;
     }
@@ -66,7 +71,7 @@ static void ndpi_search_setup_iax(struct ndpi_detection_module_struct *ndpi_stru
     for (i = 0; i < NDPI_IAX_MAX_INFORMATION_ELEMENTS; i++) {
       packet_len = packet_len + 2 + packet->payload[packet_len + 1];
       if (packet_len == packet->payload_packet_len) {
-	NDPI_LOG(NDPI_PROTOCOL_IAX, ndpi_struct, NDPI_LOG_DEBUG, "found IAX.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found IAX\n");
 	ndpi_int_iax_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -77,16 +82,13 @@ static void ndpi_search_setup_iax(struct ndpi_detection_module_struct *ndpi_stru
 
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_IAX);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 
 void ndpi_search_iax(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
-  //      struct ndpi_flow_struct       *flow=ndpi_struct->flow;
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
   if(packet->udp 
      && (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN))

--- a/src/lib/protocols/icecast.c
+++ b/src/lib/protocols/icecast.c
@@ -22,10 +22,13 @@
  *
  */
 
-
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_ICECAST
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_ICECAST
+
+#include "ndpi_api.h"
 
 static void ndpi_int_icecast_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -37,17 +40,17 @@ void ndpi_search_icecast_tcp(struct ndpi_detection_module_struct *ndpi_struct, s
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int8_t i;
 
-  NDPI_LOG(NDPI_PROTOCOL_ICECAST, ndpi_struct, NDPI_LOG_DEBUG, "search icecast.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search icecast\n");
 
   if ((packet->payload_packet_len < 500 &&
        packet->payload_packet_len >= 7 && memcmp(packet->payload, "SOURCE ", 7) == 0)
       || flow->l4.tcp.icecast_stage) {
     ndpi_parse_packet_line_info_any(ndpi_struct, flow);
-    NDPI_LOG(NDPI_PROTOCOL_ICECAST, ndpi_struct, NDPI_LOG_DEBUG, "Icecast lines=%d\n", packet->parsed_lines);
+    NDPI_LOG__DEBUG2(ndpi_struct, "Icecast lines=%d\n", packet->parsed_lines);
     for (i = 0; i < packet->parsed_lines; i++) {
       if (packet->line[i].ptr != NULL && packet->line[i].len > 4
 	  && memcmp(packet->line[i].ptr, "ice-", 4) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_ICECAST, ndpi_struct, NDPI_LOG_DEBUG, "Icecast detected.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found Icecast\n");
 	ndpi_int_icecast_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -75,18 +78,17 @@ void ndpi_search_icecast_tcp(struct ndpi_detection_module_struct *ndpi_struct, s
 
     if (packet->server_line.ptr != NULL && packet->server_line.len > NDPI_STATICSTRING_LEN("Icecast") &&
 	memcmp(packet->server_line.ptr, "Icecast", NDPI_STATICSTRING_LEN("Icecast")) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_ICECAST, ndpi_struct, NDPI_LOG_DEBUG, "Icecast detected.\n");
       /* TODO maybe store the previous protocol type as subtype?
        *      e.g. ogg or mpeg
        */
+      NDPI_LOG__TRACE(ndpi_struct, "found Icecast\n");
       ndpi_int_icecast_add_connection(ndpi_struct, flow);
       return;
     }
   }
 
  icecast_exclude:
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_ICECAST);
-  NDPI_LOG(NDPI_PROTOCOL_ICECAST, ndpi_struct, NDPI_LOG_DEBUG, "Icecast excluded.\n");
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/ipp.c
+++ b/src/lib/protocols/ipp.c
@@ -22,10 +22,14 @@
  * 
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_IPP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_IPP
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_ipp_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					struct ndpi_flow_struct *flow/* , ndpi_protocol_type_t protocol_type */)
@@ -36,22 +40,20 @@ static void ndpi_int_ipp_add_connection(struct ndpi_detection_module_struct *ndp
 void ndpi_search_ipp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 	struct ndpi_packet_struct *packet = &flow->packet;	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
 	u_int8_t i;
 
-	NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG, "search ipp\n");
+	NDPI_LOG__DEBUG(ndpi_struct, "search ipp\n");
+
 	if (packet->payload_packet_len > 20) {
 
-		NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG,
+		NDPI_LOG__DEBUG2(ndpi_struct,
 				"searching for a payload with a pattern like 'number(1to8)blanknumber(1to3)ipp://.\n");
 		/* this pattern means that there is a printer saying that his state is idle,
 		 * means that he is not printing anything at the moment */
 		i = 0;
 
 		if (packet->payload[i] < '0' || packet->payload[i] > '9') {
-			NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG, "payload does not begin with a number.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "payload does not begin with a number\n");
 			goto search_for_next_pattern;
 		}
 
@@ -60,37 +62,37 @@ void ndpi_search_ipp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 			if (!((packet->payload[i] >= '0' && packet->payload[i] <= '9') ||
 				  (packet->payload[i] >= 'a' && packet->payload[i] <= 'f') ||
 				  (packet->payload[i] >= 'A' && packet->payload[i] <= 'F')) || i > 8) {
-				NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG,
+				NDPI_LOG__DEBUG2(ndpi_struct,
 						"read symbols while the symbol is a number.\n");
 				break;
 			}
 		}
 
 		if (packet->payload[i++] != ' ') {
-			NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG, "there is no blank following the number.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "there is no blank following the number\n");
 			goto search_for_next_pattern;
 		}
 
 		if (packet->payload[i] < '0' || packet->payload[i] > '9') {
-			NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG, "no number following the blank.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "no number following the blank\n");
 			goto search_for_next_pattern;
 		}
 
 		for (;;) {
 			i++;
 			if (packet->payload[i] < '0' || packet->payload[i] > '9' || i > 12) {
-				NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG,
+				NDPI_LOG__DEBUG2(ndpi_struct,
 						"read symbols while the symbol is a number.\n");
 				break;
 			}
 		}
 
 		if (memcmp(&packet->payload[i], " ipp://", 7) != 0) {
-			NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG, "the string ' ipp://' does not follow.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "the string ' ipp://' does not follow\n");
 			goto search_for_next_pattern;
 		}
 
-		NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG, "found ipp\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found ipp\n");
 		ndpi_int_ipp_add_connection(ndpi_struct, flow);
 		return;
 	}
@@ -101,13 +103,12 @@ void ndpi_search_ipp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 		ndpi_parse_packet_line_info(ndpi_struct, flow);
 		if (packet->content_line.ptr != NULL && packet->content_line.len > 14
 			&& memcmp(packet->content_line.ptr, "application/ipp", 15) == 0) {
-			NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG, "found ipp via POST ... application/ipp.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found ipp via POST ... application/ipp\n");
 			ndpi_int_ipp_add_connection(ndpi_struct, flow);
 			return;
 		}
 	}
-	NDPI_LOG(NDPI_PROTOCOL_IPP, ndpi_struct, NDPI_LOG_DEBUG, "no ipp detected.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_IPP);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/irc.c
+++ b/src/lib/protocols/irc.c
@@ -23,9 +23,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_IRC
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_IRC
+
+#include "ndpi_api.h"
+
 #define NDPI_IRC_FIND_LESS(time_err,less) {int t1 = 0;	\
     u_int32_t timestamp = time_err[0];			\
     for(t1=0;t1 < NDPI_PROTOCOL_IRC_MAXPORT;t1++) {	\
@@ -65,7 +70,7 @@ static u_int8_t ndpi_check_for_NOTICE_or_PRIVMSG(struct ndpi_detection_module_st
   for (i = 0; i < packet->payload_packet_len - 7; i++) {
     if (packet->payload[i] == 'N' || packet->payload[i] == 'P') {
       if (memcmp(&packet->payload[i + 1], "OTICE ", 6) == 0 || memcmp(&packet->payload[i + 1], "RIVMSG ", 7) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "found NOTICE or PRIVMSG\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "found NOTICE or PRIVMSG\n");
 	return 1;
       }
     }
@@ -94,7 +99,7 @@ static u_int8_t ndpi_check_for_Nickname(struct ndpi_detection_module_struct *ndp
       if ((((packetl - (i + 1)) >= 4) && memcmp(&packet->payload[i + 1], "ick=", 4) == 0)
 	  || (((packetl - (i + 1)) >= 8) && (memcmp(&packet->payload[i + 1], "ickname=", 8) == 0))
 	  || (((packetl - (i + 1)) >= 8) && (memcmp(&packet->payload[i + 1], "ickName=", 8) == 0))) {
-	NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "found HTTP IRC Nickname pattern\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "found HTTP IRC Nickname pattern\n");
 	return 1;
       }
     }
@@ -114,7 +119,7 @@ static u_int8_t ndpi_check_for_cmd(struct ndpi_detection_module_struct *ndpi_str
   for (i = 0; i < packet->payload_packet_len - 4; i++) {
     if (packet->payload[i] == 'c') {
       if (memcmp(&packet->payload[i + 1], "md=", 3) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "found HTTP IRC cmd pattern  \n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "found HTTP IRC cmd pattern  \n");
 	return 1;
       }
     }
@@ -147,8 +152,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
   struct ndpi_packet_struct *packet = &flow->packet;
 	
 
-  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG,
-	   "called ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "start fast detect\n");
 
   /* case 1: len 1460, len 1460, len 1176 several times in one direction, than len = 4, 4096, 8192 in the other direction */
   if (packet->payload_packet_len == 1460
@@ -174,7 +178,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
       && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 0x1000
 									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
 									0x2000)) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "IRC SSL detected: ->1460,1460,1176,<-4096||8192");
+    NDPI_LOG__TRACE(ndpi_struct, "found IRC SSL: ->1460,1460,1176,<-4096||8192");
     ndpi_int_irc_add_connection(ndpi_struct, flow);
     return 1;
   }
@@ -185,27 +189,27 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
 										1 + packet->packet_direction))) {
     flow->l4.tcp.irc_stage2 = 4;
     flow->l4.tcp.irc_direction = 1 + packet->packet_direction;
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "len = 1448 first\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "len = 1448 first\n");
     return 1;
   }
   if (packet->payload_packet_len == 1448 && flow->l4.tcp.irc_stage2 == 4
       && flow->l4.tcp.irc_direction == 1 + packet->packet_direction) {
     flow->l4.tcp.irc_stage2 = 5;
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "len = 1448 second \n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "len = 1448 second \n");
     return 1;
   }
   if (packet->payload_packet_len == 1200 && flow->l4.tcp.irc_stage2 == 5
       && flow->l4.tcp.irc_direction == 1 + packet->packet_direction) {
     flow->l4.tcp.irc_stage2 = 6;
     flow->l4.tcp.irc_0x1000_full = 1;
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "len = 1200  \n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "len = 1200  \n");
     return 1;
   }
   if (packet->payload_packet_len == 4 && (flow->l4.tcp.irc_stage2 == 6 || flow->l4.tcp.irc_0x1000_full == 1)
       && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 0x1000
 									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
 									0x2000)) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "IRC SSL detected: ->1448,1448,1200,<-4096||8192");
+    NDPI_LOG__TRACE(ndpi_struct, "found IRC SSL: ->1448,1448,1200,<-4096||8192");
     ndpi_int_irc_add_connection(ndpi_struct, flow);
     return 1;
   }
@@ -222,7 +226,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
       && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 1380
 									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
 									2760)) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "IRC SSL detected: ->1380,<-1380||2760");
+    NDPI_LOG__TRACE(ndpi_struct, "found IRC SSL: ->1380,<-1380||2760");
     ndpi_int_irc_add_connection(ndpi_struct, flow);
     return 1;
   }
@@ -237,7 +241,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
       && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 1200
 									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
 									2400)) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "IRC SSL detected: ->1200,<-1200||2400");
+    NDPI_LOG__TRACE(ndpi_struct, "found IRC SSL: ->1200,<-1200||2400");
     ndpi_int_irc_add_connection(ndpi_struct, flow);
     return 1;
   }
@@ -252,7 +256,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
       && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 1024
 									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
 									2048)) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "IRC SSL detected: ->1024,<-1024||2048");
+    NDPI_LOG__TRACE(ndpi_struct, "found IRC SSL: ->1024,<-1024||2048");
     ndpi_int_irc_add_connection(ndpi_struct, flow);
     return 1;
   }
@@ -267,7 +271,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
       && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 1248
 									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
 									2496)) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "IRC SSL detected: ->1248,<-1248||2496");
+    NDPI_LOG__TRACE(ndpi_struct, "found IRC SSL: ->1248,<-1248||2496");
     ndpi_int_irc_add_connection(ndpi_struct, flow);
     return 1;
   }
@@ -282,7 +286,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
       && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 1448
 									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
 									2896)) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "IRC SSL detected: ->1448,<-1448||2896");
+    NDPI_LOG__TRACE(ndpi_struct, "found IRC SSL: ->1448,<-1448||2896");
     ndpi_int_irc_add_connection(ndpi_struct, flow);
     return 1;
   }
@@ -305,8 +309,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
   if (packet->payload_packet_len == 4
       && flow->l4.tcp.irc_stage2 == 14
       && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && ntohs(get_u_int16_t(packet->payload, 2)) == 8192) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
-	     "IRC SSL detected: ->1448,1448,1448,1448,1448,952,<-8192");
+    NDPI_LOG__TRACE(ndpi_struct, "found IRC SSL: ->1448,1448,1448,1448,1448,952,<-8192");
     ndpi_int_irc_add_connection(ndpi_struct, flow);
     return 1;
   }
@@ -339,8 +342,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
   if (packet->payload_packet_len == 4
       && flow->l4.tcp.irc_stage2 == 19
       && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && ntohs(get_u_int16_t(packet->payload, 2)) == 7168) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
-	     "IRC SSL detected: ->1024,1448,1448,1200,1448,600,<-7168");
+    NDPI_LOG__TRACE(ndpi_struct, "found IRC SSL: ->1024,1448,1448,1200,1448,600,<-7168");
     ndpi_int_irc_add_connection(ndpi_struct, flow);
     return 1;
   }
@@ -353,7 +355,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
   if (packet->payload_packet_len == 4
       && flow->l4.tcp.irc_stage2 == 20
       && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && ntohs(get_u_int16_t(packet->payload, 2)) == 2404) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "IRC SSL detected: ->1024,1380 <-2404");
+    NDPI_LOG__TRACE(ndpi_struct, "found IRC SSL: ->1024,1380 <-2404");
     ndpi_int_irc_add_connection(ndpi_struct, flow);
     return 1;
 
@@ -382,26 +384,26 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
   u_int16_t http_content_ptr_len = 0;
   u_int8_t space = 0;
 
-  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "irc : search irc\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search irc\n");
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_IRC && flow->packet_counter > 70) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "exclude irc, packet_counter > 70\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "exclude irc, packet_counter > 70\n");
     NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_IRC);
     return;
   }
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_IRC && flow->packet_counter > 30 &&
       flow->l4.tcp.irc_stage2 == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "packet_counter > 30, exclude irc.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "exclude irc, packet_counter > 30\n");
     NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_IRC);
     return;
   }
   if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_IRC) {
     if (src != NULL && ((u_int32_t)
 			(packet->tick_timestamp - src->irc_ts) < ndpi_struct->irc_timeout)) {
-      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "irc : save src connection packet detected\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "irc : save src connection packet detected\n");
       src->irc_ts = packet->tick_timestamp;
     } else if (dst != NULL && ((u_int32_t)
 			       (packet->tick_timestamp - dst->irc_ts) < ndpi_struct->irc_timeout)) {
-      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "irc : save dst connection packet detected\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "irc : save dst connection packet detected\n");
       dst->irc_ts = packet->tick_timestamp;
     }
   }
@@ -423,8 +425,7 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
       for (counter = 0; counter < dst->irc_number_of_port; counter++) {
 	if (dst->irc_port[counter] == sport || dst->irc_port[counter] == dport) {
 	  dst->last_time_port_used[counter] = packet->tick_timestamp;
-	  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
-		   "dest port matched with the DCC port and the flow is marked as IRC");
+	  NDPI_LOG__TRACE(ndpi_struct, "found IRC: dest port matched with the DCC port");
 	  ndpi_int_irc_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -434,9 +435,8 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
       for (counter = 0; counter < src->irc_number_of_port; counter++) {
 	if (src->irc_port[counter] == sport || src->irc_port[counter] == dport) {
 	  src->last_time_port_used[counter] = packet->tick_timestamp;
+	  NDPI_LOG__TRACE(ndpi_struct, "found  IRC: Source port matched with the DCC port");
 	  ndpi_int_irc_add_connection(ndpi_struct, flow);
-	  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
-		   "Source port matched with the DCC port and the flow is marked as IRC");
 	  return;
 	}
       }
@@ -465,8 +465,8 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	    || (memcmp(&packet->payload[c1], "irc.discostars.de1", 18)
 		== 0)
 	    || (memcmp(&packet->payload[c1], "irc.rizon.net", 13) == 0)) {
-	  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
-		   "IRC SSL detected with :- irc.hackthissite.org0 | irc.gamepad.ca1 | dungeon.axenet.org0 "
+	  NDPI_LOG__TRACE(ndpi_struct,
+		   "found IRC SSL: - irc.hackthissite.org0 | irc.gamepad.ca1 | dungeon.axenet.org0 "
 		   "| dazed.nuggethaus.net | irc.indymedia.org | irc.discostars.de1 ");
 	  ndpi_int_irc_add_connection(ndpi_struct, flow);
 	  break;
@@ -496,14 +496,14 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  if (packet->line[i].ptr[0] == ':') {
 	    flow->l4.tcp.irc_3a_counter++;
 	    if (flow->l4.tcp.irc_3a_counter == 7) {	/* ':' == 0x3a */
-	      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "0x3a. seven times. found irc.");
+	      NDPI_LOG__TRACE(ndpi_struct, "found irc. 0x3a. seven times.");
 	      ndpi_int_irc_add_connection(ndpi_struct, flow);
 	      goto detected_irc;
 	    }
 	  }
 	}
 	if (flow->l4.tcp.irc_3a_counter == 7) {	/* ':' == 0x3a */
-	  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "0x3a. seven times. found irc.");
+	  NDPI_LOG__TRACE(ndpi_struct, "found irc. 0x3a. seven times.");
 	  ndpi_int_irc_add_connection(ndpi_struct, flow);
 	  goto detected_irc;
 	}
@@ -518,19 +518,19 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  || (memcmp(packet->payload, "NOTICE ", 7) == 0)
 	  || (memcmp(packet->payload, "PRIVMSG ", 8) == 0)
 	  || (memcmp(packet->payload, "VERSION ", 8) == 0)) {
-	NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
+	NDPI_LOG__DEBUG2(ndpi_struct,
 		 "USER, NICK, PASS, NOTICE, PRIVMSG one time");
 	if (flow->l4.tcp.irc_stage == 2) {
-	  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "found irc");
+	  NDPI_LOG__TRACE(ndpi_struct, "found irc");
 	  ndpi_int_irc_add_connection(ndpi_struct, flow);
 	  flow->l4.tcp.irc_stage = 3;
 	}
 	if (flow->l4.tcp.irc_stage == 1) {
-	  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "second time, stage=2");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "second time, stage=2");
 	  flow->l4.tcp.irc_stage = 2;
 	}
 	if (flow->l4.tcp.irc_stage == 0) {
-	  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "first time, stage=1");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "first time, stage=1");
 	  flow->l4.tcp.irc_stage = 1;
 	}
 	/* irc packets can have either windows line breaks (0d0a) or unix line breaks (0a) */
@@ -538,13 +538,11 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	    && packet->payload[packet->payload_packet_len - 1] == 0x0a) {
 	  ndpi_parse_packet_line_info(ndpi_struct, flow);
 	  if (packet->parsed_lines > 1) {
-	    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
-		     "packet contains more than one line");
+	    NDPI_LOG__DEBUG2(ndpi_struct, "packet contains more than one line");
 	    for (c = 1; c < packet->parsed_lines; c++) {
 	      if (packet->line[c].len > 4 && (memcmp(packet->line[c].ptr, "NICK ", 5) == 0
 					      || memcmp(packet->line[c].ptr, "USER ", 5) == 0)) {
-		NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct,
-			 NDPI_LOG_TRACE, "two icq signal words in the same packet");
+		NDPI_LOG__TRACE(ndpi_struct, "found IRC: two icq signal words in the same packet");
 		ndpi_int_irc_add_connection(ndpi_struct, flow);
 		flow->l4.tcp.irc_stage = 3;
 		return;
@@ -555,14 +553,12 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	} else if (packet->payload[packet->payload_packet_len - 1] == 0x0a) {
 	  ndpi_parse_packet_line_info_any(ndpi_struct, flow);
 	  if (packet->parsed_lines > 1) {
-	    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
-		     "packet contains more than one line");
+	    NDPI_LOG__DEBUG2(ndpi_struct, "packet contains more than one line");
 	    for (c = 1; c < packet->parsed_lines; c++) {
 	      if (packet->line[c].len > 4 && (memcmp(packet->line[c].ptr, "NICK ", 5) == 0
 						   || memcmp(packet->line[c].ptr, "USER ",
 							     5) == 0)) {
-		NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
-			 "two icq signal words in the same packet");
+		NDPI_LOG__TRACE(ndpi_struct, "found IRC: two icq signal words in the same packet");
 		ndpi_int_irc_add_connection(ndpi_struct, flow);
 		flow->l4.tcp.irc_stage = 3;
 		return;
@@ -594,7 +590,7 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 		&& (ndpi_check_for_IRC_traces(packet->http_url_name.ptr, packet->http_url_name.len)))
 	    || ((packet->referer_line.ptr)
 		&& (ndpi_check_for_IRC_traces(packet->referer_line.ptr, packet->referer_line.len)))) {
-	  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
+	  NDPI_LOG__DEBUG2(ndpi_struct,
 		   "IRC detected from the Http URL/ Referer header ");
 	  flow->l4.tcp.irc_stage = 1;
 	  // HTTP POST Request body is not in the same packet.
@@ -613,22 +609,21 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	|| (((packet->payload_packet_len - http_content_ptr_len) > 5)
 	    && (memcmp(packet->payload + http_content_ptr_len, "item=", 5) == 0)
 	    && (ndpi_check_for_cmd(ndpi_struct, flow) != 0))) {
-      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "IRC Nickname, cmd,  one time");
+      NDPI_LOG__TRACE(ndpi_struct, "found IRC: Nickname, cmd,  one time");
       ndpi_int_irc_add_connection(ndpi_struct, flow);
       return;
     }
   }
 
  detected_irc:
-  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "detected_irc:");
+  NDPI_LOG__DEBUG2(ndpi_struct, "detected_irc:");
 
   if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_IRC) {
     /* maybe this can be deleted at the end */
 
     if (packet->payload[packet->payload_packet_len - 2] != 0x0d
 	&& packet->payload[packet->payload_packet_len - 1] == 0x0a) {
-      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG,
-	       "ndpi_parse_packet_line_info_any(ndpi_struct, flow);");
+      NDPI_LOG__DEBUG2(ndpi_struct, "ndpi_parse_packet_line_info_any(ndpi_struct, flow);");
       ndpi_parse_packet_line_info_any(ndpi_struct, flow);
     } else if (packet->payload[packet->payload_packet_len - 2] == 0x0d) {
       ndpi_parse_packet_line_info(ndpi_struct, flow);
@@ -637,27 +632,27 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
     }
     for (i = 0; i < packet->parsed_lines; i++) {
       if (packet->line[i].len > 6 && memcmp(packet->line[i].ptr, "NOTICE ", 7) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "NOTICE");
+	NDPI_LOG__DEBUG2(ndpi_struct, "NOTICE");
 	for (j = 7; j < packet->line[i].len - 8; j++) {
 	  if (packet->line[i].ptr[j] == ':') {
 	    if (memcmp(&packet->line[i].ptr[j + 1], "DCC SEND ", 9) == 0
 		|| memcmp(&packet->line[i].ptr[j + 1], "DCC CHAT ", 9) == 0) {
-	      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
+	      NDPI_LOG__TRACE(ndpi_struct,
 		       "found NOTICE and DCC CHAT or DCC SEND.");
 	    }
 	  }
 	}
       }
       if (packet->payload_packet_len > 0 && packet->payload[0] == 0x3a /* 0x3a = ':' */ ) {
-	NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "3a");
+	NDPI_LOG__DEBUG2(ndpi_struct, "3a");
 	for (j = 1; j < packet->line[i].len - 9; j++) {
 	  if (packet->line[i].ptr[j] == ' ') {
 	    j++;
 	    if (packet->line[i].ptr[j] == 'P') {
-	      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "P");
+	      NDPI_LOG__DEBUG2(ndpi_struct, "P");
 	      j++;
 	      if (memcmp(&packet->line[i].ptr[j], "RIVMSG ", 7) == 0)
-		NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "RIVMSG");
+		NDPI_LOG__DEBUG2(ndpi_struct, "RIVMSG");
 	      h = j + 7;
 	      goto read_privmsg;
 	    }
@@ -665,25 +660,24 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	}
       }
       if (packet->line[i].len > 7 && (memcmp(packet->line[i].ptr, "PRIVMSG ", 8) == 0)) {
-	NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG, "PRIVMSG	");
+	NDPI_LOG__DEBUG2(ndpi_struct, "PRIVMSG	");
 	h = 7;
       read_privmsg:
 	for (j = h; j < packet->line[i].len - 9; j++) {
 	  if (packet->line[i].ptr[j] == ':') {
 	    if (memcmp(&packet->line[i].ptr[j + 1], "xdcc ", 5) == 0) {
-	      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "xdcc should match.");
+	      NDPI_LOG__DEBUG2(ndpi_struct, "xdcc should match.");
 	    }
 	    j += 2;
 	    if (memcmp(&packet->line[i].ptr[j], "DCC ", 4) == 0) {
 	      j += 4;
-	      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "found DCC.");
+	      NDPI_LOG__DEBUG2(ndpi_struct, "found DCC.");
 	      if (memcmp(&packet->line[i].ptr[j], "SEND ", 5) == 0
 		  || (memcmp(&packet->line[i].ptr[j], "CHAT", 4) == 0)
 		  || (memcmp(&packet->line[i].ptr[j], "chat", 4) == 0)
 		  || (memcmp(&packet->line[i].ptr[j], "sslchat", 7) == 0)
 		  || (memcmp(&packet->line[i].ptr[j], "TSEND", 5) == 0)) {
-		NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
-			 "found CHAT,chat,sslchat,TSEND.");
+		NDPI_LOG__DEBUG2(ndpi_struct, "found CHAT,chat,sslchat,TSEND.");
 		j += 4;
 
 		while (packet->line[i].len > j &&
@@ -696,35 +690,29 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 
 		  if (packet->line[i].ptr[j] == ' ') {
 		    space++;
-		    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "space %u.", space);
+		    NDPI_LOG__DEBUG2(ndpi_struct, "space %u.", space);
 		  }
 		  if (space == 3) {
 		    j++;
-		    NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "read port.");
+		    NDPI_LOG__DEBUG2(ndpi_struct, "read port.");
 		    if (src != NULL) {
 		      k = j;
 		      port =
 			ntohs_ndpi_bytestream_to_number
 			(&packet->line[i].ptr[j], packet->payload_packet_len - j, &j);
-		      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "port %u.",
+		      NDPI_LOG__DEBUG2(ndpi_struct, "port %u.",
 			       port);
 		      j = k;
 		      // hier jetzt überlegen, wie die ports abgespeichert werden sollen
 		      if (src->irc_number_of_port < NDPI_PROTOCOL_IRC_MAXPORT)
-			NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE,
-				 "src->irc_number_of_port < NDPI_PROTOCOL_IRC_MAXPORT.");
+			NDPI_LOG__DEBUG2(ndpi_struct, "src->irc_number_of_port < NDPI_PROTOCOL_IRC_MAXPORT.");
 		      if (src->irc_number_of_port < NDPI_PROTOCOL_IRC_MAXPORT && port != 0) {
 			if (!ndpi_is_duplicate(src, port)) {
 			  src->irc_port[src->irc_number_of_port]
 			    = port;
 			  src->irc_number_of_port++;
-			  NDPI_LOG
-			    (NDPI_PROTOCOL_IRC,
-			     ndpi_struct,
-			     NDPI_LOG_DEBUG, "found port=%d",
+			  NDPI_LOG__DEBUG2(ndpi_struct, "found port=%d jjeeeeeeeeeeeeeeeeeeeeeeeee",
 			     ntohs(get_u_int16_t(src->irc_port, 0)));
-			  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG,
-				   "jjeeeeeeeeeeeeeeeeeeeeeeeee");
 			}
 			src->irc_ts = packet->tick_timestamp;
 		      } else if (port != 0 && src->irc_number_of_port == NDPI_PROTOCOL_IRC_MAXPORT) {
@@ -732,11 +720,7 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 			  less = 0;
 			  NDPI_IRC_FIND_LESS(src->last_time_port_used, less);
 			  src->irc_port[less] = port;
-			  NDPI_LOG
-			    (NDPI_PROTOCOL_IRC,
-			     ndpi_struct,
-			     NDPI_LOG_DEBUG, "found port=%d",
-			     ntohs(get_u_int16_t(src->irc_port, 0)));
+			  NDPI_LOG__DEBUG2(ndpi_struct, "found port=%d", ntohs(get_u_int16_t(src->irc_port, 0)));
 			}
 			src->irc_ts = packet->tick_timestamp;
 		      }
@@ -747,8 +731,7 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 		    if (dst != NULL) {
 		      port = ntohs_ndpi_bytestream_to_number
 			(&packet->line[i].ptr[j], packet->payload_packet_len - j, &j);
-		      NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_TRACE, "port %u.",
-			       port);
+		      NDPI_LOG__DEBUG2(ndpi_struct, "port %u.", port);
 		      // hier das gleiche wie oben.
 		      /* hier werden NDPI_PROTOCOL_IRC_MAXPORT ports pro irc flows mitgespeichert. könnte man denn nicht ein-
 		       * fach an die dst oder src einen flag setzten, dass dieser port für eine bestimmte
@@ -759,13 +742,8 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 			  dst->irc_port[dst->irc_number_of_port]
 			    = port;
 			  dst->irc_number_of_port++;
-			  NDPI_LOG
-			    (NDPI_PROTOCOL_IRC,
-			     ndpi_struct,
-			     NDPI_LOG_DEBUG, "found port=%d",
-			     ntohs(get_u_int16_t(dst->irc_port, 0)));
-			  NDPI_LOG(NDPI_PROTOCOL_IRC, ndpi_struct, NDPI_LOG_DEBUG,
-				   "juuuuuuuuuuuuuuuu");
+			  NDPI_LOG__DEBUG2(ndpi_struct, "found port=%d", ntohs(get_u_int16_t(dst->irc_port, 0)));
+			  NDPI_LOG__DEBUG2(ndpi_struct, "juuuuuuuuuuuuuuuu");
 			}
 			dst->irc_ts = packet->tick_timestamp;
 		      } else if (port != 0 && dst->irc_number_of_port == NDPI_PROTOCOL_IRC_MAXPORT) {
@@ -774,11 +752,7 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 			  NDPI_IRC_FIND_LESS(dst->last_time_port_used, less);
 			  dst->irc_port[less] = port;
 
-			  NDPI_LOG
-			    (NDPI_PROTOCOL_IRC,
-			     ndpi_struct,
-			     NDPI_LOG_DEBUG, "found port=%d",
-			     ntohs(get_u_int16_t(dst->irc_port, 0)));
+			  NDPI_LOG__DEBUG2(ndpi_struct, "found port=%d", ntohs(get_u_int16_t(dst->irc_port, 0)));
 			}
 			dst->irc_ts = packet->tick_timestamp;
 		      }

--- a/src/lib/protocols/kakaotalk_voice.c
+++ b/src/lib/protocols/kakaotalk_voice.c
@@ -24,13 +24,20 @@
 
   http://www.kakao.com/services/talk/voices
 */
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_KAKAOTALK_VOICE
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_KAKAOTALK_VOICE
+
 #include "ndpi_api.h"
 
 
-#ifdef NDPI_PROTOCOL_KAKAOTALK_VOICE
 void ndpi_search_kakaotalk_voice(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &flow->packet;
   
+  NDPI_LOG__DEBUG(ndpi_struct, "search kakaotalk_voice\n");
+
   if(packet->iph
      && packet->udp
      && (packet->payload_packet_len >= 4)
@@ -48,14 +55,14 @@ void ndpi_search_kakaotalk_voice(struct ndpi_detection_module_struct *ndpi_struc
 
       if(((ntohl(packet->iph->saddr) & 0xFFFF0000 /* 255.255.0.0 */) == 0x01C90000 /* 1.201.0.0/16 */)
 	 || ((ntohl(packet->iph->daddr) & 0xFFFF0000 /* 255.255.0.0 */) == 0x01C90000 /* 1.201.0.0/16 */)) {
+	NDPI_LOG__TRACE(ndpi_struct, "found kakaotalk_voice\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_KAKAOTALK_VOICE, NDPI_PROTOCOL_UNKNOWN);
 	return;
       }
     } 
   }
   
-  NDPI_LOG(NDPI_PROTOCOL_KAKAOTALK_VOICE, ndpi_struct, NDPI_LOG_DEBUG, "Exclude kakaotalk_voice.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_KAKAOTALK_VOICE);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/kerberos.c
+++ b/src/lib/protocols/kerberos.c
@@ -22,24 +22,28 @@
  * 
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_KERBEROS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_KERBEROS
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_kerberos_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					     struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_KERBEROS, NDPI_PROTOCOL_UNKNOWN);
+  NDPI_LOG__DEBUG(ndpi_struct, "trace KERBEROS\n");
 }
 
 
 void ndpi_search_kerberos(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+	struct ndpi_packet_struct *packet = &flow->packet;
 
+	NDPI_LOG__DEBUG(ndpi_struct, "search KERBEROS\n");
 
 	/* I have observed 0a,0c,0d,0e at packet->payload[19/21], maybe there are other possibilities */
 	if (packet->payload_packet_len >= 4 && ntohl(get_u_int32_t(packet->payload, 0)) == packet->payload_packet_len - 4) {
@@ -47,7 +51,6 @@ void ndpi_search_kerberos(struct ndpi_detection_module_struct *ndpi_struct, stru
 			packet->payload[14] == 0x05 &&
 			(packet->payload[19] == 0x0a ||
 			 packet->payload[19] == 0x0c || packet->payload[19] == 0x0d || packet->payload[19] == 0x0e)) {
-			NDPI_LOG(NDPI_PROTOCOL_KERBEROS, ndpi_struct, NDPI_LOG_DEBUG, "found KERBEROS\n");
 			ndpi_int_kerberos_add_connection(ndpi_struct, flow);
 			return;
 
@@ -56,18 +59,12 @@ void ndpi_search_kerberos(struct ndpi_detection_module_struct *ndpi_struct, stru
 			packet->payload[16] == 0x05 &&
 			(packet->payload[21] == 0x0a ||
 			 packet->payload[21] == 0x0c || packet->payload[21] == 0x0d || packet->payload[21] == 0x0e)) {
-			NDPI_LOG(NDPI_PROTOCOL_KERBEROS, ndpi_struct, NDPI_LOG_DEBUG, "found KERBEROS\n");
 			ndpi_int_kerberos_add_connection(ndpi_struct, flow);
 			return;
 
 		}
-
-
-
 	}
-
-	NDPI_LOG(NDPI_PROTOCOL_KERBEROS, ndpi_struct, NDPI_LOG_DEBUG, "no KERBEROS detected.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_KERBEROS);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/kontiki.c
+++ b/src/lib/protocols/kontiki.c
@@ -23,44 +23,46 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_KONTIKI
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_KONTIKI
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_kontiki_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					    struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_KONTIKI, NDPI_PROTOCOL_UNKNOWN);
+  NDPI_LOG__TRACE(ndpi_struct, "found Kontiki UDP\n");
 }
 
 void ndpi_search_kontiki(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
+	NDPI_LOG__DEBUG(ndpi_struct, "search Kontiki\n");
 
 	if (packet->payload_packet_len == 4 && (get_u_int32_t(packet->payload, 0) == htonl(0x02010100))) {
-		NDPI_LOG(NDPI_PROTOCOL_KONTIKI, ndpi_struct, NDPI_LOG_DEBUG, "Kontiki UDP detected.\n");
 		ndpi_int_kontiki_add_connection(ndpi_struct, flow);
 		return;
 	}
+
 	if (packet->payload_packet_len > 0 && packet->payload[0] == 0x02) {
 
 		if (packet->payload_packet_len == 20 && (get_u_int32_t(packet->payload, 16) == htonl(0x02040100))) {
-			NDPI_LOG(NDPI_PROTOCOL_KONTIKI, ndpi_struct, NDPI_LOG_DEBUG, "Kontiki UDP detected.\n");
 			ndpi_int_kontiki_add_connection(ndpi_struct, flow);
 			return;
 		}
 		if (packet->payload_packet_len == 16 && (get_u_int32_t(packet->payload, 12) == htonl(0x000004e4))) {
-			NDPI_LOG(NDPI_PROTOCOL_KONTIKI, ndpi_struct, NDPI_LOG_DEBUG, "Kontiki UDP detected.\n");
 			ndpi_int_kontiki_add_connection(ndpi_struct, flow);
 			return;
 		}
 	}
 
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_KONTIKI);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/ldap.c
+++ b/src/lib/protocols/ldap.c
@@ -22,10 +22,14 @@
  * 
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_LDAP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_LDAP
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_ldap_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					 struct ndpi_flow_struct *flow)
@@ -37,15 +41,7 @@ void ndpi_search_ldap(struct ndpi_detection_module_struct *ndpi_struct, struct n
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-//  u_int16_t dport;
-
-
-
-	NDPI_LOG(NDPI_PROTOCOL_LDAP, ndpi_struct, NDPI_LOG_DEBUG, "search ldap\n");
-
+	NDPI_LOG__DEBUG(ndpi_struct, "search ldap\n");
 
 	if (packet->payload_packet_len >= 14 && packet->payload[0] == 0x30) {
 
@@ -55,14 +51,14 @@ void ndpi_search_ldap(struct ndpi_detection_module_struct *ndpi_struct, struct n
 
 			if (packet->payload[3] == 0x01 &&
 				(packet->payload[5] == 0x60 || packet->payload[5] == 0x61) && packet->payload[6] == 0x07) {
-				NDPI_LOG(NDPI_PROTOCOL_LDAP, ndpi_struct, NDPI_LOG_DEBUG, "found ldap simple type 1\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found ldap simple type 1\n");
 				ndpi_int_ldap_add_connection(ndpi_struct, flow);
 				return;
 			}
 
 			if (packet->payload[3] == 0x02 &&
 				(packet->payload[6] == 0x60 || packet->payload[6] == 0x61) && packet->payload[7] == 0x07) {
-				NDPI_LOG(NDPI_PROTOCOL_LDAP, ndpi_struct, NDPI_LOG_DEBUG, "found ldap simple type 2\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found ldap simple type 2\n");
 				ndpi_int_ldap_add_connection(ndpi_struct, flow);
 				return;
 			}
@@ -75,7 +71,7 @@ void ndpi_search_ldap(struct ndpi_detection_module_struct *ndpi_struct, struct n
 				(packet->payload[9] == 0x60 || packet->payload[9] == 0x61 || packet->payload[9] == 0x63 ||
 				 packet->payload[9] == 0x64) && packet->payload[10] == 0x84) {
 
-				NDPI_LOG(NDPI_PROTOCOL_LDAP, ndpi_struct, NDPI_LOG_DEBUG, "found ldap type 1\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found ldap type 1\n");
 				ndpi_int_ldap_add_connection(ndpi_struct, flow);
 				return;
 			}
@@ -84,7 +80,7 @@ void ndpi_search_ldap(struct ndpi_detection_module_struct *ndpi_struct, struct n
 				(packet->payload[10] == 0x60 || packet->payload[10] == 0x61 || packet->payload[10] == 0x63 ||
 				 packet->payload[10] == 0x64) && packet->payload[11] == 0x84) {
 
-				NDPI_LOG(NDPI_PROTOCOL_LDAP, ndpi_struct, NDPI_LOG_DEBUG, "found ldap type 2\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found ldap type 2\n");
 				ndpi_int_ldap_add_connection(ndpi_struct, flow);
 				return;
 			}
@@ -92,8 +88,7 @@ void ndpi_search_ldap(struct ndpi_detection_module_struct *ndpi_struct, struct n
 	}
 
 
-	NDPI_LOG(NDPI_PROTOCOL_LDAP, ndpi_struct, NDPI_LOG_DEBUG, "ldap excluded.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_LDAP);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/lisp.c
+++ b/src/lib/protocols/lisp.c
@@ -1,5 +1,10 @@
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_LISP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_LISP
+
+#include "ndpi_api.h"
 
 #define LISP_PORT 4341
 #define LISP_PORT1 4342
@@ -16,9 +21,8 @@ static void ndpi_check_lisp(struct ndpi_detection_module_struct *ndpi_struct, st
 {
 
   struct ndpi_packet_struct *packet = &flow->packet;  
-  u_int32_t payload_len = packet->payload_packet_len;
 
-   if(packet->udp != NULL) {
+  if(packet->udp != NULL) {
 
     u_int16_t lisp_port = htons(LISP_PORT);
     u_int16_t lisp_port1 = htons(LISP_PORT1);
@@ -28,22 +32,21 @@ static void ndpi_check_lisp(struct ndpi_detection_module_struct *ndpi_struct, st
 	((packet->udp->source == lisp_port1)
        && (packet->udp->dest == lisp_port1)) ) {
      
-	  NDPI_LOG(NDPI_PROTOCOL_LISP, ndpi_struct, NDPI_LOG_DEBUG, "Found lisp.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found lisp\n");
 	  ndpi_int_lisp_add_connection(ndpi_struct, flow, 0);
 	  return;
 
       }
     }
 
-  NDPI_LOG(NDPI_PROTOCOL_LISP, ndpi_struct, NDPI_LOG_DEBUG, "exclude lisp.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_LISP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void ndpi_search_lisp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_LISP, ndpi_struct, NDPI_LOG_DEBUG, "lisp detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search lisp\n");
 
   /* skip marked packets */
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_LISP) {

--- a/src/lib/protocols/mail_imap.c
+++ b/src/lib/protocols/mail_imap.c
@@ -22,9 +22,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_MAIL_IMAP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_MAIL_IMAP
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_mail_imap_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -40,11 +45,11 @@ void ndpi_search_mail_imap_tcp(struct ndpi_detection_module_struct *ndpi_struct,
   u_int8_t saw_command = 0;
   /* const u_int8_t *command = 0; */
 
-  NDPI_LOG(NDPI_PROTOCOL_MAIL_IMAP, ndpi_struct, NDPI_LOG_DEBUG, "search IMAP.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search IMAP_IMAP\n");
   
   if (flow->l4.tcp.mail_imap_starttls == 2) {
 #ifdef NDPI_PROTOCOL_SSL
-    NDPI_LOG(NDPI_PROTOCOL_MAIL_IMAP, ndpi_struct, NDPI_LOG_DEBUG, "starttls detected\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "starttls detected\n");
     NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MAIL_IMAP);
     NDPI_DEL_PROTOCOL_FROM_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SSL);
     return;
@@ -275,7 +280,7 @@ void ndpi_search_mail_imap_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 
     if (saw_command == 1) {
       if (flow->l4.tcp.mail_imap_stage == 3 || flow->l4.tcp.mail_imap_stage == 5) {
-	NDPI_LOG(NDPI_PROTOCOL_MAIL_IMAP, ndpi_struct, NDPI_LOG_DEBUG, "mail imap identified\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found MAIL_IMAP\n");
 	ndpi_int_mail_imap_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -283,7 +288,7 @@ void ndpi_search_mail_imap_tcp(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
   if (packet->payload_packet_len > 1 && packet->payload[packet->payload_packet_len - 1] == ' ') {
-    NDPI_LOG(NDPI_PROTOCOL_MAIL_IMAP, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
 	     "maybe a split imap command -> need next packet and imap_stage is set to 4.\n");
     flow->l4.tcp.mail_imap_stage = 4;
     return;
@@ -295,13 +300,12 @@ void ndpi_search_mail_imap_tcp(struct ndpi_detection_module_struct *ndpi_struct,
   // if the packet count is low enough and at least one command or response was seen before
   if ((packet->payload_packet_len >= 2 && ntohs(get_u_int16_t(packet->payload, packet->payload_packet_len - 2)) == 0x0d0a)
       && flow->packet_counter < 6 && flow->l4.tcp.mail_imap_stage >= 1) {
-    NDPI_LOG(NDPI_PROTOCOL_MAIL_IMAP, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
 	     "no imap command or response but packet count < 6 and imap stage >= 1 -> skip\n");
     return;
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_MAIL_IMAP, ndpi_struct, NDPI_LOG_DEBUG, "exclude IMAP.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MAIL_IMAP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/mail_pop.c
+++ b/src/lib/protocols/mail_pop.c
@@ -23,9 +23,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_MAIL_POP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_MAIL_POP
+
+#include "ndpi_api.h"
+
 
 #define POP_BIT_AUTH		0x0001
 #define POP_BIT_APOP		0x0002
@@ -52,9 +57,6 @@ static int ndpi_int_mail_pop_check_for_client_commands(struct ndpi_detection_mod
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//  struct ndpi_id_struct         *src=ndpi_struct->src;
-//  struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
 	if (packet->payload_packet_len > 4) {
 		if ((packet->payload[0] == 'A' || packet->payload[0] == 'a')
 			&& (packet->payload[1] == 'U' || packet->payload[1] == 'u')
@@ -133,13 +135,10 @@ void ndpi_search_mail_pop_tcp(struct ndpi_detection_module_struct
 								*ndpi_struct, struct ndpi_flow_struct *flow)
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
-	
-//  struct ndpi_id_struct         *src=ndpi_struct->src;
-//  struct ndpi_id_struct         *dst=ndpi_struct->dst;
 	u_int8_t a = 0;
 	u_int8_t bit_count = 0;
 
-	NDPI_LOG(NDPI_PROTOCOL_MAIL_POP, ndpi_struct, NDPI_LOG_DEBUG, "search mail_pop\n");
+	NDPI_LOG__DEBUG(ndpi_struct, "search mail_pop\n");
 
 
 
@@ -165,12 +164,12 @@ void ndpi_search_mail_pop_tcp(struct ndpi_detection_module_struct
 			}
 		}
 
-		NDPI_LOG(NDPI_PROTOCOL_MAIL_POP, ndpi_struct, NDPI_LOG_DEBUG,
+		NDPI_LOG__DEBUG2(ndpi_struct,
 				"mail_pop +OK/-ERR responses: %u, unique commands: %u\n", flow->l4.tcp.mail_pop_stage, bit_count);
 
 		if ((bit_count + flow->l4.tcp.mail_pop_stage) >= 3) {
 			if (flow->l4.tcp.mail_pop_stage > 0) {
-				NDPI_LOG(NDPI_PROTOCOL_MAIL_POP, ndpi_struct, NDPI_LOG_DEBUG, "mail_pop identified\n");
+				NDPI_LOG__TRACE(ndpi_struct, "mail_pop identified\n");
 				ndpi_int_mail_pop_add_connection(ndpi_struct, flow);
 				return;
 			} else {
@@ -182,7 +181,7 @@ void ndpi_search_mail_pop_tcp(struct ndpi_detection_module_struct
 
 	} else {
 		// first part of a split packet
-		NDPI_LOG(NDPI_PROTOCOL_MAIL_POP, ndpi_struct, NDPI_LOG_DEBUG,
+		NDPI_LOG__DEBUG2(ndpi_struct,
 				"mail_pop command without line ending -> skip\n");
 		return;
 	}
@@ -193,13 +192,12 @@ void ndpi_search_mail_pop_tcp(struct ndpi_detection_module_struct
 	if (((packet->payload_packet_len > 2 && ntohs(get_u_int16_t(packet->payload, packet->payload_packet_len - 2)) == 0x0d0a)
 		 || flow->l4.tcp.pop_command_bitmask != 0 || flow->l4.tcp.mail_pop_stage != 0) && flow->packet_counter < 12) {
 		// maybe part of a split pop packet
-		NDPI_LOG(NDPI_PROTOCOL_MAIL_POP, ndpi_struct, NDPI_LOG_DEBUG,
+		NDPI_LOG__DEBUG2(ndpi_struct,
 				"maybe part of split mail_pop packet -> skip\n");
 		return;
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_MAIL_POP, ndpi_struct, NDPI_LOG_DEBUG, "exclude mail_pop\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MAIL_POP);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/mail_smtp.c
+++ b/src/lib/protocols/mail_smtp.c
@@ -23,9 +23,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_MAIL_SMTP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_MAIL_SMTP
+
+#include "ndpi_api.h"
+
 
 #define SMTP_BIT_220		0x01
 #define SMTP_BIT_250		0x02
@@ -53,12 +58,7 @@ void ndpi_search_mail_smtp_tcp(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //  struct ndpi_id_struct         *src=ndpi_struct->src;
-  //  struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-
-  NDPI_LOG(NDPI_PROTOCOL_MAIL_SMTP, ndpi_struct, NDPI_LOG_DEBUG, "search mail_smtp.\n");
-
+  NDPI_LOG__DEBUG(ndpi_struct, "search mail_smtp\n");
 
   if (packet->payload_packet_len > 2 && ntohs(get_u_int16_t(packet->payload, packet->payload_packet_len - 2)) == 0x0d0a) {
     u_int8_t a;
@@ -152,11 +152,11 @@ void ndpi_search_mail_smtp_tcp(struct ndpi_detection_module_struct
 	bit_count += (flow->l4.tcp.smtp_command_bitmask >> a) & 0x01;
       }
     }
-    NDPI_LOG(NDPI_PROTOCOL_MAIL_SMTP, ndpi_struct, NDPI_LOG_DEBUG, "seen smtp commands and responses: %u.\n",
+    NDPI_LOG__DEBUG2(ndpi_struct, "seen smtp commands and responses: %u\n",
 	     bit_count);
 
     if (bit_count >= 3) {
-      NDPI_LOG(NDPI_PROTOCOL_MAIL_SMTP, ndpi_struct, NDPI_LOG_DEBUG, "mail smtp identified\n");
+      NDPI_LOG__TRACE(ndpi_struct, "mail smtp identified\n");
       ndpi_int_mail_smtp_add_connection(ndpi_struct, flow);
       return;
     }
@@ -169,12 +169,11 @@ void ndpi_search_mail_smtp_tcp(struct ndpi_detection_module_struct
       packet->payload_packet_len >= 4 &&
       (ntohs(get_u_int16_t(packet->payload, packet->payload_packet_len - 2)) == 0x0d0a
        || memcmp(packet->payload, "220", 3) == 0 || memcmp(packet->payload, "EHLO", 4) == 0)) {
-    NDPI_LOG(NDPI_PROTOCOL_MAIL_SMTP, ndpi_struct, NDPI_LOG_DEBUG, "maybe SMTP, need next packet.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "maybe SMTP, need next packet\n");
     return;
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_MAIL_SMTP, ndpi_struct, NDPI_LOG_DEBUG, "exclude smtp\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MAIL_SMTP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 

--- a/src/lib/protocols/maplestory.c
+++ b/src/lib/protocols/maplestory.c
@@ -22,9 +22,13 @@
  * 
  */
 
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_MAPLESTORY
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_MAPLESTORY
+
+#include "ndpi_api.h"
 
 static void ndpi_int_maplestory_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -36,16 +40,13 @@ void ndpi_search_maplestory(struct ndpi_detection_module_struct *ndpi_struct, st
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-
+	NDPI_LOG__DEBUG(ndpi_struct, "search maplestory\n");
 
 	if (packet->payload_packet_len == 16
 		&& (ntohl(get_u_int32_t(packet->payload, 0)) == 0x0e003a00 || ntohl(get_u_int32_t(packet->payload, 0)) == 0x0e003b00
 			|| ntohl(get_u_int32_t(packet->payload, 0)) == 0x0e004200)
 		&& ntohs(get_u_int16_t(packet->payload, 4)) == 0x0100 && (packet->payload[6] == 0x32 || packet->payload[6] == 0x33)) {
-		NDPI_LOG(NDPI_PROTOCOL_MAPLESTORY, ndpi_struct, NDPI_LOG_DEBUG, "found maplestory.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found maplestory\n");
 		ndpi_int_maplestory_add_connection(ndpi_struct, flow);
 		return;
 	}
@@ -63,7 +64,7 @@ void ndpi_search_maplestory(struct ndpi_detection_module_struct *ndpi_struct, st
 						  NDPI_STATICSTRING_LEN("patch")) == 0
 				&& memcmp(packet->user_agent_line.ptr, "Patcher", NDPI_STATICSTRING_LEN("Patcher")) == 0
 				&& memcmp(packet->host_line.ptr, "patch.", NDPI_STATICSTRING_LEN("patch.")) == 0) {
-				NDPI_LOG(NDPI_PROTOCOL_MAPLESTORY, ndpi_struct, NDPI_LOG_DEBUG, "found maplestory update.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found maplestory update\n");
 				ndpi_int_maplestory_add_connection(ndpi_struct, flow);
 				return;
 			}
@@ -71,14 +72,13 @@ void ndpi_search_maplestory(struct ndpi_detection_module_struct *ndpi_struct, st
 				   && memcmp(&packet->payload[NDPI_STATICSTRING_LEN("GET /maple")], "story/",
 							 NDPI_STATICSTRING_LEN("story/")) == 0
 				   && memcmp(packet->user_agent_line.ptr, "AspINet", NDPI_STATICSTRING_LEN("AspINet")) == 0) {
-			NDPI_LOG(NDPI_PROTOCOL_MAPLESTORY, ndpi_struct, NDPI_LOG_DEBUG, "found maplestory update.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found maplestory update\n");
 			ndpi_int_maplestory_add_connection(ndpi_struct, flow);
 			return;
 		}
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_MAPLESTORY, ndpi_struct, NDPI_LOG_DEBUG, "exclude maplestory.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MAPLESTORY);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 

--- a/src/lib/protocols/mdns.c
+++ b/src/lib/protocols/mdns.c
@@ -20,9 +20,13 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  * 
  */
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_MDNS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_MDNS
+
+#include "ndpi_api.h"
 
 #define NDPI_MAX_MDNS_REQUESTS  128
 
@@ -65,7 +69,7 @@ static int ndpi_int_check_mdns_payload(struct ndpi_detection_module_struct
   if(((packet->payload[2] & 0x80) == 0)
      && (questions <= NDPI_MAX_MDNS_REQUESTS)
      && (answers <= NDPI_MAX_MDNS_REQUESTS)) {	
-    NDPI_LOG(NDPI_PROTOCOL_MDNS, ndpi_struct, NDPI_LOG_DEBUG, "found MDNS with question query.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found MDNS with question query\n");
     return 1;    
   }
   else if(((packet->payload[2] & 0x80) != 0)
@@ -86,7 +90,7 @@ static int ndpi_int_check_mdns_payload(struct ndpi_detection_module_struct
     strncpy(flow->protos.mdns.answer, (const char *)answer, len);
     flow->protos.mdns.answer[len] = '\0';
 
-    NDPI_LOG(NDPI_PROTOCOL_MDNS, ndpi_struct, NDPI_LOG_DEBUG, "found MDNS with answer query.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found MDNS with answer query\n");
     return 1;
   }
   
@@ -98,6 +102,8 @@ void ndpi_search_mdns(struct ndpi_detection_module_struct *ndpi_struct, struct n
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int16_t dport;
   
+  NDPI_LOG__DEBUG(ndpi_struct, "search MDNS\n");
+
   /**
      information from http://www.it-administrator.de/lexikon/multicast-dns.html 
   */
@@ -112,8 +118,7 @@ void ndpi_search_mdns(struct ndpi_detection_module_struct *ndpi_struct, struct n
       /* mdns protocol must have destination address 224.0.0.251 */
 	    if(packet->iph != NULL /* && ntohl(packet->iph->daddr) == 0xe00000fb */) {
 
-	NDPI_LOG(NDPI_PROTOCOL_MDNS, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found MDNS with destination address 224.0.0.251 (=0xe00000fb)\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found MDNS with destination address 224.0.0.251 (=0xe00000fb)\n");
 	
 	if(ndpi_int_check_mdns_payload(ndpi_struct, flow) == 1) {
 	  ndpi_int_mdns_add_connection(ndpi_struct, flow);
@@ -125,8 +130,7 @@ void ndpi_search_mdns(struct ndpi_detection_module_struct *ndpi_struct, struct n
 	const u_int32_t *daddr = packet->iphv6->ip6_dst.u6_addr.u6_addr32;
 	if(daddr[0] == htonl(0xff020000) /* && daddr[1] == 0 && daddr[2] == 0 && daddr[3] == htonl(0xfb) */) {
 
-	  NDPI_LOG(NDPI_PROTOCOL_MDNS, ndpi_struct,
-		   NDPI_LOG_DEBUG, "found MDNS with destination address ff02::fb\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found MDNS with destination address ff02::fb\n");
 	  
 	  if(ndpi_int_check_mdns_payload(ndpi_struct, flow) == 1) {
 	    ndpi_int_mdns_add_connection(ndpi_struct, flow);
@@ -137,7 +141,7 @@ void ndpi_search_mdns(struct ndpi_detection_module_struct *ndpi_struct, struct n
 #endif
     }
   }
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MDNS);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/megaco.c
+++ b/src/lib/protocols/megaco.c
@@ -18,16 +18,20 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_MEGACO
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_MEGACO
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_MEGACO
 
 void ndpi_search_megaco(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
   
-  NDPI_LOG(NDPI_PROTOCOL_MEGACO, ndpi_struct, NDPI_LOG_DEBUG, "search for MEGACO.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search for MEGACO\n");
   
   if(packet->udp != NULL) {
     if((packet->payload_packet_len > 4 && packet->payload[0] == '!' && packet->payload[1] == '/' &&
@@ -36,14 +40,13 @@ void ndpi_search_megaco(struct ndpi_detection_module_struct *ndpi_struct, struct
         packet->payload[2] == 'G' && packet->payload[3] == 'A' && packet->payload[4] == 'C' &&
         packet->payload[5] == 'O' && packet->payload[6] == '/' &&
         packet->payload[7] == '1' && packet->payload[8] == ' ' && packet->payload[9] == '[')) {
-      NDPI_LOG(NDPI_PROTOCOL_MEGACO, ndpi_struct, NDPI_LOG_DEBUG, "found MEGACO.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found MEGACO\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MEGACO, NDPI_PROTOCOL_UNKNOWN);
       return;
     } 
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_MEGACO, ndpi_struct, NDPI_LOG_DEBUG, "exclude MEGACO.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MEGACO);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/mms.c
+++ b/src/lib/protocols/mms.c
@@ -23,9 +23,13 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_CONTENT_MMS
+
+#define NDPI_CURRENT_PROTO NDPI_CONTENT_MMS
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_mms_add_connection(struct ndpi_detection_module_struct
@@ -39,9 +43,7 @@ void ndpi_search_mms_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
+  NDPI_LOG__DEBUG(ndpi_struct, "search MMS\n");
 
   /* search MSMMS packets */
   if (packet->payload_packet_len >= 20) {
@@ -49,7 +51,7 @@ void ndpi_search_mms_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	&& packet->payload[5] == 0xfa && packet->payload[6] == 0x0b
 	&& packet->payload[7] == 0xb0 && packet->payload[12] == 0x4d
 	&& packet->payload[13] == 0x4d && packet->payload[14] == 0x53 && packet->payload[15] == 0x20) {
-      NDPI_LOG(NDPI_CONTENT_MMS, ndpi_struct, NDPI_LOG_DEBUG, "MMS: MSMMS Request found \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found MMS: MSMMS Request \n");
       flow->l4.tcp.mms_stage = 1 + packet->packet_direction;
       return;
     }
@@ -59,7 +61,7 @@ void ndpi_search_mms_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	&& packet->payload[6] == 0x0b && packet->payload[7] == 0xb0
 	&& packet->payload[12] == 0x4d && packet->payload[13] == 0x4d
 	&& packet->payload[14] == 0x53 && packet->payload[15] == 0x20) {
-      NDPI_LOG(NDPI_CONTENT_MMS, ndpi_struct, NDPI_LOG_DEBUG, "MMS: MSMMS Response found \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found MMS: MSMMS Response \n");
       ndpi_int_mms_add_connection(ndpi_struct, flow);
       return;
     }
@@ -67,12 +69,11 @@ void ndpi_search_mms_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 #ifdef NDPI_PROTOCOL_HTTP
   if (NDPI_COMPARE_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_HTTP) != 0) {
 #endif							/* NDPI_PROTOCOL_HTTP */
-    NDPI_LOG(NDPI_CONTENT_MMS, ndpi_struct, NDPI_LOG_DEBUG, "MMS: exclude\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_CONTENT_MMS);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 #ifdef NDPI_PROTOCOL_HTTP
   } else {
-    NDPI_LOG(NDPI_CONTENT_MMS, ndpi_struct, NDPI_LOG_DEBUG, "MMS avoid early exclude from http\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "MMS avoid early exclude from http\n");
   }
 #endif							/* NDPI_PROTOCOL_HTTP */
 

--- a/src/lib/protocols/mpegts.c
+++ b/src/lib/protocols/mpegts.c
@@ -19,16 +19,19 @@
  *
  */
 
-
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_MPEGTS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_MPEGTS
+
+#include "ndpi_api.h"
 
 void ndpi_search_mpegts(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_MPEGTS, ndpi_struct, NDPI_LOG_DEBUG, "search for MPEGTS.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search MPEGTS\n");
 
   if((packet->udp != NULL) && ((packet->payload_packet_len % 188) == 0)) {
     u_int i, num_chunks = packet->payload_packet_len / 188;
@@ -40,13 +43,13 @@ void ndpi_search_mpegts(struct ndpi_detection_module_struct *ndpi_struct, struct
     }
 
     /* This looks MPEG TS */
+    NDPI_LOG__TRACE(ndpi_struct, "found MPEGTS\n");
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MPEGTS, NDPI_PROTOCOL_UNKNOWN);
     return;
   }    
 
  no_mpegts:
-  NDPI_LOG(NDPI_PROTOCOL_MPEGTS, ndpi_struct, NDPI_LOG_DEBUG, "Excluded MPEGTS.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MPEGTS);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/msn.c
+++ b/src/lib/protocols/msn.c
@@ -21,9 +21,15 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_api.h"
+
+#include "ndpi_protocol_ids.h"
+
 
 #ifdef NDPI_PROTOCOL_MSN
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_MSN
+
+#include "ndpi_api.h"
 
 #define MAX_PACKETS_FOR_MSN 100
 
@@ -59,17 +65,16 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
   u_int16_t plen;
   u_int16_t status = 0;
   
-  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "MSN tcp detection...\n");
 #ifdef NDPI_PROTOCOL_SSL
   if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_SSL) {
     
-    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "msn ssl ft test\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "msn ssl ft test\n");
 
     if(flow->packet_counter < 10) {
       if(flow->packet_counter == 7 && packet->payload_packet_len > 300) {
 	if(memcmp(packet->payload + 24, "MSNSLP", 6) == 0
 	   || (get_u_int32_t(packet->payload, 0) == htonl(0x30000000) && get_u_int32_t(packet->payload, 4) == 0x00000000)) {
-	  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "detected MSN File Transfer, ifdef ssl.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found MSN File Transfer, ifdef ssl\n");
 	  ndpi_int_msn_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -77,12 +82,12 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
       if(flow->packet_counter >= 5 && flow->packet_counter <= 10 && (get_u_int32_t(packet->payload, 0) == htonl(0x18000000)
 								     && get_u_int32_t(packet->payload, 4) == 0x00000000)) {
 	flow->l4.tcp.msn_ssl_ft++;
-	NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
+	NDPI_LOG__DEBUG2(ndpi_struct,
 		 "increased msn ft ssl stage to: %u at packet nr: %u\n", flow->l4.tcp.msn_ssl_ft,
 		 flow->packet_counter);
 	if (flow->l4.tcp.msn_ssl_ft == 2) {
-	  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
-		   "detected MSN File Transfer, ifdef ssl 2.\n");
+	  NDPI_LOG__TRACE(ndpi_struct,
+		   "found MSN File Transfer, ifdef ssl 2.\n");
 	  ndpi_int_msn_add_connection(ndpi_struct, flow);
 	}
 	return;
@@ -109,18 +114,13 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
        && ((ntohl(get_u_int32_t(packet->payload, 24)) == 0x000f0004 && ntohl(get_u_int32_t(packet->payload, 28)) == 0x72c64bc6)
 	   || (ntohl(get_u_int32_t(packet->payload, 20)) == 0x000f0004
 	       && ntohl(get_u_int32_t(packet->payload, 24)) == 0x72c64bc6))) {
-      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
+      NDPI_LOG__TRACE(ndpi_struct,
 	       "found MSN in packets that also contain voice.messenger.live.com.\n");
 
       /* TODO this is an alternative pattern for video detection */
       /*          if (packet->payload_packet_len > 100 &&
 		  get_u_int16_t(packet->payload, 86) == htons(0x05dc)) { */
-      if(packet->payload_packet_len > 101 && packet->payload[101] == 0x02) {
-	ndpi_int_msn_add_connection(ndpi_struct, flow);
-      } else {
-	ndpi_int_msn_add_connection(ndpi_struct, flow);
-      }
-
+      ndpi_int_msn_add_connection(ndpi_struct, flow);
       return;
     }
 
@@ -133,14 +133,12 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 
 	  if (memcmp(&packet->payload[packet->payload_packet_len - 6], "CVR",
 		     3) == 0 || memcmp(&packet->payload[packet->payload_packet_len - 8], "MSNP", 4) == 0) {
-	    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
-		     "found MSN by pattern VER...CVR/MSNP ODOA.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found MSN by pattern VER...CVR/MSNP ODOA\n");
 	    ndpi_int_msn_add_connection(ndpi_struct, flow);
 	    return;
 	  }
 	  if (ndpi_match_strprefix(&packet->payload[4], packet->payload_packet_len-4, "MSNFT")) {
-	    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
-		     "found MSN FT by pattern VER MSNFT...0d0a.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found MSN FT by pattern VER MSNFT...0d0a\n");
 	    ndpi_int_msn_add_connection(ndpi_struct, flow);
 	    return;
 	  }
@@ -157,6 +155,7 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
       if (packet->user_agent_line.ptr != NULL &&
 	  packet->user_agent_line.len > NDPI_STATICSTRING_LEN("Messenger/") &&
 	  memcmp(packet->user_agent_line.ptr, "Messenger/", NDPI_STATICSTRING_LEN("Messenger/")) == 0) {
+	NDPI_LOG__TRACE(ndpi_struct, "found MSN Messenger/\n");
 	ndpi_int_msn_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -184,8 +183,7 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	    (packet->content_line.len >= NDPI_STATICSTRING_LEN("text/x-msnmsgr") &&
 	     memcmp(packet->content_line.ptr, "text/x-msnmsgr",
 		    NDPI_STATICSTRING_LEN("text/x-msnmsgr")) == 0))) {
-	  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
-		   "found MSN by pattern POST http:// .... application/x-msn-messenger.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found MSN POST application/x-msn-messenger\n");
 	  ndpi_int_msn_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -209,16 +207,14 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	  for(c = 13; c < 50; c++) {
 	    if(memcmp(&packet->payload[c], "/", 1) == 0) {
 	      if(memcmp(&packet->payload[c], "/gateway/gateway.dll", 20) == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
-			 "found  pattern http://.../gateway/gateway.ddl.\n");
+		NDPI_LOG__DEBUG2(ndpi_struct, "found  pattern http://.../gateway/gateway.ddl\n");
 		status = 1;
 		break;
 	      }
 	    }
 	  }
 	} else if((memcmp(&packet->payload[5], "/gateway/gateway.dll", 20) == 0)) {
-	  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
-		   "found  pattern http://.../gateway/gateway.ddl.\n");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "found  pattern http://.../gateway/gateway.ddl\n");
 	  status = 1;
 	}
       }
@@ -239,7 +235,7 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	  if ((src != NULL && NDPI_COMPARE_PROTOCOL_TO_BITMASK(src->detected_protocol_bitmask, NDPI_PROTOCOL_MSN) != 0)
 	      || (dst != NULL && NDPI_COMPARE_PROTOCOL_TO_BITMASK(dst->detected_protocol_bitmask, NDPI_PROTOCOL_MSN) != 0)) {
 	    
-	    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "found MSN with pattern text/xml; charset=utf-8.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found MSN with pattern text/xml; charset=utf-8\n");
 	    ndpi_int_msn_add_connection(ndpi_struct, flow);
 	    return;
 	  }
@@ -248,10 +244,8 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 					    || memcmp(packet->line[a].ptr, "VER ", 4) == 0 ||
 					    memcmp(packet->line[a].ptr, "ANS ", 4) == 0)) {
 	      
-	      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
-		       "found MSN with pattern text/sml; charset0utf-8.\n");
-	      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct,
-		       NDPI_LOG_TRACE, "MSN xml CVS / VER / ANS found\n");
+	      NDPI_LOG__DEBUG2(ndpi_struct, "found MSN with pattern text/sml; charset0utf-8\n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found MSN xml CVS / VER / ANS found\n");
 	      ndpi_int_msn_add_connection(ndpi_struct, flow);
 	      return;
 	    }
@@ -280,13 +274,13 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	     (packet->content_line.len >= NDPI_STATICSTRING_LEN("text/x-msnmsgr") &&
 	      memcmp(packet->content_line.ptr, "text/x-msnmsgr", NDPI_STATICSTRING_LEN("text/x-msnmsgr")) == 0))) {
 	  
-	  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE,
-		   "HTTP/1.0 200 OK .... application/x-msn-messenger.\n");
+	  NDPI_LOG__TRACE(ndpi_struct,
+		   "found MSN  application/x-msn-messenger.\n");
 	  ndpi_int_msn_add_connection(ndpi_struct, flow);
 	  return;
 	}
 	if(ndpi_int_find_xmsn(ndpi_struct, flow) == 1) {
-	  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "HTTP/1.0 200 OK .... X-MSN.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found MSN X-MSN\n");
 	  ndpi_int_msn_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -296,7 +290,7 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
     /* now block proxy connection */
     if(packet->payload_packet_len >= 42) {
       if(memcmp(packet->payload, "CONNECT messenger.hotmail.com:1863 HTTP/1.", 42) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "found MSN  with pattern CONNECT messenger.hotmail.com:1863 HTTP/1..\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found MSN  with pattern CONNECT messenger.hotmail.com:1863 HTTP/1.\n");
 	ndpi_int_msn_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -322,7 +316,7 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 
 	while (plen < endlen) {
 	  if (ndpi_check_for_email_address(ndpi_struct, flow, plen) != 0) {
-	    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "found mail address\n");
+	    NDPI_LOG__DEBUG2(ndpi_struct, "found mail address\n");
 	    break;
 	  }
 	  if (packet->payload_packet_len > plen + 1
@@ -334,7 +328,7 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	    goto ndpi_msn_exclude;
 	  }
 	}
-	NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "found MSN  with pattern USR/ANS ...mail_address.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found MSN  with pattern USR/ANS ...mail_address\n");
 	ndpi_int_msn_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -362,12 +356,12 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 					      (packet->content_line.len >= NDPI_STATICSTRING_LEN("text/x-msnmsgr") &&
 					       memcmp(packet->content_line.ptr, "text/x-msnmsgr", NDPI_STATICSTRING_LEN("text/x-msnmsgr")) == 0))) {
 	
-	NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "HTTP/1.0 200 OK .... application/x-msn-messenger.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found MSN application/x-msn-messenger\n");
 	ndpi_int_msn_add_connection(ndpi_struct, flow);
 	return;
       }
       if(ndpi_int_find_xmsn(ndpi_struct, flow) == 1) {
-	NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "HTTP/1.0 200 OK .... X-MSN.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found MSN X-MSN\n");
 	ndpi_int_msn_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -381,7 +375,7 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	 && NDPI_COMPARE_PROTOCOL_TO_BITMASK(dst->detected_protocol_bitmask, NDPI_PROTOCOL_MSN) != 0)) {
     if (flow->packet_counter == 1 &&
 	packet->payload_packet_len > 12 && memcmp(packet->payload, "recipientid=", 12) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "detected file transfer.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found MSN file transfer\n");
       ndpi_int_msn_add_connection(ndpi_struct, flow);
       return;
     }
@@ -396,7 +390,7 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
     if((packet->payload_packet_len == 4 || packet->payload_packet_len == 8)
        && get_u_int32_t(packet->payload, 0) == htonl(0x04000000)) {
       
-      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "maybe first TCP MSN detected\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "maybe first TCP MSN detected\n");
       
       if(packet->payload_packet_len == 8 && get_u_int32_t(packet->payload, 4) == htonl(0x666f6f00)) {
 	flow->l4.tcp.msn_stage = 5 + packet->packet_direction;
@@ -409,12 +403,12 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
   } else if (flow->l4.tcp.msn_stage == 1 + packet->packet_direction) {
     if (packet->payload_packet_len > 10 && get_u_int32_t(packet->payload, 0) == htonl(0x666f6f00)) {
       ndpi_int_msn_add_connection(ndpi_struct, flow);
-      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "MSN File Transfer detected 1\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found MSN File Transfer 1\n");
       return;
     }
     /* did not see this pattern in any trace */
     if (packet->payload_packet_len == 56 && get_u_int32_t(packet->payload, 16) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "maybe Second TCP MSN detected\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "maybe Second TCP MSN detected\n");
       flow->l4.tcp.msn_stage = 3 + packet->packet_direction;
       return;
     }
@@ -423,30 +417,30 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
   } else if (flow->l4.tcp.msn_stage == 2 - packet->packet_direction
 	     && packet->payload_packet_len == 4 && get_u_int32_t(packet->payload, 0) == htonl(0x30000000)) {
     ndpi_int_msn_add_connection(ndpi_struct, flow);
-    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "MSN File Transfer detected 2\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found MSN File Transfer 2\n");
     return;
   } else if ((flow->l4.tcp.msn_stage == 3 + packet->packet_direction)
 	     || (flow->l4.tcp.msn_stage == 4 - packet->packet_direction)) {
     if (packet->payload_packet_len == 4 && get_u_int32_t(packet->payload, 0) == htonl(0x30000000)) {
       ndpi_int_msn_add_connection(ndpi_struct, flow);
-      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "MSN File Transfer detected 2\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found MSN File Transfer 2\n");
       return;
     }
   } else if (flow->l4.tcp.msn_stage == 6 - packet->packet_direction) {
     if ((packet->payload_packet_len == 4) &&
 	(get_u_int32_t(packet->payload, 0) == htonl(0x10000000) || get_u_int32_t(packet->payload, 0) == htonl(0x30000000))) {
       ndpi_int_msn_add_connection(ndpi_struct, flow);
-      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "MSN File Transfer detected 3\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found MSN File Transfer 3\n");
       return;
     }
   } else if (flow->l4.tcp.msn_stage == 5 + packet->packet_direction) {
     if ((packet->payload_packet_len == 20) && get_u_int32_t(packet->payload, 0) == htonl(0x10000000)) {
       ndpi_int_msn_add_connection(ndpi_struct, flow);
-      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "MSN File Transfer detected 3\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found MSN File Transfer 3\n");
       return;
     }
   }
-  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_DEBUG, "msn 7.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "msn 7\n");
   
   if (flow->packet_counter <= MAX_PACKETS_FOR_MSN) {	
     if (memcmp(&packet->payload[0], "MSG ", 4) == 0
@@ -459,13 +453,12 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	|| memcmp(&packet->payload[0], "XFR ", 4) == 0) {
       ndpi_int_msn_add_connection(ndpi_struct, flow);
       
-      NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "MSN detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found MSN\n");
       return;
     }
   }
-  NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "MSN tcp excluded.\n");
  ndpi_msn_exclude:
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MSN);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 /* search over UDP */
@@ -482,7 +475,7 @@ static void ndpi_search_msn_udp_misc(struct ndpi_detection_module_struct
   if ((src == NULL || NDPI_COMPARE_PROTOCOL_TO_BITMASK(src->detected_protocol_bitmask, NDPI_PROTOCOL_MSN) == 0)
       && (dst == NULL
 	  || NDPI_COMPARE_PROTOCOL_TO_BITMASK(dst->detected_protocol_bitmask, NDPI_PROTOCOL_MSN) == 0)) {
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MSN);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
@@ -490,7 +483,7 @@ static void ndpi_search_msn_udp_misc(struct ndpi_detection_module_struct
   if (packet->payload_packet_len == 20
       && get_u_int32_t(packet->payload, 4) == 0 && packet->payload[9] == 0
       && get_u_int16_t(packet->payload, 10) == htons(0x0100)) {
-    NDPI_LOG(NDPI_PROTOCOL_MSN, ndpi_struct, NDPI_LOG_TRACE, "msn udp misc data connection detected\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found MSN udp misc data connection\n");
     ndpi_int_msn_add_connection(ndpi_struct, flow);
   }
 
@@ -504,6 +497,7 @@ void ndpi_search_msn(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search msn\n");
   /* this if request should always be true */
   if(NDPI_COMPARE_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MSN) == 0) {
     /* we deal with tcp now */

--- a/src/lib/protocols/mssql_tds.c
+++ b/src/lib/protocols/mssql_tds.c
@@ -22,9 +22,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_MSSQL_TDS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_MSSQL_TDS
+
+#include "ndpi_api.h"
+
 
 struct tds_packet_header {
   u_int8_t type;
@@ -46,24 +51,24 @@ void ndpi_search_mssql_tds(struct ndpi_detection_module_struct *ndpi_struct, str
   struct ndpi_packet_struct *packet = &flow->packet;
   struct tds_packet_header *h = (struct tds_packet_header*) packet->payload;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search mssql_tds\n");
+
   if(packet->payload_packet_len < sizeof(struct tds_packet_header)) {
-    NDPI_LOG(NDPI_PROTOCOL_MSSQL_TDS, ndpi_struct, NDPI_LOG_DEBUG, "exclude mssql_tds\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MSSQL_TDS);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
   
   if((h->type >= 1 && h->type <= 8) || (h->type >= 14 && h->type <= 18)) {
     if(h->status == 0x00 || h->status == 0x01 || h->status == 0x02 || h->status == 0x04 || h->status == 0x08 || h->status == 0x09 || h->status == 0x10) {
       if(ntohs(h->length) == packet->payload_packet_len && h->window == 0x00) {
-	NDPI_LOG(NDPI_PROTOCOL_MSSQL_TDS, ndpi_struct, NDPI_LOG_DEBUG, "found mssql_tds\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found mssql_tds\n");
 	ndpi_int_mssql_tds_add_connection(ndpi_struct, flow);
 	return;
       }
     }
   }
   
-  NDPI_LOG(NDPI_PROTOCOL_MSSQL_TDS, ndpi_struct, NDPI_LOG_DEBUG, "exclude mssql_tds\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MSSQL_TDS);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/mysql.c
+++ b/src/lib/protocols/mysql.c
@@ -23,9 +23,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_MYSQL
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_MYSQL
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_mysql_add_connection(struct ndpi_detection_module_struct
 					  *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -36,9 +41,9 @@ static void ndpi_int_mysql_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_mysql_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search MySQL\n");
 	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
   if(packet->tcp) {
     if (packet->payload_packet_len > 38	//min length
 	&& get_u_int16_t(packet->payload, 0) == packet->payload_packet_len - 4	//first 3 bytes are length
@@ -55,7 +60,7 @@ void ndpi_search_mysql_tcp(struct ndpi_detection_module_struct *ndpi_struct, str
 	      && get_u_int64_t(packet->payload, a + 19) == 0x0ULL	//13 more
 	      && get_u_int32_t(packet->payload, a + 27) == 0x0	//filler bytes
 	      && get_u_int8_t(packet->payload, a + 31) == 0x0) {
-	    NDPI_LOG(NDPI_PROTOCOL_MYSQL, ndpi_struct, NDPI_LOG_DEBUG, "MySQL detected.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found MySQL\n");
 	    ndpi_int_mysql_add_connection(ndpi_struct, flow);
 	    return;
 	  }
@@ -65,7 +70,7 @@ void ndpi_search_mysql_tcp(struct ndpi_detection_module_struct *ndpi_struct, str
     }
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MYSQL);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/netbios.c
+++ b/src/lib/protocols/netbios.c
@@ -23,9 +23,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_NETBIOS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_NETBIOS
+
+#include "ndpi_api.h"
+
 
 struct netbios_header {
   u_int16_t transaction_id, flags, questions, answer_rrs, authority_rrs, additional_rrs;
@@ -81,10 +86,10 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
   u_int16_t dport;
   char name[64];
   
+  NDPI_LOG__DEBUG(ndpi_struct, "search netbios\n");
   if(packet->udp != NULL) {
     dport = ntohs(packet->udp->dest);
 
-    NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG, "netbios udp start\n");
 
     /*check standard NETBIOS over udp to port 137  */
     if((dport == 137 || 0) && packet->payload_packet_len >= 50) {
@@ -95,16 +100,14 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	h.questions = ntohs(h.questions), h.answer_rrs = ntohs(h.answer_rrs),
 	h.authority_rrs = ntohs(h.authority_rrs), h.additional_rrs = ntohs(h.additional_rrs);
       
-      NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-	       NDPI_LOG_DEBUG, "found netbios port 137 and payload_packet_len 50\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "found netbios port 137 and payload_packet_len 50\n");
 
       if(h.flags == 0 &&
 	  h.questions == 1 &&
 	  h.answer_rrs == 0 &&
 	  h.authority_rrs == 0 && h.additional_rrs == 0) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found netbios with questions = 1 and answers = 0, authority = 0  \n");
+	NDPI_LOG__TRACE(ndpi_struct, "found netbios with questions = 1 and answers = 0, authority = 0  \n");
 
 	ndpi_int_netbios_add_connection(ndpi_struct, flow);
 	return;
@@ -114,8 +117,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  h.answer_rrs == 0 &&
 	  h.authority_rrs == 0) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found netbios with questions = 1 and answers = 0, authority = 0 and broadcast \n");
+	NDPI_LOG__TRACE(ndpi_struct, "found netbios with questions = 1 and answers = 0, authority = 0 and broadcast \n");
 	
 	if(ndpi_netbios_name_interpret((char*)&packet->payload[12], name, sizeof(name)) > 0)
 	  snprintf((char*)flow->host_server_name, sizeof(flow->host_server_name)-1, "%s", name);
@@ -128,8 +130,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  h.answer_rrs == 0 &&
 	  h.authority_rrs == 0 && h.additional_rrs == 1) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found netbios with questions = 1 and answers, authority, additional = 0  \n");
+	NDPI_LOG__TRACE(ndpi_struct, "found netbios with questions = 1 and answers, authority, additional = 0  \n");
 
 	ndpi_int_netbios_add_connection(ndpi_struct, flow);
 	return;
@@ -139,8 +140,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  h.answer_rrs == 0 &&
 	  h.authority_rrs == 0 && h.additional_rrs == 1) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found netbios with questions = 1 and answers = 0, authority = 0  \n");
+	NDPI_LOG__TRACE(ndpi_struct, "found netbios with questions = 1 and answers = 0, authority = 0  \n");
 
 	ndpi_int_netbios_add_connection(ndpi_struct, flow);
 	return;
@@ -150,8 +150,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  h.answer_rrs == 1 &&
 	  h.authority_rrs == 0 && h.additional_rrs == 0) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG,
+	NDPI_LOG__TRACE(ndpi_struct,
 		 "found netbios with flag 8400 questions = 0 and answers = 1, authority, additional = 0  \n");
 
 	ndpi_int_netbios_add_connection(ndpi_struct, flow);
@@ -162,8 +161,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  h.answer_rrs == 1 &&
 	  h.authority_rrs == 0 && h.additional_rrs == 0) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG,
+	NDPI_LOG__TRACE(ndpi_struct,
 		 "found netbios with flag 8500 questions = 0 and answers = 1, authority, additional = 0  \n");
 
 	ndpi_int_netbios_add_connection(ndpi_struct, flow);
@@ -174,8 +172,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  h.answer_rrs == 0 &&
 	  h.authority_rrs == 0 && h.additional_rrs == 1) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG,
+	NDPI_LOG__TRACE(ndpi_struct,
 		 "found netbios with flag 2910, questions = 1 and answers, authority=0, additional = 1  \n");
 
 	ndpi_int_netbios_add_connection(ndpi_struct, flow);
@@ -186,8 +183,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  h.answer_rrs == 1 &&
 	  h.authority_rrs == 0 && h.additional_rrs == 0) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG,
+	NDPI_LOG__TRACE(ndpi_struct,
 		 "found netbios with flag ad86 questions = 0 and answers = 1, authority, additional = 0  \n");
 
 	ndpi_int_netbios_add_connection(ndpi_struct, flow);
@@ -198,8 +194,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  h.answer_rrs == 0 &&
 	  h.authority_rrs == 0 && h.additional_rrs == 0) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG,
+	NDPI_LOG__TRACE(ndpi_struct,
 		 "found netbios with flag 0110 questions = 1 and answers = 0, authority, additional = 0  \n");
 
 	ndpi_int_netbios_add_connection(ndpi_struct, flow);
@@ -208,7 +203,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 
       if((h.flags & 0xf800) == 0) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG, "possible netbios name query request\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "possible netbios name query request\n");
 
 	if(get_u_int16_t(packet->payload, 4) == htons(1) &&
 	    get_u_int16_t(packet->payload, 6) == 0 &&
@@ -217,12 +212,12 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  /* name is encoded as described in rfc883 */
 	  u_int8_t name_length = packet->payload[12];
 
-	  NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	  NDPI_LOG__DEBUG2(ndpi_struct,
 		   "possible netbios name query request, one question\n");
 
 	  if(packet->payload_packet_len == 12 + 1 + name_length + 1 + 2 + 2) {
 
-	    NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	    NDPI_LOG__DEBUG2(ndpi_struct,
 		     "possible netbios name query request, length matches\n");
 
 	    /* null terminated? */
@@ -230,7 +225,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 		get_u_int16_t(packet->payload, 12 + name_length + 2) == htons(0x0020) &&
 		get_u_int16_t(packet->payload, 12 + name_length + 4) == htons(0x0001)) {
 
-	      NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	      NDPI_LOG__TRACE(ndpi_struct,
 		       "found netbios name query request\n");
 	      ndpi_int_netbios_add_connection(ndpi_struct, flow);
 	      return;
@@ -238,7 +233,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  }
 	}
       } else if((h.flags & 0xf800) == 0x8000) {
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	NDPI_LOG__DEBUG2(ndpi_struct,
 		 "possible netbios name query response\n");
 
 	if(get_u_int16_t(packet->payload, 4) == 0 &&
@@ -248,12 +243,12 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  /* name is encoded as described in rfc883 */
 	  u_int8_t name_length = packet->payload[12];
 
-	  NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	  NDPI_LOG__DEBUG2(ndpi_struct,
 		   "possible netbios positive name query response, one answer\n");
 
 	  if(packet->payload_packet_len >= 12 + 1 + name_length + 1 + 2 + 2) {
 
-	    NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	    NDPI_LOG__DEBUG2(ndpi_struct,
 		     "possible netbios name query response, length matches\n");
 
 	    /* null terminated? */
@@ -261,7 +256,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 		get_u_int16_t(packet->payload, 12 + name_length + 2) == htons(0x0020) &&
 		get_u_int16_t(packet->payload, 12 + name_length + 4) == htons(0x0001)) {
 
-	      NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	      NDPI_LOG__TRACE(ndpi_struct,
 		       "found netbios name query response\n");
 	      ndpi_int_netbios_add_connection(ndpi_struct, flow);
 	      return;
@@ -274,12 +269,12 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  /* name is encoded as described in rfc883 */
 	  u_int8_t name_length = packet->payload[12];
 
-	  NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	  NDPI_LOG__DEBUG2(ndpi_struct,
 		   "possible netbios negative name query response, one answer\n");
 
 	  if(packet->payload_packet_len >= 12 + 1 + name_length + 1 + 2 + 2) {
 
-	    NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	    NDPI_LOG__DEBUG2(ndpi_struct,
 		     "possible netbios name query response, length matches\n");
 
 	    /* null terminated? */
@@ -287,7 +282,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 		get_u_int16_t(packet->payload, 12 + name_length + 2) == htons(0x000A) &&
 		get_u_int16_t(packet->payload, 12 + name_length + 4) == htons(0x0001)) {
 
-	      NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	      NDPI_LOG__TRACE(ndpi_struct,
 		       "found netbios name query response\n");
 	      ndpi_int_netbios_add_connection(ndpi_struct, flow);
 	      return;
@@ -300,12 +295,12 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  /* name is encoded as described in rfc883 */
 	  u_int8_t name_length = packet->payload[12];
 
-	  NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	  NDPI_LOG__DEBUG2(ndpi_struct,
 		   "possible netbios redirect name query response, one answer\n");
 
 	  if(packet->payload_packet_len >= 12 + 1 + name_length + 1 + 2 + 2) {
 
-	    NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	    NDPI_LOG__DEBUG2(ndpi_struct,
 		     "possible netbios name query response, length matches\n");
 
 	    /* null terminated? */
@@ -313,7 +308,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 		get_u_int16_t(packet->payload, 12 + name_length + 2) == htons(0x0002) &&
 		get_u_int16_t(packet->payload, 12 + name_length + 4) == htons(0x0001)) {
 
-	      NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG,
+	      NDPI_LOG__TRACE(ndpi_struct,
 		       "found netbios name query response\n");
 	      ndpi_int_netbios_add_connection(ndpi_struct, flow);
 	      return;
@@ -332,17 +327,14 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 	packet->payload_packet_len >= 14 &&
 	ntohs(get_u_int16_t(packet->payload, 10)) == packet->payload_packet_len - 14) {
 
-      NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-	       NDPI_LOG_DEBUG, "found netbios port 138 and payload length >= 112 \n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "found netbios port 138 and payload length >= 112 \n");
 
       if(packet->payload[0] >= 0x11 && packet->payload[0] <= 0x16) {
 
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found netbios with MSG-type 0x11,0x12,0x13,0x14,0x15 or 0x16\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "found netbios with MSG-type 0x11,0x12,0x13,0x14,0x15 or 0x16\n");
 
 	if(ntohl(get_u_int32_t(packet->payload, 4)) == ntohl(packet->iph->saddr)) {
-	  NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		   NDPI_LOG_DEBUG, "found netbios with checked ip-address.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found netbios with checked ip-address\n");
 
 	  if(ndpi_netbios_name_interpret((char*)&packet->payload[12], name, sizeof(name)) > 0)
 	    snprintf((char*)flow->host_server_name, sizeof(flow->host_server_name)-1, "%s", name);
@@ -357,21 +349,17 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
   if(packet->tcp != NULL) {
     dport = ntohs(packet->tcp->dest);
 
-    NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG, "netbios tcp start\n");
-
     /* destination port must be 139 */
     if(dport == 139) {
 
-      NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG, "found netbios with destination port 139\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "found netbios with destination port 139\n");
 
       /* payload_packet_len must be 72 */
       if(packet->payload_packet_len == 72) {
-	NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		 NDPI_LOG_DEBUG, "found netbios with payload_packen_len = 72. \n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "found netbios with payload_packen_len = 72. \n");
 
 	if(packet->payload[0] == 0x81 && packet->payload[1] == 0 && ntohs(get_u_int16_t(packet->payload, 2)) == 68) {
-	  NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct,
-		   NDPI_LOG_DEBUG,
+	  NDPI_LOG__TRACE(ndpi_struct,
 		   "found netbios with session request = 81, flags=0 and length od following bytes = 68. \n");
 
 	  ndpi_int_netbios_add_connection(ndpi_struct, flow);
@@ -382,8 +370,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct, struc
 
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_NETBIOS, ndpi_struct, NDPI_LOG_DEBUG, "exclude netbios\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_NETBIOS);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void init_netbios_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask)

--- a/src/lib/protocols/netflow.c
+++ b/src/lib/protocols/netflow.c
@@ -18,10 +18,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_NETFLOW
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_NETFLOW
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_NETFLOW
 
 #ifdef WIN32
 extern int gettimeofday(struct timeval * tp, struct timezone * tzp);
@@ -95,13 +99,15 @@ struct flow_ver7_rec {
   u_int32_t router_sc;  /* Router which is shortcut by switch */
 };
 
-static void ndpi_check_netflow(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
+void ndpi_search_netflow(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
   // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
   time_t now;
   struct timeval now_tv;
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search netflow\n");
 
   if((packet->udp != NULL) && (payload_len >= 24)) {
     u_int16_t version = (packet->payload[0] << 8) + packet->payload[1], uptime_offset;
@@ -132,7 +138,7 @@ static void ndpi_check_netflow(struct ndpi_detection_module_struct *ndpi_struct,
       }
 
       if((expected_len > 0) && (expected_len != payload_len)) {
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_NETFLOW);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 	return;
       }
 
@@ -159,19 +165,12 @@ static void ndpi_check_netflow(struct ndpi_detection_module_struct *ndpi_struct,
 
     if(((version == 1) && (when == 0))
        || ((when >= 946684800 /* 1/1/2000 */) && (when <= now))) {
-      NDPI_LOG(NDPI_PROTOCOL_NETFLOW, ndpi_struct, NDPI_LOG_DEBUG, "Found netflow.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found netflow\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_NETFLOW, NDPI_PROTOCOL_UNKNOWN);
       return;
     }
   }
 }
-
-void ndpi_search_netflow(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
-{
-  NDPI_LOG(NDPI_PROTOCOL_NETFLOW, ndpi_struct, NDPI_LOG_DEBUG, "netflow detection...\n");
-  ndpi_check_netflow(ndpi_struct, flow);
-}
-
 
 void init_netflow_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask)
 {

--- a/src/lib/protocols/nfs.c
+++ b/src/lib/protocols/nfs.c
@@ -23,9 +23,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_NFS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_NFS
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_nfs_add_connection(struct ndpi_detection_module_struct
 					*ndpi_struct, struct ndpi_flow_struct *flow)
@@ -37,8 +42,7 @@ void ndpi_search_nfs(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+	NDPI_LOG__DEBUG(ndpi_struct, "search NFS\n");
 
 	u_int8_t offset = 0;
 	if (packet->tcp != NULL)
@@ -47,41 +51,41 @@ void ndpi_search_nfs(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	if (packet->payload_packet_len < (40 + offset))
 		goto exclude_nfs;
 
-	NDPI_LOG(NDPI_PROTOCOL_NFS, ndpi_struct, NDPI_LOG_DEBUG, "NFS user match stage 1\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "NFS user match stage 1\n");
 
 
 	if (offset != 0 && get_u_int32_t(packet->payload, 0) != htonl(0x80000000 + packet->payload_packet_len - 4))
 		goto exclude_nfs;
 
-	NDPI_LOG(NDPI_PROTOCOL_NFS, ndpi_struct, NDPI_LOG_DEBUG, "NFS user match stage 2\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "NFS user match stage 2\n");
 
 	if (get_u_int32_t(packet->payload, 4 + offset) != 0)
 		goto exclude_nfs;
 
-	NDPI_LOG(NDPI_PROTOCOL_NFS, ndpi_struct, NDPI_LOG_DEBUG, "NFS user match stage 3\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "NFS user match stage 3\n");
 
 	if (get_u_int32_t(packet->payload, 8 + offset) != htonl(0x02))
 		goto exclude_nfs;
 
-	NDPI_LOG(NDPI_PROTOCOL_NFS, ndpi_struct, NDPI_LOG_DEBUG, "NFS match stage 3\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "NFS match stage 3\n");
 
 	if (get_u_int32_t(packet->payload, 12 + offset) != htonl(0x000186a5)
 		&& get_u_int32_t(packet->payload, 12 + offset) != htonl(0x000186a3)
 		&& get_u_int32_t(packet->payload, 12 + offset) != htonl(0x000186a0))
 		goto exclude_nfs;
 
-	NDPI_LOG(NDPI_PROTOCOL_NFS, ndpi_struct, NDPI_LOG_DEBUG, "NFS match stage 4\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "NFS match stage 4\n");
 
 	if (ntohl(get_u_int32_t(packet->payload, 16 + offset)) > 4)
 		goto exclude_nfs;
 
-	NDPI_LOG(NDPI_PROTOCOL_NFS, ndpi_struct, NDPI_LOG_DEBUG, "NFS match\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found NFS\n");
 
 	ndpi_int_nfs_add_connection(ndpi_struct, flow);
 	return;
 
   exclude_nfs:
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_NFS);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/nintendo.c
+++ b/src/lib/protocols/nintendo.c
@@ -21,10 +21,13 @@
  *
  */
 
-
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_NINTENDO
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_NINTENDO
+
+#include "ndpi_api.h"
 
 static void ndpi_int_nintendo_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					     struct ndpi_flow_struct *flow,
@@ -43,15 +46,14 @@ void ndpi_search_nintendo(struct ndpi_detection_module_struct *ndpi_struct, stru
       const char nintendo_pattern[] = { 0x32, 0xab, 0x98, 0x64, 0x02 };
 
       if(memcmp(payload, nintendo_pattern, 5) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_NINTENDO, ndpi_struct, NDPI_LOG_DEBUG, "Found nintendo.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found nintendo\n");
 	ndpi_int_nintendo_add_connection(ndpi_struct, flow, 0);
 	return;
       }
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_NINTENDO, ndpi_struct, NDPI_LOG_DEBUG, "Exclude Nintendo.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_NINTENDO);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void init_nintendo_dissector(struct ndpi_detection_module_struct *ndpi_struct,

--- a/src/lib/protocols/noe.c
+++ b/src/lib/protocols/noe.c
@@ -5,28 +5,32 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_NOE
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_NOE
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_NOE
 
 static void ndpi_int_noe_add_connection(struct ndpi_detection_module_struct
 					*ndpi_struct, struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_NOE, NDPI_PROTOCOL_UNKNOWN);
+  NDPI_LOG__TRACE(ndpi_struct, "found noe\n");
 }
 
 void ndpi_search_noe(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
   
-  NDPI_LOG(NDPI_PROTOCOL_NOE, ndpi_struct, NDPI_LOG_DEBUG, "search for NOE.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search NOE\n");
   
   if(packet->udp != NULL) {
-    NDPI_LOG(NDPI_PROTOCOL_NOE, ndpi_struct, NDPI_LOG_DEBUG, "calculating dport over udp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculating dport over udp\n");
 
     if (packet->payload_packet_len == 1 && ( packet->payload[0] == 0x05 || packet->payload[0] == 0x04 )) {
-      NDPI_LOG(NDPI_PROTOCOL_NOE, ndpi_struct, NDPI_LOG_DEBUG, "found noe.\n");
       ndpi_int_noe_add_connection(ndpi_struct, flow);
       return;
     } else if((packet->payload_packet_len == 5 || packet->payload_packet_len == 12) &&
@@ -34,19 +38,18 @@ void ndpi_search_noe(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	      (packet->payload[1] == 0x00 ) &&
 	      (packet->payload[2] != 0x00 ) &&
 	      (packet->payload[3] == 0x00 )) {
-      NDPI_LOG(NDPI_PROTOCOL_NOE, ndpi_struct, NDPI_LOG_DEBUG, "found noe.\n");
       ndpi_int_noe_add_connection(ndpi_struct, flow);
+      return;
     } else if((packet->payload_packet_len >= 25) &&
 	      (packet->payload[0] == 0x00 &&
 	       packet->payload[1] == 0x06 &&
 	       packet->payload[2] == 0x62 &&
 	       packet->payload[3] == 0x6c)) {
-      NDPI_LOG(NDPI_PROTOCOL_NOE, ndpi_struct, NDPI_LOG_DEBUG, "found noe.\n");
       ndpi_int_noe_add_connection(ndpi_struct, flow);
+      return;
     }
   } else {
-      NDPI_LOG(NDPI_PROTOCOL_NOE, ndpi_struct, NDPI_LOG_DEBUG, "exclude NOE.\n");
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_NOE);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     }
 }
 

--- a/src/lib/protocols/openft.c
+++ b/src/lib/protocols/openft.c
@@ -22,9 +22,13 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_OPENFT
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_OPENFT
 
 #include "ndpi_protocols.h"
-#ifdef NDPI_PROTOCOL_OPENFT
 
 static void ndpi_int_openft_add_connection(struct ndpi_detection_module_struct
 					   *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -37,21 +41,18 @@ void ndpi_search_openft_tcp(struct ndpi_detection_module_struct
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
 	if (packet->payload_packet_len > 5 && memcmp(packet->payload, "GET /", 5) == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_OPENFT, ndpi_struct, NDPI_LOG_DEBUG, "HTTP packet detected.\n");
+		NDPI_LOG__DEBUG2(ndpi_struct, "HTTP packet detected\n");
 		ndpi_parse_packet_line_info(ndpi_struct, flow);
 		if (packet->parsed_lines >= 2
 			&& packet->line[1].len > 13 && memcmp(packet->line[1].ptr, "X-OpenftAlias:", 14) == 0) {
-			NDPI_LOG(NDPI_PROTOCOL_OPENFT, ndpi_struct, NDPI_LOG_DEBUG, "OpenFT detected.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found OpenFT\n");
 			ndpi_int_openft_add_connection(ndpi_struct, flow);
 			return;
 		}
 	}
 
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_OPENFT);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/openvpn.c
+++ b/src/lib/protocols/openvpn.c
@@ -21,9 +21,14 @@
  *
  */
 
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_OPENVPN
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_OPENVPN
+
+#include "ndpi_api.h"
+
 
 #define P_CONTROL_HARD_RESET_CLIENT_V1  (0x01 << 3)
 #define P_CONTROL_HARD_RESET_CLIENT_V2  (0x07 << 3)
@@ -81,7 +86,7 @@ void ndpi_search_openvpn(struct ndpi_detection_module_struct* ndpi_struct,
       if (check_pkid_and_detect_hmac_size(ovpn_payload) > 0) {
         memcpy(flow->ovpn_session_id, ovpn_payload+1, 8);
 
-        NDPI_LOG(NDPI_PROTOCOL_OPENVPN, ndpi_struct, NDPI_LOG_DEBUG,
+        NDPI_LOG__DEBUG2(ndpi_struct,
 		 "session key: %02x%02x%02x%02x%02x%02x%02x%02x\n",
 		 flow->ovpn_session_id[0], flow->ovpn_session_id[1], flow->ovpn_session_id[2], flow->ovpn_session_id[3],
 		 flow->ovpn_session_id[4], flow->ovpn_session_id[5], flow->ovpn_session_id[6], flow->ovpn_session_id[7]);
@@ -95,10 +100,12 @@ void ndpi_search_openvpn(struct ndpi_detection_module_struct* ndpi_struct,
         alen = ovpn_payload[P_PACKET_ID_ARRAY_LEN_OFFSET(hmac_size)];
         session_remote = ovpn_payload + P_PACKET_ID_ARRAY_LEN_OFFSET(hmac_size) + 1 + alen * 4;
 
-        if (memcmp(flow->ovpn_session_id, session_remote, 8) == 0)
-          ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_OPENVPN, NDPI_PROTOCOL_UNKNOWN);
+        if (memcmp(flow->ovpn_session_id, session_remote, 8) == 0) {
+		NDPI_LOG__TRACE(ndpi_struct,"found openvpn\n");
+          	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_OPENVPN, NDPI_PROTOCOL_UNKNOWN);
+	  }
         else {
-          NDPI_LOG(NDPI_PROTOCOL_OPENVPN, ndpi_struct, NDPI_LOG_DEBUG,
+          NDPI_LOG__DEBUG2(ndpi_struct,
 		   "key mismatch: %02x%02x%02x%02x%02x%02x%02x%02x\n",
 		   session_remote[0], session_remote[1], session_remote[2], session_remote[3],
 		   session_remote[4], session_remote[5], session_remote[6], session_remote[7]);
@@ -111,8 +118,9 @@ void ndpi_search_openvpn(struct ndpi_detection_module_struct* ndpi_struct,
 
     flow->ovpn_counter++;
     
-    if (failed)
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_OPENVPN);
+    if (failed) {
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    }
   }
 }
 

--- a/src/lib/protocols/oracle.c
+++ b/src/lib/protocols/oracle.c
@@ -18,11 +18,15 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_ORACLE
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_ORACLE
 
 #include "ndpi_api.h"
 
 
-#ifdef NDPI_PROTOCOL_ORACLE
 static void ndpi_int_oracle_add_connection(struct ndpi_detection_module_struct
 					   *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -34,11 +38,11 @@ void ndpi_search_oracle(struct ndpi_detection_module_struct *ndpi_struct, struct
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int16_t dport = 0, sport = 0;
 
-  NDPI_LOG(NDPI_PROTOCOL_ORACLE, ndpi_struct, NDPI_LOG_DEBUG, "search for ORACLE.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search ORACLE\n");
 
   if(packet->tcp != NULL) {
     sport = ntohs(packet->tcp->source), dport = ntohs(packet->tcp->dest);
-    NDPI_LOG(NDPI_PROTOCOL_ORACLE, ndpi_struct, NDPI_LOG_DEBUG, "calculating ORACLE over tcp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculating ORACLE over tcp\n");
     /* Oracle Database 9g,10g,11g */
     if ((dport == 1521 || sport == 1521)
 	&&  (((packet->payload[0] == 0x07) && (packet->payload[1] == 0xff) && (packet->payload[2] == 0x00))
@@ -46,17 +50,16 @@ void ndpi_search_oracle(struct ndpi_detection_module_struct *ndpi_struct, struct
 	     && (packet->payload[1] != 0x00)
 	     && (packet->payload[2] == 0x00)
 		 && (packet->payload[3] == 0x00)))) {
-      NDPI_LOG(NDPI_PROTOCOL_ORACLE, ndpi_struct, NDPI_LOG_DEBUG, "found oracle.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found oracle\n");
       ndpi_int_oracle_add_connection(ndpi_struct, flow);
     } else if (packet->payload_packet_len == 213 && packet->payload[0] == 0x00 &&
                packet->payload[1] == 0xd5 && packet->payload[2] == 0x00 &&
                packet->payload[3] == 0x00 ) {
-      NDPI_LOG(NDPI_PROTOCOL_ORACLE, ndpi_struct, NDPI_LOG_DEBUG, "found oracle.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found oracle\n");
       ndpi_int_oracle_add_connection(ndpi_struct, flow);
     }
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_ORACLE, ndpi_struct, NDPI_LOG_DEBUG, "exclude ORACLE.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_ORACLE);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/oscar.c
+++ b/src/lib/protocols/oscar.c
@@ -22,6 +22,11 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_OSCAR
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_OSCAR
 
 #include "ndpi_api.h"
 
@@ -69,7 +74,6 @@
 #define EMAIL               0x0018
 #define IS_EXT              0x0085
 
-#ifdef NDPI_PROTOCOL_OSCAR
 
 static void ndpi_int_oscar_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					  struct ndpi_flow_struct *flow)
@@ -146,28 +150,28 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 	  /* No TLVs */
 	  if(packet->payload_packet_len == 10)
 	    {
-	      NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR - Sign In \n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Sign In \n");
 	      ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	      return;
 	    }
 	  /* /\* SCREEN_NAME *\/ */
 	  /* if (get_u_int16_t(packet->payload, 10) == htons(SCREEN_NAME)) /\* packet->payload[10] == 0x00 && packet->payload[11] == 0x01 *\/ */
 	  /*   { */
-	  /*     NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR - Screen Name \n"); */
+	  /*     NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Screen Name \n"); */
 	  /*     ndpi_int_oscar_add_connection(ndpi_struct, flow); */
 	  /*     return; */
 	  /*   } */
 	  /* /\* PASSWD *\/ */
 	  /* if (get_u_int16_t(packet->payload, 10) == htons(PASSWD)) /\* packet->payload[10] == 0x00 && packet->payload[11] == 0x02 *\/ */
 	  /*   { */
-	  /*     NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR - Password (roasted) \n"); */
+	  /*     NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Password (roasted) \n"); */
 	  /*     ndpi_int_oscar_add_connection(ndpi_struct, flow); */
 	  /*     return; */
 	  /*   } */
 	  /* CLIENT_NAME */
 	  if (get_u_int16_t(packet->payload, 10) == htons(CLIENT_NAME)) /* packet->payload[10] == 0x00 && packet->payload[11] == 0x03 */
 	    {
-	      NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR - Client Name \n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Client Name \n");
 	      ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	      return;
 	    }
@@ -182,7 +186,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 		       (get_u_int8_t(packet->payload, packet->payload_packet_len - 1) == 0x01) ||
 		       (get_u_int8_t(packet->payload, packet->payload_packet_len - 1) == 0x03))
 		      {
-			NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR - Login \n");
+			NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Login \n");
 			ndpi_int_oscar_add_connection(ndpi_struct, flow);
 			return;
 		      }
@@ -191,35 +195,35 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 	  /* MAJOR_VERSION */
 	  if (get_u_int16_t(packet->payload, 10) == htons(MAJOR_VERSION))
 	    {
-	      NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR - Major_Version \n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Major_Version \n");
 	      ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	      return;
 	    }
 	  /* MINOR_VERSION */
 	  if (get_u_int16_t(packet->payload, 10) == htons(MINOR_VERSION))
 	    {
-	      NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR - Minor_Version \n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Minor_Version \n");
 	      ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	      return;
 	    }
 	  /* POINT_VERSION */
 	  if (get_u_int16_t(packet->payload, 10) == htons(POINT_VERSION))
 	    {
-	      NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR - Point_Version \n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Point_Version \n");
 	      ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	      return;
 	    }
 	  /* BUILD_NUM */
 	  if (get_u_int16_t(packet->payload, 10) == htons(BUILD_NUM))
 	    {
-	      NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR - Build_Num \n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Build_Num \n");
 	      ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	      return;
 	    }
 	  /* CLIENT_RECONNECT */
 	  if (get_u_int16_t(packet->payload, 10) == htons(CLIENT_RECONNECT))
 	    {
-	      NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR - Client_Reconnect \n");
+	      NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Client_Reconnect \n");
 	      ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	      return;
 	    }
@@ -254,7 +258,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 	    type = 0;
 	  if (family == 0 || type == 0)
 	  {
-	      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_OSCAR);
+	      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 	      return;
 	  }
 
@@ -565,8 +569,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 
 	  if(excluded == 1)
 	    {
-	      NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "exclude oscar.\n");
-	      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_OSCAR);
+	      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 	    }
 
 	  /* flag */
@@ -581,7 +584,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 		  req_ID = get_u_int32_t(packet->payload, 12);
 		  if((req_ID <= ((u_int32_t)-1)))
 		    {
-		      NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR Detected \n");
+		      NDPI_LOG__TRACE(ndpi_struct, "found OSCAR\n");
 		      ndpi_int_oscar_add_connection(ndpi_struct, flow);
 		      return;
 		    }
@@ -595,7 +598,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
       */
       if (channel == O_ERROR)
 	{
-	  NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR Detected - Error frame \n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Error frame \n");
 	  ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -605,7 +608,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
       */
       if (channel == SIGNOFF)
 	{
-	  NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR Detected - Signoff frame \n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Signoff frame \n");
 	  ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -615,7 +618,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
       */
       if (channel == KEEP_ALIVE)
 	{
-	  NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR Detected - Keep Alive frame \n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found OSCAR - Keep Alive frame \n");
 	  ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -628,8 +631,8 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
       NDPI_PARSE_PACKET_LINE_INFO(ndpi_struct, flow, packet);
       if (packet->host_line.len >= 18 && packet->host_line.ptr != NULL) {
 	if (memcmp(packet->host_line.ptr, "lifestream.aol.com", 18) == 0) {
-	  NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG,
-		   "OSCAR over HTTP found, POST method\n");
+	  NDPI_LOG__TRACE(ndpi_struct,
+		   "found OSCAR over HTTP, POST method\n");
 	  ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -643,7 +646,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 	  (memcmp(&packet->payload[5], "aim/gromit/aim_express", 22) == 0) ||
 	  (memcmp(&packet->payload[5], "b/ss/aolwpaim", 13) == 0) ||
 	  (memcmp(&packet->payload[5], "hss/storage/aimtmpshare", 23) == 0)) {
-	NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR over HTTP found, GET /aim/\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found OSCAR over HTTP, GET /aim/\n");
 	ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -656,7 +659,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 	     (memcmp(packet->user_agent_line.ptr, "mobileICQ/", 10) == 0) ||
 	     (memcmp(packet->user_agent_line.ptr, "AIM%20Free/", NDPI_STATICSTRING_LEN("AIM%20Free/")) == 0) ||
 	     (memcmp(packet->user_agent_line.ptr, "AIM/", 4) == 0))) {
-	  NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR over HTTP found\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found OSCAR over HTTP\n");
 	  ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -670,8 +673,8 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 	  for (i = 0; i < (packet->referer_line.len - 22); i++) {
 	    if (packet->referer_line.ptr[i] == 'a') {
 	      if (memcmp(&packet->referer_line.ptr[i + 1], "im/gromit/aim_express", 21) == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG,
-			 "OSCAR over HTTP found : aim/gromit/aim_express\n");
+		NDPI_LOG__TRACE(ndpi_struct,
+			 "found OSCAR over HTTP : aim/gromit/aim_express\n");
 		ndpi_int_oscar_add_connection(ndpi_struct, flow);
 		return;
 	      }
@@ -682,12 +685,12 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
     }
     if (memcmp(packet->payload, "CONNECT ", 8) == 0) {
       if (memcmp(packet->payload, "CONNECT login.icq.com:443 HTTP/1.", 33) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR ICQ-HTTP FOUND\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found OSCAR ICQ-HTTP\n");
 	ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	return;
       }
       if (memcmp(packet->payload, "CONNECT login.oscar.aol.com:5190 HTTP/1.", 40) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR AIM-HTTP FOUND\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found OSCAR AIM-HTTP\n");
 	ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -697,33 +700,33 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 
   if (packet->payload_packet_len > 43
       && memcmp(packet->payload, "GET http://http.proxy.icq.com/hello HTTP/1.", 43) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR ICQ-HTTP PROXY FOUND\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found OSCAR ICQ-HTTP PROXY\n");
     ndpi_int_oscar_add_connection(ndpi_struct, flow);
     return;
   }
 
   if (packet->payload_packet_len > 46
       && memcmp(packet->payload, "GET http://aimhttp.oscar.aol.com/hello HTTP/1.", 46) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR AIM-HTTP PROXY FOUND\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found OSCAR AIM-HTTP PROXY\n");
     ndpi_int_oscar_add_connection(ndpi_struct, flow);
     return;
   }
 
   if (packet->payload_packet_len > 5 && get_u_int32_t(packet->payload, 0) == htonl(0x05010003)) {
-    NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "Maybe OSCAR Picturetransfer\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "Maybe OSCAR Picturetransfer\n");
     return;
   }
 
   if (packet->payload_packet_len == 10 && get_u_int32_t(packet->payload, 0) == htonl(0x05000001) &&
       get_u_int32_t(packet->payload, 4) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "Maybe OSCAR Picturetransfer\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "Maybe OSCAR Picturetransfer\n");
     return;
   }
 
   if (packet->payload_packet_len >= 70 &&
       memcmp(&packet->payload[packet->payload_packet_len - 26],
 	     "\x67\x00\x65\x00\x74\x00\x43\x00\x61\x00\x74\x00\x61\x00\x6c\x00\x6f\x00\x67", 19) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR PICTURE TRANSFER\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found OSCAR PICTURE TRANSFER\n");
     ndpi_int_oscar_add_connection(ndpi_struct, flow);
     return;
   }
@@ -751,7 +754,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 					      == 0)
 					     )))) {
 	// FILE TRANSFER PATTERN:: OFT3 or OFT2
-	NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR FILE TRANSFER\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found OSCAR FILE TRANSFER\n");
 	ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -759,7 +762,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
       if (memcmp(packet->payload, "ODC2", 4) == 0 && memcmp(&packet->payload[6], "\x00\x01\x00\x06", 4) == 0) {
 	//PICTURE TRANSFER PATTERN EXMAPLE::
 	//4f 44 43 32 00 4c 00 01 00 06 00 00 00 00 00 00  ODC2.L..........
-	NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR PICTURE TRANSFER\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found OSCAR PICTURE TRANSFER\n");
 	ndpi_int_oscar_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -770,7 +773,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 	&& packet->payload[packet->payload_packet_len - 12] == 'L'
 	&& (memcmp(&packet->payload[packet->payload_packet_len - 6], "DEST", 4) == 0)
 	&& (memcmp(&packet->payload[packet->payload_packet_len - 2], "\x00\x00", 2) == 0)) {
-      NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR PICTURE TRANSFER\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found OSCAR PICTURE TRANSFER\n");
       ndpi_int_oscar_add_connection(ndpi_struct, flow);
       if (ntohs(packet->tcp->dest) == 443 || ntohs(packet->tcp->source) == 443) {
 	flow->oscar_ssl_voice_stage = 1;
@@ -787,7 +790,7 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 
 
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_OSCAR) {
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_OSCAR);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 }
@@ -795,8 +798,8 @@ static void ndpi_search_oscar_tcp_connect(struct ndpi_detection_module_struct
 void ndpi_search_oscar(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
+  NDPI_LOG__DEBUG(ndpi_struct, "search OSCAR\n");
   if (packet->tcp != NULL) {
-    NDPI_LOG(NDPI_PROTOCOL_OSCAR, ndpi_struct, NDPI_LOG_DEBUG, "OSCAR :: TCP\n");
     ndpi_search_oscar_tcp_connect(ndpi_struct, flow);
   }
 }

--- a/src/lib/protocols/pando.c
+++ b/src/lib/protocols/pando.c
@@ -23,9 +23,14 @@
  *
  */
 
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_PANDO
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_PANDO
+
+#include "ndpi_api.h"
+
 static void ndpi_int_pando_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_PANDO, NDPI_PROTOCOL_UNKNOWN);
 }
@@ -35,7 +40,7 @@ static void ndpi_check_pando_tcp(struct ndpi_detection_module_struct *ndpi_struc
 	u_int32_t payload_len = packet->payload_packet_len;
 
 	if (ndpi_match_strprefix(packet->payload, payload_len, "\x0ePan")) {
-	    NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Found PANDO.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "Found PANDO\n");
 	    ndpi_int_pando_add_connection(ndpi_struct, flow);
 	}
 }
@@ -45,11 +50,11 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 	u_int32_t payload_len = packet->payload_packet_len;
 
 	/* Check if we so far detected the protocol in the request or not. */
+	NDPI_LOG__DEBUG2(ndpi_struct, "PANDO stage %u: \n", flow->pando_stage);
 	if (flow->pando_stage == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "PANDO stage 0: \n");
 
 		if ((payload_len >= 4) && (packet->payload[0] == 0x00) && (packet->payload[1] == 0x00) && (packet->payload[2] == 0x00) && (packet->payload[3] == 0x09)) {
-			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Possible PANDO request detected, we will look further for the response...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Possible PANDO request detected, we will look further for the response..\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
 			flow->pando_stage = packet->packet_direction + 1; // packet_direction 0: stage 1, packet_direction 1: stage 2
@@ -57,7 +62,7 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 		}
 
 		if (ndpi_match_strprefix(packet->payload, payload_len, "UDPA")) {
-			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Possible PANDO request detected, we will look further for the response...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Possible PANDO request detected, we will look further for the response..\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
 			flow->pando_stage = packet->packet_direction + 3; // packet_direction 0: stage 3, packet_direction 1: stage 4
@@ -65,7 +70,7 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 		}
 
 		if (ndpi_match_strprefix(packet->payload, payload_len, "UDPR") || ndpi_match_strprefix(packet->payload, payload_len, "UDPE")) {
-			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Possible PANDO request detected, we will look further for the response...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Possible PANDO request detected, we will look further for the response..\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
 			flow->pando_stage = packet->packet_direction + 5; // packet_direction 0: stage 5, packet_direction 1: stage 6
@@ -73,7 +78,6 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 		}
 
 	} else if ((flow->pando_stage == 1) || (flow->pando_stage == 2)) {
-		NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "PANDO stage %u: \n", flow->pando_stage);
 
 		/* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
 		if ((flow->pando_stage - packet->packet_direction) == 1) {
@@ -82,15 +86,14 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 
 		/* This is a packet in another direction. Check if we find the proper response. */
 		if ((payload_len == 0) || ((payload_len >= 4) && (packet->payload[0] == 0x00) && (packet->payload[1] == 0x00) && (packet->payload[2] == 0x00) && (packet->payload[3] == 0x09))) {
-			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Found PANDO.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found PANDO\n");
 			ndpi_int_pando_add_connection(ndpi_struct, flow);
 		} else {
-			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to PANDO, resetting the stage to 0...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to PANDO, resetting the stage to 0..\n");
 			flow->pando_stage = 0;
 		}
 
 	} else if ((flow->pando_stage == 3) || (flow->pando_stage == 4)) {
-		NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "PANDO stage %u: \n", flow->pando_stage);
 
 		/* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
 		if ((flow->pando_stage - packet->packet_direction) == 3) {
@@ -99,15 +102,14 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 
 		/* This is a packet in another direction. Check if we find the proper response. */
 		if ((payload_len == 0) || (ndpi_match_strprefix(packet->payload, payload_len, "UDPR") || ndpi_match_strprefix(packet->payload, payload_len, "UDPE"))) {
-			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Found PANDO.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found PANDO\n");
 			ndpi_int_pando_add_connection(ndpi_struct, flow);
 		} else {
-			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to PANDO, resetting the stage to 0...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to PANDO, resetting the stage to 0..\n");
 			flow->pando_stage = 0;
 		}
 
 	} else if ((flow->pando_stage == 5) || (flow->pando_stage == 6)) {
-		NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "PANDO stage %u: \n", flow->pando_stage);
 
 		/* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
 		if ((flow->pando_stage - packet->packet_direction) == 5) {
@@ -116,10 +118,10 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 
 		/* This is a packet in another direction. Check if we find the proper response. */
 		if (ndpi_match_strprefix(packet->payload, payload_len, "UDPA")) {
-			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "Found PANDO.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found PANDO\n");
 			ndpi_int_pando_add_connection(ndpi_struct, flow);
 		} else {
-			NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to PANDO, resetting the stage to 0...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to PANDO, resetting the stage to 0\n")
 			flow->pando_stage = 0;
 		}
 	}
@@ -128,10 +130,10 @@ static void ndpi_check_pando_udp(struct ndpi_detection_module_struct *ndpi_struc
 void ndpi_search_pando(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
 	struct ndpi_packet_struct *packet = &flow->packet;
 
+	NDPI_LOG__DEBUG(ndpi_struct, "search PANDO\n");
 	/* Break after 20 packets. */
 	if (flow->packet_counter > 20) {
-		NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_TRACE, "PANDO excluded.\n");
-		NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_PANDO);
+		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 		return;
 	}
 
@@ -144,7 +146,6 @@ void ndpi_search_pando(struct ndpi_detection_module_struct *ndpi_struct, struct 
 		return;
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_PANDO, ndpi_struct, NDPI_LOG_TRACE, "PANDO detection...\n");
 	ndpi_check_pando_tcp(ndpi_struct, flow);
 
 	if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_PANDO) {

--- a/src/lib/protocols/pcanywhere.c
+++ b/src/lib/protocols/pcanywhere.c
@@ -23,8 +23,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_PCANYWHERE
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_PCANYWHERE
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_pcanywhere_add_connection(struct ndpi_detection_module_struct
 					       *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -37,19 +43,15 @@ void ndpi_search_pcanywhere(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
   if (packet->udp != NULL && packet->udp->dest == htons(5632)
       && packet->payload_packet_len == 2
       && (memcmp(packet->payload, "NQ", 2) == 0 || memcmp(packet->payload, "ST", 2) == 0)) {
-    NDPI_LOG(NDPI_PROTOCOL_PCANYWHERE, ndpi_struct, NDPI_LOG_DEBUG,
-	     "PC Anywhere name or status query detected.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "PC Anywhere name or status query detected\n");
     ndpi_int_pcanywhere_add_connection(ndpi_struct, flow);
     return;
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_PCANYWHERE);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/postgres.c
+++ b/src/lib/protocols/postgres.c
@@ -23,8 +23,13 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_POSTGRES
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_POSTGRES
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_postgres_add_connection(struct ndpi_detection_module_struct
@@ -37,10 +42,6 @@ void ndpi_search_postgres_tcp(struct ndpi_detection_module_struct
 								*ndpi_struct, struct ndpi_flow_struct *flow)
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
-	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
 	u_int16_t size;
 
 	if (flow->l4.tcp.postgres_stage == 0) {
@@ -65,13 +66,13 @@ void ndpi_search_postgres_tcp(struct ndpi_detection_module_struct
 		if (flow->l4.tcp.postgres_stage == 2 - packet->packet_direction) {
 			//SSL accepted
 			if (packet->payload_packet_len == 1 && packet->payload[0] == 'S') {
-				NDPI_LOG(NDPI_PROTOCOL_POSTGRES, ndpi_struct, NDPI_LOG_DEBUG, "PostgreSQL detected, SSL accepted.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "PostgreSQL detected, SSL accepted\n");
 				ndpi_int_postgres_add_connection(ndpi_struct, flow);
 				return;
 			}
 			//SSL denied
 			if (packet->payload_packet_len == 1 && packet->payload[0] == 'N') {
-				NDPI_LOG(NDPI_PROTOCOL_POSTGRES, ndpi_struct, NDPI_LOG_DEBUG, "PostgreSQL detected, SSL denied.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "PostgreSQL detected, SSL denied\n");
 				ndpi_int_postgres_add_connection(ndpi_struct, flow);
 				return;
 			}
@@ -81,40 +82,40 @@ void ndpi_search_postgres_tcp(struct ndpi_detection_module_struct
 			if (packet->payload_packet_len > 8 &&
 				ntohl(get_u_int32_t(packet->payload, 5)) < 10 &&
 				ntohl(get_u_int32_t(packet->payload, 1)) == packet->payload_packet_len - 1 && packet->payload[0] == 0x52) {
-				NDPI_LOG(NDPI_PROTOCOL_POSTGRES, ndpi_struct, NDPI_LOG_DEBUG, "PostgreSQL detected, no SSL.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "PostgreSQL detected, no SSL\n");
 				ndpi_int_postgres_add_connection(ndpi_struct, flow);
 				return;
 			}
 		if (flow->l4.tcp.postgres_stage == 6
 			&& ntohl(get_u_int32_t(packet->payload, 1)) == packet->payload_packet_len - 1 && packet->payload[0] == 'p') {
-			NDPI_LOG(NDPI_PROTOCOL_POSTGRES, ndpi_struct, NDPI_LOG_DEBUG, "found postgres asymmetrically.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found postgres asymmetrically\n");
 			ndpi_int_postgres_add_connection(ndpi_struct, flow);
 			return;
 		}
 		if (flow->l4.tcp.postgres_stage == 5 && packet->payload[0] == 'R') {
 			if (ntohl(get_u_int32_t(packet->payload, 1)) == packet->payload_packet_len - 1) {
-				NDPI_LOG(NDPI_PROTOCOL_POSTGRES, ndpi_struct, NDPI_LOG_DEBUG, "found postgres asymmetrically.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found postgres asymmetrically\n");
 				ndpi_int_postgres_add_connection(ndpi_struct, flow);
 				return;
 			}
 			size = (u_int16_t)ntohl(get_u_int32_t(packet->payload, 1)) + 1;
 			if (packet->payload[size - 1] == 'S') {
 				if ((size + get_u_int32_t(packet->payload, (size + 1))) == packet->payload_packet_len) {
-					NDPI_LOG(NDPI_PROTOCOL_POSTGRES, ndpi_struct, NDPI_LOG_DEBUG, "found postgres asymmetrically.\n");
+					NDPI_LOG__TRACE(ndpi_struct, "found postgres asymmetrically\n");
 					ndpi_int_postgres_add_connection(ndpi_struct, flow);
 					return;
 				}
 			}
 			size += get_u_int32_t(packet->payload, (size + 1)) + 1;
 			if (packet->payload[size - 1] == 'S') {
-				NDPI_LOG(NDPI_PROTOCOL_POSTGRES, ndpi_struct, NDPI_LOG_DEBUG, "found postgres asymmetrically.\n");
+				NDPI_LOG__TRACE(ndpi_struct, "found postgres asymmetrically\n");
 				ndpi_int_postgres_add_connection(ndpi_struct, flow);
 				return;
 			}
 		}
 	}
 
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_POSTGRES);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/pplive.c
+++ b/src/lib/protocols/pplive.c
@@ -24,9 +24,14 @@
  * 
  */
 
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_PPLIVE
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_PPLIVE
+
+#include "ndpi_api.h"
+
 static void ndpi_int_pplive_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_PPLIVE, NDPI_PROTOCOL_UNKNOWN);
 }
@@ -37,10 +42,10 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 	
 	/* Check if we so far detected the protocol in the request or not. */
 	if (flow->pplive_stage1 == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE stage 0: \n");
+		NDPI_LOG__DEBUG2(ndpi_struct, "PPLIVE stage 0: \n");
 		
 		if (ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x41\x01")) {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Possible PPLIVE request detected, we will look further for the response...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Possible PPLIVE request detected, we will look further for the response..\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
 			flow->pplive_stage1 = packet->packet_direction + 1; // packet_direction 0: stage 1, packet_direction 1: stage 2
@@ -48,7 +53,7 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 		}
 		
 		if (ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x42\x01")) {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Possible PPLIVE request detected, we will look further for the response...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Possible PPLIVE request detected, we will look further for the response..\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
 			flow->pplive_stage1 = packet->packet_direction + 3; // packet_direction 0: stage 3, packet_direction 1: stage 4
@@ -56,7 +61,7 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 		}
 		
 		if (ndpi_match_strprefix(packet->payload, payload_len, "\x1c\x1c\x32\x01")) {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Possible PPLIVE request detected, we will look further for the response...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Possible PPLIVE request detected, we will look further for the response..\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
 			flow->pplive_stage1 = packet->packet_direction + 5; // packet_direction 0: stage 5, packet_direction 1: stage 6
@@ -64,7 +69,7 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 		}			
 
 	} else if ((flow->pplive_stage1 == 1) || (flow->pplive_stage1 == 2)) {
-		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE stage %u: \n", flow->pplive_stage1);
+		NDPI_LOG__DEBUG2(ndpi_struct, "PPLIVE stage %u: \n", flow->pplive_stage1);
 
 		/* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
 		if ((flow->pplive_stage1 - packet->packet_direction) == 1) {
@@ -73,15 +78,15 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 
 		/* This is a packet in another direction. Check if we find the proper response. */
 		if (ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x42\x01") || ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x41\x01")) {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Found PPLIVE.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Found PPLIVE\n");
 			ndpi_int_pplive_add_connection(ndpi_struct, flow);
 		} else {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to PPLIVE, resetting the stage to 0...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to PPLIVE, resetting the stage to 0..\n");
 			flow->pplive_stage1 = 0;
 		}
 		
 	} else if ((flow->pplive_stage1 == 3) || (flow->pplive_stage1 == 4)) {
-		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE stage %u: \n", flow->pplive_stage1);
+		NDPI_LOG__DEBUG2(ndpi_struct, "PPLIVE stage %u: \n", flow->pplive_stage1);
 
 		/* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
 		if ((flow->pplive_stage1 - packet->packet_direction) == 3) {
@@ -90,14 +95,14 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 
 		/* This is a packet in another direction. Check if we find the proper response. */
 		if (ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x41\x01")) {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Found PPLIVE.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found PPLIVE\n");
 			ndpi_int_pplive_add_connection(ndpi_struct, flow);
 		} else {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to PPLIVE, resetting the stage to 0...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to PPLIVE, resetting the stage to 0..\n");
 			flow->pplive_stage1 = 0;
 		}
 	} else if ((flow->pplive_stage1 == 5) || (flow->pplive_stage1 == 6)) {
-		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE stage %u: \n", flow->pplive_stage1);
+		NDPI_LOG__DEBUG2(ndpi_struct, "PPLIVE stage %u: \n", flow->pplive_stage1);
 
 		/* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
 		if ((flow->pplive_stage1 - packet->packet_direction) == 5) {
@@ -106,10 +111,10 @@ static void ndpi_check_pplive_udp1(struct ndpi_detection_module_struct *ndpi_str
 
 		/* This is a packet in another direction. Check if we find the proper response. */
 		if (ndpi_match_strprefix(packet->payload, payload_len, "\x1c\x1c\x32\x01")) {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Found PPLIVE.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "Found PPLIVE\n");
 			ndpi_int_pplive_add_connection(ndpi_struct, flow);
 		} else {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to PPLIVE, resetting the stage to 0...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to PPLIVE, resetting the stage to 0..\n");
 			flow->pplive_stage1 = 0;
 		}
 	}
@@ -121,19 +126,17 @@ static void ndpi_check_pplive_udp2(struct ndpi_detection_module_struct *ndpi_str
 	u_int32_t payload_len = packet->payload_packet_len;
 
 	/* Check if we so far detected the protocol in the request or not. */
+	NDPI_LOG__DEBUG2(ndpi_struct, "PPLIVE stage %u: \n", flow->pplive_stage2);
 	if (flow->pplive_stage2 == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE stage 0: \n");
 		
 		if ((payload_len == 57) && ndpi_match_strprefix(packet->payload, payload_len, "\xe9\x03\x41\x01")) {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Possible PPLIVE request detected, we will look further for the response...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Possible PPLIVE request detected, we will look further for the response..\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
 			flow->pplive_stage2 = packet->packet_direction + 1; // packet_direction 0: stage 1, packet_direction 1: stage 2
 		}
 
 	} else {
-		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE stage %u: \n", flow->pplive_stage2);
-
 		/* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
 		if ((flow->pplive_stage2 - packet->packet_direction) == 1) {
 			return;
@@ -141,10 +144,10 @@ static void ndpi_check_pplive_udp2(struct ndpi_detection_module_struct *ndpi_str
 
 		/* This is a packet in another direction. Check if we find the proper response. */
 		if (payload_len == 0) {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Found PPLIVE.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found PPLIVE\n");
 			ndpi_int_pplive_add_connection(ndpi_struct, flow);
 		} else {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to PPLIVE, resetting the stage to 0...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to PPLIVE, resetting the stage to 0..\n");
 			flow->pplive_stage2 = 0;
 		}
 		
@@ -156,11 +159,11 @@ static void ndpi_check_pplive_udp3(struct ndpi_detection_module_struct *ndpi_str
 	u_int32_t payload_len = packet->payload_packet_len;
 	
 	/* Check if we so far detected the protocol in the request or not. */
+	NDPI_LOG__DEBUG(ndpi_struct, "PPLIVE stage %u: \n", flow->pplive_stage3);
 	if (flow->pplive_stage3 == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE stage 0: \n");
 		
 		if ((payload_len == 94) && (packet->udp->dest == htons(5041) || packet->udp->source == htons(5041) || packet->udp->dest == htons(8303) || packet->udp->source == htons(8303))) {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Possible PPLIVE request detected, we will look further for the response...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Possible PPLIVE request detected, we will look further for the response..\n");
 
 			/* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
 			flow->pplive_stage3 = packet->packet_direction + 1; // packet_direction 0: stage 1, packet_direction 1: stage 2
@@ -168,7 +171,6 @@ static void ndpi_check_pplive_udp3(struct ndpi_detection_module_struct *ndpi_str
 		}	
 
 	} else {
-		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE stage %u: \n", flow->pplive_stage3);
 
 		/* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
 		if ((flow->pplive_stage3 - packet->packet_direction) == 1) {
@@ -177,10 +179,10 @@ static void ndpi_check_pplive_udp3(struct ndpi_detection_module_struct *ndpi_str
 
 		/* This is a packet in another direction. Check if we find the proper response. */
 		if ((payload_len == 0) || (payload_len == 49) ||(payload_len == 94)) {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Found PPLIVE.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found PPLIVE\n");
 			ndpi_int_pplive_add_connection(ndpi_struct, flow);
 		} else {
-			NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to PPLIVE, resetting the stage to 0...\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to PPLIVE, resetting the stage to 0..\n");
 			flow->pplive_stage3 = 0;
 		}
 	}
@@ -190,10 +192,11 @@ static void ndpi_check_pplive_udp3(struct ndpi_detection_module_struct *ndpi_str
 void ndpi_search_pplive(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
+	NDPI_LOG__DEBUG(ndpi_struct, "search PPLIVE\n");
+
 	/* Break after 20 packets. */
 	if (flow->packet_counter > 20) {
-		NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "Exclude PPLIVE.\n");
-		NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_PPLIVE);
+		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 		return;
 	}
 
@@ -201,7 +204,6 @@ void ndpi_search_pplive(struct ndpi_detection_module_struct *ndpi_struct, struct
 		return;
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_PPLIVE, ndpi_struct, NDPI_LOG_DEBUG, "PPLIVE detection...\n");
 	ndpi_check_pplive_udp1(ndpi_struct, flow);
 	
 	if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_PPLIVE) {

--- a/src/lib/protocols/ppstream.c
+++ b/src/lib/protocols/ppstream.c
@@ -20,9 +20,14 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  * 
  */
-#include "ndpi_protocols.h"
+
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_PPSTREAM
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_PPSTREAM
+
+#include "ndpi_api.h"
 
 #define PPS_PORT 17788
 
@@ -31,6 +36,7 @@ static void ndpi_int_ppstream_add_connection(struct ndpi_detection_module_struct
 					     *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_PPSTREAM, NDPI_PROTOCOL_UNKNOWN);
+  NDPI_LOG__TRACE(ndpi_struct, "found PPStream over UDP\n");
 }
 
 
@@ -39,6 +45,7 @@ void ndpi_search_ppstream(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search PPStream\n");
   /**
      PPS over TCP is detected inside HTTP dissector 
   */
@@ -66,8 +73,6 @@ void ndpi_search_ppstream(struct ndpi_detection_module_struct
 	    /* increase count pkt ppstream over udp */
 	    flow->l4.udp.ppstream_stage++;
 	    
-	    NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG,
-		     "found PPStream over UDP.\n");
 	    ndpi_int_ppstream_add_connection(ndpi_struct, flow);
 	    return;
 	  }       
@@ -91,8 +96,6 @@ void ndpi_search_ppstream(struct ndpi_detection_module_struct
 		    /* increase count pkt ppstream over udp */
 		    flow->l4.udp.ppstream_stage++;
 
-		    NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG,
-			     "found PPStream over UDP.\n");
 		    ndpi_int_ppstream_add_connection(ndpi_struct, flow);
 		    return;
 		  }
@@ -106,8 +109,6 @@ void ndpi_search_ppstream(struct ndpi_detection_module_struct
 		    /* increase count pkt ppstream over udp */
 		    flow->l4.udp.ppstream_stage++;
 		  
-		    NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG,
-			     "found PPStream over UDP.\n");
 		    ndpi_int_ppstream_add_connection(ndpi_struct, flow);
 		    return;
 		  }
@@ -131,8 +132,6 @@ void ndpi_search_ppstream(struct ndpi_detection_module_struct
 		/* increase count pkt ppstream over udp */
 		flow->l4.udp.ppstream_stage++;
 
-		NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG,
-			 "found PPStream over UDP.\n");
 		ndpi_int_ppstream_add_connection(ndpi_struct, flow);
 		return;
 	      }
@@ -152,8 +151,6 @@ void ndpi_search_ppstream(struct ndpi_detection_module_struct
 		/* increase count pkt ppstream over udp */
 		flow->l4.udp.ppstream_stage++;
 	      
-		NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG,
-			 "found PPStream over UDP.\n");
 		ndpi_int_ppstream_add_connection(ndpi_struct, flow);
 		return;
 	      }
@@ -172,8 +169,6 @@ void ndpi_search_ppstream(struct ndpi_detection_module_struct
 	    /* increase count pkt ppstream over udp */
 	    flow->l4.udp.ppstream_stage++;
 
-	    NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG,
-		     "found PPStream over UDP.\n");
 	    ndpi_int_ppstream_add_connection(ndpi_struct, flow);
 	    return;
 	  }
@@ -194,8 +189,6 @@ void ndpi_search_ppstream(struct ndpi_detection_module_struct
 	    /* increase count pkt ppstream over udp */
 	    flow->l4.udp.ppstream_stage++;
 	  
-	    NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG,
-		     "found PPStream over UDP.\n");
 	    ndpi_int_ppstream_add_connection(ndpi_struct, flow);
 	    return;
 	  }
@@ -210,8 +203,6 @@ void ndpi_search_ppstream(struct ndpi_detection_module_struct
 	    /* increase count pkt ppstream over udp */
 	    flow->l4.udp.ppstream_stage++;
 	  
-	    NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG,
-		     "found PPStream over UDP.\n");
 	    ndpi_int_ppstream_add_connection(ndpi_struct, flow);
 	    return;
 	  }
@@ -223,16 +214,13 @@ void ndpi_search_ppstream(struct ndpi_detection_module_struct
 	  /* increase count pkt ppstream over udp */
 	  flow->l4.udp.ppstream_stage++;
 	
-	  NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG,
-		   "found PPStream over udp.\n");
 	  ndpi_int_ppstream_add_connection(ndpi_struct, flow);
 	  return;
 	}
       }
     }
-    /* EXCLUDE PPS */
-    NDPI_LOG(NDPI_PROTOCOL_PPSTREAM, ndpi_struct, NDPI_LOG_DEBUG, "exclude PPStream.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_PPSTREAM);
+
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/pptp.c
+++ b/src/lib/protocols/pptp.c
@@ -22,12 +22,13 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
 
-
-/* include files */
-
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_PPTP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_PPTP
+
+#include "ndpi_api.h"
 
 static void ndpi_int_pptp_add_connection(struct ndpi_detection_module_struct
 										   *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -40,9 +41,7 @@ void ndpi_search_pptp(struct ndpi_detection_module_struct
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-
-	// struct ndpi_id_struct *src=ndpi_struct->src;
-	// struct ndpi_id_struct *dst=ndpi_struct->dst;
+	NDPI_LOG__DEBUG(ndpi_struct, "search pptp\n");
 
 	if (packet->payload_packet_len >= 10 && get_u_int16_t(packet->payload, 0) == htons(packet->payload_packet_len)
 		&& get_u_int16_t(packet->payload, 2) == htons(0x0001)	/* message type: control message */
@@ -50,13 +49,12 @@ void ndpi_search_pptp(struct ndpi_detection_module_struct
 		&&(get_u_int16_t(packet->payload, 8) == htons(0x0001)	/* control type: start-control-connection-request */
 		)) {
 
-		NDPI_LOG(NDPI_PROTOCOL_PPTP, ndpi_struct, NDPI_LOG_DEBUG, "found pptp.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found pptp\n");
 		ndpi_int_pptp_add_connection(ndpi_struct, flow);
 		return;
 	}
 
-	NDPI_LOG(NDPI_PROTOCOL_PPTP, ndpi_struct, NDPI_LOG_DEBUG, "exclude pptp.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_PPTP);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/qq.c
+++ b/src/lib/protocols/qq.c
@@ -22,10 +22,14 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_QQ
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_QQ
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_QQ
 
 static void ndpi_int_qq_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 				       struct ndpi_flow_struct *flow/* , */
@@ -243,7 +247,7 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
   u_int16_t no_of_patterns = 12, index = 0;
 
 
-  NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "search qq udp.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search qq udp\n");
 
 
   if (flow->qq_stage <= 3) {
@@ -273,8 +277,7 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
 	} */
       flow->qq_stage++;
       if (flow->qq_stage == 3) {
-	NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG,
-		 "found qq udp pattern 030001 or 000e35 four times.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found qq udp pattern 030001 or 000e35 four times\n");
 	ndpi_int_qq_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -287,8 +290,7 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
 	  flow->qq_stage++;
 	  // maybe we can test here packet->payload[4] == packet->payload_packet_len
 	  if (flow->qq_stage == 3) {
-	    NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG,
-		     "found qq udp pattern 02 ... 03 four times.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found qq udp pattern 02 ... 03 four times\n");
 	    /*
 	      if (packet->payload[0] == 0x04) {
 	      ndpi_int_qq_add_connection(ndpi_struct, flow, NDPI_REAL_PROTOCOL);
@@ -309,11 +311,11 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
 	  /*
 	    if (flow->qq_stage == 3 && flow->packet_direction_counter[0] > 0 &&
 	    flow->packet_direction_counter[1] > 0) {
-	    NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq udp pattern four times.\n");
+	    NDPI_LOG__DEBUG(ndpi_struct, "found qq udp pattern four times\n");
 	    ndpi_int_qq_add_connection(ndpi_struct, flow, NDPI_REAL_PROTOCOL);
 	    return;
 	    } else */ if (flow->qq_stage == 3) {
-	    NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq udp pattern four times.\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found qq udp pattern four times\n");
 	    ndpi_int_qq_add_connection(ndpi_struct, flow);
 	    return;
 	  }
@@ -332,7 +334,7 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
 	&& packet->payload[packet->payload_packet_len - 1] == 0x03) {
       flow->qq_stage++;
       if (flow->qq_stage == 3) {
-	NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG,
+	NDPI_LOG__TRACE(ndpi_struct,
 		 "found qq udp pattern 04 1159 ... 03 four times.\n");
 	ndpi_int_qq_add_connection(ndpi_struct, flow);
 	return;
@@ -345,7 +347,7 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
 	    || packet->payload[packet->payload_packet_len - 1] == 0x03)) {
       flow->qq_stage++;
       if (flow->qq_stage == 3) {
-	NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG,
+	NDPI_LOG__TRACE(ndpi_struct,
 		 "found qq udp pattern 02/06 0100 ... 03/00 four times.\n");
 	ndpi_int_qq_add_connection(ndpi_struct, flow);
 	return;
@@ -357,7 +359,7 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
 	&& ntohs(get_u_int16_t(packet->payload, 1)) == 0x1131 && packet->payload[packet->payload_packet_len - 1] == 0x03) {
       flow->qq_stage++;
       if (flow->qq_stage == 3) {
-	NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG,
+	NDPI_LOG__TRACE(ndpi_struct,
 		 "found qq udp pattern 02 1131 ... 03 four times.\n");
 	ndpi_int_qq_add_connection(ndpi_struct, flow);
 	return;
@@ -370,7 +372,7 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
 	get_u_int16_t(packet->payload, 4) == htons(0x0b0b)) {
       flow->qq_stage++;
       if (flow->qq_stage == 3) {
-	NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG,
+	NDPI_LOG__TRACE(ndpi_struct,
 		 "found qq udp pattern 0203[packet_length_0b0b] three times.\n");
 	ndpi_int_qq_add_connection(ndpi_struct, flow);
 	return;
@@ -384,7 +386,7 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
 	  && ntohs(get_u_int16_t(packet->payload, 2)) == packet->payload_packet_len) {
 	flow->qq_stage++;
 	if (flow->qq_stage == 3) {
-	  NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG,
+	  NDPI_LOG__TRACE(ndpi_struct,
 		   "found qq udp pattern 02 02 <length> four times.\n");
 	  ndpi_int_qq_add_connection(ndpi_struct, flow);
 	  return;
@@ -398,18 +400,18 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
   if (ndpi_is_valid_qq_packet(packet)) {
     flow->qq_stage++;
     if (flow->qq_stage == 3) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq over udp.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found qq over udp\n");
       ndpi_int_qq_add_connection(ndpi_struct, flow);
       return;
     }
-    NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq packet stage %d\n", flow->qq_stage);
+    NDPI_LOG__DEBUG2(ndpi_struct, "found qq packet stage %d\n", flow->qq_stage);
     return;
   }
 
   if (ndpi_is_valid_qq_ft_packet(packet)) {
     flow->qq_stage++;
     if (flow->qq_stage == 3) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq ft over udp.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found qq ft over udp\n");
       ndpi_int_qq_add_connection(ndpi_struct, flow);
       return;
     }
@@ -420,8 +422,7 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "QQ excluded\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_QQ);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 
@@ -434,22 +435,15 @@ __forceinline static
 void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
-	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-
-
   u_int16_t i = 0;
-  //  u_int16_t a = 0;
 
-  NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "search qq tcp.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search qq tcp\n");
 
   if (packet->payload_packet_len == 39 && get_u_int32_t(packet->payload, 0) == htonl(0x27000000) &&
       get_u_int16_t(packet->payload, 4) == htons(0x0014) && get_u_int32_t(packet->payload, 11) != 0 &&
       get_u_int16_t(packet->payload, packet->payload_packet_len - 2) == htons(0x0000)) {
     if (flow->qq_stage == 4) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq over tcp - maybe ft/audio/video.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found qq over tcp - maybe ft/audio/video\n");
       ndpi_int_qq_add_connection(ndpi_struct, flow);
       return;
     }
@@ -496,7 +490,7 @@ void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct
       ) {
     flow->qq_stage++;
     if (flow->qq_stage == 3) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq over tcp.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found qq over tcp\n");
       ndpi_int_qq_add_connection(ndpi_struct, flow);
       return;
     }
@@ -506,7 +500,7 @@ void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct
   if (ndpi_is_valid_qq_packet(packet)) {
     flow->qq_stage++;
     if (flow->qq_stage == 3) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq over tcp.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found qq over tcp\n");
       ndpi_int_qq_add_connection(ndpi_struct, flow);
       return;
     }
@@ -516,7 +510,7 @@ void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct
   if (ndpi_is_valid_qq_ft_packet(packet)) {
     flow->qq_stage++;
     if (flow->qq_stage == 3) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq ft over tcp.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found qq ft over tcp\n");
       ndpi_int_qq_add_connection(ndpi_struct, flow);
       return;
     }
@@ -537,7 +531,7 @@ void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct
 					     && get_u_int16_t(packet->payload, 3) == htons(0x0f5f)))) {
     flow->qq_stage++;
     if (flow->qq_stage == 3) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq udp pattern 02 ... 03 four times.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found qq udp pattern 02 ... 03 four times\n");
       ndpi_int_qq_add_connection(ndpi_struct, flow);
       return;
     }
@@ -561,7 +555,7 @@ void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct
       && packet->payload[packet->payload_packet_len - 1] == 0x03) {
     flow->qq_stage++;
     if (flow->qq_stage == 3) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__TRACE(ndpi_struct,
 	       "found qq udp pattern 04 1159 ... 03 four times.\n");
       ndpi_int_qq_add_connection(ndpi_struct, flow);
       return;
@@ -573,9 +567,9 @@ void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct
 
   if (packet->payload_packet_len > 100
       && ((memcmp(packet->payload, "GET", 3) == 0) || (memcmp(packet->payload, "POST", 4) == 0))) {
-    NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found GET or POST.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "found GET or POST\n");
     if (memcmp(packet->payload, "GET /qqfile/qq", 14) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq over tcp GET /qqfile/qq.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found qq over tcp GET /qqfile/qq\n");
       ndpi_int_qq_add_connection(ndpi_struct, flow);
       return;
     }
@@ -583,21 +577,21 @@ void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct
 
     if (packet->user_agent_line.ptr != NULL
 	&& (packet->user_agent_line.len > 7 && memcmp(packet->user_agent_line.ptr, "QQClient", 8) == 0)) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq over tcp GET...QQClient\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found qq over tcp GET...QQClient\n");
       ndpi_int_qq_add_connection(ndpi_struct, flow);
       return;
     }
     for (i = 0; i < packet->parsed_lines; i++) {
       if (packet->line[i].len > 3 && memcmp(packet->line[i].ptr, "QQ: ", 4) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq over tcp GET...QQ: \n");
+	NDPI_LOG__TRACE(ndpi_struct, "found qq over tcp GET...QQ: \n");
 	ndpi_int_qq_add_connection(ndpi_struct, flow);
 	return;
       }
     }
     if (packet->host_line.ptr != NULL) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "host line ptr\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "host line ptr\n");
       if (packet->host_line.len > 11 && memcmp(&packet->host_line.ptr[0], "www.qq.co.za", 12) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq over tcp Host: www.qq.co.za\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found qq over tcp Host: www.qq.co.za\n");
 	ndpi_int_qq_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -610,7 +604,7 @@ void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct
 	break;
       }
       if (i == 81) {
-	NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq Mail.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found qq Mail\n");
 	ndpi_int_qq_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -619,18 +613,18 @@ void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct
   if (flow->qq_stage == 0 && packet->payload_packet_len == 182 && get_u_int32_t(packet->payload, 0) == htonl(0x000000b2)
       && get_u_int32_t(packet->payload, 4) == htonl(0x01020000)
       && get_u_int32_t(packet->payload, 8) == htonl(0x04015151) && get_u_int32_t(packet->payload, 12) == htonl(0x4d61696c)) {
-    NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq Mail.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found qq Mail\n");
     ndpi_int_qq_add_connection(ndpi_struct, flow);
     return;
   }
   if (packet->payload_packet_len == 204 && flow->qq_stage == 0 && get_u_int32_t(packet->payload, 200) == htonl(0xfbffffff)) {
     for (i = 0; i < 200; i++) {
-      NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "i = %u\n", i);
+      NDPI_LOG__DEBUG2(ndpi_struct, "i = %u\n", i);
       if (packet->payload[i] != 0) {
 	break;
       }
       if (i == 199) {
-	NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "found qq chat or file transfer\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found qq chat or file transfer\n");
 	ndpi_int_qq_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -641,7 +635,7 @@ void ndpi_search_qq_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct
 #endif							/* NDPI_PROTOCOL_HTTP */
 
     NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_QQ);
-    NDPI_LOG(NDPI_PROTOCOL_QQ, ndpi_struct, NDPI_LOG_DEBUG, "QQ tcp excluded; len %u\n",
+    NDPI_LOG__DEBUG(ndpi_struct, "QQ tcp excluded; len %u\n",
 	     packet->payload_packet_len);
 
 #ifdef NDPI_PROTOCOL_HTTP

--- a/src/lib/protocols/quake.c
+++ b/src/lib/protocols/quake.c
@@ -22,10 +22,14 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_QUAKE
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_QUAKE
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_QUAKE
 
 static void ndpi_int_quake_add_connection(struct ndpi_detection_module_struct
 											*ndpi_struct, struct ndpi_flow_struct *flow)
@@ -36,10 +40,9 @@ static void ndpi_int_quake_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_quake(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
-	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
+	NDPI_LOG__DEBUG(ndpi_struct, "search Quake\n");
+	
 	if ((packet->payload_packet_len == 14
 		 && get_u_int16_t(packet->payload, 0) == 0xffff && memcmp(&packet->payload[2], "getInfo", 7) == 0)
 		|| (packet->payload_packet_len == 17
@@ -47,7 +50,7 @@ void ndpi_search_quake(struct ndpi_detection_module_struct *ndpi_struct, struct 
 		|| (packet->payload_packet_len > 20
 			&& packet->payload_packet_len < 30
 			&& get_u_int16_t(packet->payload, 0) == 0xffff && memcmp(&packet->payload[2], "getServers", 10) == 0)) {
-		NDPI_LOG(NDPI_PROTOCOL_QUAKE, ndpi_struct, NDPI_LOG_DEBUG, "Quake IV detected.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found Quake IV\n");
 		ndpi_int_quake_add_connection(ndpi_struct, flow);
 		return;
 	}
@@ -55,20 +58,20 @@ void ndpi_search_quake(struct ndpi_detection_module_struct *ndpi_struct, struct 
 	/* Quake III/Quake Live */
 	if (packet->payload_packet_len == 15 && get_u_int32_t(packet->payload, 0) == 0xffffffff
 		&& memcmp(&packet->payload[4], "getinfo", NDPI_STATICSTRING_LEN("getinfo")) == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_QUAKE, ndpi_struct, NDPI_LOG_DEBUG, "Quake III Arena/Quake Live detected.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found Quake III Arena/Quake Live\n");
 		ndpi_int_quake_add_connection(ndpi_struct, flow);
 		return;
 	}
 	if (packet->payload_packet_len == 16 && get_u_int32_t(packet->payload, 0) == 0xffffffff
 		&& memcmp(&packet->payload[4], "getchallenge", NDPI_STATICSTRING_LEN("getchallenge")) == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_QUAKE, ndpi_struct, NDPI_LOG_DEBUG, "Quake III Arena/Quake Live detected.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found Quake III Arena/Quake Live\n");
 		ndpi_int_quake_add_connection(ndpi_struct, flow);
 		return;
 	}
 	if (packet->payload_packet_len > 20 && packet->payload_packet_len < 30
 		&& get_u_int32_t(packet->payload, 0) == 0xffffffff
 		&& memcmp(&packet->payload[4], "getservers", NDPI_STATICSTRING_LEN("getservers")) == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_QUAKE, ndpi_struct, NDPI_LOG_DEBUG, "Quake III Arena/Quake Live detected.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found Quake III Arena/Quake Live\n");
 		ndpi_int_quake_add_connection(ndpi_struct, flow);
 		return;
 	}
@@ -84,8 +87,7 @@ void ndpi_search_quake(struct ndpi_detection_module_struct *ndpi_struct, struct 
 	   Quake Wars     ?????
 	 */
 
-	NDPI_LOG(NDPI_PROTOCOL_QUAKE, ndpi_struct, NDPI_LOG_DEBUG, "Quake excluded.\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_QUAKE);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -22,9 +22,13 @@
  *
  */
 
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_QUIC
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_QUIC
+
+#include "ndpi_api.h"
 
 static int quic_ports(u_int16_t sport, u_int16_t dport)
 {
@@ -68,6 +72,8 @@ void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
   u_int seq_len = quic_len((packet->payload[0] & 0x30) >> 4);
   u_int quic_hlen = 1 /* flags */ + version_len + seq_len + cid_len;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search QUIC\n");
+
   if(packet->udp != NULL
      && (udp_len > (quic_hlen+4 /* QXXX */))
      && ((packet->payload[0] & 0xC2) == 0x00)
@@ -78,7 +84,7 @@ void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
     if((version_len > 0) && (packet->payload[1+cid_len] != 'Q'))
       goto no_quic;
 
-    NDPI_LOG(NDPI_PROTOCOL_QUIC, ndpi_struct, NDPI_LOG_DEBUG, "found QUIC.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found QUIC\n");
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_QUIC, NDPI_PROTOCOL_UNKNOWN);
 
     if(packet->payload[quic_hlen+12] != 0xA0)
@@ -126,8 +132,7 @@ void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
  no_quic:
-  NDPI_LOG(NDPI_PROTOCOL_QUIC, ndpi_struct, NDPI_LOG_DEBUG, "exclude QUIC.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_QUIC);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 /* ***************************************************************** */

--- a/src/lib/protocols/radius.c
+++ b/src/lib/protocols/radius.c
@@ -18,10 +18,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_RADIUS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_RADIUS
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_RADIUS
 
 struct radius_header {
   u_int8_t code;
@@ -42,13 +46,12 @@ static void ndpi_check_radius(struct ndpi_detection_module_struct *ndpi_struct, 
        && (h->code > 0)
        && (h->code <= 5)
        && (ntohs(h->len) == payload_len)) {
-      NDPI_LOG(NDPI_PROTOCOL_RADIUS, ndpi_struct, NDPI_LOG_DEBUG, "Found radius.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "Found radius\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_RADIUS, NDPI_PROTOCOL_UNKNOWN);
 
       return;
     }
-
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RADIUS);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 }
@@ -57,7 +60,7 @@ void ndpi_search_radius(struct ndpi_detection_module_struct *ndpi_struct, struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_RADIUS, ndpi_struct, NDPI_LOG_DEBUG, "radius detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search radius\n");
 
   /* skip marked packets */
   if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_RADIUS)

--- a/src/lib/protocols/rdp.c
+++ b/src/lib/protocols/rdp.c
@@ -23,8 +23,13 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_RDP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_RDP
+
+#include "ndpi_api.h"
 
 static void ndpi_int_rdp_add_connection(struct ndpi_detection_module_struct
 					*ndpi_struct, struct ndpi_flow_struct *flow)
@@ -36,8 +41,7 @@ void ndpi_search_rdp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+  NDPI_LOG__DEBUG(ndpi_struct, "search RDP\n");
 
   if (packet->payload_packet_len > 10
       && get_u_int8_t(packet->payload, 0) > 0
@@ -45,12 +49,12 @@ void ndpi_search_rdp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
       && get_u_int8_t(packet->payload, 4) == packet->payload_packet_len - 5
       && get_u_int8_t(packet->payload, 5) == 0xe0
       && get_u_int16_t(packet->payload, 6) == 0 && get_u_int16_t(packet->payload, 8) == 0 && get_u_int8_t(packet->payload, 10) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_RDP, ndpi_struct, NDPI_LOG_DEBUG, "RDP detected.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found RDP\n");
     ndpi_int_rdp_add_connection(ndpi_struct, flow);
     return;
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RDP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/redis_net.c
+++ b/src/lib/protocols/redis_net.c
@@ -18,10 +18,14 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_REDIS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_REDIS
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_REDIS
 
 static void ndpi_int_redis_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_REDIS, NDPI_PROTOCOL_UNKNOWN);
@@ -36,8 +40,7 @@ static void ndpi_check_redis(struct ndpi_detection_module_struct *ndpi_struct, s
 
   /* Break after 20 packets. */
   if(flow->packet_counter > 20) {
-    NDPI_LOG(NDPI_PROTOCOL_REDIS, ndpi_struct, NDPI_LOG_DEBUG, "Exclude Redis.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_REDIS);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
@@ -66,11 +69,10 @@ static void ndpi_check_redis(struct ndpi_detection_module_struct *ndpi_struct, s
 	&& ((flow->redis_d2s_first_char == '+') || (flow->redis_d2s_first_char == ':')))
        || ((flow->redis_d2s_first_char == '*') 
 	   && ((flow->redis_s2d_first_char == '+') || (flow->redis_s2d_first_char == ':')))) {
-      NDPI_LOG(NDPI_PROTOCOL_REDIS, ndpi_struct, NDPI_LOG_DEBUG, "Found Redis.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "Found Redis\n");
       ndpi_int_redis_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_REDIS, ndpi_struct, NDPI_LOG_DEBUG, "Exclude Redis.\n");
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_REDIS);      
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     }
   } else
     return; /* Too early */
@@ -79,7 +81,7 @@ static void ndpi_check_redis(struct ndpi_detection_module_struct *ndpi_struct, s
 void ndpi_search_redis(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_REDIS, ndpi_struct, NDPI_LOG_DEBUG, "Redis detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search Redis\n");
 
   /* skip marked packets */
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_REDIS) {

--- a/src/lib/protocols/rsync.c
+++ b/src/lib/protocols/rsync.c
@@ -19,10 +19,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_RSYNC
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_RSYNC
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_RSYNC
 static void ndpi_int_rsync_add_connection(struct ndpi_detection_module_struct
 					  *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -33,10 +37,10 @@ void ndpi_search_rsync(struct ndpi_detection_module_struct *ndpi_struct, struct 
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_RSYNC, ndpi_struct, NDPI_LOG_DEBUG, "search for RSYNC.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search RSYNC\n");
 
   if(packet->tcp) {
-    NDPI_LOG(NDPI_PROTOCOL_RSYNC, ndpi_struct, NDPI_LOG_DEBUG, "calculating RSYNC over tcp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculating RSYNC over tcp\n");
     /*
      * Should match: memcmp(packet->payload, "@RSYNCD: 28", 14) == 0)
      */
@@ -45,12 +49,11 @@ void ndpi_search_rsync(struct ndpi_detection_module_struct *ndpi_struct, struct 
 	packet->payload[3] == 0x59 && packet->payload[4] == 0x4e &&
 	packet->payload[5] == 0x43 && packet->payload[6] == 0x44 &&
 	packet->payload[7] == 0x3a ) {
-      NDPI_LOG(NDPI_PROTOCOL_RSYNC, ndpi_struct, NDPI_LOG_DEBUG, "found rsync.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found rsync\n");
       ndpi_int_rsync_add_connection(ndpi_struct, flow);
     }
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_RSYNC, ndpi_struct, NDPI_LOG_DEBUG, "exclude RSYNC.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RSYNC);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/rtcp.c
+++ b/src/lib/protocols/rtcp.c
@@ -4,11 +4,14 @@
  * Copyright (C) 2013 Remy Mudingay <mudingay@ill.fr>
  *
  */
+#include "ndpi_protocol_ids.h"
 
+#ifdef NDPI_PROTOCOL_RTCP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_RTCP
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_RTCP
 static void ndpi_int_rtcp_add_connection(struct ndpi_detection_module_struct
 					 *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -20,18 +23,18 @@ void ndpi_search_rtcp(struct ndpi_detection_module_struct *ndpi_struct, struct n
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int16_t dport = 0, sport = 0;
 
-  NDPI_LOG(NDPI_PROTOCOL_RTCP, ndpi_struct, NDPI_LOG_DEBUG, "search for RTCP.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search RTCP\n");
 
   if(packet->tcp != NULL) {
     sport = ntohs(packet->tcp->source), dport = ntohs(packet->tcp->dest);
-    NDPI_LOG(NDPI_PROTOCOL_RTCP, ndpi_struct, NDPI_LOG_DEBUG, "calculating dport over tcp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculating dport over tcp\n");
 
     if(packet->payload_packet_len > 13 && (sport == 554 || dport == 554) &&
        packet->payload[0] == 0x00 && packet->payload[1] == 0x00 &&
        packet->payload[2] == 0x01 && packet->payload[3] == 0x01 &&
        packet->payload[4] == 0x08 && packet->payload[5] == 0x0a &&
        packet->payload[6] == 0x00 && packet->payload[7] == 0x01) {
-      NDPI_LOG(NDPI_PROTOCOL_RTCP, ndpi_struct, NDPI_LOG_DEBUG, "found rtcp.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found rtcp\n");
       ndpi_int_rtcp_add_connection(ndpi_struct, flow);
     }
   } else if(packet->udp != NULL) {
@@ -48,20 +51,19 @@ void ndpi_search_rtcp(struct ndpi_detection_module_struct *ndpi_struct, struct n
 	offset += rtcp_section_len;
     }
     
-    NDPI_LOG(NDPI_PROTOCOL_RTCP, ndpi_struct, NDPI_LOG_DEBUG, "calculating dport over udp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculating dport over udp\n");
     /* TODO changed a pair of length condition to the && from ||. Is it correct? */
     if(((packet->payload_packet_len >= 28 && packet->payload_packet_len <= 1200) &&
 	((packet->payload[0] == 0x80) && ((packet->payload[1] == 0xc8) || (packet->payload[1] == 0xc9)) && (packet->payload[2] == 0x00)))
        || (packet->payload_packet_len >= 3 && ((packet->payload[0] == 0x81) && ((packet->payload[1] == 0xc8) || (packet->payload[1] == 0xc9))
 	    && (packet->payload[2] == 0x00)))) {
-      NDPI_LOG(NDPI_PROTOCOL_RTCP, ndpi_struct, NDPI_LOG_DEBUG, "found rtcp.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found rtcp\n");
       ndpi_int_rtcp_add_connection(ndpi_struct, flow);
     }
   } else {
   exclude_rtcp:
     
-    NDPI_LOG(NDPI_PROTOCOL_RTCP, ndpi_struct, NDPI_LOG_DEBUG, "exclude RTCP.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RTCP);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/rtmp.c
+++ b/src/lib/protocols/rtmp.c
@@ -23,10 +23,14 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_RTMP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_RTMP
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_RTMP
 static void ndpi_int_rtmp_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_RTMP, NDPI_PROTOCOL_UNKNOWN);
@@ -39,24 +43,23 @@ static void ndpi_check_rtmp(struct ndpi_detection_module_struct *ndpi_struct, st
   
   /* Break after 20 packets. */
   if (flow->packet_counter > 20) {
-    NDPI_LOG(NDPI_PROTOCOL_RTMP, ndpi_struct, NDPI_LOG_DEBUG, "Exclude RTMP.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RTMP);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
   
   /* Check if we so far detected the protocol in the request or not. */
   if (flow->rtmp_stage == 0) {
-     NDPI_LOG(NDPI_PROTOCOL_RTMP, ndpi_struct, NDPI_LOG_DEBUG, "RTMP stage 0: \n");
+     NDPI_LOG__DEBUG2(ndpi_struct, "RTMP stage 0: \n");
      
      if ((payload_len >= 4) && ((packet->payload[0] == 0x03) || (packet->payload[0] == 0x06))) {
-       NDPI_LOG(NDPI_PROTOCOL_RTMP, ndpi_struct, NDPI_LOG_DEBUG, "Possible RTMP request detected, we will look further for the response...\n");
+       NDPI_LOG__DEBUG2(ndpi_struct, "Possible RTMP request detected, we will look further for the response\n");
        
        /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
        flow->rtmp_stage = packet->packet_direction + 1;
      }
      
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_RTMP, ndpi_struct, NDPI_LOG_DEBUG, "RTMP stage %u: \n", flow->rtmp_stage);
+    NDPI_LOG__DEBUG2(ndpi_struct, "RTMP stage %u: \n", flow->rtmp_stage);
     
     /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
     if ((flow->rtmp_stage - packet->packet_direction) == 1) {
@@ -65,10 +68,10 @@ static void ndpi_check_rtmp(struct ndpi_detection_module_struct *ndpi_struct, st
     
     /* This is a packet in another direction. Check if we find the proper response. */
     if ((payload_len >= 4) && ((packet->payload[0] == 0x03) || (packet->payload[0] == 0x06) || (packet->payload[0] == 0x08) || (packet->payload[0] == 0x09) || (packet->payload[0] == 0x0a))) {
-      NDPI_LOG(NDPI_PROTOCOL_RTMP, ndpi_struct, NDPI_LOG_DEBUG, "Found RTMP.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found RTMP\n");
       ndpi_int_rtmp_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_RTMP, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to RTMP, resetting the stage to 0...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to RTMP, resetting the stage to 0\n");
       flow->rtmp_stage = 0;
     }
     
@@ -79,7 +82,7 @@ void ndpi_search_rtmp(struct ndpi_detection_module_struct *ndpi_struct, struct n
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_RTMP, ndpi_struct, NDPI_LOG_DEBUG, "RTMP detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search RTMP\n");
 
   /* skip marked packets */
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_RTMP) {

--- a/src/lib/protocols/rtp.c
+++ b/src/lib/protocols/rtp.c
@@ -22,10 +22,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_RTP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_RTP
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_RTP
 
 /* http://www.myskypelab.com/2014/05/microsoft-lync-wireshark-plugin.html */
 
@@ -73,6 +77,7 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
 			    struct ndpi_flow_struct *flow,
 			    const u_int8_t * payload, const u_int16_t payload_len)
 {
+  NDPI_LOG__DEBUG(ndpi_struct, "search RTP\n");
   if (payload_len < 2)
     return;
   //struct ndpi_packet_struct *packet = &flow->packet;
@@ -89,24 +94,25 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
 	 )
 	 && (*ssid != 0)
      ) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "Found RTP.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "Found RTP\n");
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_RTP, NDPI_PROTOCOL_UNKNOWN);
     return;
   } else if((payload_len >= 12)
 	    && (((payload[0] & 0xFF) == 0x80) || ((payload[0] & 0xFF) == 0xA0)) /* RTP magic byte[1] */	    
 	    && (payloadType = isValidMSRTPType(payload[1] & 0xFF))) {
     if(payloadType == 1 /* RTP */) {
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "Found Skype for Business (former MS Lync)\n");
+      NDPI_LOG__TRACE(ndpi_struct, "Found Skype for Business (former MS Lync)\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SKYPE, NDPI_PROTOCOL_UNKNOWN);
+      return;
     } else /* RTCP */ {
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "Found MS RTCP\n");
+      NDPI_LOG__TRACE(ndpi_struct, "Found MS RTCP\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_RTCP, NDPI_PROTOCOL_UNKNOWN);
+      return;
     }
   }  
 
   /* No luck this time */
-  NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "exclude rtp.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RTP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void ndpi_search_rtp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -155,7 +161,7 @@ void init_seq(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow
 	      u_int8_t direction, u_int16_t seq, u_int8_t include_current_packet)
 {
   flow->rtp_seqnum[direction] = seq;
-  NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "rtp_seqnum[%u] = %u\n", direction, seq);
+  NDPI_LOG__DEBUG(ndpi_struct, "rtp_seqnum[%u] = %u\n", direction, seq);
 }
 
 /* returns difference between old and new highest sequence number */
@@ -173,11 +179,11 @@ u_int16_t update_seq(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 
   if (delta < RTP_MAX_OUT_OF_ORDER) {	/* in order, with permissible gap */
     flow->rtp_seqnum[direction] = seq;
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "rtp_seqnum[%u] = %u (increased by %u)\n",
+    NDPI_LOG__DEBUG(ndpi_struct, "rtp_seqnum[%u] = %u (increased by %u)\n",
 	     direction, seq, delta);
     return delta;
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "retransmission (dir %u, seqnum %u)\n",
+    NDPI_LOG__DEBUG(ndpi_struct, "retransmission (dir %u, seqnum %u)\n",
 	     direction, seq);
     return 0;
   }
@@ -192,55 +198,54 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
   u_int8_t stage;
   u_int16_t seqnum = ntohs(get_u_int16_t(payload, 2));
 
-  NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "search rtp.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search rtp\n");
 
   if (payload_len == 4 && get_u_int32_t(packet->payload, 0) == 0 && flow->packet_counter < 8) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "need next packet, maybe ClearSea out calls.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "need next packet, maybe ClearSea out calls\n");
     return;
   }
 
   if (payload_len == 5 && memcmp(payload, "hello", 5) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG(ndpi_struct,
 	     "need next packet, initial hello packet of SIP out calls.\n");
     return;
   }
 
   if (payload_len == 1 && payload[0] == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG(ndpi_struct,
 	     "need next packet, payload_packet_len == 1 && payload[0] == 0.\n");
     return;
   }
 
   if (payload_len == 3 && memcmp(payload, "png", 3) == 0) {
     /* weird packet found in Ninja GlobalIP trace */
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "skipping packet with len = 3 and png payload.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "skipping packet with len = 3 and png payload\n");
     return;
   }
 
   if (payload_len < 12) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "minimal packet size for rtp packets: 12.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "minimal packet size for rtp packets: 12\n");
     goto exclude_rtp;
   }
 
   if (payload_len == 12 && get_u_int32_t(payload, 0) == 0 && get_u_int32_t(payload, 4) == 0 && get_u_int32_t(payload, 8) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "skipping packet with len = 12 and only 0-bytes.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "skipping packet with len = 12 and only 0-bytes\n");
     return;
   }
 
   if ((payload[0] & 0xc0) == 0xc0 || (payload[0] & 0xc0) == 0x40 || (payload[0] & 0xc0) == 0x00) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "version = 3 || 1 || 0, maybe first rtp packet.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "version = 3 || 1 || 0, maybe first rtp packet\n");
     return;
   }
 
   if ((payload[0] & 0xc0) != 0x80) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct,
-	     NDPI_LOG_DEBUG, "rtp version must be 2, first two bits of a packets must be 10.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "rtp version must be 2, first two bits of a packets must be 10\n");
     goto exclude_rtp;
   }
 
   /* rtp_payload_type are the last seven bits of the second byte */
   if (flow->rtp_payload_type[packet->packet_direction] != (payload[1] & 0x7F)) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "payload_type has changed, reset stages.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "payload_type has changed, reset stages\n");
     packet->packet_direction == 0 ? (flow->rtp_stage1 = 0) : (flow->rtp_stage2 = 0);
   }
   /* first bit of first byte is not part of payload_type */
@@ -249,51 +254,48 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
   stage = (packet->packet_direction == 0 ? flow->rtp_stage1 : flow->rtp_stage2);
 
   if (stage > 0) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct,
-	     NDPI_LOG_DEBUG, "stage = %u.\n", packet->packet_direction == 0 ? flow->rtp_stage1 : flow->rtp_stage2);
+    NDPI_LOG__DEBUG(ndpi_struct, "stage = %u\n", packet->packet_direction == 0 ? flow->rtp_stage1 : flow->rtp_stage2);
     if (flow->rtp_ssid[packet->packet_direction] != get_u_int32_t(payload, 8)) {
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "ssid has changed, goto exclude rtp.\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "ssid has changed, goto exclude rtp\n");
       goto exclude_rtp;
     }
 
     if (seqnum == flow->rtp_seqnum[packet->packet_direction]) {
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "maybe \"retransmission\", need next packet.\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "maybe \"retransmission\", need next packet\n");
       return;
     } else if ((u_int16_t) (seqnum - flow->rtp_seqnum[packet->packet_direction]) < RTP_MAX_OUT_OF_ORDER) {
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG(ndpi_struct,
 	       "new packet has larger sequence number (within valid range)\n");
       update_seq(ndpi_struct, flow, packet->packet_direction, seqnum);
     } else if ((u_int16_t) (flow->rtp_seqnum[packet->packet_direction] - seqnum) < RTP_MAX_OUT_OF_ORDER) {
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG(ndpi_struct,
 	       "new packet has smaller sequence number (within valid range)\n");
       init_seq(ndpi_struct, flow, packet->packet_direction, seqnum, 1);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG(ndpi_struct,
 	       "sequence number diff is too big, goto exclude rtp.\n");
       goto exclude_rtp;
     }
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct,
-	     NDPI_LOG_DEBUG, "rtp_ssid[%u] = %u.\n", packet->packet_direction,
+    NDPI_LOG__DEBUG(ndpi_struct, "rtp_ssid[%u] = %u\n", packet->packet_direction,
 	     flow->rtp_ssid[packet->packet_direction]);
     flow->rtp_ssid[packet->packet_direction] = get_u_int32_t(payload, 8);
     if (flow->packet_counter < 3) {
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "packet_counter < 3, need next packet.\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "packet_counter < 3, need next packet\n");
     }
     init_seq(ndpi_struct, flow, packet->packet_direction, seqnum, 1);
   }
   if (seqnum <= 3) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct,
-	     NDPI_LOG_DEBUG, "sequence_number = %u, too small, need next packet, return.\n", seqnum);
+    NDPI_LOG__DEBUG(ndpi_struct, "sequence_number = %u, too small, need next packet, return\n", seqnum);
     return;
   }
 
   if (stage == 3) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "add connection I.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "add connection I\n");
     ndpi_int_rtp_add_connection(ndpi_struct, flow);
   } else {
     packet->packet_direction == 0 ? flow->rtp_stage1++ : flow->rtp_stage2++;
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "stage[%u]++; need next packet.\n",
+    NDPI_LOG__DEBUG(ndpi_struct, "stage[%u]++; need next packet\n",
 	     packet->packet_direction);
   }
   return;
@@ -302,12 +304,11 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
 #ifdef NDPI_PROTOCOL_STUN
   if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_STUN
       || /* packet->real_protocol_read_only == NDPI_PROTOCOL_STUN */) {
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "STUN: is detected, need next packet.\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "STUN: is detected, need next packet\n");
     return;
   }
 #endif							/*  NDPI_PROTOCOL_STUN */
-  NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "exclude rtp.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RTP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 
@@ -325,7 +326,7 @@ void ndpi_search_rtp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	packet->payload[0] == 0x90 && packet->payload[1] >= 0x01 && packet->payload[1] <= 0x07) {
       if (flow->packet_counter == 2)
 	flow->l4.tcp.rtp_special_packets_seen = 1;
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG(ndpi_struct,
 	       "skipping STUN-like, special yahoo packets with payload[0] == 0x90.\n");
       return;
     }
@@ -366,14 +367,12 @@ void ndpi_search_rtp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
     }
 
     if (NDPI_FLOW_PROTOCOL_EXCLUDED(ndpi_struct, flow, NDPI_PROTOCOL_STUN)) {
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "exclude rtp.\n");
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RTP);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "STUN not yet excluded, need next packet.\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "STUN not yet excluded, need next packet\n");
     }
 #else
-    NDPI_LOG(NDPI_PROTOCOL_RTP, ndpi_struct, NDPI_LOG_DEBUG, "exclude rtp.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RTP);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 #endif
   }
 }

--- a/src/lib/protocols/rtsp.c
+++ b/src/lib/protocols/rtsp.c
@@ -22,19 +22,20 @@
  *
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_RTSP
-#ifndef NDPI_PROTOCOL_RTP
-#error RTSP requires RTP detection to work correctly
-#endif
-#ifndef NDPI_PROTOCOL_RTSP
-#error RTSP requires RTSP detection to work correctly
-#endif
-#ifndef NDPI_PROTOCOL_RDP
-#error RTSP requires RDP detection to work correctly
-#endif
+ #ifndef NDPI_PROTOCOL_RTP
+ #error RTSP requires RTP detection to work correctly
+ #endif
+ #ifndef NDPI_PROTOCOL_RDP
+ #error RTSP requires RDP detection to work correctly
+ #endif
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_RTSP
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_rtsp_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					 struct ndpi_flow_struct *flow/* , */
@@ -52,7 +53,7 @@ void ndpi_search_rtsp_tcp_udp(struct ndpi_detection_module_struct
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
 
-  NDPI_LOG(NDPI_PROTOCOL_RTSP, ndpi_struct, NDPI_LOG_TRACE, "RTSP detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search RTSP\n");
 
   if (flow->rtsprdt_stage == 0
 #ifdef NDPI_PROTOCOL_RTCP
@@ -60,13 +61,13 @@ void ndpi_search_rtsp_tcp_udp(struct ndpi_detection_module_struct
 #endif
       ) {
     flow->rtsprdt_stage = 1 + packet->packet_direction;
-    NDPI_LOG(NDPI_PROTOCOL_RTSP, ndpi_struct, NDPI_LOG_DEBUG, "maybe handshake 1; need next packet, return.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "maybe handshake 1; need next packet, return\n");
     return;
   }
 
   if (flow->packet_counter < 3 && flow->rtsprdt_stage == 1 + packet->packet_direction) {
 
-    NDPI_LOG(NDPI_PROTOCOL_RTSP, ndpi_struct, NDPI_LOG_DEBUG, "maybe handshake 2; need next packet.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "maybe handshake 2; need next packet\n");
     return;
   }
 
@@ -80,20 +81,20 @@ void ndpi_search_rtsp_tcp_udp(struct ndpi_detection_module_struct
     // RTSP Server Message
     if((memcmp(packet->payload, "RTSP/1.0 ", 9) == 0)
        || (strstr(buf, "rtsp://") != NULL)) {
-      NDPI_LOG(NDPI_PROTOCOL_RTSP, ndpi_struct, NDPI_LOG_TRACE, "found RTSP/1.0 .\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "found RTSP/1.0 \n");
       if (dst != NULL) {
-	NDPI_LOG(NDPI_PROTOCOL_RTSP, ndpi_struct, NDPI_LOG_TRACE, "found dst.\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "found dst\n");
 	ndpi_packet_src_ip_get(packet, &dst->rtsp_ip_address);
 	dst->rtsp_timer = packet->tick_timestamp;
 	dst->rtsp_ts_set = 1;
       }
       if (src != NULL) {
-	NDPI_LOG(NDPI_PROTOCOL_RTSP, ndpi_struct, NDPI_LOG_TRACE, "found src.\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "found src\n");
 	ndpi_packet_dst_ip_get(packet, &src->rtsp_ip_address);
 	src->rtsp_timer = packet->tick_timestamp;
 	src->rtsp_ts_set = 1;
       }
-      NDPI_LOG(NDPI_PROTOCOL_RTSP, ndpi_struct, NDPI_LOG_TRACE, "RTSP detected.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found RTSP\n");
       flow->rtsp_control_flow = 1;
       ndpi_int_rtsp_add_connection(ndpi_struct, flow);
       return;
@@ -105,14 +106,13 @@ void ndpi_search_rtsp_tcp_udp(struct ndpi_detection_module_struct
 	  || (NDPI_COMPARE_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RTCP) == 0)
 #endif
 	  )) {
-    NDPI_LOG(NDPI_PROTOCOL_RTSP, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
 	     "maybe RTSP RTP, RTSP RTCP, RDT; need next packet.\n");
     return;
   }
 
 
-  NDPI_LOG(NDPI_PROTOCOL_RTSP, ndpi_struct, NDPI_LOG_DEBUG, "didn't find handshake, exclude.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RTSP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   return;
 }
 

--- a/src/lib/protocols/rx.c
+++ b/src/lib/protocols/rx.c
@@ -22,10 +22,14 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_api.h"
 
 #ifdef NDPI_PROTOCOL_RX
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_RX
+
+#include "ndpi_api.h"
 
 /* See http://web.mit.edu/kolya/afs/rx/rx-spec for protocol description. */
 
@@ -79,13 +83,12 @@ void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
-  NDPI_LOG(NDPI_PROTOCOL_RX, ndpi_struct, NDPI_LOG_DEBUG, "RX: pck: %d, dir[0]: %d, dir[1]: %d\n",
+  NDPI_LOG__DEBUG2(ndpi_struct, "RX: pck: %d, dir[0]: %d, dir[1]: %d\n",
            flow->packet_counter, flow->packet_direction_counter[0], flow->packet_direction_counter[1]);
 
   /* Check that packet is long enough */
   if (payload_len < sizeof(struct ndpi_rx_header)) {
-    NDPI_LOG(NDPI_PROTOCOL_RX, ndpi_struct, NDPI_LOG_DEBUG, "excluding RX\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RX);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
   
@@ -108,8 +111,7 @@ void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
   
   /* TYPE field */
   if((header->type < DATA) || (header->type > VERSION)) {
-    NDPI_LOG(NDPI_PROTOCOL_RX, ndpi_struct, NDPI_LOG_DEBUG, "excluding RX\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RX);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
@@ -157,13 +159,11 @@ void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
       case VERSION:
 	goto security;
       default:
-	NDPI_LOG(NDPI_PROTOCOL_RX, ndpi_struct, NDPI_LOG_DEBUG, "excluding RX\n");
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RX);
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 	return;
     } // switch
   } else { // FLAG
-    NDPI_LOG(NDPI_PROTOCOL_RX, ndpi_struct, NDPI_LOG_DEBUG, "excluding RX\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RX);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
@@ -171,8 +171,7 @@ void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
   /* SECURITY field */
   if(header->security > 3)
   {
-    NDPI_LOG(NDPI_PROTOCOL_RX, ndpi_struct, NDPI_LOG_DEBUG, "excluding RX\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RX);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
   
@@ -184,21 +183,20 @@ void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
     if (flow->l4.udp.rx_conn_epoch == header->conn_epoch &&
 	flow->l4.udp.rx_conn_id == header->conn_id)
     {
-      NDPI_LOG(NDPI_PROTOCOL_RX, ndpi_struct, NDPI_LOG_DEBUG, "found RX\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found RX\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_RX, NDPI_PROTOCOL_UNKNOWN);
     }
     /* https://www.central.org/frameless/numbers/rxservice.html. */
     else
     {
-      NDPI_LOG(NDPI_PROTOCOL_RX, ndpi_struct, NDPI_LOG_DEBUG, "excluding RX\n");
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RX);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
       return;
     }
   } else {
     flow->l4.udp.rx_conn_epoch = header->conn_epoch;
     flow->l4.udp.rx_conn_id = header->conn_id;
     {
-      NDPI_LOG(NDPI_PROTOCOL_RX, ndpi_struct, NDPI_LOG_DEBUG, "found RX\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found RX\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_RX, NDPI_PROTOCOL_UNKNOWN);
     }
   }
@@ -209,7 +207,7 @@ void ndpi_search_rx(struct ndpi_detection_module_struct *ndpi_struct,
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_RX, ndpi_struct, NDPI_LOG_DEBUG, "entering RX search\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search RX\n");
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_RX) {
     ndpi_check_rx(ndpi_struct, flow);
   }

--- a/src/lib/protocols/sflow.c
+++ b/src/lib/protocols/sflow.c
@@ -18,34 +18,34 @@
  *
  */
 
-
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_SFLOW
 
-static void ndpi_check_sflow(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SFLOW
+
+#include "ndpi_api.h"
+
+void ndpi_search_sflow(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;  
   // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search sflow\n");
 
   if((packet->udp != NULL)
      && (payload_len >= 24)
      /* Version */
      && (packet->payload[0] == 0) && (packet->payload[1] == 0) && (packet->payload[2] == 0)
      && ((packet->payload[3] == 2) || (packet->payload[3] == 5))) {
-    NDPI_LOG(NDPI_PROTOCOL_SFLOW, ndpi_struct, NDPI_LOG_DEBUG, "Found sflow.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found sflow\n");
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SFLOW, NDPI_PROTOCOL_UNKNOWN);
     return;
   }
-}
 
-void ndpi_search_sflow(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
-{
-  NDPI_LOG(NDPI_PROTOCOL_SFLOW, ndpi_struct, NDPI_LOG_DEBUG, "sflow detection...\n");
-  ndpi_check_sflow(ndpi_struct, flow);
+// FIXME  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
-
 
 void init_sflow_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask)
 {

--- a/src/lib/protocols/shoutcast.c
+++ b/src/lib/protocols/shoutcast.c
@@ -22,10 +22,13 @@
  * 
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_SHOUTCAST
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SHOUTCAST
+
+#include "ndpi_api.h"
 
 static void ndpi_int_shoutcast_add_connection(struct ndpi_detection_module_struct
 					      *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -39,13 +42,13 @@ void ndpi_search_shoutcast_tcp(struct ndpi_detection_module_struct
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
 
-	NDPI_LOG(NDPI_PROTOCOL_SHOUTCAST, ndpi_struct, NDPI_LOG_DEBUG, "search shoutcast.\n");
+	NDPI_LOG__DEBUG(ndpi_struct, "search shoutcast\n");
 
 	if (flow->packet_counter == 1) {
 /* this case in paul_upload_oddcast_002.pcap */
 		if (packet->payload_packet_len >= 6
 			&& packet->payload_packet_len < 80 && memcmp(packet->payload, "123456", 6) == 0) {
-			NDPI_LOG(NDPI_PROTOCOL_SHOUTCAST, ndpi_struct, NDPI_LOG_DEBUG, "Shoutcast stage 1, \"123456\".\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Shoutcast stage 1, \"123456\"\n");
 			return;
 		}
 		if (flow->packet_counter < 3
@@ -53,11 +56,11 @@ void ndpi_search_shoutcast_tcp(struct ndpi_detection_module_struct
 			&& packet->detected_protocol_stack[0] == NDPI_PROTOCOL_HTTP
 #endif
 			) {
-			NDPI_LOG(NDPI_PROTOCOL_SHOUTCAST, ndpi_struct, NDPI_LOG_DEBUG,
+			NDPI_LOG__DEBUG2(ndpi_struct,
 					"http detected, need next packet for shoutcast detection.\n");
 			if (packet->payload_packet_len > 4
 				&& get_u_int32_t(packet->payload, packet->payload_packet_len - 4) != htonl(0x0d0a0d0a)) {
-				NDPI_LOG(NDPI_PROTOCOL_SHOUTCAST, ndpi_struct, NDPI_LOG_DEBUG, "segmented packet found.\n");
+				NDPI_LOG__DEBUG2(ndpi_struct, "segmented packet found\n");
 				flow->l4.tcp.shoutcast_stage = 1 + packet->packet_direction;
 			}
 			return;
@@ -70,7 +73,7 @@ void ndpi_search_shoutcast_tcp(struct ndpi_detection_module_struct
 	}
 	/* evtl. für asym detection noch User-Agent:Winamp dazunehmen. */
 	if (packet->payload_packet_len > 11 && memcmp(packet->payload, "ICY 200 OK\x0d\x0a", 12) == 0) {
-		NDPI_LOG(NDPI_PROTOCOL_SHOUTCAST, ndpi_struct, NDPI_LOG_DEBUG, "found shoutcast by ICY 200 OK.\n");
+		NDPI_LOG__TRACE(ndpi_struct, "found shoutcast by ICY 200 OK\n");
 		ndpi_int_shoutcast_add_connection(ndpi_struct, flow);
 		return;
 	}
@@ -81,19 +84,19 @@ void ndpi_search_shoutcast_tcp(struct ndpi_detection_module_struct
 
 	if (flow->packet_counter == 2) {
 		if (packet->payload_packet_len == 2 && memcmp(packet->payload, "\x0d\x0a", 2) == 0) {
-			NDPI_LOG(NDPI_PROTOCOL_SHOUTCAST, ndpi_struct, NDPI_LOG_DEBUG, "Shoutcast stage 1 continuation.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Shoutcast stage 1 continuation\n");
 			return;
 		} else if (packet->payload_packet_len > 3 && memcmp(&packet->payload[0], "OK2", 3) == 0) {
-			NDPI_LOG(NDPI_PROTOCOL_SHOUTCAST, ndpi_struct, NDPI_LOG_DEBUG, "Shoutcast stage 2, OK2 found.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Shoutcast stage 2, OK2 found\n");
 			return;
 		} else
 			goto exclude_shoutcast;
 	} else if (flow->packet_counter == 3 || flow->packet_counter == 4) {
 		if (packet->payload_packet_len > 3 && memcmp(&packet->payload[0], "OK2", 3) == 0) {
-			NDPI_LOG(NDPI_PROTOCOL_SHOUTCAST, ndpi_struct, NDPI_LOG_DEBUG, "Shoutcast stage 2, OK2 found.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "Shoutcast stage 2, OK2 found\n");
 			return;
 		} else if (packet->payload_packet_len > 4 && memcmp(&packet->payload[0], "icy-", 4) == 0) {
-			NDPI_LOG(NDPI_PROTOCOL_SHOUTCAST, ndpi_struct, NDPI_LOG_DEBUG, "Shoutcast detected.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found Shoutcast\n");
 			ndpi_int_shoutcast_add_connection(ndpi_struct, flow);
 			return;
 		} else
@@ -101,8 +104,7 @@ void ndpi_search_shoutcast_tcp(struct ndpi_detection_module_struct
 	}
 
   exclude_shoutcast:
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SHOUTCAST);
-	NDPI_LOG(NDPI_PROTOCOL_SHOUTCAST, ndpi_struct, NDPI_LOG_DEBUG, "Shoutcast excluded.\n");
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/sip.c
+++ b/src/lib/protocols/sip.c
@@ -22,10 +22,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_SIP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SIP
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_SIP
 static void ndpi_int_sip_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					struct ndpi_flow_struct *flow,
 					u_int8_t due_to_correlation) {
@@ -41,18 +45,14 @@ void ndpi_search_sip_handshake(struct ndpi_detection_module_struct
 			       *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
-
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
   const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
-
 
   if (payload_len > 4) {
     /* search for STUN Turn ChannelData Prefix */
     u_int16_t message_len = ntohs(get_u_int16_t(packet->payload, 2));
     if (payload_len - 4 == message_len) {
-      NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "found STUN TURN ChannelData prefix.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "found STUN TURN ChannelData prefix\n");
       payload_len -= 4;
       packet_payload += 4;
     }
@@ -68,7 +68,7 @@ void ndpi_search_sip_handshake(struct ndpi_detection_module_struct
 	if ((memcmp(packet_payload, "NOTIFY ", 7) == 0 || memcmp(packet_payload, "notify ", 7) == 0)
 	    && (memcmp(&packet_payload[7], "SIP:", 4) == 0 || memcmp(&packet_payload[7], "sip:", 4) == 0)) {
 
-	  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "found sip NOTIFY.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found sip NOTIFY\n");
 	  ndpi_int_sip_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
@@ -76,14 +76,14 @@ void ndpi_search_sip_handshake(struct ndpi_detection_module_struct
 	if ((memcmp(packet_payload, "REGISTER ", 9) == 0 || memcmp(packet_payload, "register ", 9) == 0)
 	    && (memcmp(&packet_payload[9], "SIP:", 4) == 0 || memcmp(&packet_payload[9], "sip:", 4) == 0)) {
 
-	  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "found sip REGISTER.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found sip REGISTER\n");
 	  ndpi_int_sip_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
 
 	if ((memcmp(packet_payload, "INVITE ", 7) == 0 || memcmp(packet_payload, "invite ", 7) == 0)
 	    && (memcmp(&packet_payload[7], "SIP:", 4) == 0 || memcmp(&packet_payload[7], "sip:", 4) == 0)) {
-	  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "found sip INVITE.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found sip INVITE\n");
 	  ndpi_int_sip_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
@@ -95,34 +95,34 @@ void ndpi_search_sip_handshake(struct ndpi_detection_module_struct
 
 	/*
 	if (memcmp(packet_payload, "SIP/2.0 200 OK", 14) == 0 || memcmp(packet_payload, "sip/2.0 200 OK", 14) == 0) {
-	  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "found sip SIP/2.0 0K.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found sip SIP/2.0 0K\n");
 	  ndpi_int_sip_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
         */
         if (memcmp(packet_payload, "SIP/2.0 ", 8) == 0 || memcmp(packet_payload, "sip/2.0 ", 8) == 0) {
-	  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "found sip SIP/2.0 *.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found sip SIP/2.0 *\n");
 	  ndpi_int_sip_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
 
         if ((memcmp(packet_payload, "BYE ", 4) == 0 || memcmp(packet_payload, "bye ", 4) == 0)
 	    && (memcmp(&packet_payload[4], "SIP:", 4) == 0 || memcmp(&packet_payload[4], "sip:", 4) == 0)) {
-	  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "found sip BYE.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found sip BYE\n");
 	  ndpi_int_sip_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
 
         if ((memcmp(packet_payload, "ACK ", 4) == 0 || memcmp(packet_payload, "ack ", 4) == 0)
 	    && (memcmp(&packet_payload[4], "SIP:", 4) == 0 || memcmp(&packet_payload[4], "sip:", 4) == 0)) {
-	  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "found sip ACK.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found sip ACK\n");
 	  ndpi_int_sip_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
 
         if ((memcmp(packet_payload, "CANCEL ", 7) == 0 || memcmp(packet_payload, "cancel ", 7) == 0)
 	    && (memcmp(&packet_payload[4], "SIP:", 4) == 0 || memcmp(&packet_payload[4], "sip:", 4) == 0)) {
-	  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "found sip CANCEL.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found sip CANCEL\n");
 	  ndpi_int_sip_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
@@ -132,7 +132,7 @@ void ndpi_search_sip_handshake(struct ndpi_detection_module_struct
 	     || memcmp(packet_payload, "options ", 8) == 0)
 	    && (memcmp(&packet_payload[8], "SIP:", 4) == 0
 		|| memcmp(&packet_payload[8], "sip:", 4) == 0)) {
-	  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "found sip OPTIONS.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found sip OPTIONS\n");
 	  ndpi_int_sip_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
@@ -141,19 +141,19 @@ void ndpi_search_sip_handshake(struct ndpi_detection_module_struct
   /* add bitmask for tcp only, some stupid udp programs
    * send a very few (< 10 ) packets before invite (mostly a 0x0a0x0d, but just search the first 3 payload_packets here */
   if (packet->udp != NULL && flow->packet_counter < 20) {
-    NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "need next packet.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "need next packet\n");
     return;
   }
 #ifdef NDPI_PROTOCOL_STUN
   /* for STUN flows we need some more packets */
   if (packet->udp != NULL && flow->detected_protocol_stack[0] == NDPI_PROTOCOL_STUN && flow->packet_counter < 40) {
-    NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "need next STUN packet.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "need next STUN packet\n");
     return;
   }
 #endif
 
   if (payload_len == 4 && get_u_int32_t(packet_payload, 0) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "maybe sip. need next packet.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "maybe sip. need next packet\n");
     return;
   }
 #ifdef NDPI_PROTOCOL_YAHOO
@@ -161,27 +161,21 @@ void ndpi_search_sip_handshake(struct ndpi_detection_module_struct
       && packet_payload[3] == payload_len - 20 && get_u_int32_t(packet_payload, 4) == 0
       && get_u_int32_t(packet_payload, 8) == 0) {
     flow->sip_yahoo_voice = 1;
-    NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "maybe sip yahoo. need next packet.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "maybe sip yahoo. need next packet\n");
   }
   if (flow->sip_yahoo_voice && flow->packet_counter < 10) {
     return;
   }
 #endif
-  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "exclude sip.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SIP);
-  return;
-
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 
 void ndpi_search_sip(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
-  //  struct ndpi_flow_struct   *flow = ndpi_struct->flow;
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
-  NDPI_LOG(NDPI_PROTOCOL_SIP, ndpi_struct, NDPI_LOG_DEBUG, "sip detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search sip\n");
 
   /* skip marked packets */
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_SIP) {

--- a/src/lib/protocols/skinny.c
+++ b/src/lib/protocols/skinny.c
@@ -17,12 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#include "ndpi_protocol_ids.h"
 
+#ifdef NDPI_PROTOCOL_SKINNY
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SKINNY
 
 #include "ndpi_api.h"
 
 
-#ifdef NDPI_PROTOCOL_SKINNY
 static void ndpi_int_skinny_add_connection(struct ndpi_detection_module_struct
 					   *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -38,26 +41,25 @@ void ndpi_search_skinny(struct ndpi_detection_module_struct *ndpi_struct, struct
   const char keypadmsg_8_bytes[8] = { 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
   const char selectmsg_8_bytes[8] = { 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-  NDPI_LOG(NDPI_PROTOCOL_SKINNY, ndpi_struct, NDPI_LOG_DEBUG, "search for SKINNY.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search for SKINNY\n");
 
   if(packet->tcp != NULL) {
     sport = ntohs(packet->tcp->source), dport = ntohs(packet->tcp->dest);
-    NDPI_LOG(NDPI_PROTOCOL_SKINNY, ndpi_struct, NDPI_LOG_DEBUG, "calculating SKINNY over tcp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculating SKINNY over tcp\n");
     if (dport == 2000  && ((packet->payload_packet_len == 24 &&
 			    memcmp(&packet->payload[0], keypadmsg_8_bytes, 8) == 0) 
 			   || ((packet->payload_packet_len == 64) && memcmp(&packet->payload[0], pattern_8_bytes, 8) == 0))) {
-      NDPI_LOG(NDPI_PROTOCOL_SKINNY, ndpi_struct, NDPI_LOG_DEBUG, "found skinny.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found skinny\n");
       ndpi_int_skinny_add_connection(ndpi_struct, flow);
     } else if (sport == 2000 && ((packet->payload_packet_len == 28 &&
 				 memcmp(&packet->payload[0], selectmsg_8_bytes, 8) == 0 ) ||
 	       (packet->payload_packet_len == 44 &&
 		memcmp(&packet->payload[0], pattern_9_bytes, 9) == 0))) {
-      NDPI_LOG(NDPI_PROTOCOL_SKINNY, ndpi_struct, NDPI_LOG_DEBUG, "found skinny.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found skinny\n");
       ndpi_int_skinny_add_connection(ndpi_struct, flow);
     }
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_SKINNY, ndpi_struct, NDPI_LOG_DEBUG, "exclude SKINNY.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SKINNY);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/skype.c
+++ b/src/lib/protocols/skype.c
@@ -17,9 +17,14 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_SKYPE
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SKYPE
+
+#include "ndpi_api.h"
+
 
 static void ndpi_check_skype(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -44,13 +49,13 @@ static void ndpi_check_skype(struct ndpi_detection_module_struct *ndpi_struct, s
 	   ((payload_len >= 16)
 	    && (packet->payload[0] != 0x30) /* Avoid invalid SNMP detection */
 	    && (packet->payload[2] == 0x02))) {
-	  NDPI_LOG(NDPI_PROTOCOL_SKYPE, ndpi_struct, NDPI_LOG_DEBUG, "Found skype.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found skype\n");
 	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SKYPE, NDPI_PROTOCOL_UNKNOWN);
 	}
       }
       return;
     }
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SKYPE);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
 
     // TCP check
@@ -69,15 +74,16 @@ static void ndpi_check_skype(struct ndpi_detection_module_struct *ndpi_struct, s
 	// printf("[SKYPE] payload_len=%u\n", payload_len);
 	/* printf("[SKYPE] %u/%u\n", ntohs(packet->tcp->source), ntohs(packet->tcp->dest)); */
 
-	NDPI_LOG(NDPI_PROTOCOL_SKYPE, ndpi_struct, NDPI_LOG_DEBUG, "Found skype.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found skype\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SKYPE, NDPI_PROTOCOL_UNKNOWN);
       } else {
 	// printf("NO [SKYPE] payload_len=%u\n", payload_len);
       }
 
       /* printf("[SKYPE] [id: %u][len: %d]\n", flow->l4.tcp.skype_packet_id, payload_len);  */
-    } else
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SKYPE);
+    } else {
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    }
 
     return;
   }
@@ -87,7 +93,7 @@ void ndpi_search_skype(struct ndpi_detection_module_struct *ndpi_struct, struct 
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_SKYPE, ndpi_struct, NDPI_LOG_DEBUG, "skype detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search skype\n");
 
   /* skip marked packets */
   if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_SKYPE)

--- a/src/lib/protocols/smb.c
+++ b/src/lib/protocols/smb.c
@@ -20,33 +20,37 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_SMB
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SMB
+
+#include "ndpi_api.h"
 
 
 void ndpi_search_smb_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search SMB\n");
+
   /* Check connection over TCP */
   if(packet->tcp) {
-    NDPI_LOG(NDPI_PROTOCOL_SMB, ndpi_struct, NDPI_LOG_DEBUG, "search SMB.\n");
     
     if(packet->tcp->dest == htons(445)
        && packet->payload_packet_len > (32 + 4 + 4)
        && (packet->payload_packet_len - 4) == ntohl(get_u_int32_t(packet->payload, 0))
        && get_u_int32_t(packet->payload, 4) == htonl(0xff534d42)) {
       
-      NDPI_LOG(NDPI_PROTOCOL_SMB, ndpi_struct, NDPI_LOG_DEBUG, "found SMB.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found SMB\n");
 
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SMB, NDPI_PROTOCOL_UNKNOWN);
       return;
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_SMB, ndpi_struct, NDPI_LOG_DEBUG, "exclude SMB.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SMB);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/snmp.c
+++ b/src/lib/protocols/snmp.c
@@ -22,9 +22,13 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_SNMP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SNMP
+
+#include "ndpi_api.h"
 
 static void ndpi_int_snmp_add_connection(struct ndpi_detection_module_struct
 					 *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -35,10 +39,9 @@ static void ndpi_int_snmp_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_snmp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
-	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search SNMP\n");
+	
   if (packet->payload_packet_len > 32 && packet->payload[0] == 0x30) {
     int offset;
     u_int16_t u16;
@@ -52,7 +55,7 @@ void ndpi_search_snmp(struct ndpi_detection_module_struct *ndpi_struct, struct n
       break;
     default:
       if (packet->payload[1] > 0x82) {
-	NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG, "SNMP excluded, second byte is > 0x82\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "SNMP excluded, second byte is > 0x82\n");
 	goto excl;
       }
       offset = 2;
@@ -61,22 +64,22 @@ void ndpi_search_snmp(struct ndpi_detection_module_struct *ndpi_struct, struct n
     u16 = ntohs(get_u_int16_t(packet->payload, offset));
     
     if((u16 != 0x0201) && (u16 != 0x0204)) {
-      NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG, "SNMP excluded, 0x0201/0x0204 pattern not found\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "SNMP excluded, 0x0201/0x0204 pattern not found\n");
       goto excl;
     }
 
     if (packet->payload[offset + 2] >= 0x04) {
-      NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG, "SNMP excluded, version > 3\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "SNMP excluded, version > 3\n");
       goto excl;
     }
 
     if (flow->l4.udp.snmp_stage == 0) {
       if (packet->udp->dest == htons(161) || packet->udp->dest == htons(162)) {
-	NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG, "SNMP detected due to port.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found SNMP by port\n");
 	ndpi_int_snmp_add_connection(ndpi_struct, flow);
 	return;
       }
-      NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG, "SNMP stage 0.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "SNMP stage 0\n");
       if (packet->payload[offset + 2] == 3) {
 	flow->l4.udp.snmp_msg_id = ntohs(get_u_int32_t(packet->payload, offset + 8));
       } else if (packet->payload[offset + 2] == 0) {
@@ -89,41 +92,39 @@ void ndpi_search_snmp(struct ndpi_detection_module_struct *ndpi_struct, struct n
     } else if (flow->l4.udp.snmp_stage == 1 + packet->packet_direction) {
       if (packet->payload[offset + 2] == 0) {
 	if (flow->l4.udp.snmp_msg_id != get_u_int8_t(packet->payload, offset + 15) - 1) {
-	  NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG,
+	  NDPI_LOG__DEBUG2(ndpi_struct,
 		   "SNMP v1 excluded, message ID doesn't match\n");
 	  goto excl;
 	}
       }
     } else if (flow->l4.udp.snmp_stage == 2 - packet->packet_direction) {
-      NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG, "SNMP stage 1-2.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "SNMP stage 1-2\n");
       if (packet->payload[offset + 2] == 3) {
 	if (flow->l4.udp.snmp_msg_id != ntohs(get_u_int32_t(packet->payload, offset + 8))) {
-	  NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG,
+	  NDPI_LOG__DEBUG2(ndpi_struct,
 		   "SNMP v3 excluded, message ID doesn't match\n");
 	  goto excl;
 	}
       } else if (packet->payload[offset + 2] == 0) {
 	if (flow->l4.udp.snmp_msg_id != get_u_int8_t(packet->payload, offset + 15)) {
-	  NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG,
+	  NDPI_LOG__DEBUG2(ndpi_struct,
 		   "SNMP v1 excluded, message ID doesn't match\n");
 	  goto excl;
 	}
       } else {
 	if (flow->l4.udp.snmp_msg_id != ntohs(get_u_int16_t(packet->payload, offset + 15))) {
-	  NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG,
+	  NDPI_LOG__DEBUG2(ndpi_struct,
 		   "SNMP v2 excluded, message ID doesn't match\n");
 	  goto excl;
 	}
       }
-      NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG, "SNMP detected.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found SNMP\n");
       ndpi_int_snmp_add_connection(ndpi_struct, flow);
       return;
     }
-  } else {
-    NDPI_LOG(NDPI_PROTOCOL_SNMP, ndpi_struct, NDPI_LOG_DEBUG, "SNMP excluded.\n");
   }
  excl:
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SNMP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 

--- a/src/lib/protocols/socks45.c
+++ b/src/lib/protocols/socks45.c
@@ -23,11 +23,14 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#include "ndpi_protocol_ids.h"
 
+#ifdef NDPI_PROTOCOL_SOCKS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SOCKS
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_SOCKS
 static void ndpi_int_socks_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOCKS, NDPI_PROTOCOL_UNKNOWN);
@@ -40,25 +43,24 @@ static void ndpi_check_socks4(struct ndpi_detection_module_struct *ndpi_struct, 
 
   /* Break after 20 packets. */
   if(flow->packet_counter > 20) {
-    NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "Exclude SOCKS4.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SOCKS);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
   /* Check if we so far detected the protocol in the request or not. */
   if(flow->socks4_stage == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "SOCKS4 stage 0: \n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "SOCKS4 stage 0: \n");
     
     if(payload_len >= 9 && packet->payload[0] == 0x04 && 
       (packet->payload[1] == 0x01 || packet->payload[1] == 0x02) &&
       packet->payload[payload_len - 1] == 0x00)  {
-      NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "Possible SOCKS4 request detected, we will look further for the response...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "Possible SOCKS4 request detected, we will look further for the response\n");
       /* TODO: check port and ip address is valid */
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
       flow->socks4_stage = packet->packet_direction + 1;
     }
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "SOCKS4 stage %u: \n", flow->socks4_stage);
+    NDPI_LOG__DEBUG2(ndpi_struct, "SOCKS4 stage %u: \n", flow->socks4_stage);
 
     /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
     if((flow->socks4_stage - packet->packet_direction) == 1) {
@@ -66,10 +68,10 @@ static void ndpi_check_socks4(struct ndpi_detection_module_struct *ndpi_struct, 
     }
     /* This is a packet in another direction. Check if we find the proper response. */
     if(payload_len == 8 && packet->payload[0] == 0x00 && packet->payload[1] >= 0x5a && packet->payload[1] <= 0x5d) {
-      NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "Found SOCKS4.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found SOCKS4\n");
       ndpi_int_socks_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to SOCKS4, resetting the stage to 0...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to SOCKS4, resetting the stage to 0\n");
       flow->socks4_stage = 0;
     }
   }
@@ -82,24 +84,23 @@ static void ndpi_check_socks5(struct ndpi_detection_module_struct *ndpi_struct, 
 
   /* Break after 20 packets. */
   if(flow->packet_counter > 20) {
-    NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "Exclude SOCKS5.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SOCKS);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
   /* Check if we so far detected the protocol in the request or not. */
   if(flow->socks5_stage == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "SOCKS5 stage 0: \n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "SOCKS5 stage 0: \n");
 
     if((payload_len == 3) && (packet->payload[0] == 0x05) && (packet->payload[1] == 0x01) && (packet->payload[2] == 0x00)) {
-      NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "Possible SOCKS5 request detected, we will look further for the response...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "Possible SOCKS5 request detected, we will look further for the response\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
       flow->socks5_stage = packet->packet_direction + 1;
     }
 
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "SOCKS5 stage %u: \n", flow->socks5_stage);
+    NDPI_LOG__DEBUG2(ndpi_struct, "SOCKS5 stage %u: \n", flow->socks5_stage);
 
     /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
     if((flow->socks5_stage - packet->packet_direction) == 1) {
@@ -108,10 +109,10 @@ static void ndpi_check_socks5(struct ndpi_detection_module_struct *ndpi_struct, 
 
     /* This is a packet in another direction. Check if we find the proper response. */
     if((payload_len == 0) || ((payload_len == 2) && (packet->payload[0] == 0x05) && (packet->payload[1] == 0x00))) {
-      NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "Found SOCKS5.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found SOCKS5\n");
       ndpi_int_socks_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to SOCKS5, resetting the stage to 0...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to SOCKS5, resetting the stage to 0\n");
       flow->socks5_stage = 0;
     }
 
@@ -122,7 +123,7 @@ void ndpi_search_socks(struct ndpi_detection_module_struct *ndpi_struct, struct 
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_SOCKS, ndpi_struct, NDPI_LOG_DEBUG, "SOCKS detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search SOCKS\n");
 
   /* skip marked packets */
   if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS) {

--- a/src/lib/protocols/socrates.c
+++ b/src/lib/protocols/socrates.c
@@ -23,9 +23,13 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_SOCRATES
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SOCRATES
+
+#include "ndpi_api.h"
 
 static void ndpi_socrates_add_connection(struct ndpi_detection_module_struct
 					 *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -38,20 +42,16 @@ void ndpi_search_socrates(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+  NDPI_LOG__DEBUG(ndpi_struct, "search socrates\n");
 
-
-
-  NDPI_LOG(NDPI_PROTOCOL_SOCRATES, ndpi_struct, NDPI_LOG_DEBUG, "search socrates.\n");
   if (packet->udp != NULL) {
     if (packet->payload_packet_len > 9 && packet->payload[0] == 0xfe
 	&& packet->payload[packet->payload_packet_len - 1] == 0x05) {
-      NDPI_LOG(NDPI_PROTOCOL_SOCRATES, ndpi_struct, NDPI_LOG_DEBUG, "found fe.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "found fe\n");
 
-      NDPI_LOG(NDPI_PROTOCOL_SOCRATES, ndpi_struct, NDPI_LOG_DEBUG, "len match.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "len match\n");
       if (memcmp(&packet->payload[2], "socrates", 8) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_SOCRATES, ndpi_struct, NDPI_LOG_DEBUG, "found socrates udp.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found socrates udp\n");
 	ndpi_socrates_add_connection(ndpi_struct, flow);
       }
 
@@ -59,19 +59,18 @@ void ndpi_search_socrates(struct ndpi_detection_module_struct
   } else if (packet->tcp != NULL) {
     if (packet->payload_packet_len > 13 && packet->payload[0] == 0xfe
 	&& packet->payload[packet->payload_packet_len - 1] == 0x05) {
-      NDPI_LOG(NDPI_PROTOCOL_SOCRATES, ndpi_struct, NDPI_LOG_DEBUG, "found fe.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "found fe\n");
       if (packet->payload_packet_len == ntohl(get_u_int32_t(packet->payload, 2))) {
-	NDPI_LOG(NDPI_PROTOCOL_SOCRATES, ndpi_struct, NDPI_LOG_DEBUG, "len match.\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "len match\n");
 	if (memcmp(&packet->payload[6], "socrates", 8) == 0) {
-	  NDPI_LOG(NDPI_PROTOCOL_SOCRATES, ndpi_struct, NDPI_LOG_DEBUG, "found socrates tcp.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found socrates tcp\n");
 	  ndpi_socrates_add_connection(ndpi_struct, flow);
 	}
       }
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_SOCRATES, ndpi_struct, NDPI_LOG_DEBUG, "exclude socrates.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SOCRATES);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/sopcast.c
+++ b/src/lib/protocols/sopcast.c
@@ -22,10 +22,13 @@
  * 
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_SOPCAST
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SOPCAST
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_sopcast_add_connection(struct ndpi_detection_module_struct
@@ -102,15 +105,13 @@ static void ndpi_search_sopcast_tcp(struct ndpi_detection_module_struct
 	
   if (flow->packet_counter == 1 && packet->payload_packet_len == 54 && get_u_int16_t(packet->payload, 0) == ntohs(0x0036)) {
     if (ndpi_int_is_sopcast_tcp(packet->payload, packet->payload_packet_len)) {
-      NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "found sopcast TCP \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found sopcast TCP \n");
       ndpi_int_sopcast_add_connection(ndpi_struct, flow);
       return;
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "exclude sopcast TCP.  \n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SOPCAST);
-
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 
@@ -119,19 +120,14 @@ static void ndpi_search_sopcast_udp(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-  NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "search sopcast.  \n");
-
+  NDPI_LOG__DEBUG(ndpi_struct, "search sopcast.  \n");
 
   if (packet->payload_packet_len == 52 && packet->payload[0] == 0xff
       && packet->payload[1] == 0xff && packet->payload[2] == 0x01
       && packet->payload[8] == 0x02 && packet->payload[9] == 0xff
       && packet->payload[10] == 0x00 && packet->payload[11] == 0x2c
       && packet->payload[12] == 0x00 && packet->payload[13] == 0x00 && packet->payload[14] == 0x00) {
-    NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "found sopcast with if I.  \n");
+    NDPI_LOG__TRACE(ndpi_struct, "found sopcast with if I.  \n");
     ndpi_int_sopcast_add_connection(ndpi_struct, flow);
     return;
   }
@@ -140,7 +136,7 @@ static void ndpi_search_sopcast_udp(struct ndpi_detection_module_struct
       && packet->payload[8] == 0x01 && packet->payload[9] == 0xff
       && packet->payload[10] == 0x00 && packet->payload[11] == 0x14
       && packet->payload[12] == 0x00 && packet->payload[13] == 0x00) {
-    NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "found sopcast with if II.  \n");
+    NDPI_LOG__TRACE(ndpi_struct, "found sopcast with if II.  \n");
     ndpi_int_sopcast_add_connection(ndpi_struct, flow);
     return;
   }
@@ -150,7 +146,7 @@ static void ndpi_search_sopcast_udp(struct ndpi_detection_module_struct
       && packet->payload[8] == 0x03 && packet->payload[9] == 0xff
       && packet->payload[10] == 0x00 && packet->payload[11] == 0x34
       && packet->payload[12] == 0x00 && packet->payload[13] == 0x00 && packet->payload[14] == 0x00) {
-    NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "found sopcast with if III.  \n");
+    NDPI_LOG__TRACE(ndpi_struct, "found sopcast with if III.  \n");
     ndpi_int_sopcast_add_connection(ndpi_struct, flow);
     return;
   }
@@ -160,7 +156,7 @@ static void ndpi_search_sopcast_udp(struct ndpi_detection_module_struct
       && packet->payload[8] == 0x06
       && packet->payload[9] == 0x01 && packet->payload[10] == 0x00
       && packet->payload[11] == 0x22 && packet->payload[12] == 0x00 && packet->payload[13] == 0x00) {
-    NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "found sopcast with if IV.  \n");
+    NDPI_LOG__TRACE(ndpi_struct, "found sopcast with if IV.  \n");
     ndpi_int_sopcast_add_connection(ndpi_struct, flow);
     return;
   }
@@ -170,7 +166,7 @@ static void ndpi_search_sopcast_udp(struct ndpi_detection_module_struct
       && packet->payload[8] == 0x01
       && packet->payload[9] == 0x01 && packet->payload[10] == 0x00
       && packet->payload[11] == 0x14 && packet->payload[12] == 0x00 && packet->payload[13] == 0x00) {
-    NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "found sopcast with if V.  \n");
+    NDPI_LOG__TRACE(ndpi_struct, "found sopcast with if V.  \n");
     ndpi_int_sopcast_add_connection(ndpi_struct, flow);
     return;
   }
@@ -181,7 +177,7 @@ static void ndpi_search_sopcast_udp(struct ndpi_detection_module_struct
       && packet->payload[8] == 0x06
       && packet->payload[9] == 0x01 && packet->payload[10] == 0x01
       && packet->payload[11] == 0x16 && packet->payload[12] == 0x00 && packet->payload[13] == 0x00) {
-    NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "found sopcast with if VI.  \n");
+    NDPI_LOG__TRACE(ndpi_struct, "found sopcast with if VI.  \n");
     ndpi_int_sopcast_add_connection(ndpi_struct, flow);
     return;
   }
@@ -191,14 +187,14 @@ static void ndpi_search_sopcast_udp(struct ndpi_detection_module_struct
       && packet->payload[10] == 0x00 && packet->payload[11] == 0x44
       && packet->payload[16] == 0x01 && packet->payload[15] == 0x01
       && packet->payload[12] == 0x00 && packet->payload[13] == 0x00 && packet->payload[14] == 0x00) {
-    NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "found sopcast with if VII.  \n");
+    NDPI_LOG__TRACE(ndpi_struct, "found sopcast with if VII.  \n");
     ndpi_int_sopcast_add_connection(ndpi_struct, flow);
     return;
   }
 
   /* Attention please: no asymmetric detection necessary. This detection works asymmetrically as well. */
 
-  NDPI_LOG(NDPI_PROTOCOL_SOPCAST, ndpi_struct, NDPI_LOG_DEBUG, "exclude sopcast.  \n");
+  NDPI_LOG__DEBUG(ndpi_struct, "exclude sopcast.  \n");
   NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SOPCAST);
 
 }

--- a/src/lib/protocols/soulseek.c
+++ b/src/lib/protocols/soulseek.c
@@ -20,10 +20,21 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_protocols.h"
+
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_SOULSEEK
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SOULSEEK
+
+#include "ndpi_api.h"
+
+#define SOULSEEK_DETECT \
+    if(src != NULL) \
+	      src->soulseek_last_safe_access_time = packet->tick_timestamp; \
+    if(dst != NULL) \
+	      dst->soulseek_last_safe_access_time = packet->tick_timestamp; \
+    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN)
 
 void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 			      struct ndpi_flow_struct *flow)
@@ -36,14 +47,14 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
   if(packet->tcp) {
 
     if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_SOULSEEK) {
-      NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "packet marked as Soulseek\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "packet marked as Soulseek\n");
       if(src != NULL)
-	NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG,
+	NDPI_LOG__DEBUG2(ndpi_struct,
 		 "  SRC bitmask: %u, packet tick %llu , last safe access timestamp: %llu\n",
 		 NDPI_COMPARE_PROTOCOL_TO_BITMASK(src->detected_protocol_bitmask, NDPI_PROTOCOL_SOULSEEK)
 		 != 0 ? 1 : 0, (u_int64_t) packet->tick_timestamp, (u_int64_t) src->soulseek_last_safe_access_time);
       if(dst != NULL)
-	NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG,
+	NDPI_LOG__DEBUG2(ndpi_struct,
 		 "  DST bitmask: %u, packet tick %llu , last safe ts: %llu\n",
 		 NDPI_COMPARE_PROTOCOL_TO_BITMASK(dst->detected_protocol_bitmask, NDPI_PROTOCOL_SOULSEEK)
 		 != 0 ? 1 : 0, (u_int64_t) packet->tick_timestamp, (u_int64_t) dst->soulseek_last_safe_access_time);
@@ -65,13 +76,13 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       }
 
       if(src != NULL && ((u_int32_t)(packet->tick_timestamp - src->soulseek_last_safe_access_time) < ndpi_struct->soulseek_connection_ip_tick_timeout)) {
-	NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG,
+	NDPI_LOG__DEBUG2(ndpi_struct,
 		 "Soulseek: SRC update last safe access time and SKIP_FOR_TIME \n");
 	src->soulseek_last_safe_access_time = packet->tick_timestamp;
       }
 
       if(dst != NULL && ((u_int32_t)(packet->tick_timestamp - dst->soulseek_last_safe_access_time) < ndpi_struct->soulseek_connection_ip_tick_timeout)) {
-	NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG,
+	NDPI_LOG__DEBUG2(ndpi_struct,
 		 "Soulseek: DST update last safe access time and SKIP_FOR_TIME \n");
 	dst->soulseek_last_safe_access_time = packet->tick_timestamp;
       }
@@ -81,7 +92,7 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
     if(dst != NULL && dst->soulseek_listen_port != 0 && dst->soulseek_listen_port == ntohs(packet->tcp->dest)
        && ((u_int32_t)(packet->tick_timestamp - dst->soulseek_last_safe_access_time) < ndpi_struct->soulseek_connection_ip_tick_timeout)) {
       
-      NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG2(ndpi_struct,
 	       "Soulseek: Plain detection on Port : %u packet_tick_timestamp: %u soulseek_last_safe_access_time: %u soulseek_connection_ip_ticktimeout: %u\n",
 	       dst->soulseek_listen_port, packet->tick_timestamp, dst->soulseek_last_safe_access_time, ndpi_struct->soulseek_connection_ip_tick_timeout);
       
@@ -89,6 +100,7 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       if(src != NULL)
 	src->soulseek_last_safe_access_time = packet->tick_timestamp;
 
+      NDPI_LOG__TRACE(ndpi_struct, "found Soulseek\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN);
       return;
     }
@@ -121,14 +133,8 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 		  index += get_l32(packet->payload, index + 4) + 8;	// enf of "hash value"
 		  if(index == get_l32(packet->payload, 0)) {
 		    
-		    NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "Soulseek Login Detected\n");
-		    
-		    if(src != NULL)
-		      src->soulseek_last_safe_access_time = packet->tick_timestamp;
-		    if(dst != NULL)
-		      dst->soulseek_last_safe_access_time = packet->tick_timestamp;
-		    
-		    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN);
+		    NDPI_LOG__TRACE(ndpi_struct, "found soulseek Login Detected\n");
+		    SOULSEEK_DETECT;		    
 		    return;
 		  }
 		}
@@ -142,7 +148,7 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 
 	if(msgcode == 0x7d) {
 	  flow->l4.tcp.soulseek_stage = 1 + packet->packet_direction;
-	  NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "Soulseek Messages Search\n");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "Soulseek Messages Search\n");
 	  return;
 	} else if(msgcode == 0x02 && packet->payload_packet_len == 12) {
 	  const u_int32_t soulseek_listen_port = get_l32(packet->payload, 8);
@@ -152,7 +158,7 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 
 	    if(packet->tcp != NULL && src->soulseek_listen_port == 0) {
 	      src->soulseek_listen_port = soulseek_listen_port;
-	      NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "\n Listen Port Saved : %u", src->soulseek_listen_port);
+	      NDPI_LOG__DEBUG2(ndpi_struct, "\n Listen Port Saved : %u", src->soulseek_listen_port);
 
 	      if(dst != NULL)
 		dst->soulseek_last_safe_access_time = packet->tick_timestamp;
@@ -171,25 +177,17 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	      && namelen <= packet->payload_packet_len
 	      && (4 + 1 + 4 + namelen + 4 + 1 + 4) ==
 	      packet->payload_packet_len && (type == 'F' || type == 'P' || type == 'D')) {
-	    NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "soulseek detected\n");
-
-	    if(src != NULL)
-	      src->soulseek_last_safe_access_time = packet->tick_timestamp;
-	    
-	    if(dst != NULL)
-	      dst->soulseek_last_safe_access_time = packet->tick_timestamp;
-	    
-	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN);
+	    NDPI_LOG__TRACE(ndpi_struct, "found soulseek\n");
+	    SOULSEEK_DETECT;
 	    return;
 	  }
-	  NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "1\n");
 	}
-	NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "3\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "3\n");
 	//Peer Message : Pierce Firewall
 	if(packet->payload_packet_len == 9 && get_l32(packet->payload, 0) == 5
 	    && packet->payload[4] <= 0x10 && get_u_int32_t(packet->payload, 5) != 0x00000000) {
 	  flow->l4.tcp.soulseek_stage = 1 + packet->packet_direction;
-	  NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_TRACE, "Soulseek Size 9 Pierce Firewall\n");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "Soulseek Size 9 Pierce Firewall\n");
 	  return;
 	}
       }
@@ -202,14 +200,8 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	  const u_int32_t typelen = get_l32(packet->payload, 4 + 1 + 4 + usrlen);
 	  const u_int8_t type = packet->payload[4 + 1 + 4 + usrlen + 4];
 	  if(typelen == 1 && (type == 'F' || type == 'P' || type == 'D')) {
-	    NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "soulseek detected Pattern command(D|P|F).\n");
-	    
-	    if(src != NULL)
-	      src->soulseek_last_safe_access_time = packet->tick_timestamp;
-	    if(dst != NULL)
-	      dst->soulseek_last_safe_access_time = packet->tick_timestamp;
-	    
-	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN);
+	    NDPI_LOG__TRACE(ndpi_struct, "found soulseek Pattern command(D|P|F)\n");
+	    SOULSEEK_DETECT;	    
 	    return;
 	  }
 	}
@@ -219,14 +211,8 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       if(packet->payload_packet_len > 8) {
 	if((packet->payload[0] || packet->payload[1]) && get_l32(packet->payload, 4) == 9) {
 	  /* 9 is search result */
-	  NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "soulseek detected Second Pkt\n");
-	  
-	  if(src != NULL)
-	    src->soulseek_last_safe_access_time = packet->tick_timestamp;
-	  if(dst != NULL)
-	    dst->soulseek_last_safe_access_time = packet->tick_timestamp;
-	  
-	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN);
+	  NDPI_LOG__TRACE(ndpi_struct, "found soulseek Second Pkt\n");
+	  SOULSEEK_DETECT;
 	  return;
 	}
 	if(get_l32(packet->payload, 0) == packet->payload_packet_len - 4) {
@@ -235,14 +221,8 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	    {
 	      const u_int32_t usrlen = get_l32(packet->payload, 8);
 	      if(usrlen <= packet->payload_packet_len && 4 + 4 + 4 + usrlen == packet->payload_packet_len) {
-		NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "Soulseek Request Get Peer Address Detected\n");
-		
-		if(src != NULL)
-		  src->soulseek_last_safe_access_time = packet->tick_timestamp;
-		if(dst != NULL)
-		  dst->soulseek_last_safe_access_time = packet->tick_timestamp;
-		
-		ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN);
+		NDPI_LOG__TRACE(ndpi_struct, "found soulseek Request Get Peer Address Detected\n");
+		SOULSEEK_DETECT;		
 		return;
 	      }
 	    }
@@ -250,27 +230,15 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       }
 
       if(packet->payload_packet_len == 8 && get_l32(packet->payload, 4) == 0x00000004) {
-	NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "soulseek detected\n");
-
-	if(src != NULL)
-	  src->soulseek_last_safe_access_time = packet->tick_timestamp;
-	if(dst != NULL)
-	  dst->soulseek_last_safe_access_time = packet->tick_timestamp;
-	
-	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN);
+	NDPI_LOG__TRACE(ndpi_struct, "found soulseek\n");
+	SOULSEEK_DETECT;
 	return;
       }
 
       if(packet->payload_packet_len == 4
 	 && get_u_int16_t(packet->payload, 2) == 0x00 && get_u_int16_t(packet->payload, 0) != 0x00) {
-	NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "soulseek detected\n");
-	
-	if(src != NULL)
-	  src->soulseek_last_safe_access_time = packet->tick_timestamp;
-	if(dst != NULL)
-	  dst->soulseek_last_safe_access_time = packet->tick_timestamp;
-	
-	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN);
+	NDPI_LOG__TRACE(ndpi_struct, "found soulseek\n");
+	SOULSEEK_DETECT;	
 	return;
       } else if(packet->payload_packet_len == 4) {
 	flow->l4.tcp.soulseek_stage = 3;
@@ -279,33 +247,21 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
     } else if(flow->l4.tcp.soulseek_stage == 1 + packet->packet_direction) {
       if(packet->payload_packet_len > 8) {
 	if(packet->payload[4] == 0x03 && get_l32(packet->payload, 5) == 0x00000031) {
-	  NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "soulseek detected Second Pkt with SIGNATURE :: 0x0331000000 \n");
-	  
-	  if(src != NULL)
-	    src->soulseek_last_safe_access_time = packet->tick_timestamp;
-	  if(dst != NULL)
-	    dst->soulseek_last_safe_access_time = packet->tick_timestamp;
-	  
-	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN);
+	  NDPI_LOG__TRACE(ndpi_struct, "found soulseek Second Pkt with SIGNATURE :: 0x0331000000 \n");
+	  SOULSEEK_DETECT;	  
 	  return;
 	}
       }
     }
     if(flow->l4.tcp.soulseek_stage == 3 && packet->payload_packet_len == 8 && !get_u_int32_t(packet->payload, 4)) {
 
-      NDPI_LOG(NDPI_PROTOCOL_SOULSEEK, ndpi_struct, NDPI_LOG_DEBUG, "soulseek detected bcz of 8B  pkt\n");
-
-      if(src != NULL)
-	src->soulseek_last_safe_access_time = packet->tick_timestamp;
-      if(dst != NULL)
-	dst->soulseek_last_safe_access_time = packet->tick_timestamp;
-      
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SOULSEEK, NDPI_PROTOCOL_UNKNOWN);
+      NDPI_LOG__TRACE(ndpi_struct, "found soulseek bcz of 8B  pkt\n");
+      SOULSEEK_DETECT;
       return;
     }
     if(flow->l4.tcp.soulseek_stage && flow->packet_counter < 11) {
     } else {
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SOULSEEK);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     }
   }
 }

--- a/src/lib/protocols/spotify.c
+++ b/src/lib/protocols/spotify.c
@@ -21,10 +21,15 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
+
+
+#ifdef NDPI_PROTOCOL_SPOTIFY
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SPOTIFY
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_SPOTIFY
 static void ndpi_int_spotify_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					    struct ndpi_flow_struct *flow,
 					    u_int8_t due_to_correlation) {
@@ -46,7 +51,7 @@ static void ndpi_check_spotify(struct ndpi_detection_module_struct *ndpi_struct,
        && (packet->udp->dest == spotify_port)) {
       if(payload_len > 2) {
 	if(memcmp(packet->payload, "SpotUdp", 7) == 0) {
-	  NDPI_LOG(NDPI_PROTOCOL_SPOTIFY, ndpi_struct, NDPI_LOG_DEBUG, "Found spotify udp dissector.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found spotify udp dissector\n");
 	  ndpi_int_spotify_add_connection(ndpi_struct, flow, 0);
 	  return;
 	}
@@ -58,7 +63,7 @@ static void ndpi_check_spotify(struct ndpi_detection_module_struct *ndpi_struct,
        packet->payload[2] == 0x00 && packet->payload[3] == 0x00&&
        packet->payload[6] == 0x52 && packet->payload[7] == 0x0e &&
        packet->payload[8] == 0x50 ) {
-        NDPI_LOG(NDPI_PROTOCOL_SPOTIFY, ndpi_struct, NDPI_LOG_DEBUG, "Found spotify tcp dissector.\n");
+        NDPI_LOG__TRACE(ndpi_struct, "found spotify tcp dissector\n");
         ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SPOTIFY, NDPI_PROTOCOL_UNKNOWN);
      }
 
@@ -97,7 +102,7 @@ static void ndpi_check_spotify(struct ndpi_detection_module_struct *ndpi_struct,
           || ((ntohl(packet->iph->saddr) & 0xFFFFFC00 /* 255.255.252.0 */) == 0xC284A200 /* 194.132.162.0 */)
           || ((ntohl(packet->iph->daddr) & 0xFFFFFC00 /* 255.255.252.0 */) == 0xC284A200 /* 194.132.162.0 */)
 	   ) {
-        NDPI_LOG(NDPI_PROTOCOL_SPOTIFY, ndpi_struct, NDPI_LOG_DEBUG, "Found spotify via ip range.\n");
+        NDPI_LOG__TRACE(ndpi_struct, "found spotify via ip range\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SPOTIFY, NDPI_PROTOCOL_UNKNOWN);
 	  return;
 	}
@@ -105,15 +110,14 @@ static void ndpi_check_spotify(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_SPOTIFY, ndpi_struct, NDPI_LOG_DEBUG, "exclude spotify.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SPOTIFY);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void ndpi_search_spotify(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_SPOTIFY, ndpi_struct, NDPI_LOG_DEBUG, "spotify detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search spotify\n");
 
   /* skip marked packets */
   if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_SPOTIFY) {

--- a/src/lib/protocols/ssdp.c
+++ b/src/lib/protocols/ssdp.c
@@ -22,9 +22,13 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_SSDP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SSDP
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_ssdp_add_connection(struct ndpi_detection_module_struct
@@ -38,10 +42,7 @@ void ndpi_search_ssdp(struct ndpi_detection_module_struct *ndpi_struct, struct n
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-  NDPI_LOG(NDPI_PROTOCOL_SSDP, ndpi_struct, NDPI_LOG_DEBUG, "search ssdp.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search ssdp\n");
   if (packet->udp != NULL) {
 
     if (packet->payload_packet_len > 100) {
@@ -49,22 +50,21 @@ void ndpi_search_ssdp(struct ndpi_detection_module_struct *ndpi_struct, struct n
 	  || memcmp(packet->payload, "NOTIFY * HTTP/1.1", 17) == 0) {
 
 
-	NDPI_LOG(NDPI_PROTOCOL_SSDP, ndpi_struct, NDPI_LOG_DEBUG, "found ssdp.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found ssdp\n");
 	ndpi_int_ssdp_add_connection(ndpi_struct, flow);
 	return;
       }
 
 #define SSDP_HTTP "HTTP/1.1 200 OK\r\n"
       if(memcmp(packet->payload, SSDP_HTTP, strlen(SSDP_HTTP)) == 0) {
-	NDPI_LOG(NDPI_PROTOCOL_SSDP, ndpi_struct, NDPI_LOG_DEBUG, "found ssdp.\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found ssdp\n");
 	ndpi_int_ssdp_add_connection(ndpi_struct, flow);
 	return;
       }
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_SSDP, ndpi_struct, NDPI_LOG_DEBUG, "ssdp excluded.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SSDP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/ssh.c
+++ b/src/lib/protocols/ssh.c
@@ -22,9 +22,13 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_SSH
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SSH
+
+#include "ndpi_api.h"
 
 static void ndpi_int_ssh_add_connection(struct ndpi_detection_module_struct
 					*ndpi_struct, struct ndpi_flow_struct *flow){
@@ -46,8 +50,6 @@ static void ndpi_ssh_zap_cr(char *str, int len) {
 void ndpi_search_ssh_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
   if (flow->l4.tcp.ssh_stage == 0) {
     if (packet->payload_packet_len > 7 && packet->payload_packet_len < 100
@@ -56,7 +58,7 @@ void ndpi_search_ssh_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
       strncpy(flow->protos.ssh.client_signature, (const char *)packet->payload, len);
       flow->protos.ssh.client_signature[len] = '\0';
       ndpi_ssh_zap_cr(flow->protos.ssh.client_signature, len);
-      NDPI_LOG(NDPI_PROTOCOL_SSH, ndpi_struct, NDPI_LOG_DEBUG, "ssh stage 0 passed\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "ssh stage 0 passed\n");
       flow->l4.tcp.ssh_stage = 1 + packet->packet_direction;
       return;
     }
@@ -67,7 +69,7 @@ void ndpi_search_ssh_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
       strncpy(flow->protos.ssh.server_signature, (const char *)packet->payload, len);
       flow->protos.ssh.server_signature[len] = '\0';
       ndpi_ssh_zap_cr(flow->protos.ssh.server_signature, len);
-      NDPI_LOG(NDPI_PROTOCOL_SSH, ndpi_struct, NDPI_LOG_DEBUG, "found ssh\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found ssh\n");
       
       ndpi_int_ssh_add_connection(ndpi_struct, flow);
       return;
@@ -75,7 +77,7 @@ void ndpi_search_ssh_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_SSH, ndpi_struct, NDPI_LOG_DEBUG, "excluding ssh at stage %d\n", flow->l4.tcp.ssh_stage);
+  NDPI_LOG__DEBUG(ndpi_struct, "excluding ssh at stage %d\n", flow->l4.tcp.ssh_stage);
   NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SSH);
 }
 

--- a/src/lib/protocols/starcraft.c
+++ b/src/lib/protocols/starcraft.c
@@ -19,10 +19,14 @@
 *
 */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_STARCRAFT
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_STARCRAFT
+
+#include "ndpi_api.h"
+
 
 /* Sender or receiver are one of the known login portals? */
 u_int8_t sc2_match_logon_ip(struct ndpi_packet_struct* packet)
@@ -112,7 +116,7 @@ u_int8_t ndpi_check_starcraft_udp(struct ndpi_detection_module_struct* ndpi_stru
 
 void ndpi_search_starcraft(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow)
 {
-  NDPI_LOG(NDPI_PROTOCOL_STARCRAFT, ndpi_struct, NDPI_LOG_DEBUG, "Starcraft protocol detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search Starcraft\n");
   if (flow->packet.detected_protocol_stack[0] != NDPI_PROTOCOL_STARCRAFT) {
     struct ndpi_packet_struct* packet = &flow->packet;
     int8_t result = 0;
@@ -120,24 +124,22 @@ void ndpi_search_starcraft(struct ndpi_detection_module_struct* ndpi_struct, str
     if (packet->udp != NULL) {
       result = ndpi_check_starcraft_udp(ndpi_struct, flow);
       if (result == 1) {
-	//printf("Found Starcraft 2 [Game, UDP]\n");
-	NDPI_LOG(NDPI_PROTOCOL_STARCRAFT, ndpi_struct, NDPI_LOG_DEBUG, "Found Starcraft 2 [Game, UDP]\n");
+	NDPI_LOG__TRACE(ndpi_struct, "Found Starcraft 2 [Game, UDP]\n");
+        ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_STARCRAFT, NDPI_PROTOCOL_UNKNOWN);
+	return;
       }
     }
     else if (packet->tcp != NULL) {
       result = ndpi_check_starcraft_tcp(ndpi_struct, flow);
       if (result == 1) {
-	//printf("Found Starcraft 2 [Client, TCP]\n");
-	NDPI_LOG(NDPI_PROTOCOL_STARCRAFT, ndpi_struct, NDPI_LOG_DEBUG, "Found Starcraft 2 [Client, TCP]\n");
+	NDPI_LOG__TRACE(ndpi_struct, "Found Starcraft 2 [Client, TCP]\n");
+        ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_STARCRAFT, NDPI_PROTOCOL_UNKNOWN);
+	return;
       }
     }
 
-    if (result == 1) {
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_STARCRAFT, NDPI_PROTOCOL_UNKNOWN);
-    }
-    else if (result == -1) {
-      NDPI_LOG(NDPI_PROTOCOL_STARCRAFT, ndpi_struct, NDPI_LOG_DEBUG, "Starcraft excluded\n");
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_STARCRAFT);
+    if (result == -1) {
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     }
   }
 }

--- a/src/lib/protocols/stealthnet.c
+++ b/src/lib/protocols/stealthnet.c
@@ -22,10 +22,13 @@
  * 
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_STEALTHNET
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_STEALTHNET
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_stealthnet_add_connection(struct ndpi_detection_module_struct
@@ -39,20 +42,16 @@ void ndpi_search_stealthnet(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-
-  //  struct ndpi_id_struct *src = flow->src;
-  //  struct ndpi_id_struct *dst = flow->dst;
-
+  NDPI_LOG__DEBUG(ndpi_struct, "search stealthnet\n");
 
   if (packet->payload_packet_len > 40
       && memcmp(packet->payload, "LARS REGENSBURGER'S FILE SHARING PROTOCOL", 41) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_STEALTHNET, ndpi_struct, NDPI_LOG_DEBUG, "found stealthnet\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found stealthnet\n");
     ndpi_int_stealthnet_add_connection(ndpi_struct, flow);
     return;
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_STEALTHNET, ndpi_struct, NDPI_LOG_DEBUG, "exclude stealthnet.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_STEALTHNET);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 

--- a/src/lib/protocols/steam.c
+++ b/src/lib/protocols/steam.c
@@ -23,10 +23,14 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  * 
  */
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_STEAM
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_STEAM
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_STEAM
 static void ndpi_int_steam_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_STEAM, NDPI_PROTOCOL_UNKNOWN);
 }
@@ -38,7 +42,7 @@ static void ndpi_check_steam_http(struct ndpi_detection_module_struct *ndpi_stru
   if (packet->user_agent_line.ptr != NULL 
       && packet->user_agent_line.len >= 23 
       && memcmp(packet->user_agent_line.ptr, "Valve/Steam HTTP Client", 23) == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found STEAM\n");
     ndpi_int_steam_add_connection(ndpi_struct, flow);
   }
 }
@@ -48,10 +52,10 @@ static void ndpi_check_steam_tcp(struct ndpi_detection_module_struct *ndpi_struc
   u_int32_t payload_len = packet->payload_packet_len;
 	
   if (flow->steam_stage == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage 0: \n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "STEAM stage 0: \n");
 	    
     if ((payload_len == 1 && packet->payload[0] == 0x01) || ((payload_len == 4 || payload_len == 5) && ndpi_match_strprefix(packet->payload, payload_len, "\x01\x00\x00\x00"))) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "Possible STEAM request detected, we will look further for the response..\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
       flow->steam_stage = packet->packet_direction + 1; // packet_direction 0: stage 1, packet_direction 1: stage 2
@@ -59,14 +63,14 @@ static void ndpi_check_steam_tcp(struct ndpi_detection_module_struct *ndpi_struc
     }
 		
     if ((payload_len == 1 && packet->payload[0] == 0x00) || ((payload_len == 4 || payload_len == 5) && ndpi_match_strprefix(packet->payload, payload_len, "\x00\x00\x00"))) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "Possible STEAM request detected, we will look further for the response..\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
       flow->steam_stage = packet->packet_direction + 3; // packet_direction 0: stage 3, packet_direction 1: stage 4
       return;
     }
   } else if ((flow->steam_stage == 1) || (flow->steam_stage == 2)) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage %u: \n", flow->steam_stage);
+    NDPI_LOG__DEBUG2(ndpi_struct, "STEAM stage %u: \n", flow->steam_stage);
 
     /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
     if ((flow->steam_stage - packet->packet_direction) == 1) {
@@ -75,14 +79,14 @@ static void ndpi_check_steam_tcp(struct ndpi_detection_module_struct *ndpi_struc
 
     /* This is a packet in another direction. Check if we find the proper response. */
     if ((payload_len == 1 && packet->payload[0] == 0x00) || ((payload_len == 4 || payload_len == 5) && ndpi_match_strprefix(packet->payload, payload_len, "\x00\x00\x00"))) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found STEAM\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to STEAM, resetting the stage to 0...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to STEAM, resetting the stage to 0..\n");
       flow->steam_stage = 0;
     }
   } else if ((flow->steam_stage == 3) || (flow->steam_stage == 4)) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage %u: \n", flow->steam_stage);
+    NDPI_LOG__DEBUG2(ndpi_struct, "STEAM stage %u: \n", flow->steam_stage);
 
     /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
     if ((flow->steam_stage - packet->packet_direction) == 3) {
@@ -91,10 +95,10 @@ static void ndpi_check_steam_tcp(struct ndpi_detection_module_struct *ndpi_struc
 
     /* This is a packet in another direction. Check if we find the proper response. */
     if ((payload_len == 1 && packet->payload[0] == 0x01) || ((payload_len == 4 || payload_len == 5) && ndpi_match_strprefix(packet->payload, payload_len, "\x01\x00\x00\x00"))) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found STEAM\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to STEAM, resetting the stage to 0...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to STEAM, resetting the stage to 0..\n");
       flow->steam_stage = 0;
     }
   }
@@ -105,17 +109,17 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
   u_int32_t payload_len = packet->payload_packet_len;
 	
   if (ndpi_match_strprefix(packet->payload, payload_len, "VS01")) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found STEAM\n");
     ndpi_int_steam_add_connection(ndpi_struct, flow);
     return;
   }
 
   /* Check if we so far detected the protocol in the request or not. */
   if (flow->steam_stage1 == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage 0: \n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "STEAM stage 0: \n");
 		
     if (ndpi_match_strprefix(packet->payload, payload_len, "\x31\xff\x30\x2e")) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "Possible STEAM request detected, we will look further for the response..\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
       flow->steam_stage1 = packet->packet_direction + 1; // packet_direction 0: stage 1, packet_direction 1: stage 2
@@ -123,7 +127,7 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
     }
 		
     if (ndpi_match_strprefix(packet->payload, payload_len, "\xff\xff\xff\xff")) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "Possible STEAM request detected, we will look further for the response..\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
       flow->steam_stage1 = packet->packet_direction + 3; // packet_direction 0: stage 3, packet_direction 1: stage 4
@@ -131,7 +135,7 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
     }
 
   } else if ((flow->steam_stage1 == 1) || (flow->steam_stage1 == 2)) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage %u: \n", flow->steam_stage1);
+    NDPI_LOG__DEBUG2(ndpi_struct, "STEAM stage %u: \n", flow->steam_stage1);
 
     /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
     if ((flow->steam_stage1 - packet->packet_direction) == 1) {
@@ -140,15 +144,15 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
 
     /* This is a packet in another direction. Check if we find the proper response. */
     if (ndpi_match_strprefix(packet->payload, payload_len, "\xff\xff\xff\xff")) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found STEAM\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to STEAM, resetting the stage to 0...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to STEAM, resetting the stage to 0..\n");
       flow->steam_stage1 = 0;
     }
 		
   } else if ((flow->steam_stage1 == 3) || (flow->steam_stage1 == 4)) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage %u: \n", flow->steam_stage1);
+    NDPI_LOG__DEBUG2(ndpi_struct, "STEAM stage %u: \n", flow->steam_stage1);
 
     /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
     if ((flow->steam_stage1 - packet->packet_direction) == 3) {
@@ -157,10 +161,10 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
 
     /* This is a packet in another direction. Check if we find the proper response. */
     if (ndpi_match_strprefix(packet->payload, payload_len, "\x31\xff\x30\x2e")) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found STEAM\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to STEAM, resetting the stage to 0...\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "The reply did not seem to belong to STEAM, resetting the stage to 0..\n");
       flow->steam_stage1 = 0;
     }
 		
@@ -173,17 +177,17 @@ static void ndpi_check_steam_udp2(struct ndpi_detection_module_struct *ndpi_stru
 
   /* Check if we so far detected the protocol in the request or not. */
   if (flow->steam_stage2 == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage 0: \n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "STEAM stage 0: \n");
 		
     if ((payload_len == 25) && ndpi_match_strprefix(packet->payload, payload_len, "\xff\xff\xff\xff")) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "Possible STEAM request detected, we will look further for the response..\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
       flow->steam_stage2 = packet->packet_direction + 1; // packet_direction 0: stage 1, packet_direction 1: stage 2
     }
 
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage %u: \n", flow->steam_stage2);
+    NDPI_LOG__DEBUG2(ndpi_struct, "STEAM stage %u: \n", flow->steam_stage2);
 
     /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
     if ((flow->steam_stage2 - packet->packet_direction) == 1) {
@@ -192,10 +196,10 @@ static void ndpi_check_steam_udp2(struct ndpi_detection_module_struct *ndpi_stru
 
     /* This is a packet in another direction. Check if we find the proper response. */
     if ((payload_len == 0) || ndpi_match_strprefix(packet->payload, payload_len, "\xff\xff\xff\xff")) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found STEAM\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to STEAM, resetting the stage to 0...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to STEAM, resetting the stage to 0..\n");
       flow->steam_stage2 = 0;
     }
 		
@@ -208,17 +212,17 @@ static void ndpi_check_steam_udp3(struct ndpi_detection_module_struct *ndpi_stru
 
   /* Check if we so far detected the protocol in the request or not. */
   if (flow->steam_stage3 == 0) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage 0: \n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "STEAM stage 0: \n");
 		
     if ((payload_len == 4) && (packet->payload[0] == 0x39) && (packet->payload[1] == 0x18) && (packet->payload[2] == 0x00) && (packet->payload[3] == 0x00)) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Possible STEAM request detected, we will look further for the response...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "Possible STEAM request detected, we will look further for the response..\n");
 
       /* Encode the direction of the packet in the stage, so we will know when we need to look for the response packet. */
       flow->steam_stage3 = packet->packet_direction + 1; // packet_direction 0: stage 1, packet_direction 1: stage 2
     }
 
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM stage %u: \n", flow->steam_stage3);
+    NDPI_LOG__DEBUG2(ndpi_struct, "STEAM stage %u: \n", flow->steam_stage3);
 
     /* At first check, if this is for sure a response packet (in another direction. If not, do nothing now and return. */
     if ((flow->steam_stage3 - packet->packet_direction) == 1) {
@@ -227,10 +231,10 @@ static void ndpi_check_steam_udp3(struct ndpi_detection_module_struct *ndpi_stru
 
     /* This is a packet in another direction. Check if we find the proper response. */
     if ((payload_len == 0) || ((payload_len == 8) && (packet->payload[0] == 0x3a) && (packet->payload[1] == 0x18) && (packet->payload[2] == 0x00) && (packet->payload[3] == 0x00))) {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Found STEAM.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found STEAM\n");
       ndpi_int_steam_add_connection(ndpi_struct, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "The reply did not seem to belong to STEAM, resetting the stage to 0...\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "The reply did not seem to belong to STEAM, resetting the stage to 0..\n");
       flow->steam_stage3 = 0;
     }
 		
@@ -242,8 +246,7 @@ void ndpi_search_steam(struct ndpi_detection_module_struct *ndpi_struct, struct 
 	
   /* Break after 20 packets. */
   if (flow->packet_counter > 20) {
-    NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "Exclude STEAM.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_STEAM);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
@@ -256,7 +259,7 @@ void ndpi_search_steam(struct ndpi_detection_module_struct *ndpi_struct, struct 
     return;
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_STEAM, ndpi_struct, NDPI_LOG_DEBUG, "STEAM detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search STEAM\n");
   ndpi_check_steam_http(ndpi_struct, flow);
 	
   if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM) {

--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -21,10 +21,14 @@
  * along with nDPI. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_protocols.h"
+
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_STUN
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_STUN
+
+#include "ndpi_api.h"
 
 #define MAX_NUM_STUN_PKTS     10
 
@@ -64,7 +68,7 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
 
   if((strncmp((const char*)payload, (const char*)"RSP/", 4) == 0)
      && (strncmp((const char*)&payload[7], (const char*)" STUN_", 6) == 0)) {
-    NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "Found stun.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found stun\n");
     goto udp_stun_found;
   }
 
@@ -159,10 +163,10 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
     u_int8_t mod;
     u_int8_t old = 1;
     u_int8_t padding = 0;
-    NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "len and type match.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "len and type match\n");
 
     if(payload_length == 20) {
-      NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "found stun.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found stun\n");
       goto udp_stun_found;
     }
 
@@ -183,7 +187,7 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
 		  || payload[a + 1] == 0x2a || payload[a + 1] == 0x29 || payload[a + 1] == 0x50
 		  || payload[a + 1] == 0x54 || payload[a + 1] == 0x55)))) {
 
-	NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "attribute match.\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "attribute match\n");
 
 	a += ((payload[a + 2] << 8) + payload[a + 3] + 4);
 	mod = a % 4;
@@ -191,7 +195,7 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
 	  padding = 4 - mod;
 	}
 	if(a == payload_length || (padding && (a + padding) == payload_length)) {
-	  NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "found stun.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found stun\n");
 	  goto udp_stun_found;
 	}
 
@@ -215,7 +219,7 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
 	if((payload[a + padding] == 0x40) && (payload[a + padding + 1] == 0x00))
 	  goto udp_stun_found;
 
-	NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "New STUN - attribute match.\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "New STUN - attribute match\n");
 
 	old = 0;
 	a += ((payload[a + 2 + padding] << 8) + payload[a + 3 + padding] + 4);
@@ -225,7 +229,7 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
 	  a += 4 - mod;
 	}
 	if(a == payload_length) {
-	  NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "found stun.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found stun\n");
 	  goto udp_stun_found;
 	}
       } else {
@@ -254,7 +258,7 @@ void ndpi_search_stun(struct ndpi_detection_module_struct *ndpi_struct, struct n
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int8_t is_whatsapp = 0, is_skype = 0;
 
-  NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "search stun.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search stun\n");
 
   if(packet->tcp) {
     /* STUN may be encapsulated in TCP packets */
@@ -267,10 +271,10 @@ void ndpi_search_stun(struct ndpi_detection_module_struct *ndpi_struct, struct n
       if(ndpi_int_check_stun(ndpi_struct, flow, packet->payload + 2,
 			     packet->payload_packet_len - 2, &is_whatsapp, &is_skype) == NDPI_IS_STUN) {
 	if(is_skype) {
-	  NDPI_LOG(NDPI_PROTOCOL_SKYPE, ndpi_struct, NDPI_LOG_DEBUG, "Found Skype\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found Skype\n");
 	  ndpi_int_stun_add_connection(ndpi_struct, NDPI_PROTOCOL_SKYPE, flow);
 	} else {
-	  NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "found UDP stun.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "found UDP stun\n");
 	  ndpi_int_stun_add_connection(ndpi_struct,
 				       is_whatsapp ? NDPI_PROTOCOL_WHATSAPP_VOICE : NDPI_PROTOCOL_STUN, flow);
 	}
@@ -282,10 +286,10 @@ void ndpi_search_stun(struct ndpi_detection_module_struct *ndpi_struct, struct n
   if(ndpi_int_check_stun(ndpi_struct, flow, packet->payload,
 			 packet->payload_packet_len, &is_whatsapp, &is_skype) == NDPI_IS_STUN) {
     if(is_skype) {
-      NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "Found Skype\n");
+      NDPI_LOG__TRACE(ndpi_struct, "Found Skype\n");
       ndpi_int_stun_add_connection(ndpi_struct, NDPI_PROTOCOL_SKYPE, flow);
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "found UDP stun.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found UDP stun\n");
       ndpi_int_stun_add_connection(ndpi_struct,
 				   is_whatsapp ? NDPI_PROTOCOL_WHATSAPP_VOICE : NDPI_PROTOCOL_STUN, flow);
     }
@@ -293,8 +297,7 @@ void ndpi_search_stun(struct ndpi_detection_module_struct *ndpi_struct, struct n
   }
 
   if(flow->num_stun_udp_pkts >= MAX_NUM_STUN_PKTS) {
-    NDPI_LOG(NDPI_PROTOCOL_STUN, ndpi_struct, NDPI_LOG_DEBUG, "exclude stun.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_STUN);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/syslog.c
+++ b/src/lib/protocols/syslog.c
@@ -22,9 +22,13 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_SYSLOG
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_SYSLOG
+
+#include "ndpi_api.h"
 
 static void ndpi_int_syslog_add_connection(struct ndpi_detection_module_struct
 					   *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -36,45 +40,41 @@ void ndpi_search_syslog(struct ndpi_detection_module_struct
 			*ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
-	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
   u_int8_t i;
 
-  NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG, "search syslog\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search syslog\n");
 
   if (packet->payload_packet_len > 20 && packet->payload_packet_len <= 1024 && packet->payload[0] == '<') {
-    NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG, "checked len>20 and <1024 and first symbol=<.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "checked len>20 and <1024 and first symbol=<\n");
 
     for (i = 1; i <= 3; i++) {
       if (packet->payload[i] < '0' || packet->payload[i] > '9') {
 		break;
       }
     }
-    NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
              "read symbols while the symbol is a number.\n");
 
     if (packet->payload[i++] != '>') {
-      NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG, "there is no > following the number.\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "excluded, there is no > following the number\n");
       NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SYSLOG);
       return;
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG, "a > following the number.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "a > following the number\n");
     }
 
     if (packet->payload[i] == 0x20) {
-      NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG, "a blank following the >: increment i.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "a blank following the >: increment i\n");
       i++;
     } else {
-      NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG, "no blank following the >: do nothing.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "no blank following the >: do nothing\n");
     }
 
     /* check for "last message repeated" */
     if (i + sizeof("last message") - 1 <= packet->payload_packet_len &&
 	memcmp(packet->payload + i, "last message", sizeof("last message") - 1) == 0) {
 
-      NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG, "found syslog by 'last message' string.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found syslog by 'last message' string\n");
 
       ndpi_int_syslog_add_connection(ndpi_struct, flow);
 
@@ -84,7 +84,7 @@ void ndpi_search_syslog(struct ndpi_detection_module_struct
 
       /* snort events */
 
-      NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG, "found syslog by 'snort: ' string.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found syslog by 'snort: ' string\n");
 
       ndpi_int_syslog_add_connection(ndpi_struct, flow);
 
@@ -103,27 +103,20 @@ void ndpi_search_syslog(struct ndpi_detection_module_struct
 	&& memcmp(&packet->payload[i], "Oct", 3) != 0
 	&& memcmp(&packet->payload[i], "Nov", 3) != 0 && memcmp(&packet->payload[i], "Dec", 3) != 0) {
 
-
-      NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG,
-	       "no month-shortname following: syslog excluded.\n");
-
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SYSLOG);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
       return;
 
     } else {
 
-      NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG,
-	       "a month-shortname following: syslog detected.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found syslog\n");
 
       ndpi_int_syslog_add_connection(ndpi_struct, flow);
 
       return;
     }
   }
-  NDPI_LOG(NDPI_PROTOCOL_SYSLOG, ndpi_struct, NDPI_LOG_DEBUG, "no syslog detected.\n");
-
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SYSLOG);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/teamspeak.c
+++ b/src/lib/protocols/teamspeak.c
@@ -17,49 +17,53 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "ndpi_api.h"
-
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_TEAMSPEAK
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_TEAMSPEAK
+
+#include "ndpi_api.h"
 
 static void ndpi_int_teamspeak_add_connection(struct ndpi_detection_module_struct
                                              *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TEAMSPEAK, NDPI_PROTOCOL_UNKNOWN);
 }
-  u_int16_t tdport = 0, tsport = 0;
-  u_int16_t udport = 0, usport = 0;
 
 
 void ndpi_search_teamspeak(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-    struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &flow->packet;
 
-if (packet->udp != NULL) {
-  usport = ntohs(packet->udp->source), udport = ntohs(packet->udp->dest);
-  /* http://www.imfirewall.com/en/protocols/teamSpeak.htm  */
-  if (((usport == 9987 || udport == 9987) || (usport == 8767 || udport == 8767)) && packet->payload_packet_len >= 20) {
-     NDPI_LOG(NDPI_PROTOCOL_TEAMSPEAK, ndpi_struct, NDPI_LOG_DEBUG, "found TEAMSPEAK udp.\n");
-     ndpi_int_teamspeak_add_connection(ndpi_struct, flow);
+  NDPI_LOG__DEBUG(ndpi_struct, "search teamspeak\n");
+  
+  if (packet->udp != NULL) {
+    u_int16_t udport, usport;
+    usport = ntohs(packet->udp->source), udport = ntohs(packet->udp->dest);
+    /* http://www.imfirewall.com/en/protocols/teamSpeak.htm  */
+    if (((usport == 9987 || udport == 9987) || (usport == 8767 || udport == 8767)) && packet->payload_packet_len >= 20) {
+       NDPI_LOG__TRACE(ndpi_struct, "found TEAMSPEAK udp\n");
+       ndpi_int_teamspeak_add_connection(ndpi_struct, flow);
+    }
   }
-}
-else if (packet->tcp != NULL) {
-  tsport = ntohs(packet->tcp->source), tdport = ntohs(packet->tcp->dest);
+  else if (packet->tcp != NULL) {
+    u_int16_t tdport, tsport;
+    tsport = ntohs(packet->tcp->source), tdport = ntohs(packet->tcp->dest);
   /* https://github.com/Youx/soliloque-server/wiki/Connection-packet */
   if(packet->payload_packet_len >= 20) {
     if (((memcmp(packet->payload, "\xf4\xbe\x03\x00", 4) == 0)) ||
           ((memcmp(packet->payload, "\xf4\xbe\x02\x00", 4) == 0)) ||
             ((memcmp(packet->payload, "\xf4\xbe\x01\x00", 4) == 0))) {
-     NDPI_LOG(NDPI_PROTOCOL_TEAMSPEAK, ndpi_struct, NDPI_LOG_DEBUG, "found TEAMSPEAK tcp.\n");
+     NDPI_LOG__TRACE(ndpi_struct, "found TEAMSPEAK tcp\n");
      ndpi_int_teamspeak_add_connection(ndpi_struct, flow);
     }  /* http://www.imfirewall.com/en/protocols/teamSpeak.htm  */
   } else if ((tsport == 14534 || tdport == 14534) || (tsport == 51234 || tdport == 51234)) {
-     NDPI_LOG(NDPI_PROTOCOL_TEAMSPEAK, ndpi_struct, NDPI_LOG_DEBUG, "found TEAMSPEAK.\n");
+     NDPI_LOG__TRACE(ndpi_struct, "found TEAMSPEAK\n");
      ndpi_int_teamspeak_add_connection(ndpi_struct, flow);
    }
   }
-  NDPI_LOG(NDPI_PROTOCOL_TEAMSPEAK, ndpi_struct, NDPI_LOG_DEBUG, "TEAMSPEAK excluded.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_TEAMSPEAK);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   return;
 }
 

--- a/src/lib/protocols/teamviewer.c
+++ b/src/lib/protocols/teamviewer.c
@@ -22,23 +22,28 @@
  *
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_TEAMVIEWER
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_TEAMVIEWER
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_teamview_add_connection(struct ndpi_detection_module_struct
                                              *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TEAMVIEWER, NDPI_PROTOCOL_UNKNOWN);
-  NDPI_LOG(NDPI_PROTOCOL_TEAMVIEWER, ndpi_struct, NDPI_LOG_TRACE, "TEAMWIEWER Found.\n");
+  NDPI_LOG__TRACE(ndpi_struct, "found teamwiewer\n");
 }
 
 
 void ndpi_search_teamview(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
-  NDPI_LOG(NDPI_PROTOCOL_TEAMVIEWER, ndpi_struct, NDPI_LOG_TRACE, "TEAMWIEWER detection...\n");
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search teamwiewer\n");
   /*
     TeamViewer
     178.77.120.0/25
@@ -95,7 +100,7 @@ void ndpi_search_teamview(struct ndpi_detection_module_struct *ndpi_struct, stru
     }
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_TEAMVIEWER);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/telegram.c
+++ b/src/lib/protocols/telegram.c
@@ -23,15 +23,19 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_TELEGRAM
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_TELEGRAM
+
+#include "ndpi_api.h"
 
 static void ndpi_int_telegram_add_connection(struct ndpi_detection_module_struct
                                              *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TELEGRAM, NDPI_PROTOCOL_UNKNOWN);
-  NDPI_LOG(NDPI_PROTOCOL_TELEGRAM, ndpi_struct, NDPI_LOG_TRACE, "TELEGRAM Found.\n");
+  NDPI_LOG__TRACE(ndpi_struct, "found telegram\n");
 }
 
 
@@ -40,7 +44,7 @@ void ndpi_search_telegram(struct ndpi_detection_module_struct *ndpi_struct, stru
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int16_t dport /* , sport */;
   
-  NDPI_LOG(NDPI_PROTOCOL_TELEGRAM, ndpi_struct, NDPI_LOG_TRACE, "TELEGRAM detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search telegram\n");
 
   if (packet->payload_packet_len == 0)
     return;
@@ -63,7 +67,7 @@ void ndpi_search_telegram(struct ndpi_detection_module_struct *ndpi_struct, stru
     }
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_TELEGRAM);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/telnet.c
+++ b/src/lib/protocols/telnet.c
@@ -23,9 +23,13 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
+
 #ifdef NDPI_PROTOCOL_TELNET
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_TELNET
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_telnet_add_connection(struct ndpi_detection_module_struct
@@ -76,30 +80,25 @@ u_int8_t search_iac(struct ndpi_detection_module_struct *ndpi_struct, struct ndp
 void ndpi_search_telnet_tcp(struct ndpi_detection_module_struct
 			    *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  //  struct ndpi_packet_struct *packet = &flow->packet;
-	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
 
-  NDPI_LOG(NDPI_PROTOCOL_TELNET, ndpi_struct, NDPI_LOG_DEBUG, "search telnet.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search telnet\n");
 
   if (search_iac(ndpi_struct, flow) == 1) {
 
     if (flow->l4.tcp.telnet_stage == 2) {
-      NDPI_LOG(NDPI_PROTOCOL_TELNET, ndpi_struct, NDPI_LOG_DEBUG, "telnet identified.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found telnet\n");
       ndpi_int_telnet_add_connection(ndpi_struct, flow);
       return;
     }
     flow->l4.tcp.telnet_stage++;
-    NDPI_LOG(NDPI_PROTOCOL_TELNET, ndpi_struct, NDPI_LOG_DEBUG, "telnet stage %u.\n", flow->l4.tcp.telnet_stage);
+    NDPI_LOG__DEBUG2(ndpi_struct, "telnet stage %u\n", flow->l4.tcp.telnet_stage);
     return;
   }
 
   if ((flow->packet_counter < 12 && flow->l4.tcp.telnet_stage > 0) || flow->packet_counter < 6) {
     return;
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_TELNET, ndpi_struct, NDPI_LOG_DEBUG, "telnet excluded.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_TELNET);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
   return;
 }

--- a/src/lib/protocols/teredo.c
+++ b/src/lib/protocols/teredo.c
@@ -18,24 +18,30 @@
  *
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_TEREDO
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_TEREDO
+
+#include "ndpi_api.h"
 
 /* https://en.wikipedia.org/wiki/Teredo_tunneling */
 void ndpi_search_teredo(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct,"search teredo\n");
   if(packet->udp
      && packet->iph
      && ((ntohl(packet->iph->daddr) & 0xF0000000) == 0xE0000000 /* A multicast address */)
      && ((ntohs(packet->udp->source) == 3544) || (ntohs(packet->udp->dest) == 3544))
-     && (packet->payload_packet_len >= 40 /* IPv6 header */))
+     && (packet->payload_packet_len >= 40 /* IPv6 header */)) {
+    NDPI_LOG__TRACE(ndpi_struct,"found teredo\n");
     ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TEREDO, NDPI_PROTOCOL_UNKNOWN);
-  else
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_TEREDO);
+  }  else {
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  }
 }
 
 

--- a/src/lib/protocols/tftp.c
+++ b/src/lib/protocols/tftp.c
@@ -22,9 +22,13 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_TFTP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_TFTP
+
+#include "ndpi_api.h"
 
 static void ndpi_int_tftp_add_connection(struct ndpi_detection_module_struct
 					 *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -37,30 +41,29 @@ void ndpi_search_tftp(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_TFTP, ndpi_struct, NDPI_LOG_DEBUG, "search TFTP.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search TFTP\n");
 
   if (packet->payload_packet_len > 3 && flow->l4.udp.tftp_stage == 0
       && ntohl(get_u_int32_t(packet->payload, 0)) == 0x00030001) {
-    NDPI_LOG(NDPI_PROTOCOL_TFTP, ndpi_struct, NDPI_LOG_DEBUG, "maybe tftp. need next packet.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "maybe tftp. need next packet\n");
     flow->l4.udp.tftp_stage = 1;
     return;
   }
   if (packet->payload_packet_len > 3 && (flow->l4.udp.tftp_stage == 1)
       && ntohl(get_u_int32_t(packet->payload, 0)) == 0x00040001) {
 
-    NDPI_LOG(NDPI_PROTOCOL_TFTP, ndpi_struct, NDPI_LOG_DEBUG, "found tftp.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found tftp\n");
     ndpi_int_tftp_add_connection(ndpi_struct, flow);
     return;
   }
   if (packet->payload_packet_len > 1
       && ((packet->payload[0] == 0 && packet->payload[packet->payload_packet_len - 1] == 0)
 	  || (packet->payload_packet_len == 4 && ntohl(get_u_int32_t(packet->payload, 0)) == 0x00040000))) {
-    NDPI_LOG(NDPI_PROTOCOL_TFTP, ndpi_struct, NDPI_LOG_DEBUG, "skip initial packet.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "skip initial packet\n");
     return;
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_TFTP, ndpi_struct, NDPI_LOG_DEBUG, "exclude TFTP.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_TFTP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/thunder.c
+++ b/src/lib/protocols/thunder.c
@@ -22,9 +22,14 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_THUNDER
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_THUNDER
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_thunder_add_connection(struct ndpi_detection_module_struct *ndpi_struct, 
 					    struct ndpi_flow_struct *flow/* , ndpi_protocol_type_t protocol_type */)
@@ -55,26 +60,21 @@ void ndpi_int_search_thunder_udp(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
   if (packet->payload_packet_len > 8 && packet->payload[0] >= 0x30
       && packet->payload[0] < 0x40 && packet->payload[1] == 0 && packet->payload[2] == 0 && packet->payload[3] == 0) {
     if (flow->thunder_stage == 3) {
-      NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG, "THUNDER udp detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found THUNDER udp\n");
       ndpi_int_thunder_add_connection(ndpi_struct, flow);
       return;
     }
 
     flow->thunder_stage++;
-    NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
 	     "maybe thunder udp packet detected, stage increased to %u\n", flow->thunder_stage);
     return;
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG,
-	   "excluding thunder udp at stage %u\n", flow->thunder_stage);
-
+  NDPI_LOG__DEBUG(ndpi_struct, "excluding thunder udp at stage %u\n", flow->thunder_stage);
   NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_THUNDER);
 }
 
@@ -89,19 +89,16 @@ void ndpi_int_search_thunder_tcp(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
   if (packet->payload_packet_len > 8 && packet->payload[0] >= 0x30
       && packet->payload[0] < 0x40 && packet->payload[1] == 0 && packet->payload[2] == 0 && packet->payload[3] == 0) {
     if (flow->thunder_stage == 3) {
-      NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG, "THUNDER tcp detected\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found THUNDER tcp\n");
       ndpi_int_thunder_add_connection(ndpi_struct, flow);
       return;
     }
 
     flow->thunder_stage++;
-    NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
 	     "maybe thunder tcp packet detected, stage increased to %u\n", flow->thunder_stage);
     return;
   }
@@ -110,7 +107,7 @@ void ndpi_int_search_thunder_tcp(struct ndpi_detection_module_struct
       && memcmp(packet->payload, "POST / HTTP/1.1\r\n", 17) == 0) {
     ndpi_parse_packet_line_info(ndpi_struct, flow);
 
-    NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
 	     "maybe thunder http POST packet detected, parsed packet lines: %u, empty line set %u (at: %u)\n",
 	     packet->parsed_lines, packet->empty_line_position_set, packet->empty_line_position);
 
@@ -124,15 +121,13 @@ void ndpi_int_search_thunder_tcp(struct ndpi_detection_module_struct
 	&& packet->payload[packet->empty_line_position + 3] == 0x00
 	&& packet->payload[packet->empty_line_position + 4] == 0x00
 	&& packet->payload[packet->empty_line_position + 5] == 0x00) {
-      NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG,
-	       "maybe thunder http POST packet application does match\n");
+      NDPI_LOG__TRACE(ndpi_struct,
+	       "found thunder http POST packet application does match\n");
       ndpi_int_thunder_add_connection(ndpi_struct, flow);
       return;
     }
   }
-  NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG,
-	   "excluding thunder tcp at stage %u\n", flow->thunder_stage);
-
+  NDPI_LOG__DEBUG(ndpi_struct, "excluding thunder tcp at stage %u\n", flow->thunder_stage);
   NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_THUNDER);
 }
 
@@ -153,12 +148,12 @@ void ndpi_int_search_thunder_http(struct ndpi_detection_module_struct
   if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_THUNDER) {
     if (src != NULL && ((u_int32_t)
 			(packet->tick_timestamp - src->thunder_ts) < ndpi_struct->thunder_timeout)) {
-      NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG2(ndpi_struct,
 	       "thunder : save src connection packet detected\n");
       src->thunder_ts = packet->tick_timestamp;
     } else if (dst != NULL && ((u_int32_t)
 			       (packet->tick_timestamp - dst->thunder_ts) < ndpi_struct->thunder_timeout)) {
-      NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG,
+      NDPI_LOG__DEBUG2(ndpi_struct,
 	       "thunder : save dst connection packet detected\n");
       dst->thunder_ts = packet->tick_timestamp;
     }
@@ -167,7 +162,7 @@ void ndpi_int_search_thunder_http(struct ndpi_detection_module_struct
 
   if (packet->payload_packet_len > 5
       && memcmp(packet->payload, "GET /", 5) == 0 && NDPI_SRC_OR_DST_HAS_PROTOCOL(src, dst, NDPI_PROTOCOL_THUNDER)) {
-    NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG, "HTTP packet detected.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "HTTP packet detected\n");
     ndpi_parse_packet_line_info(ndpi_struct, flow);
 
     if (packet->parsed_lines > 7
@@ -186,8 +181,8 @@ void ndpi_int_search_thunder_http(struct ndpi_detection_module_struct
 	&& packet->user_agent_line.len > 49
 	&& memcmp(packet->user_agent_line.ptr,
 		  "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)", 50) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_THUNDER, ndpi_struct, NDPI_LOG_DEBUG,
-	       "Thunder HTTP download detected, adding flow.\n");
+      NDPI_LOG__TRACE(ndpi_struct,
+	       "found thunder HTTP download detected\n");
       ndpi_int_thunder_add_connection(ndpi_struct, flow);
     }
   }

--- a/src/lib/protocols/tinc.c
+++ b/src/lib/protocols/tinc.c
@@ -18,11 +18,14 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#include "ndpi_protocol_ids.h"
 
+#ifdef NDPI_PROTOCOL_TINC
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_TINC
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_TINC
 
 static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -52,7 +55,7 @@ static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, st
 
 	/* cache_free(ndpi_struct->tinc_cache); */
 
-        NDPI_LOG(NDPI_PROTOCOL_TINC, ndpi_struct, NDPI_LOG_DEBUG, "Found tinc udp connection\n");
+        NDPI_LOG__TRACE(ndpi_struct, "found tinc udp connection\n");
         ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TINC, NDPI_PROTOCOL_UNKNOWN);
       }
     }
@@ -111,7 +114,7 @@ static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, st
 	      ndpi_struct->tinc_cache = cache_new(TINC_CACHE_MAX_SIZE);              
 
 	    cache_add(ndpi_struct->tinc_cache, &(flow->tinc_cache_entry), sizeof(flow->tinc_cache_entry));
-	    NDPI_LOG(NDPI_PROTOCOL_TINC, ndpi_struct, NDPI_LOG_DEBUG, "Found tinc tcp connection\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "found tinc tcp connection\n");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TINC, NDPI_PROTOCOL_UNKNOWN);
 	  }
 	  return;
@@ -123,14 +126,13 @@ static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, st
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_TINC, ndpi_struct, NDPI_LOG_DEBUG, "exclude tinc.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_TINC);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void ndpi_search_tinc(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow) {
   struct ndpi_packet_struct* packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_TINC, ndpi_struct, NDPI_LOG_DEBUG, "tinc detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "tinc detection\n");
 
   if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_TINC) {
     if(packet->tcp_retransmission == 0) {

--- a/src/lib/protocols/tor.c
+++ b/src/lib/protocols/tor.c
@@ -5,9 +5,14 @@
  * Copyright (C) 2013 Remy Mudingay <mudingay@ill.fr>
  *
  */
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_TOR
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_TOR
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_tor_add_connection(struct ndpi_detection_module_struct
 					*ndpi_struct, struct ndpi_flow_struct *flow) {
@@ -88,23 +93,22 @@ void ndpi_search_tor(struct ndpi_detection_module_struct *ndpi_struct, struct nd
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int16_t dport = 0, sport = 0;
 
-  NDPI_LOG(NDPI_PROTOCOL_TOR, ndpi_struct, NDPI_LOG_DEBUG, "search for TOR.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search for TOR\n");
 
   if(packet->tcp != NULL) {
     sport = ntohs(packet->tcp->source), dport = ntohs(packet->tcp->dest);
-    NDPI_LOG(NDPI_PROTOCOL_TOR, ndpi_struct, NDPI_LOG_DEBUG, "calculating TOR over tcp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculating TOR over tcp\n");
 
     if ((((dport == 9001) || (sport == 9001)) || ((dport == 9030) || (sport == 9030)))
 	&& ((packet->payload[0] == 0x17) || (packet->payload[0] == 0x16)) 
 	&& (packet->payload[1] == 0x03) 
 	&& (packet->payload[2] == 0x01) 
 	&& (packet->payload[3] == 0x00)) {
-      NDPI_LOG(NDPI_PROTOCOL_TOR, ndpi_struct, NDPI_LOG_DEBUG, "found tor.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found tor\n");
       ndpi_int_tor_add_connection(ndpi_struct, flow);
     }
   } else {
-    NDPI_LOG(NDPI_PROTOCOL_TOR, ndpi_struct, NDPI_LOG_DEBUG, "exclude TOR.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_TOR);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/tvants.c
+++ b/src/lib/protocols/tvants.c
@@ -22,10 +22,13 @@
  * 
  */
 
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_TVANTS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_TVANTS
+
+#include "ndpi_api.h"
 
 static void ndpi_int_tvants_add_connection(struct ndpi_detection_module_struct
 					   *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -40,13 +43,8 @@ void ndpi_search_tvants_udp(struct ndpi_detection_module_struct
 			    *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
-	
 
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-
-  NDPI_LOG(NDPI_PROTOCOL_TVANTS, ndpi_struct, NDPI_LOG_DEBUG, "search tvants.  \n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search tvants.  \n");
 
   if (packet->udp != NULL && packet->payload_packet_len > 57
       && packet->payload[0] == 0x04 && packet->payload[1] == 0x00
@@ -57,7 +55,7 @@ void ndpi_search_tvants_udp(struct ndpi_detection_module_struct
       && (memcmp(&packet->payload[48], "TVANTS", 6) == 0
 	  || memcmp(&packet->payload[49], "TVANTS", 6) == 0 || memcmp(&packet->payload[51], "TVANTS", 6) == 0)) {
 
-    NDPI_LOG(NDPI_PROTOCOL_TVANTS, ndpi_struct, NDPI_LOG_DEBUG, "found tvants over udp.  \n");
+    NDPI_LOG__TRACE(ndpi_struct, "found tvants over udp.  \n");
     ndpi_int_tvants_add_connection(ndpi_struct, flow);
 
   } else if (packet->tcp != NULL && packet->payload_packet_len > 15
@@ -67,12 +65,11 @@ void ndpi_search_tvants_udp(struct ndpi_detection_module_struct
 	     && packet->payload[6] == 0x00 && packet->payload[7] == 0x00
 	     && memcmp(&packet->payload[8], "TVANTS", 6) == 0) {
 
-    NDPI_LOG(NDPI_PROTOCOL_TVANTS, ndpi_struct, NDPI_LOG_DEBUG, "found tvants over tcp.  \n");
+    NDPI_LOG__TRACE(ndpi_struct, "found tvants over tcp.  \n");
     ndpi_int_tvants_add_connection(ndpi_struct, flow);
 
   }
-  NDPI_LOG(NDPI_PROTOCOL_TVANTS, ndpi_struct, NDPI_LOG_DEBUG, "exclude tvants.  \n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_TVANTS);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 

--- a/src/lib/protocols/tvuplayer.c
+++ b/src/lib/protocols/tvuplayer.c
@@ -22,10 +22,13 @@
  *
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_TVUPLAYER
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_TVUPLAYER
+
+#include "ndpi_api.h"
 
 static void ndpi_int_tvuplayer_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					      struct ndpi_flow_struct *flow/* , */
@@ -39,19 +42,14 @@ void ndpi_search_tvuplayer(struct ndpi_detection_module_struct *ndpi_struct, str
   struct ndpi_packet_struct *packet = &flow->packet;
 	
 
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-  NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "search tvuplayer.  \n");
-
-
+  NDPI_LOG__DEBUG(ndpi_struct, "search tvuplayer.  \n");
 
   if (packet->tcp != NULL) {
     if ((packet->payload_packet_len == 36 || packet->payload_packet_len == 24)
 	&& packet->payload[0] == 0x00
 	&& ntohl(get_u_int32_t(packet->payload, 2)) == 0x31323334
 	&& ntohl(get_u_int32_t(packet->payload, 6)) == 0x35363837 && packet->payload[10] == 0x01) {
-      NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "found tvuplayer over tcp.  \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found tvuplayer over tcp.  \n");
       ndpi_int_tvuplayer_add_connection(ndpi_struct, flow);
       return;
     }
@@ -62,7 +60,7 @@ void ndpi_search_tvuplayer(struct ndpi_detection_module_struct *ndpi_struct, str
 	NDPI_PARSE_PACKET_LINE_INFO(ndpi_struct, flow, packet);
 	if (packet->user_agent_line.ptr != NULL &&
 	    packet->user_agent_line.len >= 8 && (memcmp(packet->user_agent_line.ptr, "MacTVUP", 7) == 0)) {
-	  NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "Found user agent as MacTVUP.\n");
+	  NDPI_LOG__TRACE(ndpi_struct, "Found user agent as MacTVUP\n");
 	  ndpi_int_tvuplayer_add_connection(ndpi_struct, flow);
 	  return;
 	}
@@ -79,7 +77,7 @@ void ndpi_search_tvuplayer(struct ndpi_detection_module_struct *ndpi_struct, str
 	&& packet->payload[12] == 0x02 && packet->payload[13] == 0xff
 	&& packet->payload[19] == 0x2c && ((packet->payload[26] == 0x05 && packet->payload[27] == 0x14)
 					   || (packet->payload[26] == 0x14 && packet->payload[27] == 0x05))) {
-      NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "found tvuplayer pattern type I.  \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found tvuplayer pattern type I.  \n");
       ndpi_int_tvuplayer_add_connection(ndpi_struct, flow);
       return;
     }
@@ -91,7 +89,7 @@ void ndpi_search_tvuplayer(struct ndpi_detection_module_struct *ndpi_struct, str
 	&& packet->payload[33] == 0xff && packet->payload[34] == 0x01
 	&& packet->payload[39] == 0x32 && ((packet->payload[46] == 0x05 && packet->payload[47] == 0x14)
 					   || (packet->payload[46] == 0x14 && packet->payload[47] == 0x05))) {
-      NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "found tvuplayer pattern type II.  \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found tvuplayer pattern type II.  \n");
       ndpi_int_tvuplayer_add_connection(ndpi_struct, flow);
       return;
     }
@@ -103,7 +101,7 @@ void ndpi_search_tvuplayer(struct ndpi_detection_module_struct *ndpi_struct, str
 	    || packet->payload[11] == 0x06 || packet->payload[11] == 0x22)
 	&& packet->payload[12] == 0x01 && (packet->payload[13] == 0xff || packet->payload[13] == 0x01)
 	&& packet->payload[19] == 0x14) {
-      NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "found tvuplayer pattern type III.  \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found tvuplayer pattern type III.  \n");
       ndpi_int_tvuplayer_add_connection(ndpi_struct, flow);
       return;
     }
@@ -113,7 +111,7 @@ void ndpi_search_tvuplayer(struct ndpi_detection_module_struct *ndpi_struct, str
 	&& packet->payload[12] == 0x01 && packet->payload[13] == 0xff
 	&& packet->payload[19] == 0x14 && packet->payload[32] == 0x03
 	&& packet->payload[33] == 0xff && packet->payload[34] == 0x01 && packet->payload[39] == 0x34) {
-      NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "found tvuplayer pattern type IV.  \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found tvuplayer pattern type IV.  \n");
       ndpi_int_tvuplayer_add_connection(ndpi_struct, flow);
       return;
     }
@@ -122,7 +120,7 @@ void ndpi_search_tvuplayer(struct ndpi_detection_module_struct *ndpi_struct, str
 	&& packet->payload[10] == 0x00 && packet->payload[11] == 0x00
 	&& packet->payload[12] == 0x01 && packet->payload[13] == 0xff
 	&& packet->payload[19] == 0x14 && packet->payload[33] == 0xff && packet->payload[39] == 0x14) {
-      NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "found tvuplayer pattern type V.  \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found tvuplayer pattern type V.  \n");
       ndpi_int_tvuplayer_add_connection(ndpi_struct, flow);
       return;
     }
@@ -131,7 +129,7 @@ void ndpi_search_tvuplayer(struct ndpi_detection_module_struct *ndpi_struct, str
 	&& packet->payload[12] == 0x03 && packet->payload[13] == 0xff
 	&& packet->payload[19] == 0x32 && ((packet->payload[26] == 0x05 && packet->payload[27] == 0x14)
 					   || (packet->payload[26] == 0x14 && packet->payload[27] == 0x05))) {
-      NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "found tvuplayer pattern type VI.  \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found tvuplayer pattern type VI.  \n");
       ndpi_int_tvuplayer_add_connection(ndpi_struct, flow);
       return;
     }
@@ -140,14 +138,13 @@ void ndpi_search_tvuplayer(struct ndpi_detection_module_struct *ndpi_struct, str
 	&& packet->payload[0] == 0x00 && packet->payload[2] == 0x00
 	&& packet->payload[10] == 0x00 && packet->payload[11] == 0x00
 	&& packet->payload[12] == 0x06 && packet->payload[13] == 0x00 && packet->payload[19] == 0x30) {
-      NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "found tvuplayer pattern type VII.  \n");
+      NDPI_LOG__TRACE(ndpi_struct, "found tvuplayer pattern type VII.  \n");
       ndpi_int_tvuplayer_add_connection(ndpi_struct, flow);
       return;
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_TVUPLAYER, ndpi_struct, NDPI_LOG_DEBUG, "exclude tvuplayer.  \n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_TVUPLAYER);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
 }
 

--- a/src/lib/protocols/ubntac2.c
+++ b/src/lib/protocols/ubntac2.c
@@ -19,9 +19,14 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_UBNTAC2
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_UBNTAC2
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_ubntac2_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -33,7 +38,8 @@ void ndpi_search_ubntac2(struct ndpi_detection_module_struct *ndpi_struct, struc
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_UBNTAC2, ndpi_struct, NDPI_LOG_TRACE, "UBNTAC2 detection... plen:%i %i:%i\n", packet->payload_packet_len, ntohs(packet->udp->source), ntohs(packet->udp->dest));
+  NDPI_LOG__DEBUG(ndpi_struct, "search ubntac2\n");
+  NDPI_LOG__DEBUG2(ndpi_struct, "UBNTAC2 detection... plen:%i %i:%i\n", packet->payload_packet_len, ntohs(packet->udp->source), ntohs(packet->udp->dest));
 
   if(packet->udp) {
     if(packet->payload_packet_len >= 135 &&
@@ -64,7 +70,7 @@ void ndpi_search_ubntac2(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  flow->protos.ubntac2.version[len] = '\0';
 	}
 	
-	NDPI_LOG(NDPI_PROTOCOL_UBNTAC2, ndpi_struct, NDPI_LOG_DEBUG, "UBNT AirControl 2 request\n");
+	NDPI_LOG__TRACE(ndpi_struct, "UBNT AirControl 2 request\n");
 	
 	ndpi_int_ubntac2_add_connection(ndpi_struct, flow);
       }
@@ -72,7 +78,7 @@ void ndpi_search_ubntac2(struct ndpi_detection_module_struct *ndpi_struct, struc
     }
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_UBNTAC2);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/usenet.c
+++ b/src/lib/protocols/usenet.c
@@ -23,10 +23,13 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_USENET
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_USENET
+
+#include "ndpi_api.h"
 
 static void ndpi_int_usenet_add_connection(struct ndpi_detection_module_struct
 					   *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -41,17 +44,9 @@ void ndpi_search_usenet_tcp(struct ndpi_detection_module_struct
 {
 	struct ndpi_packet_struct *packet = &flow->packet;
 	
-//      struct ndpi_id_struct         *src=ndpi_struct->src;
-//      struct ndpi_id_struct         *dst=ndpi_struct->dst;
+	NDPI_LOG__DEBUG(ndpi_struct, "search usenet\n");
 
-	NDPI_LOG(NDPI_PROTOCOL_USENET, ndpi_struct, NDPI_LOG_DEBUG, "USENET: search usenet.\n");
-
-
-
-
-
-	NDPI_LOG(NDPI_PROTOCOL_USENET, ndpi_struct, NDPI_LOG_DEBUG, "USENET: STAGE IS %u.\n", flow->l4.tcp.usenet_stage);
-
+	NDPI_LOG__DEBUG2(ndpi_struct, "STAGE IS %u\n", flow->l4.tcp.usenet_stage);
 
 	// check for the first server replay
 	/*
@@ -62,10 +57,10 @@ void ndpi_search_usenet_tcp(struct ndpi_detection_module_struct
 		&& ((memcmp(packet->payload, "200 ", 4) == 0)
 			|| (memcmp(packet->payload, "201 ", 4) == 0))) {
 
-		NDPI_LOG(NDPI_PROTOCOL_USENET, ndpi_struct, NDPI_LOG_DEBUG, "USENET: found 200 or 201.\n");
+		NDPI_LOG__DEBUG2(ndpi_struct, "found 200 or 201\n");
 		flow->l4.tcp.usenet_stage = 1 + packet->packet_direction;
 
-		NDPI_LOG(NDPI_PROTOCOL_USENET, ndpi_struct, NDPI_LOG_DEBUG, "USENET: maybe hit.\n");
+		NDPI_LOG__DEBUG2(ndpi_struct, "maybe hit\n");
 		return;
 	}
 
@@ -78,28 +73,23 @@ void ndpi_search_usenet_tcp(struct ndpi_detection_module_struct
 	// check for client username
 	if (flow->l4.tcp.usenet_stage == 2 - packet->packet_direction) {
 		if (packet->payload_packet_len > 20 && (memcmp(packet->payload, "AUTHINFO USER ", 14) == 0)) {
-			NDPI_LOG(NDPI_PROTOCOL_USENET, ndpi_struct, NDPI_LOG_DEBUG, "USENET: username found\n");
+			NDPI_LOG__DEBUG2(ndpi_struct, "username found\n");
 			flow->l4.tcp.usenet_stage = 3 + packet->packet_direction;
 
-			NDPI_LOG(NDPI_PROTOCOL_USENET, ndpi_struct, NDPI_LOG_DEBUG, "USENET: found usenet.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found usenet\n");
 			ndpi_int_usenet_add_connection(ndpi_struct, flow);
 			return;
 		} else if (packet->payload_packet_len == 13 && (memcmp(packet->payload, "MODE READER\r\n", 13) == 0)) {
-			NDPI_LOG(NDPI_PROTOCOL_USENET, ndpi_struct, NDPI_LOG_DEBUG,
-					"USENET: no login necessary but we are a client.\n");
+			NDPI_LOG__DEBUG2(ndpi_struct,
+					"no login necessary but we are a client.\n");
 
-			NDPI_LOG(NDPI_PROTOCOL_USENET, ndpi_struct, NDPI_LOG_DEBUG, "USENET: found usenet.\n");
+			NDPI_LOG__TRACE(ndpi_struct, "found usenet\n");
 			ndpi_int_usenet_add_connection(ndpi_struct, flow);
 			return;
 		}
 	}
 
-
-
-	NDPI_LOG(NDPI_PROTOCOL_USENET, ndpi_struct, NDPI_LOG_DEBUG, "USENET: exclude usenet.\n");
-
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_USENET);
-
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/vhua.c
+++ b/src/lib/protocols/vhua.c
@@ -17,7 +17,11 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#include "ndpi_protocol_ids.h"
 
+#ifdef NDPI_PROTOCOL_VHUA
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_VHUA
 
 #include "ndpi_api.h"
 
@@ -28,11 +32,10 @@
 
  */
 
-#ifdef NDPI_PROTOCOL_VHUA
 
 static void ndpi_int_vhua_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_VHUA, NDPI_PROTOCOL_UNKNOWN);
-  NDPI_LOG(NDPI_PROTOCOL_VHUA, ndpi_struct, NDPI_LOG_TRACE, "VHUA Found.\n");
+  NDPI_LOG__TRACE(ndpi_struct, "found VHUA\n");
 }
 
 
@@ -47,8 +50,7 @@ static void ndpi_check_vhua(struct ndpi_detection_module_struct *ndpi_struct, st
   if((flow->packet_counter > 3)
      || (packet->udp == NULL)
      || (packet->payload_packet_len < sizeof(p0))) {
-    NDPI_LOG(NDPI_PROTOCOL_VHUA, ndpi_struct, NDPI_LOG_TRACE, "Exclude VHUA.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_VHUA);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   } else if(memcmp(packet->payload, p0, sizeof(p0)) == 0) {
     ndpi_int_vhua_add_connection(ndpi_struct, flow);
   }
@@ -57,7 +59,7 @@ static void ndpi_check_vhua(struct ndpi_detection_module_struct *ndpi_struct, st
 void ndpi_search_vhua(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_VHUA, ndpi_struct, NDPI_LOG_TRACE, "VHUA detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search VHUA\n");
 
   /* skip marked packets */
   if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_VHUA) {

--- a/src/lib/protocols/viber.c
+++ b/src/lib/protocols/viber.c
@@ -18,31 +18,34 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "ndpi_protocol_ids.h"
+
+#ifdef NDPI_PROTOCOL_VIBER
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_VIBER
 
 #include "ndpi_api.h"
 
-#ifdef NDPI_PROTOCOL_VIBER
 
 void ndpi_search_viber(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
   
-  NDPI_LOG(NDPI_PROTOCOL_VIBER, ndpi_struct, NDPI_LOG_DEBUG, "search for VIBER.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search for VIBER\n");
   
   if(packet->udp != NULL) {
-    NDPI_LOG(NDPI_PROTOCOL_VIBER, ndpi_struct, NDPI_LOG_DEBUG, "calculating dport over udp.\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "calculating dport over udp\n");
 
     if((packet->payload_packet_len == 12 && packet->payload[2] == 0x03 && packet->payload[3] == 0x00)
        || (packet->payload_packet_len == 20 && packet->payload[2] == 0x09 && packet->payload[3] == 0x00)
        || ((packet->payload_packet_len < 135) && (packet->payload[0] == 0x11))) {
-      NDPI_LOG(NDPI_PROTOCOL_VIBER, ndpi_struct, NDPI_LOG_DEBUG, "found VIBER.\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "found VIBER\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_VIBER, NDPI_PROTOCOL_UNKNOWN);
       return;
     } 
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_VIBER, ndpi_struct, NDPI_LOG_DEBUG, "exclude VIBER.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_VIBER);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/vmware.c
+++ b/src/lib/protocols/vmware.c
@@ -17,28 +17,32 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_api.h"
+
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_VMWARE
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_VMWARE
+
+#include "ndpi_api.h"
 
 void ndpi_search_vmware(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search vmware\n");
   /* Check whether this is an VMWARE flow */
   if(packet->udp != NULL){
     if((packet->payload_packet_len == 66) &&
        (ntohs(packet->udp->dest) == 902) &&
        ((packet->payload[0] & 0xFF) == 0xA4)){
       
-      NDPI_LOG(NDPI_PROTOCOL_VMWARE, ndpi_struct, NDPI_LOG_DEBUG, "Found vmware.\n");
+      NDPI_LOG__TRACE(ndpi_struct, "found vmware\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_VMWARE, NDPI_PROTOCOL_UNKNOWN);
       return;
     }
   }
-  NDPI_LOG(NDPI_PROTOCOL_VMWARE, ndpi_struct, NDPI_LOG_DEBUG, "exclude vmware.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_VMWARE);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void init_vmware_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask)

--- a/src/lib/protocols/vnc.c
+++ b/src/lib/protocols/vnc.c
@@ -20,15 +20,19 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_VNC
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_VNC
+
+#include "ndpi_api.h"
 
 void ndpi_search_vnc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search vnc\n");
   /* search over TCP */
   if(packet->tcp) {
     
@@ -39,7 +43,7 @@ void ndpi_search_vnc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  (memcmp(packet->payload, "RFB 003.007", 11) == 0 && packet->payload[11] == 0x0a) ||
 	  (memcmp(packet->payload, "RFB 003.008", 11) == 0 && packet->payload[11] == 0x0a) ||
 	  (memcmp(packet->payload, "RFB 004.001", 11) == 0 && packet->payload[11] == 0x0a))) {	   
-	NDPI_LOG(NDPI_PROTOCOL_VNC, ndpi_struct, NDPI_LOG_DEBUG, "reached vnc stage one\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "reached vnc stage one\n");
 	flow->l4.tcp.vnc_stage = 1 + packet->packet_direction;
 	return;
       }
@@ -51,14 +55,13 @@ void ndpi_search_vnc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  (memcmp(packet->payload, "RFB 003.008", 11) == 0 && packet->payload[11] == 0x0a) ||
 	  (memcmp(packet->payload, "RFB 004.001", 11) == 0 && packet->payload[11] == 0x0a))) {
 	
-	NDPI_LOG(NDPI_PROTOCOL_VNC, ndpi_struct, NDPI_LOG_DEBUG, "found vnc\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found vnc\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_VNC, NDPI_PROTOCOL_UNKNOWN);
 	return;
       }
     }
   }
-  /* exclude VNC */
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_VNC);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/warcraft3.c
+++ b/src/lib/protocols/warcraft3.c
@@ -22,12 +22,13 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
 
-
-/* include files */
-
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_WARCRAFT3
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_WARCRAFT3
+
+#include "ndpi_api.h"
 
 static void ndpi_int_warcraft3_add_connection(struct ndpi_detection_module_struct
 					      *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -40,52 +41,48 @@ void ndpi_search_warcraft3(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
   u_int16_t l; /* 
 		  Leave it as u_int32_t because otherwise 'u_int16_t temp' 
 		  might overflood it and thus generate an infinite loop
 	       */
 
-  NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "search WARCRAFT3\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search WARCRAFT3\n");
 
 
   if (flow->packet_counter == 1 && packet->payload_packet_len == 1 && packet->payload[0] == 0x01) {
-    NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "maybe warcraft3: packet_len == 1\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "maybe warcraft3: packet_len == 1\n");
     return;
   } else if (packet->payload_packet_len >= 4 && (packet->payload[0] == 0xf7 || packet->payload[0] == 0xff)) {
 
-    NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "packet_payload begins with 0xf7 or 0xff\n");
+    NDPI_LOG__DEBUG2(ndpi_struct, "packet_payload begins with 0xf7 or 0xff\n");
 
     l = packet->payload[2] + (packet->payload[3] << 8);	// similar to ntohs
 
-    NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "l = %u \n", l);
+    NDPI_LOG__DEBUG2(ndpi_struct, "l = %u \n", l);
 
     while (l <= (packet->payload_packet_len - 4)) {
       if (packet->payload[l] == 0xf7) {
 	u_int16_t temp = (packet->payload[l + 2 + 1] << 8) + packet->payload[l + 2];
-	NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "another f7 visited.\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "another f7 visited\n");
 
 	if((temp <= 2) || (temp > 1500)) {
-	  NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "break\n");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "break\n");
 	  break;
 	} else {
 	  l += temp;
-	  NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "l = %u \n", l);
+	  NDPI_LOG__DEBUG2(ndpi_struct, "l = %u \n", l);
 	}
       } else {
-	NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "break\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "break\n");
 	break;
       }
     }
 
     if (l == packet->payload_packet_len) {
-      NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "maybe WARCRAFT3\n");
-      NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "flow->packet_counter = %u \n",
+      NDPI_LOG__DEBUG2(ndpi_struct, "maybe WARCRAFT3 flow->packet_counter = %u \n",
 	       flow->packet_counter);
       if (flow->packet_counter > 2) {
-	NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "detected WARCRAFT3\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found WARCRAFT3\n");
 	ndpi_int_warcraft3_add_connection(ndpi_struct, flow);
 	return;
       }
@@ -93,8 +90,7 @@ void ndpi_search_warcraft3(struct ndpi_detection_module_struct
     }
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_WARCRAFT3, ndpi_struct, NDPI_LOG_DEBUG, "no warcraft3 detected.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_WARCRAFT3);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/whoisdas.c
+++ b/src/lib/protocols/whoisdas.c
@@ -17,14 +17,21 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_protocols.h"
+
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_WHOIS_DAS
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_WHOIS_DAS
+
+#include "ndpi_api.h"
+
 
 void ndpi_search_whois_das(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
+  NDPI_LOG__DEBUG(ndpi_struct, "search WHOIS/DAS\n");
   if(packet->tcp != NULL) {
     u_int16_t sport = ntohs(packet->tcp->source), dport = ntohs(packet->tcp->dest);
     
@@ -45,15 +52,14 @@ void ndpi_search_whois_das(struct ndpi_detection_module_struct *ndpi_struct, str
 	flow->host_server_name[i] = '\0';
 	flow->server_id = ((sport == 43) || (sport == 4343)) ? flow->src : flow->dst;
 	
-	NDPI_LOG(NDPI_PROTOCOL_WHOIS_DAS, ndpi_struct, NDPI_LOG_DEBUG, "[WHOIS/DAS] %s\n", flow->host_server_name);
+	NDPI_LOG__TRACE(ndpi_struct, "[WHOIS/DAS] %s\n", flow->host_server_name);
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_WHOIS_DAS, NDPI_PROTOCOL_UNKNOWN);
 	return;
       }
     }
   }
-  /* exclude WHOIS */
-  NDPI_LOG(NDPI_PROTOCOL_WHOIS_DAS, ndpi_struct, NDPI_LOG_TRACE, "WHOIS Excluded.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_WHOIS_DAS);
+
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/world_of_kung_fu.c
+++ b/src/lib/protocols/world_of_kung_fu.c
@@ -22,11 +22,12 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
 
-
-/* include files */
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_WORLD_OF_KUNG_FU
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_WORLD_OF_KUNG_FU
+#include "ndpi_api.h"
+
 
 static void ndpi_int_world_of_kung_fu_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -37,22 +38,18 @@ void ndpi_search_world_of_kung_fu(struct ndpi_detection_module_struct *ndpi_stru
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-  NDPI_LOG(NDPI_PROTOCOL_WORLD_OF_KUNG_FU, ndpi_struct, NDPI_LOG_DEBUG, "search world_of_kung_fu.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search world_of_kung_fu\n");
 
   if ((packet->payload_packet_len == 16)
       && ntohl(get_u_int32_t(packet->payload, 0)) == 0x0c000000 && ntohl(get_u_int32_t(packet->payload, 4)) == 0xd2000c00
       && (packet->payload[9]
 	  == 0x16) && ntohs(get_u_int16_t(packet->payload, 10)) == 0x0000 && ntohs(get_u_int16_t(packet->payload, 14)) == 0x0000) {
-    NDPI_LOG(NDPI_PROTOCOL_WORLD_OF_KUNG_FU, ndpi_struct, NDPI_LOG_DEBUG, "detected world_of_kung_fu.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "detected world_of_kung_fu\n");
     ndpi_int_world_of_kung_fu_add_connection(ndpi_struct, flow);
     return;
   }
 
-  NDPI_LOG(NDPI_PROTOCOL_WORLD_OF_KUNG_FU, ndpi_struct, NDPI_LOG_DEBUG, "exclude world_of_kung_fu.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_WORLD_OF_KUNG_FU);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/world_of_warcraft.c
+++ b/src/lib/protocols/world_of_warcraft.c
@@ -21,12 +21,13 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
-
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_WORLDOFWARCRAFT
 
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_WORLDOFWARCRAFT
+
+#include "ndpi_api.h"
 
 static void ndpi_int_worldofwarcraft_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 						    struct ndpi_flow_struct *flow/* , */
@@ -58,7 +59,7 @@ void ndpi_search_worldofwarcraft(struct ndpi_detection_module_struct
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
 
-  NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct, NDPI_LOG_DEBUG, "Search World of Warcraft.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search World of Warcraft\n");
 
   if (packet->tcp != NULL) {
     /*
@@ -72,8 +73,7 @@ void ndpi_search_worldofwarcraft(struct ndpi_detection_module_struct
       memcmp(packet->user_agent_line.ptr, "Blizzard Web Client",
       NDPI_STATICSTRING_LEN("Blizzard Web Client")) == 0) {
       ndpi_int_worldofwarcraft_add_connection(ndpi_struct, flow);
-      NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct, NDPI_LOG_DEBUG,
-      "World of Warcraft: Web Client found\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "World of Warcraft: Web Client found\n");
       return;
       }
       }
@@ -89,7 +89,7 @@ void ndpi_search_worldofwarcraft(struct ndpi_detection_module_struct
 	  && memcmp(&packet->host_line.ptr[packet->host_line.len - NDPI_STATICSTRING_LEN("worldofwarcraft.com")],
 		    "worldofwarcraft.com", NDPI_STATICSTRING_LEN("worldofwarcraft.com")) == 0) {
 	ndpi_int_worldofwarcraft_add_connection(ndpi_struct, flow);
-	NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct, NDPI_LOG_DEBUG,
+	NDPI_LOG__TRACE(ndpi_struct,
 		 "World of Warcraft: Web Client found\n");
 	return;
       }
@@ -97,14 +97,14 @@ void ndpi_search_worldofwarcraft(struct ndpi_detection_module_struct
     if (packet->payload_packet_len == 50 && memcmp(&packet->payload[2], "WORLD OF WARCRAFT CONNECTION",
 						   NDPI_STATICSTRING_LEN("WORLD OF WARCRAFT CONNECTION")) == 0) {
       ndpi_int_worldofwarcraft_add_connection(ndpi_struct, flow);
-      NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct, NDPI_LOG_DEBUG, "World of Warcraft: Login found\n");
+      NDPI_LOG__TRACE(ndpi_struct, "World of Warcraft: Login found\n");
       return;
     }
     if (packet->tcp->dest == htons(3724) && packet->payload_packet_len < 70
 	&& packet->payload_packet_len > 40 && (memcmp(&packet->payload[4], "WoW", 3) == 0
 					       || memcmp(&packet->payload[5], "WoW", 3) == 0)) {
       ndpi_int_worldofwarcraft_add_connection(ndpi_struct, flow);
-      NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct, NDPI_LOG_DEBUG, "World of Warcraft: Login found\n");
+      NDPI_LOG__TRACE(ndpi_struct, "World of Warcraft: Login found\n");
       return;
     }
 
@@ -112,8 +112,7 @@ void ndpi_search_worldofwarcraft(struct ndpi_detection_module_struct
       if (packet->tcp->source == htons(3724)
 	  && packet->payload_packet_len == 8 && get_u_int32_t(packet->payload, 0) == htonl(0x0006ec01)) {
 	ndpi_int_worldofwarcraft_add_connection(ndpi_struct, flow);
-	NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "World of Warcraft: connection detected\n");
+	NDPI_LOG__TRACE(ndpi_struct, "World of Warcraft: connection detected\n");
 	return;
       }
 
@@ -127,16 +126,14 @@ void ndpi_search_worldofwarcraft(struct ndpi_detection_module_struct
 	  ntohs(get_u_int16_t(packet->payload, 0)) == (packet->payload_packet_len - 2)) {
 	if (get_u_int32_t(packet->payload, 2) == htonl(0xec010100)) {
 
-	  NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct,
-		   NDPI_LOG_DEBUG, "probably World of Warcraft, waiting for final packet\n");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "probably World of Warcraft, waiting for final packet\n");
 	  flow->l4.tcp.wow_stage = 2;
 	  return;
 	} else if (packet->payload_packet_len == 41 &&
 		   (get_u_int16_t(packet->payload, 2) == htons(0x0085) ||
 		    get_u_int16_t(packet->payload, 2) == htons(0x0034) ||
 		    get_u_int16_t(packet->payload, 2) == htons(0x1960))) {
-	  NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct,
-		   NDPI_LOG_DEBUG, "maybe World of Warcraft, need next\n");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "maybe World of Warcraft, need next\n");
 	  flow->l4.tcp.wow_stage = 1;
 	  return;
 	}
@@ -155,21 +152,18 @@ void ndpi_search_worldofwarcraft(struct ndpi_detection_module_struct
 	   || memcmp(&packet->payload[packet->payload_packet_len - 30],
 		     "\x94\xec\xff\xfd\x67\x62\xd4\x67\xfb\xf9\xdd\xbd\xfd\x01\xc0\x8f\xf9\x81", 18) == 0)) {
 	ndpi_int_worldofwarcraft_add_connection(ndpi_struct, flow);
-	NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "World of Warcraft: connection detected\n");
+	NDPI_LOG__TRACE(ndpi_struct, "World of Warcraft: connection detected\n");
 	return;
       }
       if (packet->payload_packet_len > 32 &&
 	  ntohs(get_u_int16_t(packet->payload, 0)) == (packet->payload_packet_len - 2)) {
 	if (get_u_int16_t(packet->payload, 4) == 0) {
 
-	  NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct,
-		   NDPI_LOG_DEBUG, "probably World of Warcraft, waiting for final packet\n");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "probably World of Warcraft, waiting for final packet\n");
 	  flow->l4.tcp.wow_stage = 2;
 	  return;
 	} else if (get_u_int32_t(packet->payload, 2) == htonl(0x12050000)) {
-	  NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct,
-		   NDPI_LOG_DEBUG, "probably World of Warcraft, waiting for final packet\n");
+	  NDPI_LOG__DEBUG2(ndpi_struct, "probably World of Warcraft, waiting for final packet\n");
 	  flow->l4.tcp.wow_stage = 2;
 	  return;
 	}
@@ -179,16 +173,14 @@ void ndpi_search_worldofwarcraft(struct ndpi_detection_module_struct
     if (flow->l4.tcp.wow_stage == 2) {
       if (packet->payload_packet_len == 4) {
 	ndpi_int_worldofwarcraft_add_connection(ndpi_struct, flow);
-	NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "World of Warcraft: connection detected\n");
+	NDPI_LOG__TRACE(ndpi_struct, "World of Warcraft: connection detected\n");
 	return;
       } else if (packet->payload_packet_len > 4 && packet->payload_packet_len <= 16 && packet->payload[4] == 0x0c) {
 	ndpi_int_worldofwarcraft_add_connection(ndpi_struct, flow);
-	NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "World of Warcraft: connection detected\n");
+	NDPI_LOG__TRACE(ndpi_struct, "World of Warcraft: connection detected\n");
 	return;
       } else if (flow->packet_counter < 3) {
-	NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct, NDPI_LOG_DEBUG, "waiting for final packet\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "waiting for final packet\n");
 	return;
       }
     }
@@ -199,14 +191,13 @@ void ndpi_search_worldofwarcraft(struct ndpi_detection_module_struct
 	  get_u_int32_t(packet->payload, 0) == htonl(0x40000aed) && get_u_int32_t(packet->payload, 4) == htonl(0xea070aed)) {
 
 	ndpi_int_worldofwarcraft_add_connection(ndpi_struct, flow);
-	NDPI_LOG(NDPI_PROTOCOL_WORLDOFWARCRAFT, ndpi_struct,
-		 NDPI_LOG_DEBUG, "World of Warcraft: connection detected\n");
+	NDPI_LOG__TRACE(ndpi_struct, "World of Warcraft: connection detected\n");
 	return;
       }
     }
   }
 
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_WORLDOFWARCRAFT);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/xbox.c
+++ b/src/lib/protocols/xbox.c
@@ -21,9 +21,11 @@
  * 
  */
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_XBOX
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_XBOX
+#include "ndpi_api.h"
 
 static void ndpi_int_xbox_add_connection(struct ndpi_detection_module_struct
 					 *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -36,9 +38,6 @@ void ndpi_search_xbox(struct ndpi_detection_module_struct *ndpi_struct, struct n
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //  struct ndpi_id_struct *src = flow->src;
-  //  struct ndpi_id_struct *dst = flow->dst;
-
   /*
    * XBOX UDP DETCTION ONLY
    * the xbox TCP detection is done by http code
@@ -49,7 +48,7 @@ void ndpi_search_xbox(struct ndpi_detection_module_struct *ndpi_struct, struct n
     u_int16_t dport = ntohs(packet->udp->dest);
     u_int16_t sport = ntohs(packet->udp->source);
 
-    NDPI_LOG(NDPI_PROTOCOL_XBOX, ndpi_struct, NDPI_LOG_DEBUG, "search xbox\n");
+    NDPI_LOG__DEBUG(ndpi_struct, "search xbox\n");
 
     if (packet->payload_packet_len > 12 &&
 	get_u_int32_t(packet->payload, 0) == 0 && packet->payload[5] == 0x58 &&
@@ -62,7 +61,7 @@ void ndpi_search_xbox(struct ndpi_detection_module_struct *ndpi_struct, struct n
 	  (packet->payload[4] == 0x06 && packet->payload[6] == 0x4e)) {
 
 	ndpi_int_xbox_add_connection(ndpi_struct, flow);
-	NDPI_LOG(NDPI_PROTOCOL_XBOX, ndpi_struct, NDPI_LOG_DEBUG, "xbox udp connection detected\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found xbox udp connection detected\n");
 	return;
       }
     }
@@ -76,10 +75,10 @@ void ndpi_search_xbox(struct ndpi_detection_module_struct *ndpi_struct, struct n
 	    || (packet->payload_packet_len == 28 && ntohl(get_u_int32_t(packet->payload, 0)) == 0x015f2c00))) {
       if (flow->l4.udp.xbox_stage == 1) {
 	ndpi_int_xbox_add_connection(ndpi_struct, flow);
-	NDPI_LOG(NDPI_PROTOCOL_XBOX, ndpi_struct, NDPI_LOG_DEBUG, "xbox udp connection detected\n");
+	NDPI_LOG__TRACE(ndpi_struct, "found xbox udp connection detected\n");
 	return;
       }
-      NDPI_LOG(NDPI_PROTOCOL_XBOX, ndpi_struct, NDPI_LOG_DEBUG, "maybe xbox.\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "maybe xbox\n");
       flow->l4.udp.xbox_stage++;
       return;
     }
@@ -88,8 +87,7 @@ void ndpi_search_xbox(struct ndpi_detection_module_struct *ndpi_struct, struct n
 #ifdef NDPI_PROTOCOL_HTTP
     if(NDPI_COMPARE_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_HTTP) != 0) {
 #endif
-      NDPI_LOG(NDPI_PROTOCOL_XBOX, ndpi_struct, NDPI_LOG_DEBUG, "xbox udp excluded.\n");
-      NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_XBOX);
+      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     }
   }
   /* to not exclude tcp traffic here, done by http code... */

--- a/src/lib/protocols/xdmcp.c
+++ b/src/lib/protocols/xdmcp.c
@@ -22,9 +22,13 @@
  * 
  */
 
+#include "ndpi_protocol_ids.h"
 
-#include "ndpi_protocols.h"
 #ifdef NDPI_PROTOCOL_XDMCP
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_XDMCP
+
+#include "ndpi_api.h"
 
 
 static void ndpi_int_xdmcp_add_connection(struct ndpi_detection_module_struct
@@ -38,17 +42,14 @@ void ndpi_search_xdmcp(struct ndpi_detection_module_struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 	
-  //      struct ndpi_id_struct         *src=ndpi_struct->src;
-  //      struct ndpi_id_struct         *dst=ndpi_struct->dst;
-
-  NDPI_LOG(NDPI_PROTOCOL_XDMCP, ndpi_struct, NDPI_LOG_DEBUG, "search xdmcp.\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search xdmcp\n");
 
   if (packet->tcp != NULL && (ntohs(packet->tcp->dest) >= 6000 && ntohs(packet->tcp->dest) <= 6005)
       && packet->payload_packet_len == 48
       && packet->payload[0] == 0x6c && packet->payload[1] == 0x00
       && ntohs(get_u_int16_t(packet->payload, 6)) == 0x1200 && ntohs(get_u_int16_t(packet->payload, 8)) == 0x1000) {
 
-    NDPI_LOG(NDPI_PROTOCOL_XDMCP, ndpi_struct, NDPI_LOG_DEBUG, "found xdmcp over tcp.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found xdmcp over tcp\n");
     ndpi_int_xdmcp_add_connection(ndpi_struct, flow);
     return;
   }
@@ -56,14 +57,12 @@ void ndpi_search_xdmcp(struct ndpi_detection_module_struct
       && packet->payload_packet_len >= 6 && packet->payload_packet_len == 6 + ntohs(get_u_int16_t(packet->payload, 4))
       && ntohs(get_u_int16_t(packet->payload, 0)) == 0x0001 && ntohs(get_u_int16_t(packet->payload, 2)) == 0x0002) {
 
-    NDPI_LOG(NDPI_PROTOCOL_XDMCP, ndpi_struct, NDPI_LOG_DEBUG, "found xdmcp over udp.\n");
+    NDPI_LOG__TRACE(ndpi_struct, "found xdmcp over udp\n");
     ndpi_int_xdmcp_add_connection(ndpi_struct, flow);
     return;
   }
 
-
-  NDPI_LOG(NDPI_PROTOCOL_XDMCP, ndpi_struct, NDPI_LOG_DEBUG, "exclude xdmcp.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_XDMCP);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/yahoo.c
+++ b/src/lib/protocols/yahoo.c
@@ -20,9 +20,12 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  * 
  */
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_YAHOO
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_YAHOO
+#include "ndpi_api.h"
+
 
 
 struct ndpi_yahoo_header {
@@ -87,8 +90,6 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
   struct ndpi_id_struct *dst = flow->dst;
 
   const struct ndpi_yahoo_header *yahoo = (struct ndpi_yahoo_header *) packet->payload;
-  
-  if(packet->tcp) {
 
     if(packet->payload_packet_len > 0) {
       /* packet must be at least 20 bytes long */
@@ -96,11 +97,11 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	 && memcmp(yahoo->YMSG_str, "YMSG", 4) == 0 && ((packet->payload_packet_len - 20) == ntohs(yahoo->len)
 							|| check_ymsg(packet->payload, packet->payload_packet_len))) {
      
-	NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_TRACE, "YAHOO FOUND\n");
+	NDPI_LOG__DEBUG(ndpi_struct, "YAHOO FOUND\n");
 	flow->yahoo_detection_finished = 2;
 
 	if(ntohs(yahoo->service) == 24 || ntohs(yahoo->service) == 152 || ntohs(yahoo->service) == 74) {
-	  NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_TRACE, "YAHOO conference or chat invite  found");
+	  NDPI_LOG__DEBUG(ndpi_struct, "YAHOO conference or chat invite  found");
 
 	  if(src != NULL)
 	    src->yahoo_conf_logged_in = 1;
@@ -108,13 +109,13 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	    dst->yahoo_conf_logged_in = 1;
 	}
 	if(ntohs(yahoo->service) == 27 || ntohs(yahoo->service) == 155 || ntohs(yahoo->service) == 160) {
-	  NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_TRACE, "YAHOO conference or chat logoff found");
+	  NDPI_LOG__DEBUG(ndpi_struct, "YAHOO conference or chat logoff found");
 	  if(src != NULL) {
 	    src->yahoo_conf_logged_in = 0;
 	    src->yahoo_voice_conf_logged_in = 0;
 	  }
 	}
-	NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	NDPI_LOG__TRACE(ndpi_struct, "found YAHOO");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	return;
 	
@@ -140,7 +141,7 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 			&& NDPI_COMPARE_PROTOCOL_TO_BITMASK(dst->detected_protocol_bitmask, NDPI_PROTOCOL_YAHOO)
 			!= 0)) {
 	    /* this is mostly a file transfer */
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	    NDPI_LOG__TRACE(ndpi_struct, "found YAHOO");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	    return;
 	  }
@@ -151,7 +152,7 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 
 	  if ((packet->user_agent_line.len >= 21)
 	      && (memcmp(packet->user_agent_line.ptr, "YahooMobileMessenger/", 21) == 0)) {
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO(Mobile)");
+	    NDPI_LOG__TRACE(ndpi_struct, "found YAHOO(Mobile)");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	    return;
 	  }
@@ -169,27 +170,23 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	      && memcmp(packet->line[4].ptr, "User-Agent: Mozilla/5.0",
 			23) == 0 && packet->line[5].len >= 23
 	      && memcmp(packet->line[5].ptr, "Cache-Control: no-cache", 23) == 0) {
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_TRACE,
-		     "YAHOO HTTP POST P2P FILETRANSFER FOUND\n");
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	    NDPI_LOG__TRACE(ndpi_struct, "found YAHOO HTTP POST P2P FILETRANSFER\n");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	    return;
 	  }
 
 	  if (packet->host_line.ptr != NULL && packet->host_line.len >= 26 &&
 	      memcmp(packet->host_line.ptr, "filetransfer.msg.yahoo.com", 26) == 0) {
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_TRACE, "YAHOO HTTP POST FILETRANSFER FOUND\n");
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	    NDPI_LOG__TRACE(ndpi_struct, "found YAHOO HTTP POST FILETRANSFER\n");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	    return;
 	  }
 	  /* now check every line */
 	  for (a = 0; a < packet->parsed_lines; a++) {
 	    if (packet->line[a].len >= 4 && memcmp(packet->line[a].ptr, "YMSG", 4) == 0) {
-	      NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct,
-		       NDPI_LOG_TRACE,
+	      NDPI_LOG__DEBUG(ndpi_struct,
 		       "YAHOO HTTP POST FOUND, line is: %.*s\n", packet->line[a].len, packet->line[a].ptr);
-	      NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	      NDPI_LOG__TRACE(ndpi_struct, "found YAHOO");
 	      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	      return;
 	    }
@@ -197,8 +194,8 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	  if (packet->parsed_lines > 8 && packet->line[8].len > 250 && packet->line[8].ptr != NULL) {
 	    if (memcmp(packet->line[8].ptr, "<Session ", 9) == 0) {
 	      if (ndpi_check_for_YmsgCommand(packet->line[8].len, packet->line[8].ptr)) {
-		NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG,
-			 "found HTTP Proxy Yahoo Chat <Ymsg Command= pattern  \n");
+		NDPI_LOG__TRACE(ndpi_struct,
+			 "found YAHOO HTTP Proxy Yahoo Chat <Ymsg Command= pattern  \n");
 		ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 		return;
 	      }
@@ -209,8 +206,7 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	  if((src != NULL && NDPI_COMPARE_PROTOCOL_TO_BITMASK(src->detected_protocol_bitmask, NDPI_PROTOCOL_YAHOO) != 0)
 	     || (dst != NULL && NDPI_COMPARE_PROTOCOL_TO_BITMASK(dst->detected_protocol_bitmask, NDPI_PROTOCOL_YAHOO) != 0)) {
 	    
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_TRACE, "YAHOO HTTP GET /Messenger. match\n");
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	    NDPI_LOG__TRACE(ndpi_struct, "found YAHOO HTTP GET /Messenger. match\n");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	    return;
 	  }
@@ -222,13 +218,13 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	      && memcmp(packet->user_agent_line.ptr, "YahooMobileMessenger/", NDPI_STATICSTRING_LEN("YahooMobileMessenger/")) == 0)
 	     || (packet->user_agent_line.len >= 15 && (memcmp(packet->user_agent_line.ptr, "Y!%20Messenger/", 15) == 0))) {
 	    
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO(Mobile)");
+	    NDPI_LOG__TRACE(ndpi_struct, "found YAHOO(Mobile)");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	    return;
 	  }
 	  if(packet->host_line.ptr != NULL && packet->host_line.len >= NDPI_STATICSTRING_LEN("msg.yahoo.com") &&
 	     memcmp(&packet->host_line.ptr[packet->host_line.len - NDPI_STATICSTRING_LEN("msg.yahoo.com")], "msg.yahoo.com", NDPI_STATICSTRING_LEN("msg.yahoo.com")) == 0) {
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	    NDPI_LOG__TRACE(ndpi_struct, "found YAHOO");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	    return;
 	  }
@@ -242,10 +238,10 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	
 	if (packet->parsed_lines > 2 && packet->line[1].len == 0) {
 	  
-	  NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_TRACE, "first line is empty.\n");
+	  NDPI_LOG__DEBUG(ndpi_struct, "first line is empty\n");
 	  if (packet->line[2].len > 13 && memcmp(packet->line[2].ptr, "<Ymsg Command=", 14) == 0) {
 
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_TRACE, "YAHOO web chat found\n");
+	    NDPI_LOG__TRACE(ndpi_struct, "YAHOO web chat found\n");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	    return;
 	  }
@@ -254,8 +250,7 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 
       if (packet->payload_packet_len > 38 && memcmp(packet->payload, "CONNECT scs.msg.yahoo.com:5050 HTTP/1.", 38) == 0) {
 	
-	NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_TRACE, "YAHOO-HTTP FOUND\n");
-	NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	NDPI_LOG__TRACE(ndpi_struct, "found YAHOO-HTTP\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	return;
       }
@@ -264,7 +259,7 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	  || (dst != NULL && NDPI_COMPARE_PROTOCOL_TO_BITMASK(dst->detected_protocol_bitmask, NDPI_PROTOCOL_YAHOO) != 0)) {
 	if (packet->payload_packet_len == 6 && memcmp(packet->payload, "YAHOO!", 6) == 0) {
 	  
-	  NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	  NDPI_LOG__TRACE(ndpi_struct, "found YAHOO");
 	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	  return;
 	}
@@ -274,8 +269,6 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	if (packet->payload_packet_len == 8 && (memcmp(packet->payload, "<SNDIMG>", 8) == 0 || memcmp(packet->payload, "<REQIMG>", 8) == 0
 						|| memcmp(packet->payload, "<RVWCFG>", 8) == 0 || memcmp(packet->payload, "<RUPCFG>", 8) == 0)) {
 	  
-	  NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_TRACE, "YAHOO SNDIMG or REQIMG or RVWCFG or RUPCFG FOUND\n");
-
 	  if(src != NULL) {
 	    if (memcmp(packet->payload, "<SNDIMG>", 8) == 0) {
 	      src->yahoo_video_lan_dir = 0;
@@ -293,7 +286,7 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	    dst->yahoo_video_lan_timer = packet->tick_timestamp;
 
 	  }
-	  NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO subtype VIDEO");
+	  NDPI_LOG__TRACE(ndpi_struct, "found YAHOO subtype VIDEO");
 	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 	  return;
 	}
@@ -302,9 +295,8 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	  
 	  if (src->yahoo_video_lan_dir == 1) {
 
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	    NDPI_LOG__TRACE(ndpi_struct, "found YAHOO IMG MARKED");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "IMG MARKED");
 	    return;
 	  }
 	}
@@ -312,9 +304,8 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	    && ((u_int32_t) (packet->tick_timestamp - dst->yahoo_video_lan_timer) < ndpi_struct->yahoo_lan_video_timeout)) {
 	  if (dst->yahoo_video_lan_dir == 0) {
 	    
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO");
+	    NDPI_LOG__TRACE(ndpi_struct, "found YAHOO IMG MARKED");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "IMG MARKED");
 	    return;
 	  }
 	}
@@ -326,8 +317,7 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	{
 	  if (flow->l4.tcp.yahoo_http_proxy_stage == 0) {
 	    
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG,
-		     "YAHOO maybe HTTP proxy packet 1 => need next packet\n");
+	    NDPI_LOG__DEBUG2(ndpi_struct, "YAHOO maybe HTTP proxy packet 1 => need next packet\n");
 	    flow->l4.tcp.yahoo_http_proxy_stage = 1 + packet->packet_direction;
 	    return;
 	  }
@@ -335,12 +325,12 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	    if ((packet->payload_packet_len > 250) && (memcmp(packet->payload, "<Session ", 9) == 0)) {
 	      if (ndpi_check_for_YmsgCommand(packet->payload_packet_len, packet->payload)) {
 		
-		NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found HTTP Proxy Yahoo Chat <Ymsg Command= pattern  \n");
+		NDPI_LOG__TRACE(ndpi_struct, "found HTTP Proxy Yahoo Chat <Ymsg Command= pattern  \n");
 		ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 		return;
 	      }
 	    }
-	    NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "YAHOO maybe HTTP proxy still initial direction => need next packet\n");
+	    NDPI_LOG__DEBUG2(ndpi_struct, "YAHOO maybe HTTP proxy still initial direction => need next packet\n");
 	    return;
 	  }
 	  if (flow->l4.tcp.yahoo_http_proxy_stage == 2 - packet->packet_direction) {
@@ -354,7 +344,7 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 		  memcmp(packet->line[4].ptr, "<Session ", 9) == 0 &&
 		  memcmp(packet->line[8].ptr, "<Ymsg ", 6) == 0) {
 
-		NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "found YAHOO over HTTP proxy");
+		NDPI_LOG__TRACE(ndpi_struct, "found YAHOO over HTTP proxy");
 		ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_YAHOO, NDPI_PROTOCOL_UNKNOWN);
 		return;
 	      }
@@ -362,16 +352,15 @@ static void ndpi_search_yahoo_tcp(struct ndpi_detection_module_struct *ndpi_stru
 	  }
 	}
     }
-    /* exclude YAHOO */
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_YAHOO);
-  }
+
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 void ndpi_search_yahoo(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_YAHOO, ndpi_struct, NDPI_LOG_DEBUG, "search yahoo\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search yahoo\n");
   
   if(packet->payload_packet_len > 0 && flow->yahoo_detection_finished == 0) {
 
@@ -385,13 +374,16 @@ void ndpi_search_yahoo(struct ndpi_detection_module_struct *ndpi_struct, struct 
 #ifdef NDPI_PROTOCOL_SSL
 	 || packet->detected_protocol_stack[0] == NDPI_PROTOCOL_SSL) {
 #endif
+        /* search over TCP */
 	ndpi_search_yahoo_tcp(ndpi_struct, flow);
       }
     }
     /* search over UDP */
     else if(packet->udp != NULL) {
-      if(flow->src == NULL || NDPI_COMPARE_PROTOCOL_TO_BITMASK(flow->src->detected_protocol_bitmask, NDPI_PROTOCOL_YAHOO) == 0)
-	NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_YAHOO);
+      if ( flow->src == NULL || 
+	   NDPI_COMPARE_PROTOCOL_TO_BITMASK(flow->src->detected_protocol_bitmask, NDPI_PROTOCOL_YAHOO) == 0) {
+	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      }
       return;
     }
   }

--- a/src/lib/protocols/zattoo.c
+++ b/src/lib/protocols/zattoo.c
@@ -20,9 +20,13 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_ZATTOO
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_ZATTOO
+
+#include "ndpi_api.h"
 	
 #ifndef WIN32
 static inline
@@ -33,12 +37,20 @@ u_int8_t ndpi_int_zattoo_user_agent_set(struct ndpi_detection_module_struct *ndp
 {
   if(flow->packet.user_agent_line.ptr != NULL && flow->packet.user_agent_line.len == 111) {
     if(memcmp(flow->packet.user_agent_line.ptr + flow->packet.user_agent_line.len - 25, "Zattoo/4", sizeof("Zattoo/4") - 1) == 0) {
-      NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "found zattoo useragent\n");
+      NDPI_LOG__DEBUG(ndpi_struct, "found zattoo useragent\n");
       return 1;
     }
   }
   return 0;
 }
+
+#define ZATTOO_DETECTED \
+      if (src != NULL)				 \
+	src->zattoo_ts = packet->tick_timestamp; \
+      if (dst != NULL)				 \
+	dst->zattoo_ts = packet->tick_timestamp; \
+						 \
+      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN)
 
 void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
@@ -47,6 +59,8 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
   struct ndpi_id_struct *dst = flow->dst;
 
   u_int16_t i;
+
+  NDPI_LOG__DEBUG(ndpi_struct, "search ZATTOO\n");
 
   if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_ZATTOO) {
     if(src != NULL && ((u_int32_t) (packet->tick_timestamp - src->zattoo_ts) < ndpi_struct->zattoo_connection_timeout))
@@ -59,26 +73,14 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
   if(packet->tcp != NULL) {
     if(packet->payload_packet_len > 50 && memcmp(packet->payload, "GET /frontdoor/fd?brand=Zattoo&v=", 33) == 0) {
 
-      NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "add connection over tcp with pattern GET /frontdoor/fd?brand=Zattoo&v=\n");
-
-      if (src != NULL)
-	src->zattoo_ts = packet->tick_timestamp;
-      if (dst != NULL)
-	dst->zattoo_ts = packet->tick_timestamp;
-      
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN);
+      NDPI_LOG__TRACE(ndpi_struct, "found zattoo. add connection over tcp with pattern GET /frontdoor/fd?brand=Zattoo&v=\n");
+      ZATTOO_DETECTED;
       return;
     }
     if(packet->payload_packet_len > 50	&& memcmp(packet->payload, "GET /ZattooAdRedirect/redirect.jsp?user=", 40) == 0) {
       
-      NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "add connection over tcp with pattern GET /ZattooAdRedirect/redirect.jsp?user=\n");
-
-      if(src != NULL)
-	src->zattoo_ts = packet->tick_timestamp;
-      if(dst != NULL)
-	dst->zattoo_ts = packet->tick_timestamp;
-      
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN);
+      NDPI_LOG__TRACE(ndpi_struct, "found zattoo. add connection over tcp with pattern GET /ZattooAdRedirect/redirect.jsp?user=\n");
+      ZATTOO_DETECTED;
       return;
     }
     if(packet->payload_packet_len > 50 && (memcmp(packet->payload, "POST /channelserver/player/channel/update HTTP/1.1", 50) == 0
@@ -89,14 +91,8 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
       for(i = 0; i < packet->parsed_lines; i++) {
 	if(packet->line[i].len >= 18 && (memcmp(packet->line[i].ptr, "User-Agent: Zattoo", 18) == 0)) {
 	  
-	  NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "add connection over tcp with pattern POST /channelserver/player/channel/update HTTP/1.1\n");
-	  
-	  if(src != NULL)
-	    src->zattoo_ts = packet->tick_timestamp;
-	  if(dst != NULL)
-	    dst->zattoo_ts = packet->tick_timestamp;
-	  
-	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN);
+	  NDPI_LOG__TRACE(ndpi_struct, "found zattoo. add connection over tcp with pattern POST /channelserver/player/channel/update HTTP/1.1\n");
+	  ZATTOO_DETECTED;
 	  return;
 	}
       }
@@ -107,12 +103,8 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
 
       if(ndpi_int_zattoo_user_agent_set(ndpi_struct, flow)) {
 	
-	if(src != NULL)
-	  src->zattoo_ts = packet->tick_timestamp;
-	if(dst != NULL)
-	  dst->zattoo_ts = packet->tick_timestamp;
-	
-	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN);
+	NDPI_LOG__TRACE(ndpi_struct, "found zattoo. add connection over tcp with pattern GET / or POST /\n");
+	ZATTOO_DETECTED;
 	return;
       }
     } else if(packet->payload_packet_len > 50 && memcmp(packet->payload, "POST http://", 12) == 0) {
@@ -141,14 +133,8 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
 	   && packet->payload[packet->empty_line_position + 6] ==
 	   0x0a && packet->payload[packet->empty_line_position + 7] == 0x00) {
 	  
-	  NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "add connection over tcp with pattern POST http://\n");
-	  
-	  if(src != NULL)
-	    src->zattoo_ts = packet->tick_timestamp;
-	  if(dst != NULL)
-	    dst->zattoo_ts = packet->tick_timestamp;
-	  
-	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN);
+	  NDPI_LOG__TRACE(ndpi_struct, "found zattoo. add connection over tcp with pattern POST http://\n");
+	  ZATTOO_DETECTED;
 	  return;
 	}
       }
@@ -160,20 +146,14 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
 	 && packet->payload[2] == 0x00
 	 && packet->payload[3] == 0x04 && packet->payload[4] == 0x0a && packet->payload[5] == 0x00) {
 	flow->zattoo_stage = 1 + packet->packet_direction;
-	NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "need next packet, seen pattern 0x030400040a00\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "need next packet, seen pattern 0x030400040a00\n");
 	return;
       }
       /* the following is searching for flash, not for zattoo. */
     } else if(flow->zattoo_stage == 2 - packet->packet_direction && packet->payload_packet_len > 50 && packet->payload[0] == 0x03 && packet->payload[1] == 0x04) {
       
-      NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "add connection over tcp with 0x0304.\n");
-
-      if(src != NULL)
-	src->zattoo_ts = packet->tick_timestamp;
-      if(dst != NULL)
-	dst->zattoo_ts = packet->tick_timestamp;
-      
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN);
+      NDPI_LOG__TRACE(ndpi_struct, "found zattoo. add connection over tcp with 0x0304\n");
+      ZATTOO_DETECTED;
       return;
       
     } else if(flow->zattoo_stage == 1 + packet->packet_direction) {
@@ -181,7 +161,7 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
 	
 	flow->zattoo_stage = 3 + packet->packet_direction;
 
-	NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "need next packet, seen pattern 0x0000\n");
+	NDPI_LOG__DEBUG2(ndpi_struct, "need next packet, seen pattern 0x0000\n");
 	return;
       }
       if(packet->payload_packet_len > 50
@@ -190,46 +170,29 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
 	  && packet->payload[2] == 0x00
 	  && packet->payload[3] == 0x04 && packet->payload[4] == 0x0a && packet->payload[5] == 0x00) {
       }
-      NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "need next packet, seen pattern 0x030400040a00\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "need next packet, seen pattern 0x030400040a00\n");
       return;
       
     } else if(flow->zattoo_stage == 4 - packet->packet_direction && packet->payload_packet_len > 50 && packet->payload[0] == 0x03 && packet->payload[1] == 0x04) {
 
-      NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "add connection over tcp with 0x0304.\n");
-      
-      if(src != NULL)
-	src->zattoo_ts = packet->tick_timestamp;
-      if(dst != NULL)
-	dst->zattoo_ts = packet->tick_timestamp;
-      
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN);
+      NDPI_LOG__TRACE(ndpi_struct, "found zattoo. add connection over tcp with 0x0304\n");
+      ZATTOO_DETECTED;
       return;
       
     } else if(flow->zattoo_stage == 5 + packet->packet_direction && (packet->payload_packet_len == 125)) {
 
-      NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "detected zattoo.\n");
-
-      if(src != NULL)
-	src->zattoo_ts = packet->tick_timestamp;
-      if(dst != NULL)
-	dst->zattoo_ts = packet->tick_timestamp;
-      
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN);
+      NDPI_LOG__TRACE(ndpi_struct, "found zattoo\n");
+      ZATTOO_DETECTED;
       return;
       
     } else if(flow->zattoo_stage == 6 - packet->packet_direction && packet->payload_packet_len == 1412) {
-      NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "found zattoo.\n");
 
-      if(src != NULL)
-	src->zattoo_ts = packet->tick_timestamp;
-      if(dst != NULL)
-	dst->zattoo_ts = packet->tick_timestamp;
-      
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN);
+      NDPI_LOG__TRACE(ndpi_struct, "found zattoo\n");
+      ZATTOO_DETECTED;
       return;
     }
     
-    NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
 	     "ZATTOO: discarded the flow (TCP): packet_size: %u; Flowstage: %u\n",
 	     packet->payload_packet_len, flow->zattoo_stage);
 
@@ -246,27 +209,21 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
       
       if(++flow->zattoo_stage == 2) {
 
-	NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "add connection over udp.\n");
-	if(src != NULL)
-	  src->zattoo_ts = packet->tick_timestamp;
-	if(dst != NULL)
-	  dst->zattoo_ts = packet->tick_timestamp;
-	
-	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_UNKNOWN);
+	NDPI_LOG__TRACE(ndpi_struct, "found zattoo. add connection over udp\n");
+	ZATTOO_DETECTED;
 	return;
       }
-      NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "need next packet udp.\n");
+      NDPI_LOG__DEBUG2(ndpi_struct, "need next packet udp\n");
       return;
     }
 
-    NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG,
+    NDPI_LOG__DEBUG2(ndpi_struct,
 	     "ZATTOO: discarded the flow (UDP): packet_size: %u; Flowstage: %u\n",
 	     packet->payload_packet_len, flow->zattoo_stage);
 
   }
-  /* exclude ZATTOO */
-  NDPI_LOG(NDPI_PROTOCOL_ZATTOO, ndpi_struct, NDPI_LOG_DEBUG, "exclude zattoo.\n");
-  NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_ZATTOO);
+
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/zeromq.c
+++ b/src/lib/protocols/zeromq.c
@@ -17,13 +17,16 @@
  * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "ndpi_api.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_ZMQ
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_ZMQ
+
+#include "ndpi_api.h"
 
 static void ndpi_int_zmq_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZMQ, NDPI_PROTOCOL_UNKNOWN);
-  NDPI_LOG(NDPI_PROTOCOL_ZMQ, ndpi_struct, NDPI_LOG_TRACE, "ZMQ Found.\n");
+  NDPI_LOG__TRACE(ndpi_struct, "found ZMQ\n");
 }
 
 
@@ -39,8 +42,7 @@ static void ndpi_check_zmq(struct ndpi_detection_module_struct *ndpi_struct, str
 
   /* Break after 17 packets. */
   if(flow->packet_counter > 17) {
-    NDPI_LOG(NDPI_PROTOCOL_ZMQ, ndpi_struct, NDPI_LOG_TRACE, "Exclude ZMQ.\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_ZMQ);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
@@ -85,7 +87,7 @@ static void ndpi_check_zmq(struct ndpi_detection_module_struct *ndpi_struct, str
 void ndpi_search_zmq(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  NDPI_LOG(NDPI_PROTOCOL_ZMQ, ndpi_struct, NDPI_LOG_TRACE, "ZMQ detection...\n");
+  NDPI_LOG__DEBUG(ndpi_struct, "search ZMQ\n");
 
   /* skip marked packets */
   if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_ZMQ) {

--- a/src/lib/third_party/src/ahocorasick.c
+++ b/src/lib/third_party/src/ahocorasick.c
@@ -258,6 +258,7 @@ void ac_automata_display (AC_AUTOMATA_t * thiz, char repcast)
   struct edge * e;
   AC_PATTERN_t sid;
 
+#ifndef __KERNEL__
   printf("---------------------------------\n");
 
   for (i=0; i<thiz->all_nodes_num; i++)
@@ -295,6 +296,7 @@ void ac_automata_display (AC_AUTOMATA_t * thiz, char repcast)
       }
       printf("---------------------------------\n");
     }
+#endif
 }
 
 /******************************************************************************

--- a/src/lib/third_party/src/ndpi_patricia.c
+++ b/src/lib/third_party/src/ndpi_patricia.c
@@ -55,6 +55,10 @@
 #endif
 #include "ndpi_patricia.h"
 
+#ifdef __KERNEL__
+#undef PATRICIA_DEBUG
+#endif
+
 void ndpi_DeleteEntry(void *a) {
   ndpi_free(a);
 }


### PR DESCRIPTION
levels of debug output:
 0 - ERROR: Only for errors.
 1 - TRACE: Start of each packets and if found protocol.
 2 - DEBUG: Start of searching each protocol and excluding protocols.
 3 - DEBUG_EXTRA: For all other messages.

Added field ndpi_struct->debug_logging for enable debug output of each protocols.

Simple macros for debugging output are added:
NDPI_LOG__ERROR(), NDPI_LOG__TRACE(), NDPI_LOG__DEBUG(), NDPI_LOG__DEBUG2(),
NDPI_EXCLUDE_PROTO()