### PR TITLE
Update Citrix dissector - UDP detection

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -758,6 +758,9 @@ struct ndpi_flow_udp_struct {
   /* NDPI_PROTOCOL_SKYPE */
   u_int8_t skype_packet_id;
 
+  /* NDPI_PROTOCOL_CITRIX */
+  u_int8_t citrix_packet_id;
+
   /* NDPI_PROTOCOL_TEAMVIEWER */
   u_int8_t teamviewer_stage;
 

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -1182,10 +1182,10 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
 			  NDPI_PROTOCOL_CATEGORY_WEB,
 			  ndpi_build_default_ports(ports_a, 8080, 3128, 0, 0, 0) /* TCP */,
 			  ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
-  ndpi_set_proto_defaults(ndpi_str, NDPI_PROTOCOL_ACCEPTABLE, NDPI_PROTOCOL_CITRIX, 0 /* can_have_a_subprotocol */,
+  ndpi_set_proto_defaults(ndpi_str, NDPI_PROTOCOL_ACCEPTABLE, NDPI_PROTOCOL_CITRIX, 1 ,
 			  no_master, no_master, "Citrix", NDPI_PROTOCOL_CATEGORY_NETWORK,
 			  ndpi_build_default_ports(ports_a, 1494, 2598, 0, 0, 0) /* TCP */,
-			  ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
+			  ndpi_build_default_ports(ports_b, 1494, 2598, 0, 0, 0) /* UDP */);
   ndpi_set_proto_defaults(ndpi_str, NDPI_PROTOCOL_ACCEPTABLE, NDPI_PROTOCOL_WEBEX, 0 /* can_have_a_subprotocol */,
 			  no_master, no_master, "Webex", NDPI_PROTOCOL_CATEGORY_VOIP,
 			  ndpi_build_default_ports(ports_a, 0, 0, 0, 0, 0) /* TCP */,

--- a/src/lib/protocols/rtp.c
+++ b/src/lib/protocols/rtp.c
@@ -87,12 +87,14 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
   u_int8_t payloadType, payload_type = payload[1] & 0x7F;
 
   /* Check whether this is an RTP flow */
+  if( payload_type == 0)
+	return;
   if((payload_len >= 12)
      && (((payload[0] & 0xFF) == 0x80) || ((payload[0] & 0xFF) == 0xA0)) /* RTP magic byte[1] */
      && ((payload_type < 72) || (payload_type > 76))
      && ((payload_type <= 34)
 	 || ((payload_type >= 96) && (payload_type <= 127))
-	 /* http://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml */
+	/* http://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml */
        )
     ) {
     NDPI_LOG_INFO(ndpi_struct, "Found RTP\n");

--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -276,14 +276,14 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
 
   flow->protos.stun_ssl.stun.num_udp_pkts++;
 
-  if((payload[0] == 0x80 && payload_length < 512 && ((msg_len+20) <= payload_length))) {
+ /* if((payload[0] == 0x80 && payload_length < 512 && ((msg_len+20) <= payload_length))) {
     flow->guessed_host_protocol_id = NDPI_PROTOCOL_WHATSAPP_CALL;
-    return(NDPI_IS_STUN); /* This is WhatsApp Call */
-  } else if((payload[0] == 0x90) && (((msg_len+11) == payload_length) ||
+    return(NDPI_IS_STUN); */ /* This is WhatsApp Call */
+ /* } else */if((payload[0] == 0x90) && (((msg_len+11) == payload_length) ||
                 (flow->protos.stun_ssl.stun.num_binding_requests >= 4))) {
     flow->guessed_host_protocol_id = NDPI_PROTOCOL_WHATSAPP_CALL;
     return(NDPI_IS_STUN); /* This is WhatsApp Call */
-  }
+  } 
 
   if(payload[0] != 0x80 && (msg_len + 20) > payload_length)
     return(NDPI_IS_NOT_STUN);


### PR DESCRIPTION
Hello,
I have add Citrix UDP protocol detection in citrix dissector. For this, i need to do some modification in STUN and RTP dissector.
By default citrix udp is detected as WhatsAppCall, Stun or RTP protocol
Are you ok for this patch ?