### PR TITLE
Adds bound check before calling ndpi_handle_ipv6_extension_headers

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,23 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+ Fuzzing:
+   runs-on: ubuntu-latest
+   steps:
+   - name: Build Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'ndpi'
+       dry-run: false
+   - name: Run Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'ndpi'
+       fuzz-seconds: 600
+       dry-run: false
+   - name: Upload Crash
+     uses: actions/upload-artifact@v1
+     if: failure()
+     with:
+       name: artifacts
+       path: ./out/artifacts

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1700,6 +1700,9 @@ ether_type_check:
     iph6 = (struct ndpi_ipv6hdr *)&packet[ip_offset];
     proto = iph6->ip6_hdr.ip6_un1_nxt;
     ip_len = ntohs(iph6->ip6_hdr.ip6_un1_plen);
+    if (header->caplen < ip_offset + sizeof(struct ndpi_ipv6hdr + ntohs(iph_v6->ip6_hdr.ip6_un1_plen))
+      return(nproto); /* Too short for IPv6 payload*/
+
 
     const u_int8_t *l4ptr = (((const u_int8_t *) iph6) + sizeof(struct ndpi_ipv6hdr));
     if(ndpi_handle_ipv6_extension_headers(NULL, &l4ptr, &ip_len, &proto) != 0) {

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -939,12 +939,6 @@ static struct ndpi_flow_info *get_ndpi_flow_info6(struct ndpi_workflow * workflo
   iph.daddr = iph6->ip6_dst.u6_addr.u6_addr32[2] + iph6->ip6_dst.u6_addr.u6_addr32[3];
   iph.protocol = iph6->ip6_hdr.ip6_un1_nxt;
 
-  if(iph.protocol == IPPROTO_DSTOPTS /* IPv6 destination option */) {
-    const u_int8_t *options = (const u_int8_t*)iph6 + sizeof(const struct ndpi_ipv6hdr);
-
-    iph.protocol = options[0];
-  }
-
   return(get_ndpi_flow_info(workflow, 6, vlan_id, tunnel_type,
 			    &iph, iph6, ip_offset, ipsize,
 			    ntohs(iph6->ip6_hdr.ip6_un1_plen),
@@ -1708,6 +1702,7 @@ ether_type_check:
     if(ndpi_handle_ipv6_extension_headers(NULL, &l4ptr, &ip_len, &proto) != 0) {
       return(nproto);
     }
+    iph6->ip6_hdr.ip6_un1_nxt = proto;
 
     iph = NULL;
   } else {


### PR DESCRIPTION
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21719 (introduced by latest PR fixing the behavior with multiple IPv6 extensions)