### PR TITLE
Add NDPI prefix for HTTP_METHOD enum to avoid name collisions

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -356,15 +356,15 @@ PACK_ON struct tinc_cache_entry {
 } PACK_OFF;
 
 typedef enum {
-	      HTTP_METHOD_UNKNOWN = 0,
-	      HTTP_METHOD_OPTIONS,
-	      HTTP_METHOD_GET,
-	      HTTP_METHOD_HEAD,
-	      HTTP_METHOD_POST,
-	      HTTP_METHOD_PUT,
-	      HTTP_METHOD_DELETE,
-	      HTTP_METHOD_TRACE,
-	      HTTP_METHOD_CONNECT
+	      NDPI_HTTP_METHOD_UNKNOWN = 0,
+	      NDPI_HTTP_METHOD_OPTIONS,
+	      NDPI_HTTP_METHOD_GET,
+	      NDPI_HTTP_METHOD_HEAD,
+	      NDPI_HTTP_METHOD_POST,
+	      NDPI_HTTP_METHOD_PUT,
+	      NDPI_HTTP_METHOD_DELETE,
+	      NDPI_HTTP_METHOD_TRACE,
+	      NDPI_HTTP_METHOD_CONNECT
 } ndpi_http_method;
 
 struct ndpi_lru_cache {

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -260,25 +260,25 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
       }
 
       if(flow->packet.http_method.len < 3)
-        flow->http.method = HTTP_METHOD_UNKNOWN;
+        flow->http.method = NDPI_HTTP_METHOD_UNKNOWN;
       else {
         switch(flow->packet.http_method.ptr[0]) {
-        case 'O':  flow->http.method = HTTP_METHOD_OPTIONS; break;
-        case 'G':  flow->http.method = HTTP_METHOD_GET; break;
-        case 'H':  flow->http.method = HTTP_METHOD_HEAD; break;
+        case 'O':  flow->http.method = NDPI_HTTP_METHOD_OPTIONS; break;
+        case 'G':  flow->http.method = NDPI_HTTP_METHOD_GET; break;
+        case 'H':  flow->http.method = NDPI_HTTP_METHOD_HEAD; break;
 
         case 'P':
           switch(flow->packet.http_method.ptr[1]) {
-          case 'O': flow->http.method = HTTP_METHOD_POST; break;
-          case 'U': flow->http.method = HTTP_METHOD_PUT; break;
+          case 'O': flow->http.method = NDPI_HTTP_METHOD_POST; break;
+          case 'U': flow->http.method = NDPI_HTTP_METHOD_PUT; break;
           }
           break;
 
-        case 'D':   flow->http.method = HTTP_METHOD_DELETE; break;
-        case 'T':   flow->http.method = HTTP_METHOD_TRACE; break;
-        case 'C':   flow->http.method = HTTP_METHOD_CONNECT; break;
+        case 'D':   flow->http.method = NDPI_HTTP_METHOD_DELETE; break;
+        case 'T':   flow->http.method = NDPI_HTTP_METHOD_TRACE; break;
+        case 'C':   flow->http.method = NDPI_HTTP_METHOD_CONNECT; break;
         default:
-          flow->http.method = HTTP_METHOD_UNKNOWN;
+          flow->http.method = NDPI_HTTP_METHOD_UNKNOWN;
           break;
         }
       }
@@ -949,7 +949,7 @@ void ndpi_search_http_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 ndpi_http_method ndpi_get_http_method(struct ndpi_detection_module_struct *ndpi_mod,
 				      struct ndpi_flow_struct *flow) {
   if(!flow)
-    return(HTTP_METHOD_UNKNOWN);
+    return(NDPI_HTTP_METHOD_UNKNOWN);
   else
     return(flow->http.method);
 }


### PR DESCRIPTION
ref: https://stackoverflow.com/questions/35380279/avoid-name-collisions-with-enum-in-c-c99

Signed-off-by: chiehminw <chiehminw@synology.com>