### PR TITLE
Added missing file, func, and line parameters to call-back typedef.

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -61,7 +61,8 @@ typedef struct ndpi_protocol_bitmask_struct {
 
 /* NDPI_DEBUG_FUNCTION_PTR (cast) */
 typedef void (*ndpi_debug_function_ptr) (u_int32_t protocol, void *module_struct,
-					 ndpi_log_level_t log_level, const char *format, ...);
+					 ndpi_log_level_t log_level, const char *file, const char *func, unsigned line,
+					 const char *format, ...);
 
 
 /* ************************************************************ */


### PR DESCRIPTION
I believe the prototype for ndpi_debug_function_ptr is missing the file, func, and line parameters.