### PR TITLE
Moved ndpi_config.h from ndpi_main.h to ndpi_main.c...

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -18,6 +18,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "ndpi_config.h"
+#endif
+
 #ifdef linux
 #define _GNU_SOURCE
 #include <sched.h>

--- a/example/ndpi_util.c
+++ b/example/ndpi_util.c
@@ -21,6 +21,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "ndpi_config.h"
+#endif
+
 #include <stdlib.h>
 
 #ifdef WIN32

--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -24,7 +24,6 @@
 #ifndef __NDPI_MAIN_H__
 #define __NDPI_MAIN_H__
 
-#include "ndpi_config.h"
 #include "ndpi_includes.h"
 #include "ndpi_define.h"
 #include "ndpi_protocol_ids.h"

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -21,6 +21,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "ndpi_config.h"
+#endif
+
 #include <stdlib.h>
 #include <errno.h>
 #include "ahocorasick.h"


### PR DESCRIPTION
... and example source files.

This fixes the changes made in commit 0624afd422b7fbdd2b481a299ac9bf62fa9ec706 where the autoconf-generated config was being included from the public API via ndpi_main.h.

Autoconf configs are not meant to be included into global scope.