### PR TITLE
The le32toh() function used in some places on BSD OSes requires sys/en…

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -41,6 +41,10 @@
 #include <unistd.h>
 #endif
 
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
+#include <sys/endian.h>
+#endif
+
 #include "ndpi_content_match.c.inc"
 #include "third_party/include/ndpi_patricia.h"
 #include "third_party/include/ht_hash.h"

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -22,6 +22,10 @@
  *
  */
 
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
+#include <sys/endian.h>
+#endif
+
 #include "ndpi_protocol_ids.h"
 
 #define NDPI_CURRENT_PROTO NDPI_PROTOCOL_QUIC


### PR DESCRIPTION
…dian.h to be included.