### PR TITLE
Fuzz4fix

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1709,6 +1709,8 @@ ether_type_check:
   }
 
   if(workflow->prefs.decode_tunnels && (proto == IPPROTO_UDP)) {
+    if (header->caplen < ip_offset + ip_len + sizeof(struct ndpi_udphdr))
+      return(nproto); /* Too short for UDP header*/
     struct ndpi_udphdr *udp = (struct ndpi_udphdr *)&packet[ip_offset+ip_len];
     u_int16_t sport = ntohs(udp->source), dport = ntohs(udp->dest);
 

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1359,7 +1359,7 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
     return(nproto);
   }
 
-  if(!flow->detection_completed) {
+  if(!flow->detection_completed && payload_len > 0) {
     u_int enough_packets =
       (((proto == IPPROTO_UDP) && ((flow->src2dst_packets + flow->dst2src_packets) > max_num_udp_dissected_pkts))
        || ((proto == IPPROTO_TCP) && ((flow->src2dst_packets + flow->dst2src_packets) > max_num_tcp_dissected_pkts))) ? 1 : 0;

--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -72,7 +72,7 @@ static void ndpi_add_connection_as_bittorrent(struct ndpi_detection_module_struc
     } else
       bt_hash = (const char*)&flow->packet.payload[28];
 
-    if(bt_hash) memcpy(flow->protos.bittorrent.hash, bt_hash, 20);
+    if(bt_hash && flow->packet.payload_packet_len >= 20 + (bt_hash-flow->packet.payload)) memcpy(flow->protos.bittorrent.hash, bt_hash, 20);
   }
 
   ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_BITTORRENT, NDPI_PROTOCOL_UNKNOWN);

--- a/src/lib/protocols/mail_imap.c
+++ b/src/lib/protocols/mail_imap.c
@@ -161,7 +161,7 @@ void ndpi_search_mail_imap_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	    && (packet->payload[command_start + 4] == 'N' || packet->payload[command_start + 4] == 'n')) {
 	  /* xxxx LOGIN "username" "password" */
 	  char str[256], *item;
-	  u_int len = packet->payload_packet_len > sizeof(str) ? sizeof(str) : packet->payload_packet_len;
+	  u_int len = packet->payload_packet_len >= sizeof(str) ? sizeof(str)-1 : packet->payload_packet_len;
 	  
 	  strncpy(str, (const char*)packet->payload, len);
 	  str[len] = '\0';


### PR DESCRIPTION
Should fix 
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20766
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20727
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20830
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20777

A better fit (against root cause) would be to read all IPv6 option headers in ndpi reader as ndpi library does