### PR TITLE
Prevent missing text lines and invalid reads past end-of-buffer.

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4641,7 +4641,11 @@ void ndpi_parse_packet_line_info(struct ndpi_detection_module_struct *ndpi_struc
   packet->line[packet->parsed_lines].ptr = packet->payload;
   packet->line[packet->parsed_lines].len = 0;
 
-  for(a = 0; a < packet->payload_packet_len-2; a++) {
+  for(a = 0; a < packet->payload_packet_len; a++) {
+
+    if((a + 1) == packet->payload_packet_len)
+	  return; /* Return if only one byte remains (prevent invalid reads past end-of-buffer) */
+
     if(get_u_int16_t(packet->payload, a) == ntohs(0x0d0a)) { /* If end of line char sequence CR+NL "\r\n", process line */
       packet->line[packet->parsed_lines].len = (u_int16_t)(((unsigned long) &packet->payload[a]) - ((unsigned long) packet->line[packet->parsed_lines].ptr));
 
@@ -4820,9 +4824,6 @@ void ndpi_parse_packet_line_info(struct ndpi_detection_module_struct *ndpi_struc
       packet->parsed_lines++;
       packet->line[packet->parsed_lines].ptr = &packet->payload[a + 2];
       packet->line[packet->parsed_lines].len = 0;
-
-      if((a + 2) >= packet->payload_packet_len)
-	    return;
 
       a++; /* next char in the payload */
     }


### PR DESCRIPTION
The recent revert commit 6373c355cfd497d57609b8ecfc62717758ac7154 applied to ndpi_parse_packet_line_info resurrects an old bug where the lines that are aligned with the end of the packet buffer will not be parsed.  The commit is an attempt to prevent invalid reads past the end of the packet buffer.  This PR moves the end-of-bounds test to before the 16-bit read and returns if true.  This fixes the case where a text line ends aligned to the end of the buffer, and it fixes the invalid read issue.

Here is a link to source code that demonstrates the problem: [test.c](http://sokoloski.ca/parse-line/test.c)

Here is a link to the Valgrind output from the above test program: [valgrind.log](http://sokoloski.ca/parse-line/valgrind.log)

Signed-off-by: Darryl Sokoloski <darryl@sokoloski.ca>