### PR TITLE
Win32 lib appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 version: 3.1.{build}
 branches:
   only:
-    - win32-lib-appveyor
+    - dev
 environment:
   matrix:
     - COMPILER: mingw

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,7 @@
 version: 3.1.{build}
+branches:
+  only:
+    - win32-lib-appveyor
 environment:
   matrix:
     - COMPILER: mingw

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,14 @@
+version: 3.1.{build}
+environment:
+  matrix:
+    - COMPILER: mingw
+      MINGW_DIR: c:\msys64\mingw32
+
+before_build:
+  - set Path=%MINGW_DIR%\bin;%Path%
+
+build_script:
+  - set Path=%MINGW_DIR%\bin;c:\msys64\usr\bin;
+  - bash autogen.sh
+  - cd src/lib
+  - make

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh     -crlf
+*.ac     -crlf
+*.am     -crlf

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # nDPI
 
 [![Build Status](https://travis-ci.org/ntop/nDPI.png?branch=dev)](https://travis-ci.org/ntop/nDPI)
+[![Appveyor Status](https://ci.appveyor.com/api/projects/status/github/ntop/nDPI?svg=true)](https://ci.appveyor.com/project/ntop/ndpi)
 [![Code Quality: Cpp](https://img.shields.io/lgtm/grade/cpp/g/ntop/nDPI.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ntop/nDPI/context:cpp)
 [![Total Alerts](https://img.shields.io/lgtm/alerts/g/ntop/nDPI.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ntop/nDPI/alerts)
 

--- a/configure.seed
+++ b/configure.seed
@@ -96,28 +96,32 @@ AS_IF([test "${with_hyperscan+set}" = set],[
      ])
 ])
 
-if test -f $PCAP_HOME/libpcap/libpcap.a; then :
-     echo "Using libpcap from $PCAP_HOME"
-     PCAP_INC="-I $PCAP_HOME/libpcap"
-     PCAP_LIB="$PCAP_HOME/libpcap/libpcap.a $PCAP_HOME/lib/libpfring.a $LIBNUMA `$PCAP_HOME/lib/pfring_config --libs`"
-
-     AC_CHECK_LIB([rt], [clock_gettime],   [PCAP_LIB="$PCAP_LIB -lrt"])
-     AC_CHECK_LIB([nl], [nl_handle_alloc], [PCAP_LIB="$PCAP_LIB -lnl"])
-     # The dlopen() function is in libdl on GLIBC-based systems
-     # and in the C library for *BSD systems
-     AC_CHECK_LIB([dl], [dlopen, dlsym],   [DL_LIB="-ldl"],
-                  [AC_CHECK_LIB([c], [dlopen, dlsym], [DL_LIB="-lc"],
-                                [AC_MSG_ERROR([unable to find the dlopen(), dlsym() functions]) ]) ])
-else
-    AC_CHECK_LIB([pcap], [pcap_open_live], [PCAP_LIB="-lpcap"])
-
-     if test $ac_cv_lib_pcap_pcap_open_live = "no"; then :
-       echo ""
-       echo "ERROR: Missing libpcap(-dev) library required to compile the example application"
-       echo "ERROR: Please install it and try again"
-       exit
-   fi
-fi
+case "$host" in
+   *-*-mingw32*|*-*-msys)
+      CFLAGS="${CFLAGS} -DOS_WIN32"
+      LDFLAGS="${LDFLAGS} -lws2_32 -lucrtbase"
+      ;;
+   *)
+      if test -f $PCAP_HOME/libpcap/libpcap.a; then :
+         echo "Using libpcap from $PCAP_HOME"
+         PCAP_INC="-I $PCAP_HOME/libpcap"
+         PCAP_LIB="$PCAP_HOME/libpcap/libpcap.a $PCAP_HOME/lib/libpfring.a $LIBNUMA `$PCAP_HOME/lib/pfring_config --libs`"
+	 AC_CHECK_LIB([rt], [clock_gettime],   [PCAP_LIB="$PCAP_LIB -lrt"])
+         AC_CHECK_LIB([nl], [nl_handle_alloc], [PCAP_LIB="$PCAP_LIB -lnl"])
+         # The dlopen() function is in libdl on GLIBC-based systems
+         # and in the C library for *BSD systems
+         AC_CHECK_LIB([dl], [dlopen, dlsym],   [DL_LIB="-ldl"],[AC_CHECK_LIB([c], [dlopen, dlsym], [DL_LIB="-lc"],[AC_MSG_ERROR([unable to find the dlopen(), dlsym() functions]) ]) ])
+      else
+         AC_CHECK_LIB([pcap], [pcap_open_live], [PCAP_LIB="-lpcap"])
+	 if test $ac_cv_lib_pcap_pcap_open_live = "no"; then :
+            echo ""
+            echo "ERROR: Missing libpcap(-dev) library required to compile the example application"
+            echo "ERROR: Please install it and try again"
+            exit
+	 fi
+      fi
+      ;;
+esac
 
 dnl> https://github.com/json-c/json-c
 AC_ARG_ENABLE([json-c],

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -15,6 +15,7 @@ libdir     = ${prefix}/lib
 includedir = ${prefix}/include/ndpi
 CC         = @CC@
 CFLAGS     += -fPIC -DPIC -I../include -Ithird_party/include -DNDPI_LIB_COMPILATION -O2 -g -Wall @CUSTOM_NDPI@
+LDFLAGS    = @LDFLAGS@
 RANLIB     = ranlib
 
 OBJECTS   = $(patsubst protocols/%.c, protocols/%.o, $(wildcard protocols/*.c)) $(patsubst third_party/src/%.c, third_party/src/%.o, $(wildcard third_party/src/*.c)) $(patsubst ./%.c, ./%.o, $(wildcard ./*.c))
@@ -42,15 +43,15 @@ ndpi_main.c: ndpi_content_match.c.inc
 
 $(NDPI_LIB_STATIC): $(OBJECTS)
 	   ar rc $@ $(OBJECTS)
-	   $(RANLIB) $@	       
+	   $(RANLIB) $@      
 
 $(NDPI_LIB_SHARED): $(OBJECTS)
-	$(CC) -shared -fPIC $(SONAME_FLAG) -o $@ $(OBJECTS)
+	$(CC) -shared -fPIC $(SONAME_FLAG) -o $@ $(OBJECTS) $(LDFLAGS)
 	ln -fs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE)
 	ln -fs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR)
 
 %.o: %.c $(HEADERS) Makefile
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@ $(LDFLAGS)
 
 clean:
 	/bin/rm -f $(NDPI_LIB_STATIC) $(OBJECTS) *.o *.so *.lo $(NDPI_LIB_SHARED)

--- a/src/lib/protocols/btlib.c
+++ b/src/lib/protocols/btlib.c
@@ -39,7 +39,9 @@ typedef unsigned long long int u_int64_t;
 
 #include <stdint.h>
 #include <stdlib.h>
+#ifndef WIN32
 #include <arpa/inet.h>
+#endif
 #endif
 
 #include "btlib.h"


### PR DESCRIPTION
In this PR, I added an initial Appveyor CI to automatically build libndpi using mingw on Windows:
* ./configure now detect host and set required flags to build on mingw.
* Fix for btlib.c.
* /src/lib/Makefile.in correctly links to winsocket.
* appveyor.yml to build libndpi
* Added .gitattributes to avoid some errors running autogen on Windows platform.

I also added a status badge, you will be able to see it once you enable nDPI repository within an ntop free account in Appveyor.com.

Best regards
Zied