### PR TITLE
Add SONAME property to shared library

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -25,6 +25,10 @@ NDPI_LIB_SHARED_BASE = libndpi.so
 NDPI_LIB_SHARED      = $(NDPI_LIB_SHARED_BASE).@NDPI_VERSION_SHORT@
 NDPI_LIBS            = $(NDPI_LIB_STATIC) $(NDPI_LIB_SHARED)
 
+ifneq ($(OS),Windows_NT)
+OS := $(shell uname)
+endif
+
 ifeq ($(OS),Darwin)
 CC=clang
 SONAME_FLAG=

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -27,6 +27,9 @@ NDPI_LIBS            = $(NDPI_LIB_STATIC) $(NDPI_LIB_SHARED)
 
 ifeq ($(OS),Darwin)
 CC=clang
+SONAME_FLAG=
+else
+SONAME_FLAG=-Wl,-soname,$(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR)
 endif
 
 all: $(NDPI_LIBS)
@@ -38,7 +41,7 @@ $(NDPI_LIB_STATIC): $(OBJECTS)
 	   $(RANLIB) $@	       
 
 $(NDPI_LIB_SHARED): $(OBJECTS)
-	$(CC) -shared -fPIC -Wl,-soname,$(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR) -o $@ $(OBJECTS)
+	$(CC) -shared -fPIC $(SONAME_FLAG) -o $@ $(OBJECTS)
 	ln -Ffs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE)
 
 %.o: %.c $(HEADERS) Makefile

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -19,6 +19,7 @@ RANLIB     = ranlib
 
 OBJECTS   = $(patsubst protocols/%.c, protocols/%.o, $(wildcard protocols/*.c)) $(patsubst third_party/src/%.c, third_party/src/%.o, $(wildcard third_party/src/*.c)) ndpi_main.o
 HEADERS   = $(wildcard ../include/*.h)
+NDPI_VERSION_MAJOR   = @NDPI_MAJOR@
 NDPI_LIB_STATIC      = libndpi.a
 NDPI_LIB_SHARED_BASE = libndpi.so
 NDPI_LIB_SHARED      = $(NDPI_LIB_SHARED_BASE).@NDPI_VERSION_SHORT@
@@ -37,7 +38,7 @@ $(NDPI_LIB_STATIC): $(OBJECTS)
 	   $(RANLIB) $@	       
 
 $(NDPI_LIB_SHARED): $(OBJECTS)
-	$(CC) -shared -fPIC -o $@ $(OBJECTS)
+	$(CC) -shared -fPIC -Wl,-soname,$(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR) -o $@ $(OBJECTS)
 	ln -Ffs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE)
 
 %.o: %.c $(HEADERS) Makefile


### PR DESCRIPTION
Added command in the Makefile to correctly populate the SONAME property of the shared object.

The command should work fine with both clang and GCC.