### PR TITLE
Fix MPLS header parsing in ndpiReader.

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -178,7 +178,15 @@ struct ndpi_wifi_header
 PACK_ON
 struct ndpi_mpls_header
 {
+  /* Before using this strcut to parse an MPLS header, you will need to convert
+   * the 4-byte data to the correct endianess with ntohl(). */
+#if defined(__LITTLE_ENDIAN__)
+  u_int32_t ttl:8, s:1, exp:3, label:20;
+#elif defined(__BIG_ENDIAN__)
   u_int32_t label:20, exp:3, s:1, ttl:8;
+#else
+# error "Byte order must be defined"
+#endif
 } PACK_OFF;
 
 /* ++++++++++++++++++++++++ IP header ++++++++++++++++++++++++ */


### PR DESCRIPTION
Reported at https://bugs.debian.org/886133.
The current parsing for the MPLS header in examples/ndpi_util.c has
multiple issues:
- the bitfield order is incorrect for little endian architectures
- ntohl() is applied to a 20 bit label, which has unclear purpose
- if multiple labels are detected, the while loop parsing labels will
never exit due to a missing re-read of the mpls label
- the last label is identified by looking inside the label field, while
it should be done by looking at the S bit

This change fixes the above issues.
Notice that bitfield ordering is implementation-dependent, so C
bitfields should not be used in the first place to parse network
packets.