### PR TITLE
Fix memory leak in ndpiReader.

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -185,7 +185,7 @@ void ndpi_payload_analyzer(struct ndpi_flow_info *flow,
   u_int16_t i, j;
   u_int16_t scan_len = ndpi_min(max_packet_payload_dissection, payload_len);
 
-  if((flow->entropy.src2dst_pkt_count+flow->entropy.dst2src_pkt_count) <= max_num_packets_per_flow) {
+  if((flow->src2dst_packets+flow->dst2src_packets) <= max_num_packets_per_flow) {
 #ifdef DEBUG_PAYLOAD
     printf("[hashval: %u][proto: %u][vlan: %u][%s:%u <-> %s:%u][direction: %s][payload_len: %u]\n",
 	   flow->hashval, flow->protocol, flow->vlan_id,

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -848,7 +848,7 @@ extern "C" {
 		     ndpi_serializer *serializer);
 
   /* ptree (trie) API */
-  ndpi_ptree_t* ndpi_ptree_create();
+  ndpi_ptree_t* ndpi_ptree_create(void);
   int ndpi_ptree_insert(ndpi_ptree_t *tree, const ndpi_ip_addr_t *addr, u_int8_t bits, uint user_data);
   int ndpi_ptree_match_addr(ndpi_ptree_t *tree, const ndpi_ip_addr_t *addr, uint *user_data);
   void ndpi_ptree_destroy(ndpi_ptree_t *tree);

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6546,7 +6546,7 @@ ndpi_l4_proto_info ndpi_get_l4_proto_info(struct ndpi_detection_module_struct *n
 
 /* ******************************************************************** */
 
-ndpi_ptree_t* ndpi_ptree_create() {
+ndpi_ptree_t* ndpi_ptree_create(void) {
   ndpi_ptree_t *tree = (ndpi_ptree_t*) ndpi_malloc(sizeof(ndpi_ptree_t));
 
   if(tree) {


### PR DESCRIPTION
Changes in library for strict function prototype.

Memory leak was due to earlier changes to use entropy fields which gets reset every 10 packets and memory not freed for previous allocation. Stick to original functionality of payload analysis of first <n> packets of a flow.

Signed-off-by: Ravi Kerur <ravi.kerur@viasat.com>