### PR TITLE
example: fix compilation of ndpireader on latest dpdk.

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1792,8 +1792,15 @@ u_int32_t ethernet_crc32(const void* data, size_t n_bytes) {
 
 #ifdef USE_DPDK
 
+#include <rte_version.h>
+#include <rte_ether.h>
+
 static const struct rte_eth_conf port_conf_default = {
+#if (RTE_VERSION < RTE_VERSION_NUM(19, 8, 0, 0))
 						      .rxmode = { .max_rx_pkt_len = ETHER_MAX_LEN }
+#else
+						      .rxmode = { .max_rx_pkt_len = RTE_ETHER_MAX_LEN }
+#endif
 };
 
 /* ************************************ */


### PR DESCRIPTION
reader_util.c:1708:43: error: 'ETHER_MAX_LEN' undeclared here (not in a function)
             .rxmode = { .max_rx_pkt_len = ETHER_MAX_LEN }
                                           ^~~~~~~~~~~~~

DPDK before 19.08 had a macro ETHER_MAX_LEN, in later versions it was
changed to RTE_ETHER_MAX_LEN.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>