### PR TITLE
Extract SSL/TLS version and cipher suite

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1004,6 +1004,8 @@ struct ndpi_flow_struct {
     } ntp;
 
     struct {
+      u_int8_t ssl_version, tls_version;
+      u_int16_t cipher_suite;
       char client_certificate[48], server_certificate[48];
     } ssl;
 

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1004,8 +1004,7 @@ struct ndpi_flow_struct {
     } ntp;
 
     struct {
-      u_int8_t ssl_version, tls_version;
-      u_int16_t cipher_suite;
+      u_int16_t version, cipher_suite;
       char client_certificate[48], server_certificate[48];
     } ssl;
 

--- a/src/lib/protocols/ssl.c
+++ b/src/lib/protocols/ssl.c
@@ -186,19 +186,22 @@ int getSSLcertificate(struct ndpi_detection_module_struct *ndpi_struct,
 
     if (handshake_protocol == 0x02) {
 
-        flow->protos.ssl.ssl_version = packet->payload[9];
-        flow->protos.ssl.tls_version = packet->payload[10];
+        flow->protos.ssl.version = 
+            packet->payload[10] + (packet->payload[9] << 8);
 
-        NDPI_LOG_DBG2(ndpi_struct, "SSL/TLS version: 0x%02hhx/0x%02hhx\n",
-            flow->protos.ssl.ssl_version, flow->protos.ssl.tls_version);
+        NDPI_LOG_DBG2(ndpi_struct, "SSL/TLS version: 0x%04hx\n",
+            flow->protos.ssl.version);
 
         u_int offset, base_offset = 43;
         if (base_offset <= packet->payload_packet_len) {
             u_int16_t session_id_len = packet->payload[base_offset];
-            flow->protos.ssl.cipher_suite = packet->payload[base_offset + session_id_len + 2] + (packet->payload[base_offset + session_id_len + 1] << 8);
 
-            NDPI_LOG_DBG2(ndpi_struct, "SSL session ID len: %hu, %04hx\n",
-                session_id_len, flow->protos.ssl.cipher_suite);
+            flow->protos.ssl.cipher_suite = 
+                packet->payload[base_offset + session_id_len + 2] +
+                (packet->payload[base_offset + session_id_len + 1] << 8);
+
+            NDPI_LOG_DBG2(ndpi_struct, "SSL cipher suite: 0x%04hx\n",
+                flow->protos.ssl.cipher_suite);
         }
     }
 

--- a/src/lib/protocols/ssl.c
+++ b/src/lib/protocols/ssl.c
@@ -161,6 +161,10 @@ int getSSLcertificate(struct ndpi_detection_module_struct *ndpi_struct,
   }
 #endif
 
+	if (! flow->l4.tcp.ssl_seen_client_cert)
+        flow->protos.ssl.client_certificate[0] = '\0';
+	if (! flow->l4.tcp.ssl_seen_server_cert)
+        flow->protos.ssl.server_certificate[0] = '\0';
   /*
     Nothing matched so far: let's decode the certificate with some heuristics
     Patches courtesy of Denys Fedoryshchenko <nuclearcat@nuclearcat.com>
@@ -183,27 +187,6 @@ int getSSLcertificate(struct ndpi_detection_module_struct *ndpi_struct,
 	u_int num_found = 0;
 
 	flow->l4.tcp.ssl_seen_server_cert = 1;
-
-    if (handshake_protocol == 0x02) {
-
-        flow->protos.ssl.version = 
-            packet->payload[10] + (packet->payload[9] << 8);
-
-        NDPI_LOG_DBG2(ndpi_struct, "SSL/TLS version: 0x%04hx\n",
-            flow->protos.ssl.version);
-
-        u_int offset, base_offset = 43;
-        if (base_offset <= packet->payload_packet_len) {
-            u_int16_t session_id_len = packet->payload[base_offset];
-
-            flow->protos.ssl.cipher_suite = 
-                packet->payload[base_offset + session_id_len + 2] +
-                (packet->payload[base_offset + session_id_len + 1] << 8);
-
-            NDPI_LOG_DBG2(ndpi_struct, "SSL cipher suite: 0x%04hx\n",
-                flow->protos.ssl.cipher_suite);
-        }
-    }
 
 	/* Check after handshake protocol header (5 bytes) and message header (4 bytes) */
 	for(i = 9; i < packet->payload_packet_len-3; i++) {
@@ -249,11 +232,40 @@ int getSSLcertificate(struct ndpi_detection_module_struct *ndpi_struct,
 		stripCertificateTrailer(buffer, buffer_len);
 		snprintf(flow->protos.ssl.server_certificate,
 			 sizeof(flow->protos.ssl.server_certificate), "%s", buffer);
-		return(1 /* Server Certificate */);
+		break; /* Found Server Certificate; but now try to extract SSL/TLS version/cipher */
 	      }
 	    }
 	  }
 	}
+
+    if (handshake_protocol == 0x02) {
+
+        flow->protos.ssl.version =
+            packet->payload[10] + (packet->payload[9] << 8);
+
+        NDPI_LOG_DBG2(ndpi_struct, "SSL/TLS version: 0x%04hx\n",
+            flow->protos.ssl.version);
+
+        u_int offset, base_offset = 43;
+        if (base_offset <= packet->payload_packet_len) {
+            u_int16_t session_id_len = packet->payload[base_offset];
+
+            flow->protos.ssl.cipher_suite =
+                packet->payload[base_offset + session_id_len + 2] +
+                (packet->payload[base_offset + session_id_len + 1] << 8);
+
+            NDPI_LOG_DBG2(ndpi_struct, "SSL cipher suite: 0x%04hx\n",
+                flow->protos.ssl.cipher_suite);
+        }
+    }
+
+    if (flow->protos.ssl.server_certificate[0] != '\0')
+        return 1; /* Found Server Certificate. */
+    if (flow->protos.ssl.client_certificate[0] != '\0') {
+        snprintf(buffer, buffer_len, "%s", flow->protos.ssl.client_certificate);
+        return 2; /* Previously found Client Certificate. */
+    }
+
       } else if(handshake_protocol == 0x01 /* Client Hello */) {
 	u_int offset, base_offset = 43;
 	if (base_offset + 2 <= packet->payload_packet_len)


### PR DESCRIPTION
Extract SSL/TLS version from TLS ServerHello reply packets.  This will incur additional processing after seeing a ClientHello packet which previously would stop after seeing a client certificate.  The additional overhead would be minimal.  If this isn't desirable, I suggest it be made optional by enabling during compile-time or run-time. 