### PR TITLE
Fix crash due to recent code changes when using hyperscan and mining_…

### DIFF
--- a/src/include/ndpi_classify.h
+++ b/src/include/ndpi_classify.h
@@ -88,6 +88,6 @@ void ndpi_timer_sub(const struct timeval *a, const struct timeval *b, struct tim
 void ndpi_timer_clear(struct timeval *a);
 unsigned int ndpi_timeval_to_milliseconds(struct timeval ts);
 unsigned int ndpi_timeval_to_microseconds(struct timeval ts);
-void ndpi_log_timestamp(char *log_ts, u_int log_ts_len);
+void ndpi_log_timestamp(char *log_ts, uint32_t log_ts_len);
 
 #endif /* NDPI_CLASSIFY_H */

--- a/src/lib/ndpi_classify.c
+++ b/src/lib/ndpi_classify.c
@@ -679,7 +679,7 @@ ndpi_timeval_to_microseconds(struct timeval ts)
 }
 
 void
-ndpi_log_timestamp(char *log_ts, u_int log_ts_len)
+ndpi_log_timestamp(char *log_ts, uint32_t log_ts_len)
 {
     struct timeval tv;
     time_t nowtime;

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4264,7 +4264,6 @@ void ndpi_load_ip_category(struct ndpi_detection_module_struct *ndpi_str,
  */
 int ndpi_load_hostname_category(struct ndpi_detection_module_struct *ndpi_str,
 				char *name, ndpi_protocol_category_t category) {
-  AC_PATTERN_t ac_pattern;
 
   if(name == NULL)
     return(-1);
@@ -4272,8 +4271,6 @@ int ndpi_load_hostname_category(struct ndpi_detection_module_struct *ndpi_str,
 #if 0
   printf("===> %s() Loading %s as %u\n", __FUNCTION__, name, category);
 #endif
-
-    memset(&ac_pattern, 0, sizeof(ac_pattern));
 
 #ifdef HAVE_HYPERSCAN
     {
@@ -4293,6 +4290,10 @@ int ndpi_load_hostname_category(struct ndpi_detection_module_struct *ndpi_str,
 	return(-1);
     }
 #else
+    AC_PATTERN_t ac_pattern;
+
+    memset(&ac_pattern, 0, sizeof(ac_pattern));
+
     if(ndpi_str->custom_categories.hostnames_shadow.ac_automa == NULL)
       return(-1);
 
@@ -4342,6 +4343,11 @@ int ndpi_enable_loaded_categories(struct ndpi_detection_module_struct *ndpi_str)
       head = head->next;
     }
 
+    if(i != ndpi_str->custom_categories.num_to_load){
+      ndpi_free(expressions);
+      return(-1);
+    }
+
     free_hyperscan_memory(ndpi_str->custom_categories.hostnames);
     ndpi_str->custom_categories.hostnames = (struct hs*)ndpi_malloc(sizeof(struct hs));
 
@@ -4367,6 +4373,7 @@ int ndpi_enable_loaded_categories(struct ndpi_detection_module_struct *ndpi_str)
     }
 
     ndpi_str->custom_categories.to_load = NULL;
+    ndpi_str->custom_categories.num_to_load = 0;
 
     if(rc < 0) {
       ndpi_free(ndpi_str->custom_categories.hostnames);


### PR DESCRIPTION
…hosts.

Fix crash due to non reset of variables when hyperscan is used. Plus define proper type for timestamps as it causes compilation errors when integrated with OVS.

Signed-off-by: Ravi Kerur <ravi.kerur@viasat.com>