### PR TITLE
Add more compilers to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,6 @@ matrix:
 before_install:
   - eval "${MATRIX_EVAL}"
 
-install: 
-#macos 
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
-
 before_script:
   - ./autogen.sh
 #  - lcov --directory . --zerocounters
@@ -81,7 +77,7 @@ before_script:
 script:
   - ./configure
   - make
-#
+
 #after_script:
   - cd tests
   - ./do.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,14 +60,22 @@ matrix:
       env:
         - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
 
+    - os: linux
+      compiler: clang-7
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-xenial-7
+          packages:
+            - clang-7
+            - libpcap-dev
+            - autogen
+      env:
+        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
 
 
-  exclude:
-  # osx use always clang for build...
-  - os: osx
-    compiler: gcc
 
-before_install:
+  before_install:
   - eval "${MATRIX_EVAL}"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,36 @@
 language: c
 
-os:
-  #  - osx # tmp disable osx
-  - linux
-
-compiler:
-  - clang
-  - gcc
-
-
 matrix:
   include:
+    - os: osx
+      compiler: clang
+
     - os: linux
       compiler: gcc
+      addons:
+        apt:
+          packages:
+            - libpcap-dev
+            - autogen
+
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - libpcap-dev
+            - autogen
+
+    - os: linux
+      compiler: gcc-8
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - g++-8
+            - libpcap-dev
+            - autogen
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
@@ -30,6 +42,8 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-9
+            - libpcap-dev
+            - autogen
       env:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
 
@@ -41,6 +55,8 @@ matrix:
             - llvm-toolchain-xenial-8
           packages:
             - clang-8
+            - libpcap-dev
+            - autogen
       env:
         - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
 
@@ -57,8 +73,6 @@ before_install:
 install: 
 #macos 
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
-#linux
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install libpcap-dev autogen; fi 
 
 before_script:
   - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-8
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-8
           packages:
             - clang-8
             - libpcap-dev
@@ -65,7 +66,8 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-7
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-7
           packages:
             - clang-7
             - libpcap-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,27 @@ compiler:
   - clang
   - gcc
 
+
 matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
   exclude:
   # osx use always clang for build...
   - os: osx
     compiler: gcc
+
+before_install:
+  - eval "${MATRIX_EVAL}"
 
 install: 
 #macos 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,29 @@ matrix:
             - g++-7
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+      env:
+        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
+
+
 
   exclude:
   # osx use always clang for build...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 
 os:
-  - osx
+  #  - osx # tmp disable osx
   - linux
 
 compiler:
@@ -18,22 +18,12 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-    - os: linux
-      compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
             - g++-8
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
     - os: linux
-      compiler: gcc
+      compiler: gcc-9
       addons:
         apt:
           sources:
@@ -42,6 +32,17 @@ matrix:
             - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
+
+    - os: linux
+      compiler: clang-8
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-xenial-8
+          packages:
+            - clang-8
+      env:
+        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
 
 
 
@@ -57,9 +58,7 @@ install:
 #macos 
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
 #linux
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update || true; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install build-essential; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install libpcap-dev libtool autoconf automake autogen; fi 
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install libpcap-dev autogen; fi 
 
 before_script:
   - ./autogen.sh

--- a/configure.seed
+++ b/configure.seed
@@ -69,9 +69,6 @@ if test $SYSTEM = "Darwin"; then
  CC=clang
 fi
  
-if test $ax_cv_PTHREAD_CLANG = "yes"; then
- CC=clang
-fi
  
 HS_LIB=
 HS_INC=


### PR DESCRIPTION
Add gcc-{8,9} and clang-{7,8} to travis.
Remove unnecessary install commands.
Change dependency installation to use apt addon
Remove forced clang in Makefile.am when using a version of clang (allows clang-8 to be used).