### PR TITLE
ndpi_typedefs.h : missing include

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -25,6 +25,7 @@
 #define __NDPI_TYPEDEFS_H__
 
 #include "ndpi_define.h"
+#include "ndpi_protocol_ids.h"
 
 /* Needed to have access to HAVE_* defines */
 #include "ndpi_config.h"


### PR DESCRIPTION
include to ndpi_protocol_ids.h needed for:
- NDPI_PROTOCOL_SIZE
- NDPI_MAX_SUPPORTED_PROTOCOLS
- NDPI_MAX_NUM_CUSTOM_PROTOCOLS