### PR TITLE
Use a more standard path for pkg-config files.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = src/lib example tests
 
-pkgconfigdir = $(prefix)/libdata/pkgconfig
+pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libndpi.pc
 
 EXTRA_DIST = autogen.sh


### PR DESCRIPTION
The Linuxes I've checked all seem to use /usr/{,local/}lib*/pkgconfig,
not /usr/libdata/.  I think FreeBSD does use /usr/libdata/ but also
supports /usr/lib*/pkgconfig, although I have not tested this change
on a FreeBSD system.

This should fix #621.