### PR TITLE
Change type

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -1011,7 +1011,7 @@ static void printFlow(u_int16_t id, struct ndpi_flow_info *flow, u_int16_t threa
   
   if(csv_fp != NULL) {
     float data_ratio = ndpi_data_ratio(flow->src2dst_bytes, flow->dst2src_bytes);
-    float f = (float)flow->first_seen, l = (float)flow->last_seen;
+    double f = (double)flow->first_seen, l = (double)flow->last_seen;
     
     /* PLEASE KEEP IN SYNC WITH printCSVHeader() */
 


### PR DESCRIPTION
Use double type instead of float when printing time for CSV file.
Float type is too small for 64 bit int time so cast corrupts value.