### PR TITLE
FIX H.323 broken detection

### DIFF
--- a/src/lib/protocols/h323.c
+++ b/src/lib/protocols/h323.c
@@ -31,8 +31,7 @@ void ndpi_search_h323(struct ndpi_detection_module_struct *ndpi_struct, struct n
     /* H323  */
     if(packet->payload_packet_len >= 3
        && (packet->payload[0] == 0x03)
-       && (packet->payload[1] == 0x00)
-       && (packet->payload[2] == 0x00)) {
+       && (packet->payload[1] == 0x00)) {
 	struct tpkt *t = (struct tpkt*)packet->payload;
 	u_int16_t len = ntohs(t->len);
 


### PR DESCRIPTION
TPKT header length field can have value more then 255, and in fact in all of the cases I've met it is more then 255.
Thus checking real H.323 packet like this:
(packet->payload[2] == 0x00)
stop detecting H.323 conversation at all.