### PR TITLE
Fix for missing line breaks in CSV file

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -1146,10 +1146,11 @@ static void printFlow(u_int16_t id, struct ndpi_flow_info *flow, u_int16_t threa
   if(enable_joy_stats) {
     /* Print entropy values for monitored flows. */
     flowGetBDMeanandVariance(flow);
-    if(csv_fp) fprintf(csv_fp, "\n");
     fflush(out);
     fprintf(out, "[score: %.4f]", flow->entropy.score);
   }
+	
+  if(csv_fp) fprintf(csv_fp, "\n");
     
   fprintf(out, "[proto: ");
   if(flow->tunnel_type != ndpi_no_tunnel)


### PR DESCRIPTION
If "-v" is used as an argument, the line breaks are missing in the csv file ("-C"), because the argument "-J" is assumed. Moving the condition for the CSV file handler out of the scope of the "enable_joy_stats" condition removes this dependency and the CSV file is formatted correctly.