### PR TITLE
parse protocol's string_to_match into hex which could be match by hyperscan

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -811,12 +811,13 @@ static int hyperscan_load_patterns(struct hs *hs, u_int num_patterns,
 
 /* ******************************************************************** */
 
-char* string2hex(const char *pat) {
+static char* string2hex(const char *pat) {
   u_int patlen, i;
   char *hexbuf, *buf;
 
   patlen = strlen(pat);
   hexbuf = (char*)calloc(sizeof(char), patlen * 4 + 1);
+  if(!hexbuf) return(-1);
 
   for (i = 0, buf = hexbuf; i < patlen; i++, buf += 4) {
     snprintf(buf, 5, "\\x%02x", (unsigned char)pat[i]);


### PR DESCRIPTION
if one protocol do not have it's regex (pattern_to_match)
then parse it's string (string_to_match) into hex
so we can match every protocol with hyperscan
and we do not need to [add "\\\\" manually](https://github.com/ntop/nDPI/commit/d2bc3ea20927ace331abcd8b939cb6e74fbc8ce1).