### PR TITLE
Do not use the available clang as the default compiler.

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -51,12 +51,6 @@ if test $SHORT_MACHINE = "arm"; then
 else
      AC_CHECK_LIB([numa], [numa_available], [LIBNUMA="-lnuma"])
 fi
-
-if test -z `which clang`; then
-CC=gcc
-else
-CC=clang
-fi
  
 HS_LIB=
 HS_INC=


### PR DESCRIPTION
You can use the CC environment variable when running autogen.sh and configure.