### PR TITLE
Fixed heap overflow caused by missing lengthcheck in reader uutil.

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1719,7 +1719,7 @@ struct ndpi_proto ndpi_workflow_process_packet(struct ndpi_workflow * workflow,
     workflow->stats.mpls_count++;
     type = ETH_P_IP, ip_offset += 4;
 
-    while(!mpls.mpls.s) {
+    while(!mpls.mpls.s && (((bpf_u_int32)ip_offset) + 4 < header->caplen)) {
       mpls.u32 = *((uint32_t *) &packet[ip_offset]);
       mpls.u32 = ntohl(mpls.u32);
       ip_offset += 4;


### PR DESCRIPTION
 * triggered by fuzz traces from wireshark

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>