### PR TITLE
Also create the libndpi.so.2 link.

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -47,6 +47,7 @@ $(NDPI_LIB_STATIC): $(OBJECTS)
 $(NDPI_LIB_SHARED): $(OBJECTS)
 	$(CC) -shared -fPIC $(SONAME_FLAG) -o $@ $(OBJECTS)
 	ln -Ffs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE)
+	ln -Ffs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR)
 
 %.o: %.c $(HEADERS) Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
@@ -58,5 +59,6 @@ install: $(NDPI_LIBS)
 	mkdir -p $(DESTDIR)$(libdir)
 	cp $(NDPI_LIBS) $(DESTDIR)$(libdir)/
 	ln -Ffs $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED) $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED_BASE)
+	ln -Ffs $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED) $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR)
 	mkdir -p $(DESTDIR)$(includedir)
 	cp ../include/*.h $(DESTDIR)$(includedir)


### PR DESCRIPTION
This is created bydefault by all build tools for libraries and required in certain cases. FreeBSD linker requires it when using SONAME.