### PR TITLE
exit code of tests effects travis build status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ before_script:
 script:
   - ./configure
   - make
-
-after_script:
   - cd tests
   - ./do.sh
 


### PR DESCRIPTION
According to https://docs.travis-ci.com/user/job-lifecycle/#breaking-the-build the exit code of `after_script` does not effect build status.
Moving running the test to the scripts sections means if they fail it's caught and reported as part of the travis result.

Fixes #733 