### PR TITLE
Add ndpi_includes.h to include headers

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -11,7 +11,8 @@ libndpi_la_include_HEADERS = ../include/ndpi_api.h \
 			     ../include/ndpi_main.h \
 			     ../include/ndpi_protocol_ids.h \
 			     ../include/ndpi_protocols.h \
-			     ../include/ndpi_typedefs.h
+			     ../include/ndpi_typedefs.h \
+			     ../include/ndpi_includes.h
 
 libndpi_la_SOURCES = ndpi_content_match.c.inc \
 		     ndpi_main.c \


### PR DESCRIPTION
Not sure if you still accept patches to this branch but without this the header file doesn't get installed to the system.