### PR TITLE
Include <sys/types.h> for u_int16_t.

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -27,6 +27,7 @@
 
 #include <stdlib.h>
 #include <errno.h>
+#include <sys/types.h>
 #include "ahocorasick.h"
 #include "libcache.h"
 


### PR DESCRIPTION
On various embedded environments (ex: OpenWrt, EdgeOS), <sys/types.h> must be included for u_intX_t types.  The Hyperscan changes made recently introduced a u_int16_t member in actypes.h which is undeclared in certain environments without this explicit include.

Signed-off-by: Darryl Sokoloski <darryl@sokoloski.ca>