### PR TITLE
Fix double-strdup memory leak in ndpi_handle_rule

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -2837,7 +2837,7 @@ int ndpi_handle_rule(struct ndpi_detection_module_struct *ndpi_mod,
 			      ndpi_mod->ndpi_num_supported_protocols,
 			      0 /* can_have_a_subprotocol */, no_master,
 			      no_master,
-			      ndpi_strdup(proto),
+			      proto,
 			      NDPI_PROTOCOL_CATEGORY_UNSPECIFIED, /* TODO add protocol category support in rules */
 			      ndpi_build_default_ports(ports_a, 0, 0, 0, 0, 0) /* TCP */,
 			      ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);


### PR DESCRIPTION
proto is being strdup'd both in the call to ndpi_set_proto_defaults and
inside of that function as well, leaking the memory.