### PR TITLE
Move the configure include file inclusion and code depending on it in…

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -854,6 +854,22 @@ typedef struct ndpi_proto {
 
 #ifdef NDPI_LIB_COMPILATION
 
+/* Needed to have access to HAVE_* defines */
+#include "ndpi_config.h"
+
+#ifdef HAVE_HYPERSCAN
+struct hs_list {
+    char *expression;
+    unsigned int id;
+    struct hs_list *next;
+};
+
+struct hs {
+  hs_database_t *database;
+  hs_scratch_t  *scratch;
+};
+#endif
+
 struct ndpi_detection_module_struct {
   NDPI_PROTOCOL_BITMASK detection_bitmask;
   NDPI_PROTOCOL_BITMASK generic_http_packet_bitmask;

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -49,17 +49,6 @@
 
 #ifdef HAVE_HYPERSCAN
 #include <hs/hs.h>
-
-struct hs_list {
-    char *expression;
-    unsigned int id;
-    struct hs_list *next;
-};
-
-struct hs {
-  hs_database_t *database;
-  hs_scratch_t  *scratch;
-};
 #endif
 
 #define NDPI_CONST_GENERIC_PROTOCOL_NAME  "GenericProtocol"


### PR DESCRIPTION
… code protected by the NDPI_LIB_COMPILATION define, this should avoid it polluting the environment when including this file from ntopng.

This should fix the problem with configure generated include file being leaked when building ntopng, while keeping the same logic when building nDPI.

I have only compile tested this on FreeBSD. I need to run test this, which I will be able to do tomorrow.

In the while please review the patch, if the approach I've chosen is acceptable.

Thanks!