### PR TITLE
Allow -fsanitize for LLVM as well as for GCC.

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -4,13 +4,11 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 
-AC_ARG_WITH(llvm_sanitizer,     [  --with-llvm-sanitizer   Build with support for the LLVM address sanitizer])
+AC_ARG_WITH(sanitizer,     [  --with-sanitizer      Build with support for address, undefined and leak sanitizer])
 
-AS_IF([test "${with_llvm_sanitizer+set}" = set],[
-     CFLAGS="${CFLAGS} -g -O2 -Wno-unused-value -fsanitize=address -fno-omit-frame-pointer"
-     LDFLAGS="${LDFLAGS} -fsanitize=address"
-     CC=clang
-     CXX=clang++
+AS_IF([test "${with_sanitizer+set}" = set],[
+     CFLAGS="${CFLAGS} -g3 -O0 -Wno-unused-value -fsanitize=address -fsanitize=undefined -fno-sanitize=alignment -fno-sanitize=shift -fsanitize=leak -fno-omit-frame-pointer"
+     LDFLAGS="${LDFLAGS} -fsanitize=address -fsanitize=undefined -fno-sanitize=alignment -fno-sanitize=shift -fsanitize=leak"
 ])
 
 LT_INIT
@@ -130,6 +128,9 @@ AS_IF([test "x$enable_fuzztargets" = "xyes"], [
     AC_PROG_CXX
     AC_LANG_PUSH(C++)
     tmp_saved_flags=$[]_AC_LANG_PREFIX[]FLAGS
+    AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer],,
+        [AC_MSG_ERROR([--enable-fuzztargets requires -fsanitize=fuzzer which is only supported by LLVM])],
+        [-Werror])
     AS_IF([test "x$LIB_FUZZING_ENGINE" = "x"], [
         LIB_FUZZING_ENGINE=-fsanitize=fuzzer
         AC_SUBST(LIB_FUZZING_ENGINE)

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS


### PR DESCRIPTION
     * renamed --with-llvm-sanitizer to --with-sanitizer
     * disable all optimisations (-O0) if --with-sanitizer set,
       no functions/paramaters/variables will be optimised, improves debugging
     * enable undefined behaviour sanitizer (ubsan)
     * enable leak sanitizer (lsan)
     * check if -fsanitize=fuzzer is available and --enable-fuzztargets set,
       fail if not (only supported by clang)
     * include level 3 debugging information (-g3), improves macro debugging
     * disabled ubsan misaligned pointer access and lshift overflow

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>