### PR TITLE
Enable building on OpenBSD 6.7

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -692,7 +692,7 @@ static struct ndpi_flow_info *get_ndpi_flow_info(struct ndpi_workflow * workflow
 						 u_int8_t **payload,
 						 u_int16_t *payload_len,
 						 u_int8_t *src_to_dst_direction,
-                                                 struct timeval when) {
+                                                 pkt_timeval when) {
   u_int32_t idx, l4_offset, hashval;
   struct ndpi_flow_info flow;
   void *ret;
@@ -979,7 +979,7 @@ static struct ndpi_flow_info *get_ndpi_flow_info6(struct ndpi_workflow * workflo
 						  u_int8_t **payload,
 						  u_int16_t *payload_len,
 						  u_int8_t *src_to_dst_direction,
-                                                  struct timeval when) {
+                                                  pkt_timeval when) {
   struct ndpi_iphdr iph;
 
   memset(&iph, 0, sizeof(iph));
@@ -1300,7 +1300,7 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
 					   u_int16_t ipsize, u_int16_t rawsize,
 					   const struct pcap_pkthdr *header,
 					   const u_char *packet,
-                       struct timeval when,
+                       pkt_timeval when,
                        FILE * csv_fp) {
   struct ndpi_id_struct *src, *dst;
   struct ndpi_flow_info *flow = NULL;
@@ -1330,7 +1330,7 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
 			       &payload, &payload_len, &src_to_dst_direction, when);
 
   if(flow != NULL) {
-    struct timeval tdiff;
+    pkt_timeval tdiff;
 
     workflow->stats.ip_packet_count++;
     workflow->stats.total_wire_bytes += rawsize + 24 /* CRC etc */,

--- a/example/reader_util.h
+++ b/example/reader_util.h
@@ -31,6 +31,7 @@
 
 #include "uthash.h"
 #include <pcap.h>
+#include "ndpi_includes.h"
 #include "ndpi_classify.h"
 #include "ndpi_typedefs.h"
 
@@ -128,13 +129,13 @@ struct flow_metrics {
 
 struct ndpi_entropy {
   // Entropy fields
-  struct timeval src2dst_last_pkt_time, dst2src_last_pkt_time, flow_last_pkt_time;
+  pkt_timeval src2dst_last_pkt_time, dst2src_last_pkt_time, flow_last_pkt_time;
   u_int16_t src2dst_pkt_len[MAX_NUM_PKTS];                     /*!< array of packet appdata lengths */
-  struct timeval src2dst_pkt_time[MAX_NUM_PKTS];               /*!< array of arrival times          */
+  pkt_timeval src2dst_pkt_time[MAX_NUM_PKTS];               /*!< array of arrival times          */
   u_int16_t dst2src_pkt_len[MAX_NUM_PKTS];                     /*!< array of packet appdata lengths */
-  struct timeval dst2src_pkt_time[MAX_NUM_PKTS];               /*!< array of arrival times          */
-  struct timeval src2dst_start;                                /*!< first packet arrival time       */
-  struct timeval dst2src_start;                                /*!< first packet arrival time       */
+  pkt_timeval dst2src_pkt_time[MAX_NUM_PKTS];               /*!< array of arrival times          */
+  pkt_timeval src2dst_start;                                /*!< first packet arrival time       */
+  pkt_timeval dst2src_start;                                /*!< first packet arrival time       */
   u_int32_t src2dst_opackets;                                  /*!< non-zero packet counts          */
   u_int32_t dst2src_opackets;                                  /*!< non-zero packet counts          */
   u_int16_t src2dst_pkt_count;                                 /*!< packet counts                   */

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -8,4 +8,5 @@ library_include_HEADERS = ndpi_api.h \
 		ndpi_protocol_ids.h \
 		ndpi_protocols.h \
 		ndpi_win32.h \
+		ndpi_includes_OpenBSD.h \
 		ndpi_includes.h

--- a/src/include/ndpi_classify.h
+++ b/src/include/ndpi_classify.h
@@ -43,7 +43,7 @@
 #ifndef NDPI_CLASSIFY_H
 #define NDPI_CLASSIFY_H
 
-
+#include "ndpi_includes.h"
 
 /* constants */
 #define NUM_PARAMETERS_SPLT_LOGREG 208
@@ -66,27 +66,27 @@ extern float parameters_bd[NUM_PARAMETERS_BD_LOGREG];
 extern float parameters_splt[NUM_PARAMETERS_SPLT_LOGREG];
 
 /* Classifier functions */
-float ndpi_classify(const unsigned short *pkt_len, const struct timeval *pkt_time,
-       const unsigned short *pkt_len_twin, const struct timeval *pkt_time_twin,
-       struct timeval start_time, struct timeval start_time_twin, uint32_t max_num_pkt_len,
+float ndpi_classify(const unsigned short *pkt_len, const pkt_timeval *pkt_time,
+       const unsigned short *pkt_len_twin, const pkt_timeval *pkt_time_twin,
+       pkt_timeval start_time, pkt_timeval start_time_twin, uint32_t max_num_pkt_len,
        uint16_t sp, uint16_t dp, uint32_t op, uint32_t ip, uint32_t np_o, uint32_t np_i,
        uint32_t ob, uint32_t ib, uint16_t use_bd, const uint32_t *bd, const uint32_t *bd_t);
 
-void ndpi_merge_splt_arrays(const uint16_t *pkt_len, const struct timeval *pkt_time,
-       const uint16_t *pkt_len_twin, const struct timeval *pkt_time_twin,
-       struct timeval start_time, struct timeval start_time_twin,
+void ndpi_merge_splt_arrays(const uint16_t *pkt_len, const pkt_timeval *pkt_time,
+       const uint16_t *pkt_len_twin, const pkt_timeval *pkt_time_twin,
+       pkt_timeval start_time, pkt_timeval start_time_twin,
        uint16_t s_idx, uint16_t r_idx,
        uint16_t *merged_lens, uint16_t *merged_times);
 
 void ndpi_update_params(classifier_type_codes_t param_type, const char *param_file);
 
 void ndpi_flow_info_freer(void *node);
-unsigned int ndpi_timer_eq(const struct timeval *a, const struct timeval *b);
-unsigned int ndpi_timer_lt(const struct timeval *a, const struct timeval *b);
-void ndpi_timer_sub(const struct timeval *a, const struct timeval *b, struct timeval *result);
-void ndpi_timer_clear(struct timeval *a);
-unsigned int ndpi_timeval_to_milliseconds(struct timeval ts);
-unsigned int ndpi_timeval_to_microseconds(struct timeval ts);
+unsigned int ndpi_timer_eq(const pkt_timeval *a, const pkt_timeval *b);
+unsigned int ndpi_timer_lt(const pkt_timeval *a, const pkt_timeval *b);
+void ndpi_timer_sub(const pkt_timeval *a, const pkt_timeval *b, pkt_timeval *result);
+void ndpi_timer_clear(pkt_timeval *a);
+unsigned int ndpi_timeval_to_milliseconds(pkt_timeval ts);
+unsigned int ndpi_timeval_to_microseconds(pkt_timeval ts);
 void ndpi_log_timestamp(char *log_ts, uint32_t log_ts_len);
 
 #endif /* NDPI_CLASSIFY_H */

--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -35,7 +35,9 @@
 #include <endian.h>
 #define __BYTE_ORDER BYTE_ORDER
 #if BYTE_ORDER == LITTLE_ENDIAN
+#ifndef __LITTLE_ENDIAN__
 #define __LITTLE_ENDIAN__
+#endif /* __LITTLE_ENDIAN__ */
 #else
 #define __BIG_ENDIAN__
 #endif/* BYTE_ORDER */

--- a/src/include/ndpi_includes.h
+++ b/src/include/ndpi_includes.h
@@ -57,7 +57,7 @@
 #if defined __NetBSD__ || defined __OpenBSD__
 #include <netinet/in_systm.h>
 
-#ifdef __OpenBSD__
+#if defined __OpenBSD__
 #include <pthread.h>
 
 #endif
@@ -66,5 +66,9 @@
 #endif
 
 #endif	/* Win32 */
+
+#if defined __OpenBSD__
+#include "ndpi_includes_OpenBSD.h"
+#endif /* __OpenBSD__ */
 
 #endif /* __NDPI_INCLUDES_H__ */

--- a/src/include/ndpi_includes_OpenBSD.h
+++ b/src/include/ndpi_includes_OpenBSD.h
@@ -1,0 +1,43 @@
+/*
+ * ndpi_includes_OpenBSD.h
+ *
+ * Copyright (C) 2011-16 - ntop.org
+ *
+ * This file is part of nDPI, an open source deep packet inspection
+ * library based on the OpenDPI and PACE technology by ipoque GmbH
+ *
+ * nDPI is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * nDPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with nDPI.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __NDPI_INCLUDES_OPENBSD_H__
+#define __NDPI_INCLUDES_OPENBSD_H__
+
+#ifdef __OpenBSD__
+
+#ifndef IPPROTO_SCTP
+#define IPPROTO_SCTP 132
+#endif /* IPPROTO_SCTP */
+
+#endif /* __OpenBSD__ */
+
+
+#ifdef __OpenBSD__
+#include <net/bpf.h>
+typedef struct bpf_timeval pkt_timeval;
+#else
+typedef struct timeval pkt_timeval;
+#endif /* __OpenBSD__ */
+
+#endif /* __NDPI_INCLUDES_OPENBSD_H__ */

--- a/src/lib/ndpi_classify.c
+++ b/src/lib/ndpi_classify.c
@@ -240,9 +240,9 @@ float ndpi_parameters_bd[NUM_PARAMETERS_BD_LOGREG] = {
 };
 
 /**
- * \fn void ndpi_merge_splt_arrays (const uint16_t *pkt_len, const struct timeval *pkt_time,
- const uint16_t *pkt_len_twin, const struct timeval *pkt_time_twin,
- struct timeval start_time, struct timeval start_time_twin,
+ * \fn void ndpi_merge_splt_arrays (const uint16_t *pkt_len, const pkt_timeval *pkt_time,
+ const uint16_t *pkt_len_twin, const pkt_timeval *pkt_time_twin,
+ pkt_timeval start_time, pkt_timeval start_time_twin,
  uint16_t s_idx, uint16_t r_idx,
  uint16_t *merged_lens, uint16_t *merged_times,
  uint32_t max_num_pkt_len, uint32_t max_merged_num_pkts)
@@ -260,16 +260,16 @@ float ndpi_parameters_bd[NUM_PARAMETERS_BD_LOGREG] = {
  * \return none
  */
 void
-ndpi_merge_splt_arrays (const uint16_t *pkt_len, const struct timeval *pkt_time,
-                        const uint16_t *pkt_len_twin, const struct timeval *pkt_time_twin,
-                        struct timeval start_time, struct timeval start_time_twin,
+ndpi_merge_splt_arrays (const uint16_t *pkt_len, const pkt_timeval *pkt_time,
+                        const uint16_t *pkt_len_twin, const pkt_timeval *pkt_time_twin,
+                        pkt_timeval start_time, pkt_timeval start_time_twin,
                         uint16_t s_idx, uint16_t r_idx,
                         uint16_t *merged_lens, uint16_t *merged_times)
 {
   int s,r;
-  struct timeval ts_start = { 0, 0 }; /* initialize to avoid spurious warnings */
-  struct timeval tmp, tmp_r;
-  struct timeval start_m;
+  pkt_timeval ts_start = { 0, 0 }; /* initialize to avoid spurious warnings */
+  pkt_timeval tmp, tmp_r;
+  pkt_timeval start_m;
 
   if(r_idx + s_idx == 0) {
     return ;
@@ -419,9 +419,9 @@ ndpi_get_mc_rep_times (uint16_t *times, float *time_mc, uint16_t num_packets)
 }
 
 /**
- * \fn float classify (const unsigned short *pkt_len, const struct timeval *pkt_time,
- const unsigned short *pkt_len_twin, const struct timeval *pkt_time_twin,
- struct timeval start_time, struct timeval start_time_twin, uint32_t max_num_pkt_len,
+ * \fn float classify (const unsigned short *pkt_len, const pkt_timeval *pkt_time,
+ const unsigned short *pkt_len_twin, const pkt_timeval *pkt_time_twin,
+ pkt_timeval start_time, pkt_timeval start_time_twin, uint32_t max_num_pkt_len,
  uint16_t sp, uint16_t dp, uint32_t op, uint32_t ip, uint32_t np_o, uint32_t np_i,
  uint32_t ob, uint32_t ib, uint16_t use_bd, const uint32_t *bd, const uint32_t *bd_t)
  * \param pkt_len length of the packet
@@ -445,9 +445,9 @@ ndpi_get_mc_rep_times (uint16_t *times, float *time_mc, uint16_t num_packets)
  * \return float score
  */
 float
-ndpi_classify (const unsigned short *pkt_len, const struct timeval *pkt_time,
-               const unsigned short *pkt_len_twin, const struct timeval *pkt_time_twin,
-               struct timeval start_time, struct timeval start_time_twin, uint32_t max_num_pkt_len,
+ndpi_classify (const unsigned short *pkt_len, const pkt_timeval *pkt_time,
+               const unsigned short *pkt_len_twin, const pkt_timeval *pkt_time_twin,
+               pkt_timeval start_time, pkt_timeval start_time_twin, uint32_t max_num_pkt_len,
                uint16_t sp, uint16_t dp, uint32_t op, uint32_t ip, uint32_t np_o, uint32_t np_i,
                uint32_t ob, uint32_t ib, uint16_t use_bd, const uint32_t *bd, const uint32_t *bd_t)
 {
@@ -604,8 +604,8 @@ ndpi_update_params (classifier_type_codes_t param_type, const char *param_file)
  * \return 1 if equal, 0 otherwise
  */
 unsigned int
-ndpi_timer_eq(const struct timeval *a,
-              const struct timeval *b)
+ndpi_timer_eq(const pkt_timeval *a,
+              const pkt_timeval *b)
 {
   if(a->tv_sec == b->tv_sec && a->tv_usec == b->tv_usec) {
     return 1;
@@ -615,8 +615,8 @@ ndpi_timer_eq(const struct timeval *a,
 }
 
 unsigned int
-ndpi_timer_lt(const struct timeval *a,
-              const struct timeval *b)
+ndpi_timer_lt(const pkt_timeval *a,
+              const pkt_timeval *b)
 {
   return (a->tv_sec == b->tv_sec) ?
     (a->tv_usec < b->tv_usec):(a->tv_sec < b->tv_sec);
@@ -630,9 +630,9 @@ ndpi_timer_lt(const struct timeval *a,
  * \return none
  */
 void
-ndpi_timer_sub(const struct timeval *a,
-               const struct timeval *b,
-               struct timeval *result)
+ndpi_timer_sub(const pkt_timeval *a,
+               const pkt_timeval *b,
+               pkt_timeval *result)
 {
   result->tv_sec = a->tv_sec - b->tv_sec;
   result->tv_usec = a->tv_usec - b->tv_usec;
@@ -648,7 +648,7 @@ ndpi_timer_sub(const struct timeval *a,
  * \return none
  */
 void
-ndpi_timer_clear(struct timeval *a)
+ndpi_timer_clear(pkt_timeval *a)
 {
   a->tv_sec = a->tv_usec = 0;
 }
@@ -659,7 +659,7 @@ ndpi_timer_clear(struct timeval *a)
  * \return unsigned int - Milliseconds
  */
 unsigned int
-ndpi_timeval_to_milliseconds(struct timeval ts)
+ndpi_timeval_to_milliseconds(pkt_timeval ts)
 {
   unsigned int result = ts.tv_usec / 1000 + ts.tv_sec * 1000;
   return result;
@@ -671,7 +671,7 @@ ndpi_timeval_to_milliseconds(struct timeval ts)
  * \return unsigned int - Milliseconds
  */
 unsigned int
-ndpi_timeval_to_microseconds(struct timeval ts)
+ndpi_timeval_to_microseconds(pkt_timeval ts)
 {
   unsigned int result = ts.tv_usec + ts.tv_sec * 1000 * 1000;
   return result;
@@ -680,7 +680,7 @@ ndpi_timeval_to_microseconds(struct timeval ts)
 void
 ndpi_log_timestamp(char *log_ts, uint32_t log_ts_len)
 {
-  struct timeval tv;
+  pkt_timeval tv;
   time_t nowtime;
   struct tm nowtm_r;
   char tmbuf[NDPI_TIMESTAMP_LEN];

--- a/src/lib/ndpi_community_id.c
+++ b/src/lib/ndpi_community_id.c
@@ -31,6 +31,7 @@
 
 #include "ndpi_api.h"
 #include "ndpi_config.h"
+#include "ndpi_includes.h"
 
 #include <time.h>
 #ifndef WIN32


### PR DESCRIPTION
The major blocker is incompatibility of interfaces and types returned for packet timestamps. BSD retunrs bpf_timeval, while non-BSD systems return timeval. These two types are essentially the same, so I am introducing a third type which is aliased to one or another depending on the operating system used.