### PR TITLE
add improved boundary check and check malloc return is NULL

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -2943,6 +2943,9 @@ static void ndpi_process_packet(u_char *args,
   /* allocate an exact size buffer to check overflows */
   uint8_t *packet_checked = malloc(header->caplen);
 
+  if(packet_checked == NULL){
+    return ;
+  }
   memcpy(packet_checked, packet, header->caplen);
   p = ndpi_workflow_process_packet(ndpi_thread_info[thread_id].workflow, header, packet_checked, csv_fp);
 
@@ -3047,7 +3050,10 @@ static void ndpi_process_packet(u_char *args,
      Leave the free as last statement to avoid crashes when ndpi_detection_giveup()
      is called above by printResults()
   */
-  free(packet_checked);
+  if(packet_checked){
+    free(packet_checked);
+    packet_checked = NULL;
+  }
 }
 
 /**

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4928,7 +4928,7 @@ void ndpi_parse_packet_line_info(struct ndpi_detection_module_struct *ndpi_str, 
   packet->line[packet->parsed_lines].len = 0;
 
   for (a = 0; ((a+1) < packet->payload_packet_len) && (packet->parsed_lines < NDPI_MAX_PARSE_LINES_PER_PACKET); a++) {
-    if((packet->payload[a] == 0x0d) && (packet->payload[a+1] == 0x0a)) {
+    if(((a + 1) < packet->payload_packet_len) &&(packet->payload[a] == 0x0d) && (packet->payload[a+1] == 0x0a)) {
       /* If end of line char sequence CR+NL "\r\n", process line */
 
       if(((a + 3) < packet->payload_packet_len)


### PR DESCRIPTION
### Commit Summary

* add the malloc return and free pointer check
* add the boundary check ,when parse the HTTP protocol headers

### File Changes

* M `example/ndpiReader.c`
* M `src/lib/ndpi_main.c`

### Why changes

* valgrind memcheck give the warnings