### PR TITLE
- Respect CC variable, avoiding hardcoding gcc which for example is n…

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -32,7 +32,7 @@ $(NDPI_LIB_STATIC): $(OBJECTS)
 	   $(RANLIB) $@	       
 
 $(NDPI_LIB_SHARED): $(OBJECTS)
-	gcc -shared -fPIC -o $@ $(OBJECTS)
+	$(CC) -shared -fPIC -Wl,-soname,$(NDPI_LIB_SHARED) -o $@ $(OBJECTS)
 	ln -Fs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE)
 
 %.o: %.c $(HEADERS) Makefile


### PR DESCRIPTION
…ot present in FreeBSD by default.

- Provide a SONAME for the library. Required by FreeBSD pkg management tool to track libraries properly.