### PR TITLE
Added option --enable-debug-messages.

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -109,6 +109,10 @@ AS_IF([test "x$enable_json_c" != "xno"], [
 	     ])
        ])
 
+AC_ARG_ENABLE([debug-messages],
+    AS_HELP_STRING([--enable-debug-messages], [Define NDPI_ENABLE_DEBUG_MESSAGES=1]), [
+	AC_DEFINE(NDPI_ENABLE_DEBUG_MESSAGES, 1, [Enable ndpi_debug_messages]) ])
+
 AC_CHECK_LIB(pthread, pthread_setaffinity_np, AC_DEFINE_UNQUOTED(HAVE_PTHREAD_SETAFFINITY_NP, 1, [libc has pthread_setaffinity_np]))
 
 AC_CONFIG_FILES([Makefile src/lib/Makefile example/Makefile tests/Makefile libndpi.pc src/include/ndpi_define.h])

--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -24,6 +24,7 @@
 #ifndef __NDPI_MAIN_H__
 #define __NDPI_MAIN_H__
 
+#include "ndpi_config.h"
 #include "ndpi_includes.h"
 #include "ndpi_define.h"
 #include "ndpi_protocol_ids.h"

--- a/src/lib/protocols/checkmk.c
+++ b/src/lib/protocols/checkmk.c
@@ -21,10 +21,14 @@
  *
  *
  */
-
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #ifdef NDPI_PROTOCOL_CHECKMK
+
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_CHECKMK
+
+#include "ndpi_api.h"
+
 
 static void ndpi_int_checkmk_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					    struct ndpi_flow_struct *flow)

--- a/src/lib/protocols/non_tcp_udp.c
+++ b/src/lib/protocols/non_tcp_udp.c
@@ -23,9 +23,11 @@
  */
 
 
-#include "ndpi_protocols.h"
+#include "ndpi_protocol_ids.h"
 
 #if defined(NDPI_PROTOCOL_IP_IPSEC) || defined(NDPI_PROTOCOL_IP_GRE) || defined(NDPI_PROTOCOL_IP_ICMP)  || defined(NDPI_PROTOCOL_IP_IGMP) || defined(NDPI_PROTOCOL_IP_EGP) || defined(NDPI_PROTOCOL_IP_SCTP) || defined(NDPI_PROTOCOL_IP_OSPF) || defined(NDPI_PROTOCOL_IP_IP_IN_IP)
+
+#include "ndpi_api.h"
 
 #define set_protocol_and_bmask(nprot)					\
   {									\

--- a/src/lib/protocols/openft.c
+++ b/src/lib/protocols/openft.c
@@ -28,7 +28,7 @@
 
 #define NDPI_CURRENT_PROTO NDPI_PROTOCOL_OPENFT
 
-#include "ndpi_protocols.h"
+#include "ndpi_api.h"
 
 static void ndpi_int_openft_add_connection(struct ndpi_detection_module_struct
 					   *ndpi_struct, struct ndpi_flow_struct *flow)


### PR DESCRIPTION
The configurator option "--enable-debug-messages" is added to enable
debug information output (define NDPI_ENABLE_DEBUG_MESSAGES=1).
Mandatory inclusion of the file ndpi_config.h in all the compiled files.