### PR TITLE
Fixed CodeInspector issues.

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -13,10 +13,18 @@ AS_IF([test "${with_sanitizer+set}" = set],[
 
 LT_INIT
 
-AC_PROG_CC(clang gcc)
-AM_PROG_CC_C_O(clang gcc)
-AC_PROG_CXX(clang++ g++)
-AC_PROG_CC_STDC(clang gcc)
+SYSTEM=`uname -s`
+if test $SYSTEM = "Darwin"; then
+  AC_PROG_CC(clang gcc)
+  AM_PROG_CC_C_O(clang gcc)
+  AC_PROG_CXX(clang++ g++)
+  AC_PROG_CC_STDC(clang gcc)
+else
+  AC_PROG_CC
+  AM_PROG_CC_C_O
+  AC_PROG_CXX
+  AC_PROG_CC_STDC
+fi
 AC_LANG_WERROR
 AX_PTHREAD
 
@@ -78,10 +86,6 @@ else
 fi
 
 MACHINE=`uname -m`
-SYSTEM=`uname -s`
-if test $SYSTEM = "Darwin"; then
- CC=clang
-fi
 
 CUSTOM_NDPI=
 

--- a/fuzz/fuzz_ndpi_reader.c
+++ b/fuzz/fuzz_ndpi_reader.c
@@ -118,28 +118,33 @@ int main(int argc, char ** argv)
 
   if (fseek(pcap_file, 0, SEEK_END) != 0) {
     perror("fseek(SEEK_END) failed");
+    fclose(pcap_file);
     return 1;
   }
 
   pcap_file_size = ftell(pcap_file);
   if (pcap_file_size < 0) {
     perror("ftell failed");
+    fclose(pcap_file);
     return 1;
   }
 
   if (fseek(pcap_file, 0, SEEK_SET) != 0) {
     perror("fseek(0, SEEK_SET)  failed");
+    fclose(pcap_file);
     return 1;
   }
 
   pcap_buffer = malloc(pcap_file_size);
   if (pcap_buffer == NULL) {
     perror("malloc failed");
+    fclose(pcap_file);
     return 1;
   }
 
   if (fread(pcap_buffer, sizeof(*pcap_buffer), pcap_file_size, pcap_file) != pcap_file_size) {
     perror("fread failed");
+    fclose(pcap_file);
     return 1;
   }
 

--- a/tests/do.sh
+++ b/tests/do.sh
@@ -9,7 +9,7 @@ PCAPS=`cd pcap; /bin/ls *.pcap`
 
 fuzzy_testing() {
 	if [ -f ../fuzz/fuzz_ndpi_reader ]; then
-		../fuzz/fuzz_ndpi_reader -max_total_time=${MAX_TOTAL_TIME:-592} -print_pcs=1 -workers=${FUZZY_WORKERS:-0} -jobs=${FUZZY_JOBS:-0} pcap/
+		../fuzz/fuzz_ndpi_reader -max_total_time="${MAX_TOTAL_TIME:-592}" -print_pcs=1 -workers="${FUZZY_WORKERS:-0}" -jobs="${FUZZY_JOBS:-0}" pcap/
 	fi
 }
 


### PR DESCRIPTION
 * Removed compiler search list for AC_PROG_CC, AM_PROG_CC_C_O, AC_PROG_CXX, AC_PROG_CC_STDC
   The list rendered the AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer]) useless as it did use
   clang for AX_CHECK_COMPILE_FLAG but gcc during the compile process. Seems broken somehow.

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>