### PR TITLE
Use relative path for library link

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -61,7 +61,7 @@ distclean: clean
 install: $(NDPI_LIBS)
 	mkdir -p $(DESTDIR)$(libdir)
 	cp $(NDPI_LIBS) $(DESTDIR)$(libdir)/
-	ln -Ffs $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED) $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED_BASE)
-	ln -Ffs $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED) $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR)
+	cp -P $(NDPI_LIB_SHARED_BASE) $(DESTDIR)$(libdir)/
+	cp -P $(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR) $(DESTDIR)$(libdir)/
 	mkdir -p $(DESTDIR)$(includedir)
 	cp ../include/*.h $(DESTDIR)$(includedir)


### PR DESCRIPTION
relative link path can preserve link relation after packaging and
doplying to new machine

ex:
$ make DESTDIR=/tmp/ndpi install
$ tar czf ndpi.tar.gz /tmp/ndpi
$ tar xf ndpi.tar.gz -C /lib

Orignal install script will caused the /lib/libndpi.so.2 links to
/tmp/ndpi/libndpi.so.2.9.0 which is not intended

Signed-off-by: chiehminw <chiehminw@synology.com>