### PR TITLE
Update libcache

### DIFF
--- a/src/lib/third_party/include/libcache.h
+++ b/src/lib/third_party/include/libcache.h
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include <stdint.h>
 
+typedef struct cache_entry *cache_entry;
+
+typedef struct cache_entry_map *cache_entry_map;
+
 /**
  * @brief Codes representing the result of some functions
  *
@@ -99,5 +103,7 @@ cache_result cache_remove(cache_t cache, void *item, uint32_t item_size);
  */
 void cache_free(cache_t cache);
 
+cache_entry cache_entry_new(void);
+cache_entry_map cache_entry_map_new(void);
 
 #endif


### PR DESCRIPTION
Using ndpi_calloc(), ndpi_free() in libcache.
Fixing warnings about mixing declaration and code.