### PR TITLE
example: fix build warning.

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -21,7 +21,9 @@
 #include "ndpi_config.h"
 
 #ifdef linux
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <sched.h>
 #endif
 #include <stdio.h>


### PR DESCRIPTION
ndpiReader.c:24:0: warning: "_GNU_SOURCE" redefined
 #define _GNU_SOURCE
<command-line>:0:0: note: this is the location of the previous definition

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>