### PR TITLE
More travis, autogen and autoconf improvments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ matrix:
 
     - os: linux
       compiler: gcc-8
+      dist: bionic
       addons:
         apt:
           sources:
@@ -80,6 +81,7 @@ matrix:
 
     - os: linux
       compiler: gcc-9
+      dist: bionic
       addons:
         apt:
           sources:
@@ -93,6 +95,7 @@ matrix:
 
     - os: linux
       compiler: clang-8
+      dist: xential
       addons:
         apt:
           sources:
@@ -107,6 +110,7 @@ matrix:
 
     - os: linux
       compiler: clang-7
+      dist: xential
       addons:
         apt:
           sources:
@@ -120,9 +124,10 @@ matrix:
         - MATRIX_EVAL="CC=clang-7"
 
     - name: fuzza
-      env: CFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" LDFLAGS="-g3 -O0" QA_FUZZ=asan CC=clang-7 && ASAN_SYMBOLIZER_PATH=/usr/local/clang-7.0.0/bin/llvm-symbolizer
+      env: QA_FUZZ=asan CC=clang-7 CXX=clang++-7 && ASAN_SYMBOLIZER_PATH=/usr/local/clang-7.0.0/bin/llvm-symbolizer
       os: linux
       compiler: clang-7
+      dist: xential
       addons:
         apt:
           sources:
@@ -133,9 +138,10 @@ matrix:
             - libpcap-dev
             - autogen
     - name: fuzzm
-      env: CFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory -fsanitize=fuzzer-no-link" LDFLAGS="-g3 -O0 -fsanitize=memory" QA_FUZZ=msan CC=clang-7 && MSAN_SYMBOLIZER_PATH=/usr/local/clang-7.0.0/bin/llvm-symbolizer
+      env: CFLAGS="-fsanitize=memory -fsanitize=fuzzer-no-link" LDFLAGS="-fsanitize=memory" QA_FUZZ=msan CC=clang-7 CXX=clang++-7 && MSAN_SYMBOLIZER_PATH=/usr/local/clang-7.0.0/bin/llvm-symbolizer
       os: linux
       compiler: clang-7
+      dist: xential
       addons:
         apt:
           sources:
@@ -146,9 +152,10 @@ matrix:
             - libpcap-dev
             - autogen
     - name: fuzzu
-      env: CFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" LDFLAGS="-g3 -O0" QA_FUZZ=ubsan CC=clang-7
+      env: QA_FUZZ=ubsan CC=clang-7 CXX=clang++-7
       os: linux
       compiler: clang-7
+      dist: xential
       addons:
         apt:
           sources:

--- a/autogen.sh
+++ b/autogen.sh
@@ -58,4 +58,4 @@ cat configure | sed "s/#define PACKAGE/#define NDPI_PACKAGE/g" | sed "s/#define 
 cat configure.tmp > configure
 
 chmod +x configure
-./configure "$*"
+./configure ${*}

--- a/configure.seed
+++ b/configure.seed
@@ -114,10 +114,7 @@ case "$host" in
       else
          AC_CHECK_LIB([pcap], [pcap_open_live], [PCAP_LIB="-lpcap"])
 	 if test $ac_cv_lib_pcap_pcap_open_live = "no"; then :
-            echo ""
-            echo "ERROR: Missing libpcap(-dev) library required to compile the example application"
-            echo "ERROR: Please install it and try again"
-            exit
+		 AC_MSG_ERROR([Missing libpcap(-dev) library required to compile the example application. Please install it and try again.])
 	 fi
       fi
       ;;


### PR DESCRIPTION
 * removed travis-ci CFLAGS/LDFLAGS as same is done via autoconf
 * removed double quotes in autogen, causes errors if multiple configure args used
 * let configure script fail with an exit code != 0 if libpcap-dev not found
 * travis-ci should use ubuntu-bionic for all builds referencing apt

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

(re-added CXX as required for -ffuzzer)