### PR TITLE
Use ChangeLog date instead of build date

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -30,7 +30,7 @@ if test -d ".git"; then :
      GIT_RELEASE="${PACKAGE_VERSION}-${GIT_NUM}-${GIT_TAG}"
 else
      GIT_RELEASE="${PACKAGE_VERSION}"
-     GIT_DATE=`date`
+     GIT_DATE=`date -u -r CHANGELOG.md`
 fi
 
 AC_DEFINE_UNQUOTED(NDPI_GIT_RELEASE, "${GIT_RELEASE}", [GIT Release])


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

This date call works with GNU date and BSD date.
Also use UTC/gmtime to be independent of timezone.

This PR was done while working on reproducible builds for openSUSE.