### PR TITLE
build: cleanup of dpdk examples.

### DIFF
--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -13,7 +13,7 @@ ndpiReader: $(OBJS) $(LIBNDPI)
 %.o: %.c $(HEADERS) Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
-install: ndpiReader
+install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin/
 	cp ndpiReader $(DESTDIR)$(PREFIX)/bin/
 	[ -f build/app/ndpiReader.dpdk ] && cp build/app/ndpiReader.dpdk $(DESTDIR)$(PREFIX)/bin/ || true
@@ -23,7 +23,9 @@ dpdk:
 	make -f Makefile.dpdk
 
 clean:
-	/bin/rm -f *.o ndpiReader
+	/bin/rm -f *.o ndpiReader ndpiReader.dpdk
+	/bin/rm -f .*.dpdk.cmd .*.o.cmd *.dpdk.map .*.o.d
+	/bin/rm -f _install _postbuild _postinstall _preinstall
 	/bin/rm -rf build
 
 distclean: clean


### PR DESCRIPTION
- clean install dependencies on example binary
- add more rules to clean command

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>