### PR TITLE
Add libcache to installed headers and removed relative import

### DIFF
--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = ndpiReader
 
-AM_CPPFLAGS = -I$(top_srcdir)/src/include @PCAP_INC@
+AM_CPPFLAGS = -I$(top_srcdir)/src/include -I$(top_srcdir)/src/lib/third_party/include @PCAP_INC@
 AM_CFLAGS = @PTHREAD_CFLAGS@ # --coverage
 
 LDADD = $(top_builddir)/src/lib/libndpi.la @JSON_C_LIB@ @PTHREAD_LIBS@ @PCAP_LIB@ @DL_LIB@ -lm

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -25,7 +25,7 @@
 #define __NDPI_TYPEDEFS_H__
 
 #include "ndpi_define.h"
-#include "../lib/third_party/include/libcache.h"
+#include "libcache.h"
 
 #define BT_ANNOUNCE
 #define SNAP_EXT

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -12,7 +12,8 @@ libndpi_la_include_HEADERS = ../include/ndpi_api.h \
 			     ../include/ndpi_includes.h \
 			     ../include/ndpi_protocol_ids.h \
 			     ../include/ndpi_protocols.h \
-			     ../include/ndpi_typedefs.h
+			     ../include/ndpi_typedefs.h \
+			     third_party/include/libcache.h
 
 libndpi_la_SOURCES = ndpi_content_match.c.inc \
 		     ndpi_main.c \


### PR DESCRIPTION
My application (fastnetmon) refused to compile with the latest checkout of nDPI because of the relative import for libcache.h. This only works while building the source package but breaks after installing the header files to the system.

Also because the libcache header file wasn't added to the include headers, it didn't get copied to the system on install.