### PR TITLE
Remove autoconf include from typedefs header.

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -26,9 +26,6 @@
 
 #include "ndpi_define.h"
 
-/* Needed to have access to HAVE_* defines */
-#include "ndpi_config.h"
-
 /* NDPI_LOG_LEVEL */
 typedef enum {
   NDPI_LOG_ERROR,
@@ -853,14 +850,6 @@ typedef struct ndpi_proto {
 
 #define NUM_CUSTOM_CATEGORIES      5
 #define CUSTOM_CATEGORY_LABEL_LEN 32
-
-#ifdef HAVE_HYPERSCAN
-struct hs_list {
-  char *expression;
-  unsigned int id;
-  struct hs_list *next;
-};
-#endif
 
 #ifdef NDPI_LIB_COMPILATION
 

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -48,9 +48,13 @@
 
 #ifdef HAVE_HYPERSCAN
 #include <hs/hs.h>
-#endif
 
-#ifdef HAVE_HYPERSCAN
+struct hs_list {
+    char *expression;
+    unsigned int id;
+    struct hs_list *next;
+};
+
 struct hs {
   hs_database_t *database;
   hs_scratch_t  *scratch;


### PR DESCRIPTION
Including this file in any "public" API header breaks all projects that also use autotools because macros such as PACKAGE_VERSION will be redefined.

Signed-off-by: Darryl Sokoloski <darryl@sokoloski.ca>