### PR TITLE
Return before calling ndpi_match_host_subprotocol when...

### DIFF
--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -197,6 +197,9 @@ void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 	off++;
       }
 
+	if(is_query && ndpi_struct->dns_dissect_response)
+	  return; /* The response will set the verdict */
+
       flow->host_server_name[j] = '\0';
 
       flow->protos.dns.num_queries = (u_int8_t)dns_header.num_queries,
@@ -217,9 +220,6 @@ void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 #endif
     
       if(flow->packet.detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) {
-	if(is_query && ndpi_struct->dns_dissect_response)
-	  return; /* The response will set the verdict */
-	
 	/**
 	   Do not set the protocol with DNS if ndpi_match_host_subprotocol() has
 	   matched a subprotocol


### PR DESCRIPTION
ndpi_flow.**dns_dissect_response** is enabled.

Otherwise responses will never be seen if a host sub-protocol matched (ndpi_flow->packet.detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN).

Dissecting DNS responses is disabled by default and is likely not used by many implementations.  It is possible this is a bug that has gone unnoticed.