### PR TITLE
Correct the include file path in -I CFLAGS argument.

### DIFF
--- a/libndpi.pc.in
+++ b/libndpi.pc.in
@@ -7,4 +7,4 @@ Name: libndpi
 Description: deep packet inspection library
 Version: @VERSION@
 Libs: -L${libdir} -lndpi
-Cflags: -I${includedir}/libndpi-@VERSION@
+Cflags: -I${includedir}/ndpi


### PR DESCRIPTION
src/lib/Makefile.in install headers into ${prefix}/include/ndpi,
but the shipped libndpi.pc.in specifies a different path.  Therefore
anything trying to build using $(pkg-config --cflags libndpi) will
fail to find the nDPI headers.

This patch simply makes libndpi.pc.in agree with src/lib/Makefile.in.