### PR TITLE
Fixed heap overflow caused by missing lengthcheck in 802.11 LLC heade…

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1686,6 +1686,8 @@ struct ndpi_proto ndpi_workflow_process_packet(struct ndpi_workflow * workflow,
       break;
 
     /* Check ether_type from LLC */
+    if(header->caplen < (eth_offset + wifi_len + radio_len + sizeof(struct ndpi_llc_header_snap)))
+      return(nproto);
     llc = (struct ndpi_llc_header_snap*)(packet + eth_offset + wifi_len + radio_len);
     if(llc->dsap == SNAP)
       type = ntohs(llc->snap.proto_ID);


### PR DESCRIPTION
…r parsing.

* triggered by fuzz traces from wireshark

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>