### PR TITLE
Compute packet_direction consistently independently from endianness

### DIFF
--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -338,4 +338,26 @@
 #define NDPI_MINOR                              @NDPI_MINOR@
 #define NDPI_PATCH                              @NDPI_PATCH@
 
+
+#ifdef __APPLE__
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#endif /* __APPLE__ */
+
 #endif /* __NDPI_DEFINE_INCLUDE_FILE__ */

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -3693,7 +3693,7 @@ void ndpi_connection_tracking(struct ndpi_detection_module_struct *ndpi_struct,
   if(ndpi_struct->direction_detect_disable) {
     packet->packet_direction = flow->packet_direction;
   } else {
-    if(iph != NULL && iph->saddr < iph->daddr)
+    if(iph != NULL && le32toh(iph->saddr) < le32toh(iph->daddr))
       packet->packet_direction = 1;
 
 #ifdef NDPI_DETECTION_SUPPORT_IPV6
@@ -3717,7 +3717,7 @@ void ndpi_connection_tracking(struct ndpi_detection_module_struct *ndpi_struct,
     packet->num_retried_bytes = 0;
 
     if(!ndpi_struct->direction_detect_disable)
-      packet->packet_direction = (tcph->source < tcph->dest) ? 1 : 0;
+      packet->packet_direction = (le16toh(tcph->source) < le16toh(tcph->dest)) ? 1 : 0;
 
     if(tcph->syn != 0 && tcph->ack == 0 && flow->l4.tcp.seen_syn == 0 && flow->l4.tcp.seen_syn_ack == 0
        && flow->l4.tcp.seen_ack == 0) {
@@ -3781,7 +3781,7 @@ void ndpi_connection_tracking(struct ndpi_detection_module_struct *ndpi_struct,
     }
   } else if(udph != NULL) {
     if(!ndpi_struct->direction_detect_disable)
-      packet->packet_direction = (udph->source < udph->dest) ? 1 : 0;
+      packet->packet_direction = (le16toh(udph->source) < le16toh(udph->dest)) ? 1 : 0;
   }
 
   if(flow->packet_counter < MAX_PACKET_COUNTER && packet->payload_packet_len) {

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -96,8 +96,8 @@ void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
 	     && (packet->payload[i+1] == 'N')
 	     && (packet->payload[i+2] == 'I')
 	     && (packet->payload[i+3] == 0)) {
-	    u_int32_t offset = *((u_int32_t*)&packet->payload[i+4]);
-	    u_int32_t prev_offset = *((u_int32_t*)&packet->payload[i-4]);
+	    u_int32_t offset = le32toh(*((u_int32_t*)&packet->payload[i+4]));
+	    u_int32_t prev_offset = le32toh(*((u_int32_t*)&packet->payload[i-4]));
 	    int len = offset-prev_offset;
 	    int sni_offset = i+prev_offset+1;
 


### PR DESCRIPTION
Ensure packet_direction is computed in the same way on little endian and
big endian architectures.
This change will convert IP addresses and port from little endian to host
endian (instead of converting from network endian to host endian) so
that it does not change the behavior on little endian architecture where
ndpi is usually developed.
A better (but more invasive) change would be to use the ntoh*()
functions and then adjust all affected tests.
