### PR TITLE
Fixed ndpi_win32.h so that it compiles on MinGW+GCC

### DIFF
--- a/src/include/ndpi_win32.h
+++ b/src/include/ndpi_win32.h
@@ -24,7 +24,18 @@
 #ifndef __NDPI_WIN32_H__
 #define __NDPI_WIN32_H__
 
+// fix a MinGW build issue "error: multiple storage classes in declaration specifiers" due to MinGW
+// defining extern for __forceinline types
+#if (defined(__MINGW32__) || defined(__MINGW64__)) && defined(__GNUC__)
+// MinGW winnt.h uses FORCEINLINE which is originally defined as __forceinline, but requires extern
+#undef FORCEINLINE
+#define FORCEINLINE extern __inline__ __attribute__((__always_inline__,__gnu_inline__))
+#undef __forceinline
+#define __forceinline __inline__ __attribute__((__always_inline__,__gnu_inline__))
+#endif
+
 #include <winsock2.h>
+#include <windows.h>
 #include <ws2tcpip.h>
 #include <process.h>
 #include <io.h>
@@ -40,7 +51,7 @@
 
 #define	IPVERSION	4 /* on *nix it is defined in netinet/ip.h */ 
 
-extern char* strsep(char **sp, const char *sep);
+extern char* strsep(char **sp, char *sep);
 
 typedef unsigned char  u_char;
 typedef unsigned short u_short;

--- a/src/include/ndpi_win32.h
+++ b/src/include/ndpi_win32.h
@@ -27,11 +27,8 @@
 // fix a MinGW build issue "error: multiple storage classes in declaration specifiers" due to MinGW
 // defining extern for __forceinline types
 #if (defined(__MINGW32__) || defined(__MINGW64__)) && defined(__GNUC__)
-// MinGW winnt.h uses FORCEINLINE which is originally defined as __forceinline, but requires extern
-#undef FORCEINLINE
-#define FORCEINLINE extern __inline__ __attribute__((__always_inline__,__gnu_inline__))
-#undef __forceinline
-#define __forceinline __inline__ __attribute__((__always_inline__,__gnu_inline__))
+#define MINGW_GCC
+#define __mingw_forceinline __inline__ __attribute__((__always_inline__,__gnu_inline__))
 #endif
 
 #include <winsock2.h>

--- a/src/lib/protocols/attic/ftp.c
+++ b/src/lib/protocols/attic/ftp.c
@@ -43,6 +43,8 @@ static void ndpi_int_ftp_add_connection(struct ndpi_detection_module_struct *ndp
  */
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif
@@ -78,8 +80,11 @@ u_int8_t ndpi_int_check_possible_ftp_command(const struct ndpi_packet_struct *pa
 /**
  * ftp replies are are 3-digit number followed by space or hyphen
  */
+
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif
@@ -108,6 +113,8 @@ u_int8_t ndpi_int_check_possible_ftp_reply(const struct ndpi_packet_struct *pack
  */
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif

--- a/src/lib/protocols/irc.c
+++ b/src/lib/protocols/irc.c
@@ -39,8 +39,11 @@ static void ndpi_int_irc_add_connection(struct ndpi_detection_module_struct *ndp
 }
 
 	
+
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif

--- a/src/lib/protocols/qq.c
+++ b/src/lib/protocols/qq.c
@@ -81,6 +81,8 @@ static const u_int16_t ndpi_valid_qq_versions[] = {
 	
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif
@@ -172,6 +174,8 @@ u_int8_t ndpi_is_valid_qq_packet(const struct ndpi_packet_struct *packet)
 	
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif
@@ -428,6 +432,8 @@ static void ndpi_search_qq_udp(struct ndpi_detection_module_struct *ndpi_struct,
 	
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif

--- a/src/lib/protocols/rtp.c
+++ b/src/lib/protocols/rtp.c
@@ -148,6 +148,8 @@ static void ndpi_int_rtp_add_connection(struct ndpi_detection_module_struct
 
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif
@@ -162,6 +164,8 @@ void init_seq(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow
 
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif

--- a/src/lib/protocols/sip.c
+++ b/src/lib/protocols/sip.c
@@ -34,6 +34,8 @@ static void ndpi_int_sip_add_connection(struct ndpi_detection_module_struct *ndp
 
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif

--- a/src/lib/protocols/sopcast.c
+++ b/src/lib/protocols/sopcast.c
@@ -43,6 +43,8 @@ static void ndpi_int_sopcast_add_connection(struct ndpi_detection_module_struct
 	
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif

--- a/src/lib/protocols/telnet.c
+++ b/src/lib/protocols/telnet.c
@@ -37,6 +37,8 @@ static void ndpi_int_telnet_add_connection(struct ndpi_detection_module_struct
 	
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif

--- a/src/lib/protocols/thunder.c
+++ b/src/lib/protocols/thunder.c
@@ -47,6 +47,8 @@ static void ndpi_int_thunder_add_connection(struct ndpi_detection_module_struct 
 	
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif
@@ -81,6 +83,8 @@ void ndpi_int_search_thunder_udp(struct ndpi_detection_module_struct
 	
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif
@@ -139,6 +143,8 @@ void ndpi_int_search_thunder_tcp(struct ndpi_detection_module_struct
 	
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif

--- a/src/lib/protocols/world_of_warcraft.c
+++ b/src/lib/protocols/world_of_warcraft.c
@@ -38,6 +38,8 @@ static void ndpi_int_worldofwarcraft_add_connection(struct ndpi_detection_module
 
 #if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif

--- a/src/lib/protocols/yahoo.c
+++ b/src/lib/protocols/yahoo.c
@@ -52,8 +52,10 @@ static u_int8_t ndpi_check_for_YmsgCommand(u_int16_t len, const u_int8_t * ptr)
 }
 
        
-#ifndef WIN32
+#if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif

--- a/src/lib/protocols/zattoo.c
+++ b/src/lib/protocols/zattoo.c
@@ -24,8 +24,10 @@
 
 #ifdef NDPI_PROTOCOL_ZATTOO
 	
-#ifndef WIN32
+#if !defined(WIN32)
 static inline
+#elif defined(MINGW_GCC)
+__mingw_forceinline static
 #else
 __forceinline static
 #endif


### PR DESCRIPTION
The Windows build process seems relatively untested and I had to make a couple of changes to make it build on MinGW-w64 (autotools Perl include paths actually seems to be broken on base MinGW, so technically this is on MSYS2 in the MinGW-w64 toolchain, where autotools works without fiddling...)

I'm not sure I like the `__forceinline` redefine, but it works and is restricted to MinGW GCC builds. The only alternative I can think of is defining an `ndpi_forceinline` macro or similar, but that's a more sweeping change.

Known issue: the example still doesn't compile (while the example has a `WIN32` ifdef, it tries to include `sys/socket.h` which is not "and will never be" a part of MinGW - you're supposed to just use `winsock2.h` which is also included). It does on Cygwin but that's because it's a full compatibility layer with the associated baggage. I just ran `make` in the `src/libs` dir and copied the library files; I don't know if `make install` matters on Windows anyway.