### PR TITLE
Extract SSL/TLS version and Cipher Suite

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1003,8 +1003,7 @@ struct ndpi_flow_struct {
     } ntp;
 
     struct {
-      u_int8_t ssl_version, tls_version;
-      u_int16_t cipher_suite;
+      u_int16_t version, cipher_suite;
       char client_certificate[48], server_certificate[48];
     } ssl;
 

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1003,6 +1003,8 @@ struct ndpi_flow_struct {
     } ntp;
 
     struct {
+      u_int8_t ssl_version, tls_version;
+      u_int16_t cipher_suite;
       char client_certificate[48], server_certificate[48];
     } ssl;
 

--- a/src/lib/protocols/ssl.c
+++ b/src/lib/protocols/ssl.c
@@ -186,19 +186,22 @@ int getSSLcertificate(struct ndpi_detection_module_struct *ndpi_struct,
 
     if (handshake_protocol == 0x02) {
 
-        flow->protos.ssl.ssl_version = packet->payload[9];
-        flow->protos.ssl.tls_version = packet->payload[10];
+        flow->protos.ssl.version = 
+            packet->payload[10] + (packet->payload[9] << 8);
 
-        NDPI_LOG_DBG2(ndpi_struct, "SSL/TLS version: 0x%02hhx/0x%02hhx\n",
-            flow->protos.ssl.ssl_version, flow->protos.ssl.tls_version);
+        NDPI_LOG_DBG2(ndpi_struct, "SSL/TLS version: 0x%04hx\n",
+            flow->protos.ssl.version);
 
         u_int offset, base_offset = 43;
         if (base_offset <= packet->payload_packet_len) {
             u_int16_t session_id_len = packet->payload[base_offset];
-            flow->protos.ssl.cipher_suite = packet->payload[base_offset + session_id_len + 2] + (packet->payload[base_offset + session_id_len + 1] << 8);
 
-            NDPI_LOG_DBG2(ndpi_struct, "SSL session ID len: %hu, %04hx\n",
-                session_id_len, flow->protos.ssl.cipher_suite);
+            flow->protos.ssl.cipher_suite = 
+                packet->payload[base_offset + session_id_len + 2] +
+                (packet->payload[base_offset + session_id_len + 1] << 8);
+
+            NDPI_LOG_DBG2(ndpi_struct, "SSL cipher suite: 0x%04hx\n",
+                flow->protos.ssl.cipher_suite);
         }
     }
 


### PR DESCRIPTION
For review:

This patch extracts the SSL/TLS version and Cipher Suite from the TLS Handshake/ServerHello packet.  We use this information to look for and warn about known, insecure versions/ciphers.