### PR TITLE
fix run ARM architecture will cause sigbus error

### DIFF
--- a/src/lib/protocols/someip.c
+++ b/src/lib/protocols/someip.c
@@ -87,7 +87,7 @@ static void ndpi_int_someip_add_connection (struct ndpi_detection_module_struct 
   NDPI_LOG_INFO(ndpi_struct, "found SOME/IP\n");
 }
 
-static u_int32_t someip_data_cover_32(u_int8_t *data)
+static u_int32_t someip_data_cover_32(const u_int8_t *data)
 {
   u_int32_t value;
 

--- a/src/lib/protocols/someip.c
+++ b/src/lib/protocols/someip.c
@@ -87,6 +87,14 @@ static void ndpi_int_someip_add_connection (struct ndpi_detection_module_struct 
   NDPI_LOG_INFO(ndpi_struct, "found SOME/IP\n");
 }
 
+static u_int32_t someip_data_cover_32(u_int8_t *data)
+{
+  u_int32_t value;
+
+  memcpy(&value,data,sizeof(u_int32_t));
+
+  return value;
+}
 /**
  * Dissector function that searches SOME/IP headers
  */
@@ -111,8 +119,8 @@ void ndpi_search_someip (struct ndpi_detection_module_struct *ndpi_struct,
   }
  
   //we extract the Message ID and Request ID and check for special cases later
-  u_int32_t message_id = ntohl(*((u_int32_t *)&packet->payload[0]));
-  u_int32_t request_id = ntohl(*((u_int32_t *)&packet->payload[8]));
+  u_int32_t message_id = ntohl(someip_data_cover_32(&packet->payload[0]));
+  u_int32_t request_id = ntohl(someip_data_cover_32(&packet->payload[8]));
 
   NDPI_LOG_DBG2(ndpi_struct, "====>>>> SOME/IP Message ID: %08x [len: %u]\n",
 	   message_id, packet->payload_packet_len);
@@ -125,7 +133,7 @@ void ndpi_search_someip (struct ndpi_detection_module_struct *ndpi_struct,
   //####Maximum packet size in SOMEIP depends on the carrier protocol, and I'm not certain how well enforced it is, so let's leave that for round 2####
 
   // we extract the remaining length
-  u_int32_t someip_len = ntohl(*((u_int32_t *)&packet->payload[4]));
+  u_int32_t someip_len = ntohl(someip_data_cover_32(&packet->payload[4]));
   if (packet->payload_packet_len != (someip_len + 8)) {
     NDPI_LOG_DBG(ndpi_struct, "Excluding SOME/IP .. Length field invalid!\n");
     NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SOMEIP);


### PR DESCRIPTION
error info:
Using nDPI (3.3.0-2408-3d9285f1) [1 thread(s)]
Capturing live traffic from device br0...
Running thread 0...
Bus error

use the syslog  see:
Unhandled fault: alignment fault (0x92000021) at 0x00000000f67004aa

gdb info:
(gdb) r -i br0
Starting program: /tmp/ndpiReader -i br0
    warning: Unable to find libthread_db matching inferior's thread library, thread debugging will 
     not be available.

    -----------------------------------------------------------
* NOTE: This is demo app to show *some* nDPI features.
* In this demo we have implemented only some basic features
* just to show you what you can do with the library. Feel
* free to extend it and send us the patches for inclusion
------------------------------------------------------------

Using nDPI (3.3.0-2408-3d9285f1) [1 thread(s)]
Capturing live traffic from device br0...
[New LWP 9883]
Running thread 0...

Thread 2 "ndpiReader" received signal SIGBUS, Bus error.
[Switching to LWP 9883]
ndpi_search_someip (ndpi_struct=0xf7218008, flow=0xf6f021b0) at protocols/someip.c:115
115	protocols/someip.c: No such file or directory.
this will be a undefined handle in some ARM device ;

so ,use the safe way to get the value;

tesk ok!