### PR TITLE
Added missing ndpiReader dependency for the install target

### DIFF
--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -23,7 +23,7 @@ ndpiReader: libndpiReader.a $(LIBNDPI) $(EXECUTABLE_SOURCES:%.c=%.o)
 %.o: %.c $(HEADERS) Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
-install:
+install: ndpiReader
 	mkdir -p $(DESTDIR)$(PREFIX)/bin/
 	mkdir -p $(DESTDIR)$(PREFIX)/share/ndpi
 	cp ndpiReader $(DESTDIR)$(PREFIX)/bin/


### PR DESCRIPTION
The install target should be aware that the ndpiReader has to be built.
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>