### PR TITLE
Re-Added corpus zipfile generation required for google-oss fuzzer

### DIFF
--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -27,3 +27,10 @@ endif
 fuzz_ndpi_reader_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
     $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
     $(fuzz_ndpi_reader_LDFLAGS) $(LDFLAGS) -o $@
+
+# required for Google oss-fuzz
+# see https://github.com/google/oss-fuzz/tree/master/projects/ndpi
+testpcaps := $(wildcard ../tests/pcap/*.pcap)
+
+fuzz_ndpi_reader_seed_corpus.zip: $(testpcaps)
+	zip -r fuzz_ndpi_reader_seed_corpus.zip $(testpcaps)


### PR DESCRIPTION
There will be another MR which goes to https://github.com/google/oss-fuzz and will generate the corpus zipfile before fuzzing starts.

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>