### PR TITLE
Symlink the shared library to pwd.

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -49,6 +49,6 @@ clean:
 install: $(NDPI_LIBS)
 	mkdir -p $(DESTDIR)$(libdir)
 	cp $(NDPI_LIBS) $(DESTDIR)$(libdir)/
-	ln -Fs $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED) $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED_BASE)
+	ln -Fs $(NDPI_LIB_SHARED) $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED_BASE)
 	mkdir -p $(DESTDIR)$(includedir)
 	cp ../include/*.h $(DESTDIR)$(includedir)


### PR DESCRIPTION
DESTDIR is used, for instance, by distros to facilitate installing
to a temp path for testing / package-building.

In general nDPI supports DESTDIR (yay!), but using an absolute path
for the target of the library link has two problems:

1) If DESTDIR is set to /some/tmp/path, we end up with a link that
points to /some/tmp/path/usr/lib/libndpi-x.y.z, which is definitely
not what is intended - once the package is installed, the link is
broken.

2) Absolute links are problematic for distributions; pointing to
/usr/lib/libndpi-x.y.z during package build-and-test would point to
either a nonexistent file, or an old and possibly wrong one.

Both of these are avoided if we just link to the target with no path
at all.