### PR TITLE
Add -Werror back in and resolve errors raised due to it

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -14,7 +14,7 @@ prefix     = @prefix@
 libdir     = ${prefix}/lib
 includedir = ${prefix}/include/ndpi
 CC         = @CC@
-CFLAGS     += -fPIC -DPIC -I../include -Ithird_party/include -DNDPI_LIB_COMPILATION -O2 -g -Wall
+CFLAGS     += -fPIC -DPIC -I../include -Ithird_party/include -DNDPI_LIB_COMPILATION -O2 -g -Wall -Werror
 RANLIB     = ranlib
 
 OBJECTS   = $(patsubst protocols/%.c, protocols/%.o, $(wildcard protocols/*.c)) $(patsubst third_party/src/%.c, third_party/src/%.o, $(wildcard third_party/src/*.c)) ndpi_main.o ndpi_utils.o

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -2263,13 +2263,14 @@ int ndpi_match_custom_category(struct ndpi_detection_module_struct *ndpi_struct,
 
 int ndpi_get_custom_category_match(struct ndpi_detection_module_struct *ndpi_struct,
 				   char *name_or_ip, unsigned long *id) {
-  char ipbuf[64];
+  char ipbuf[65];
   struct in_addr pin;
 
   if(!ndpi_struct->custom_categories.categories_loaded)
     return -1;
 
-  strncpy(ipbuf, name_or_ip, sizeof(ipbuf));
+  // Retain null terminator
+  strncpy(ipbuf, name_or_ip, sizeof(ipbuf)-1);
   char *ptr = strrchr(ipbuf, '/');
 
   if(ptr)


### PR DESCRIPTION
Tested with gcc-8 and gcc-9.
It was removed due to #741, which was fixed with f570eccf8143a07475cbd2dd3f4fd9b7261d1298.