### PR TITLE
ossfuzz.sh: do not use wildcards for fuzzer e.g. fuzz/fuzz*

### DIFF
--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -27,4 +27,6 @@ sh autogen.sh
 ./configure --enable-fuzztargets
 make
 make -C fuzz fuzz_ndpi_reader_seed_corpus.zip
-cp -v fuzz/fuzz* "$OUT/"
+# copy fuzz executables to output directory
+cp -v fuzz/fuzz_ndpi_reader "$OUT/"
+cp -v fuzz/fuzz_process_packet "$OUT/"


### PR DESCRIPTION
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

This PR should fix all fuzzing tests once google/oss-fuzz#4041 was merged.