### PR TITLE
Added DHCP class identifier support.

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1031,6 +1031,7 @@ struct ndpi_flow_struct {
 
     struct {
       char fingerprint[48];
+      char class_ident[48];
     } dhcp;
   } protos;
 

--- a/src/lib/protocols/dhcp.c
+++ b/src/lib/protocols/dhcp.c
@@ -104,6 +104,13 @@ void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struct, stru
 		       "%02X",  dhcp->options[i+2+idx] & 0xFF);
 	      offset += 2;
 	    }
+	  } else if(id == 60 /* Class Identifier */) {
+	    char *name = (char*)&dhcp->options[i+2];
+	    int j = 0;
+
+	    j = ndpi_min(len, sizeof(flow->protos.dhcp.class_ident)-1);
+	    strncpy((char*)flow->protos.dhcp.class_ident, name, j);
+	    flow->protos.dhcp.class_ident[j] = '\0';
 	  } else if(id == 12 /* Host Name */) {
 	    char *name = (char*)&dhcp->options[i+2];
 	    int j = 0;


### PR DESCRIPTION
For improved OS detection via a service like [https://fingerbank.org/](url), three metrics can be combined to significantly improve accuracy:

1. DHCP parameter request list (fingerprint).
2. DHCP client identifier (when available).
3. Full UA from HTTP (when available).

The client-identifier is stored in the DHCP structure under the protocols union and is of 48 bytes in length.  Combined with the existing fingerprint buffer, the DHCP structure now occupies 96 bytes.  In other words, there is no additional memory required to store this additional information in the flow structure.