### PR TITLE
Fix read buffer overflow in stun

### DIFF
--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -314,7 +314,7 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
        https://en.wikipedia.org/wiki/Skype_for_Business
        */
 
-      while((offset+2) < payload_length) {
+      while((offset+4) < payload_length) {
         u_int16_t attribute = ntohs(*((u_int16_t*)&payload[offset]));
         u_int16_t len = ntohs(*((u_int16_t*)&payload[offset+2]));
         u_int16_t x = (len + 4) % 4;


### PR DESCRIPTION
Found by oss-fuzz :
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19332

The line
`u_int16_t len = ntohs(*((u_int16_t*)&payload[offset+2]));`
accesses 2 bytes starting from `offset+2` so we need at least 4 bytes