### PR TITLE
Add chmod +x to the generated configure file in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -44,4 +44,5 @@ autoreconf -ivf
 cat configure | sed "s/#define PACKAGE/#define NDPI_PACKAGE/g" | sed "s/#define VERSION/#define NDPI_VERSION/g"  > configure.tmp
 cat configure.tmp > configure
 
+chmod +x configure
 ./configure $*


### PR DESCRIPTION
Fix an error when running autogen.sh on Ubuntu (16.04 LTS):

`
zyp@zyp-pc:~/code/nDPI_zyp$ ./autogen.sh 
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: running: /usr/bin/autoconf --force
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:7: installing './compile'
configure.ac:5: installing './missing'
example/Makefile.am: installing './depcomp'
autoreconf: Leaving directory `.'
./autogen.sh: 47: ./autogen.sh: ./configure: Permission denied
zyp@zyp-pc:~/code/nDPI_zyp$ 
`

Simply adding a chmod command to make the generated "configure" file executable fixes it.