### PR TITLE
Improved fuzz_ndpi_reader which supports now SMP/MT w/o race-coniditi…

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -7,8 +7,8 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_ARG_WITH(sanitizer,     [  --with-sanitizer      Build with support for address, undefined and leak sanitizer])
 
 AS_IF([test "${with_sanitizer+set}" = set],[
-     CFLAGS="${CFLAGS} -g3 -O0 -Wno-unused-value -fsanitize=address -fsanitize=undefined -fno-sanitize=alignment -fno-sanitize=shift -fsanitize=leak -fno-omit-frame-pointer"
-     LDFLAGS="${LDFLAGS} -fsanitize=address -fsanitize=undefined -fno-sanitize=alignment -fno-sanitize=shift -fsanitize=leak"
+     CFLAGS="${CFLAGS} -g3 -O0 -Wno-unused-value -fsanitize=address -fsanitize=undefined -fno-sanitize=alignment -fsanitize=leak -fno-omit-frame-pointer"
+     LDFLAGS="${LDFLAGS} -fsanitize=address -fsanitize=undefined -fno-sanitize=alignment -fsanitize=leak"
 ])
 
 LT_INIT

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,4 +1,4 @@
-bin_PROGRAMS = fuzz_process_packet fuzz_ndpi_reader
+bin_PROGRAMS = fuzz_process_packet fuzz_ndpi_reader fuzz_ndpi_reader_with_main
 
 fuzz_process_packet_SOURCES = fuzz_process_packet.c
 fuzz_process_packet_CFLAGS =
@@ -6,8 +6,6 @@ fuzz_process_packet_LDFLAGS = ../src/lib/libndpi.a $(ADDITIONAL_LIBS)
 if HAS_FUZZLDFLAGS
 fuzz_process_packet_CFLAGS += $(LIB_FUZZING_ENGINE)
 fuzz_process_packet_LDFLAGS += $(LIB_FUZZING_ENGINE)
-#else
-#    fuzz_process_packet_SOURCES += onefile.c
 endif
 # force usage of CXX for linker
 fuzz_process_packet_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
@@ -20,13 +18,19 @@ fuzz_ndpi_reader_LDFLAGS = ../example/libndpiReader.a ../src/lib/libndpi.a $(PCA
 if HAS_FUZZLDFLAGS
 fuzz_ndpi_reader_CFLAGS += $(LIB_FUZZING_ENGINE)
 fuzz_ndpi_reader_LDFLAGS += $(LIB_FUZZING_ENGINE)
-#else
-#    fuzz_ndpi_reader_SOURCES += onefile.c
 endif
 # force usage of CXX for linker
 fuzz_ndpi_reader_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
     $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
     $(fuzz_ndpi_reader_LDFLAGS) $(LDFLAGS) -o $@
+
+fuzz_ndpi_reader_with_main_SOURCES = fuzz_ndpi_reader.c
+fuzz_ndpi_reader_with_main_CFLAGS = -I../example/ -DBUILD_MAIN
+fuzz_ndpi_reader_with_main_LDFLAGS = ../example/libndpiReader.a ../src/lib/libndpi.a $(PCAP_LIB) $(ADDITIONAL_LIBS)
+# force usage of CXX for linker
+fuzz_ndpi_reader_with_main_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+    $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
+    $(fuzz_ndpi_reader_with_main_LDFLAGS) $(LDFLAGS) -o $@
 
 # required for Google oss-fuzz
 # see https://github.com/google/oss-fuzz/tree/master/projects/ndpi

--- a/tests/do.sh
+++ b/tests/do.sh
@@ -9,7 +9,7 @@ PCAPS=`cd pcap; /bin/ls *.pcap`
 
 fuzzy_testing() {
 	if [ -f ../fuzz/fuzz_ndpi_reader ]; then
-		../fuzz/fuzz_ndpi_reader -max_total_time=592 -print_pcs=1 -jobs=1 -workers=1 pcap/
+		../fuzz/fuzz_ndpi_reader -max_total_time=${MAX_TOTAL_TIME:-592} -print_pcs=1 -workers=${FUZZY_WORKERS:-0} -jobs=${FUZZY_JOBS:-0} pcap/
 	fi
 }
 


### PR DESCRIPTION
…ons.

./tests/do.sh can supports SMP/MT via environment variables.
Removed -fno-sanitize=shift as well, was fixed by 317d3ffd.

(fuzz_ndpi_reader_with_main is required as ndpiReader is sometimes too restrictive results in non reporoducible errors)

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>