### PR TITLE
Fix several bugs found by Address Sanitizer (ASan)

### DIFF
--- a/example/MacOS/ndpiExample/ndpiExample.xcodeproj/project.pbxproj
+++ b/example/MacOS/ndpiExample/ndpiExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E32F1ECB20844620005739B7 /* whatsapp.c in Sources */ = {isa = PBXBuildFile; fileRef = E32F1ECA20844620005739B7 /* whatsapp.c */; };
 		E3953F5420254989000BBA0D /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E3953F5320254989000BBA0D /* AppDelegate.m */; };
 		E3953F5720254989000BBA0D /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E3953F5620254989000BBA0D /* ViewController.m */; };
 		E3953F5920254989000BBA0D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E3953F5820254989000BBA0D /* Assets.xcassets */; };
@@ -187,6 +188,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		E32F1ECA20844620005739B7 /* whatsapp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = whatsapp.c; sourceTree = "<group>"; };
 		E3953F4F20254989000BBA0D /* ndpiExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ndpiExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3953F5220254989000BBA0D /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		E3953F5320254989000BBA0D /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -644,6 +646,7 @@
 				E39542ED20255354000BBA0D /* yahoo.c */,
 				E39542EE20255354000BBA0D /* zattoo.c */,
 				E39542EF20255354000BBA0D /* zeromq.c */,
+				E32F1ECA20844620005739B7 /* whatsapp.c */,
 			);
 			path = protocols;
 			sourceTree = "<group>";
@@ -947,6 +950,7 @@
 				E395454420255355000BBA0D /* zattoo.c in Sources */,
 				E39544FD20255354000BBA0D /* noe.c in Sources */,
 				E395451620255354000BBA0D /* shoutcast.c in Sources */,
+				E32F1ECB20844620005739B7 /* whatsapp.c in Sources */,
 				E395455E202558E6000BBA0D /* ndpi_util.c in Sources */,
 				E3953F5420254989000BBA0D /* AppDelegate.m in Sources */,
 				E39543C520255354000BBA0D /* dropbox.c in Sources */,

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -663,7 +663,7 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
 
       /* Check for additional field introduced by Steam */
       int x = 1;
-      if((memcmp(packet->line[x].ptr, "x-steam-sid", 11)) == 0) {
+      if(packet->line[x].len >= 11 && (memcmp(packet->line[x].ptr, "x-steam-sid", 11)) == 0) {
 	    NDPI_LOG_INFO(ndpi_struct, "found STEAM\n");
 	    ndpi_int_http_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_STEAM);
 	    check_content_type_and_change_protocol(ndpi_struct, flow);

--- a/src/lib/protocols/msn.c
+++ b/src/lib/protocols/msn.c
@@ -442,15 +442,16 @@ static void ndpi_search_msn_tcp(struct ndpi_detection_module_struct *ndpi_struct
   }
   NDPI_LOG_DBG(ndpi_struct, "msn 7\n");
   
-  if (flow->packet_counter <= MAX_PACKETS_FOR_MSN) {	
-    if (memcmp(&packet->payload[0], "MSG ", 4) == 0
+  if (flow->packet_counter <= MAX_PACKETS_FOR_MSN) {
+    if (packet->payload_packet_len >=4 &&  (memcmp(&packet->payload[0], "MSG ", 4) == 0
 	|| memcmp(&packet->payload[0], "PNG", 3) == 0
 	|| memcmp(&packet->payload[0], "QNG ", 4) == 0
 	|| memcmp(&packet->payload[0], "OUT", 3) == 0
 	|| memcmp(&packet->payload[0], "RNG ", 4) == 0
 	|| memcmp(&packet->payload[0], "NLN ", 4) == 0
 	|| memcmp(&packet->payload[0], "UBX ", 4) == 0
-	|| memcmp(&packet->payload[0], "XFR ", 4) == 0) {
+	|| memcmp(&packet->payload[0], "XFR ", 4) == 0)
+       ){
       ndpi_int_msn_add_connection(ndpi_struct, flow);
       
       NDPI_LOG_INFO(ndpi_struct, "found MSN\n");

--- a/src/lib/protocols/tor.c
+++ b/src/lib/protocols/tor.c
@@ -31,7 +31,7 @@ int ndpi_is_ssl_tor(struct ndpi_detection_module_struct *ndpi_struct,
     len = strlen(certificate);
 
   /* Check if it ends in .com or .net */
-  if(strcmp(&certificate[len-4], ".com") && strcmp(&certificate[len-4], ".net"))
+  if(len>=4 && strcmp(&certificate[len-4], ".com") && strcmp(&certificate[len-4], ".net"))
     return(0);
   
   if((len < 6)


### PR DESCRIPTION
I tried to use Address Sanitizer (ASan, https://github.com/google/sanitizers) to detect bad memory access. I used the build-in Address Sanitizer setting in Xcode project to enable it (Product->Scheme->Edit Scheme->Diagnostics, check "Address Sanitizer").

I found several bugs after running against several pcap files. These bugs are all caused by reading memory that is out of the assigned bound, e.g., the packet payload length is 3 and we memcmp it to a 4-char C string.