### PR TITLE
Fuzz6fix

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1691,12 +1691,11 @@ ether_type_check:
       return(nproto); /* Too short for IPv6 header*/
     iph6 = (struct ndpi_ipv6hdr *)&packet[ip_offset];
     proto = iph6->ip6_hdr.ip6_un1_nxt;
-    ip_len = sizeof(struct ndpi_ipv6hdr);
+    ip_len = ntohs(iph6->ip6_hdr.ip6_un1_plen);
 
-    if(proto == IPPROTO_DSTOPTS /* IPv6 destination option */) {
-      u_int8_t *options = (u_int8_t*)&packet[ip_offset+ip_len];
-      proto = options[0];
-      ip_len += 8 * (options[1] + 1);
+    const u_int8_t *l4ptr = (((const u_int8_t *) iph6) + sizeof(struct ndpi_ipv6hdr));
+    if(ndpi_handle_ipv6_extension_headers(NULL, &l4ptr, &ip_len, &proto) != 0) {
+      return(nproto);
     }
 
     iph = NULL;

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1745,6 +1745,9 @@ ether_type_check:
       }
     } else if((sport == TZSP_PORT) || (dport == TZSP_PORT)) {
       /* https://en.wikipedia.org/wiki/TZSP */
+      if (header->caplen < ip_offset + ip_len + sizeof(struct ndpi_udphdr) + 4)
+        return(nproto); /* Too short for TZSP*/
+
       u_int offset           = ip_offset+ip_len+sizeof(struct ndpi_udphdr);
       u_int8_t version       = packet[offset];
       u_int8_t ts_type       = packet[offset+1];

--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -150,6 +150,10 @@ extern "C" {
 #define ndpi_match_strprefix(payload, payload_len, str)			\
   ndpi_match_prefix((payload), (payload_len), (str), (sizeof(str)-1))
 
+#ifdef NDPI_DETECTION_SUPPORT_IPV6
+    int ndpi_handle_ipv6_extension_headers(struct ndpi_detection_module_struct *ndpi_str, const u_int8_t ** l4ptr, u_int16_t * l4len, u_int8_t * nxt_hdr);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -3645,7 +3645,7 @@ void ndpi_set_protocol_detection_bitmask2(struct ndpi_detection_module_struct *n
  * 	nxt_hdr: protocol of the actual payload
  * returns 0 upon success and 1 upon failure
  */
-static int ndpi_handle_ipv6_extension_headers(struct ndpi_detection_module_struct *ndpi_str, const u_int8_t ** l4ptr, u_int16_t * l4len, u_int8_t * nxt_hdr)
+int ndpi_handle_ipv6_extension_headers(struct ndpi_detection_module_struct *ndpi_str, const u_int8_t ** l4ptr, u_int16_t * l4len, u_int8_t * nxt_hdr)
 {
   while((*nxt_hdr == 0 || *nxt_hdr == 43 || *nxt_hdr == 44 || *nxt_hdr == 60 || *nxt_hdr == 135 || *nxt_hdr == 59)) {
     u_int16_t ehdr_len;

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4687,7 +4687,7 @@ void ndpi_fill_protocol_category(struct ndpi_detection_module_struct *ndpi_str,
       }
     }
 
-    if(flow->protos.stun_ssl.ssl.client_requested_server_name[0] != '\0') {
+    if(flow->l4.tcp.tls.hello_processed == 1 && flow->protos.stun_ssl.ssl.client_requested_server_name[0] != '\0') {
       unsigned long id;
       int rc = ndpi_match_custom_category(ndpi_str,
 					  (char *)flow->protos.stun_ssl.ssl.client_requested_server_name,

--- a/src/lib/protocols/irc.c
+++ b/src/lib/protocols/irc.c
@@ -677,7 +677,7 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 	      if (memcmp(&packet->line[i].ptr[j], "SEND ", 5) == 0
 		  || (memcmp(&packet->line[i].ptr[j], "CHAT", 4) == 0)
 		  || (memcmp(&packet->line[i].ptr[j], "chat", 4) == 0)
-		  || (memcmp(&packet->line[i].ptr[j], "sslchat", 7) == 0)
+		  || (j+7 < packet->line[i].len && memcmp(&packet->line[i].ptr[j], "sslchat", 7) == 0)
 		  || (memcmp(&packet->line[i].ptr[j], "TSEND", 5) == 0)) {
 		NDPI_LOG_DBG2(ndpi_struct, "found CHAT,chat,sslchat,TSEND.");
 		j += 4;

--- a/src/lib/protocols/netbios.c
+++ b/src/lib/protocols/netbios.c
@@ -80,7 +80,8 @@ static void ndpi_int_netbios_add_connection(struct ndpi_detection_module_struct 
   char name[64];
   u_int off = flow->packet.payload[12] == 0x20 ? 12 : 14;
   
-  if(ndpi_netbios_name_interpret((char*)&flow->packet.payload[off], flow->packet.payload_packet_len - off, name, sizeof(name)) > 0)
+  if(off > flow->packet.payload_packet_len &&
+     ndpi_netbios_name_interpret((char*)&flow->packet.payload[off], flow->packet.payload_packet_len - off, name, sizeof(name)) > 0)
     snprintf((char*)flow->host_server_name, sizeof(flow->host_server_name)-1, "%s", name);    
 
   if(sub_protocol == NDPI_PROTOCOL_UNKNOWN)

--- a/src/lib/protocols/postgres.c
+++ b/src/lib/protocols/postgres.c
@@ -97,7 +97,7 @@ void ndpi_search_postgres_tcp(struct ndpi_detection_module_struct
 				return;
 			}
 			size = (u_int16_t)ntohl(get_u_int32_t(packet->payload, 1)) + 1;
-			if (packet->payload[size - 1] == 'S') {
+			if (size > 0 && size - 1 < packet->payload_packet_len && packet->payload[size - 1] == 'S') {
 				if ((size + get_u_int32_t(packet->payload, (size + 1))) == packet->payload_packet_len) {
 					NDPI_LOG_INFO(ndpi_struct, "found postgres asymmetrically\n");
 					ndpi_int_postgres_add_connection(ndpi_struct, flow);
@@ -105,7 +105,7 @@ void ndpi_search_postgres_tcp(struct ndpi_detection_module_struct
 				}
 			}
 			size += get_u_int32_t(packet->payload, (size + 1)) + 1;
-			if (packet->payload[size - 1] == 'S') {
+			if (size > 0 && size - 1 < packet->payload_packet_len && packet->payload[size - 1] == 'S') {
 				NDPI_LOG_INFO(ndpi_struct, "found postgres asymmetrically\n");
 				ndpi_int_postgres_add_connection(ndpi_struct, flow);
 				return;

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -130,7 +130,7 @@ void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
 	    while((sni_offset < udp_len) && (packet->payload[sni_offset] == '-'))
 	      sni_offset++;
 
-	    if((sni_offset+len) < udp_len) {
+	    if(len > 0 && (sni_offset+len) < udp_len) {
 	      int max_len = sizeof(flow->host_server_name)-1, j = 0;
 	      ndpi_protocol_match_result ret_match;
 	      

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1105,7 +1105,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		u_int8_t version_len = packet->payload[s_offset];
 		char version_str[256];
 		u_int8_t version_str_len = 0;
-		
+		version_str[0] = 0;
 #ifdef DEBUG_TLS
 		printf("Client SSL [TLS version len: %u]\n", version_len);
 #endif

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1069,7 +1069,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		s_offset += 2;
 		tot_alpn_len += s_offset;
 
-		while(s_offset < tot_alpn_len) {
+		while(s_offset < tot_alpn_len && s_offset < total_len) {
 		  u_int8_t alpn_i, alpn_len = packet->payload[s_offset++];
 
 		  if((s_offset + alpn_len) <= tot_alpn_len) {


### PR DESCRIPTION
Should fix bugs reported by oss-fuzz and Github Security Lab (so far)

One functional change is to export `ndpi_handle_ipv6_extension_headers` and use it in the example