### PR TITLE
Propagate prefix settings to Makefiles

### DIFF
--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -3,7 +3,7 @@ CFLAGS=-g -I../src/include @CFLAGS@
 LIBNDPI=../src/lib/libndpi.a
 LDFLAGS=$(LIBNDPI) @PCAP_LIB@ -lpthread @LDFLAGS@
 OBJS=ndpiReader.o ndpi_util.o
-PREFIX?=/usr/local
+PREFIX?=@prefix@
 
 all: ndpiReader @DPDK_TARGET@
 

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -10,7 +10,7 @@
 #
 # Installation directories
 #
-prefix     = /usr/local
+prefix     = @prefix@
 libdir     = ${prefix}/lib
 includedir = ${prefix}/include/ndpi
 CC         = @CC@


### PR DESCRIPTION
A "make install" was failing because the --prefix flag setting was not being propagated to the Makefiles.