### PR TITLE
Add ndpi_set_proto_category, which is actually used by ntopng.

### DIFF
--- a/libndpi.sym
+++ b/libndpi.sym
@@ -59,3 +59,4 @@ ndpi_category_set_name
 ndpi_category_get_name
 ndpi_is_custom_category
 ndpi_is_subprotocol_informative
+ndpi_set_proto_category


### PR DESCRIPTION
While testing the FreeBSD port update I got an error about missing symbols when compiling ntopng, so I think this should be added to the exported ones.