### PR TITLE
Initial support for Intel hyperscan pattern matching library

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -937,6 +937,11 @@ struct ndpi_detection_module_struct {
 
   u_int8_t http_dont_dissect_response:1, dns_dissect_response:1,
     direction_detect_disable:1; /* disable internal detection of packet direction */
+
+#ifdef HAVE_HYPERSCAN
+  hs_database_t *hs_database;
+  hs_scratch_t *hs_scratch;
+#endif
 };
 
 struct ndpi_flow_struct {


### PR DESCRIPTION
The [Intel hypescan library](https://github.com/intel/hyperscan) is a high-performance multiple regex matching library. It follows the [pcrepattern regex pattern](https://www.pcre.org/original/doc/html/pcrepattern.html).

This commit provides an initial skeleton for the library integration, which could be a possible replacement for the ndpi automa (in some enviroments).

This code is a work-in-progress, the steps needed for full integration are:
- Add configure script detection of this library. It should set `HAVE_HYPERSCAN`, include `hs/hs.h` , and link with `-lhs`
- `hs_compile_multi` should be initialized with the contents of `ndpi_content_match.c.inc` file
- When the hyperscan library is used, the original ndpi automa initialization code should be disabled
- Use in bigrams, content matching and other points where the ndpi automa is used