### PR TITLE
Fix invalid function prototype

### DIFF
--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -798,7 +798,7 @@ extern "C" {
   //void * ndpi_malloc(size_t size);
   //void * ndpi_calloc(unsigned long count, size_t size);
   //void ndpi_free(void *ptr);
-  u_int8_t ndpi_get_api_version();
+  u_int8_t ndpi_get_api_version(void);
 
   /* https://github.com/corelight/community-id-spec */
   int ndpi_flowv4_flow_hash(u_int8_t l4_proto, u_int32_t src_ip, u_int32_t dst_ip, u_int16_t src_port, u_int16_t dst_port,


### PR DESCRIPTION
Solves a warning when compiling with strict-prototypes.