### PR TITLE
Fixes leaks in ndpi_add_host_url_subprotocol

### DIFF
--- a/src/lib/third_party/include/ahocorasick.h
+++ b/src/lib/third_party/include/ahocorasick.h
@@ -63,7 +63,7 @@ AC_ERROR_t      ac_automata_add      (AC_AUTOMATA_t * thiz, AC_PATTERN_t * str);
 void            ac_automata_finalize (AC_AUTOMATA_t * thiz);
 int             ac_automata_search   (AC_AUTOMATA_t * thiz, AC_TEXT_t * str, AC_REP_t * param);
 void            ac_automata_reset    (AC_AUTOMATA_t * thiz);
-void            ac_automata_release  (AC_AUTOMATA_t * thiz);
+void            ac_automata_release  (AC_AUTOMATA_t * thiz, u_int8_t free_pattern);
 void            ac_automata_display  (AC_AUTOMATA_t * thiz, char repcast);
 
 #endif

--- a/src/lib/third_party/include/node.h
+++ b/src/lib/third_party/include/node.h
@@ -59,7 +59,7 @@ void        node_register_matchstr (AC_NODE_t * thiz, AC_PATTERN_t * str);
 void        node_register_outgoing (AC_NODE_t * thiz, AC_NODE_t * next, AC_ALPHABET_t alpha);
 AC_NODE_t * node_find_next         (AC_NODE_t * thiz, AC_ALPHABET_t alpha);
 AC_NODE_t * node_findbs_next       (AC_NODE_t * thiz, AC_ALPHABET_t alpha);
-void        node_release           (AC_NODE_t * thiz);
+void        node_release           (AC_NODE_t * thiz, u_int8_t free_pattern);
 void        node_assign_id         (AC_NODE_t * thiz);
 void        node_sort_edges        (AC_NODE_t * thiz);
 

--- a/src/lib/third_party/src/ahocorasick.c
+++ b/src/lib/third_party/src/ahocorasick.c
@@ -227,8 +227,9 @@ void ac_automata_reset (AC_AUTOMATA_t * thiz)
  * Release all allocated memories to the automata
  * PARAMS:
  * AC_AUTOMATA_t * thiz: the pointer to the automata
+ * uint8_t free_pattern: if true, deallocate the patterns strings
  ******************************************************************************/
-void ac_automata_release (AC_AUTOMATA_t * thiz)
+void ac_automata_release (AC_AUTOMATA_t * thiz, u_int8_t free_pattern)
 {
   unsigned int i;
   AC_NODE_t * n;
@@ -236,7 +237,7 @@ void ac_automata_release (AC_AUTOMATA_t * thiz)
   for (i=0; i < thiz->all_nodes_num; i++)
     {
       n = thiz->all_nodes[i];
-      node_release(n);
+      node_release(n, free_pattern);
     }
   ndpi_free(thiz->all_nodes);
   ndpi_free(thiz);

--- a/src/lib/third_party/src/node.c
+++ b/src/lib/third_party/src/node.c
@@ -73,8 +73,13 @@ void node_init(AC_NODE_t * thiz)
  * FUNCTION: node_release
  * Release node
  ******************************************************************************/
-void node_release(AC_NODE_t * thiz)
+void node_release(AC_NODE_t * thiz, u_int8_t free_pattern)
 {
+  if(free_pattern) {
+    for(int i=0; i<thiz->matched_patterns_num; i++)
+      ndpi_free(thiz->matched_patterns[i].astring);
+  }
+
   ndpi_free(thiz->matched_patterns);
   ndpi_free(thiz->outgoing);
   ndpi_free(thiz);


### PR DESCRIPTION
It is now possible to deallocate strings in ac_automata_release via an additional parameter.
In general, allocating strings in nDPI itself is convenient for an application as this frees the application from the burden to keeping track of strings.