### PR TITLE
Fix travis-ci related errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
         apt:
           packages:
             - libpcap-dev
-	    - libgcrypt20-dev
+            - libgcrypt20-dev
             - autogen
 
     - os: linux
@@ -22,7 +22,7 @@ matrix:
         apt:
           packages:
             - libpcap-dev
-    	    - libgcrypt20-dev
+            - libgcrypt20-dev
             - autogen
 
     - os: linux
@@ -33,8 +33,8 @@ matrix:
         apt:
           packages:
             - libpcap-dev
-	    - libgcrypt20-dev
-	    - autogen
+            - libgcrypt20-dev
+            - autogen
 
     - os: linux
       compiler: clang
@@ -44,7 +44,7 @@ matrix:
         apt:
           packages:
             - libpcap-dev
-	    - libgcrypt20-dev	    
+            - libgcrypt20-dev
             - autogen
 
 # Targets below have been disabled as we have no way
@@ -78,7 +78,7 @@ matrix:
           packages:
             - g++-8
             - libpcap-dev
-    	    - libgcrypt20-dev
+            - libgcrypt20-dev
             - autogen
       env:
         - MATRIX_EVAL="CC=gcc-8"
@@ -92,7 +92,7 @@ matrix:
           packages:
             - g++-9
             - libpcap-dev
-	    - libgcrypt20-dev
+            - libgcrypt20-dev
             - autogen
       env:
         - MATRIX_EVAL="CC=gcc-9"
@@ -107,7 +107,7 @@ matrix:
           packages:
             - clang-8
             - libpcap-dev
-	    - libgcrypt20-dev
+            - libgcrypt20-dev
             - autogen
       env:
         - MATRIX_EVAL="CC=clang-8"
@@ -122,7 +122,7 @@ matrix:
           packages:
             - clang-7
             - libpcap-dev
-	    - libgcrypt20-dev
+            - libgcrypt20-dev
             - autogen
       env:
         - MATRIX_EVAL="CC=clang-7"
@@ -139,7 +139,7 @@ matrix:
           packages:
             - clang-7
             - libpcap-dev
-	    - libgcrypt20-dev
+            - libgcrypt20-dev
             - autogen
     - name: fuzzm
       env: CXXFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory -fsanitize=fuzzer-no-link" CFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory -fsanitize=fuzzer-no-link" LDFLAGS="-g3 -O0 -fsanitize=memory" QA_FUZZ=msan CC=clang-7 && CXX=clang++-7 MSAN_SYMBOLIZER_PATH=/usr/local/clang-7.0.0/bin/llvm-symbolizer
@@ -153,7 +153,7 @@ matrix:
           packages:
             - clang-7
             - libpcap-dev
-	    - libgcrypt20-dev
+            - libgcrypt20-dev
             - autogen
     - name: fuzzu
       env: CXXFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=undefined -fsanitize=fuzzer-no-link" CFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=undefined -fno-sanitize-recover=undefined,integer -fsanitize=fuzzer-no-link" LDFLAGS="-g3 -O0 -fsanitize=undefined" QA_FUZZ=ubsan CC=clang-7 && CXX=clang++-7
@@ -167,11 +167,11 @@ matrix:
           packages:
             - clang-7
             - libpcap-dev
-	    - libgcrypt20-dev
+            - libgcrypt20-dev
             - autogen
 
 
-  before_install:
+before_install:
   - eval "${MATRIX_EVAL}"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,16 +142,13 @@ matrix:
             - libgcrypt20-dev
             - autogen
     - name: fuzzm
-      env: CXXFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory -fsanitize=fuzzer-no-link" CFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory -fsanitize=fuzzer-no-link" LDFLAGS="-g3 -O0 -fsanitize=memory" QA_FUZZ=msan CC=clang-7 && CXX=clang++-7 MSAN_SYMBOLIZER_PATH=/usr/local/clang-7.0.0/bin/llvm-symbolizer
+      env: CXXFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory -fsanitize=fuzzer-no-link" CFLAGS="-g3 -O0 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory -fsanitize=fuzzer-no-link" LDFLAGS="-g3 -O0 -fsanitize=memory" QA_FUZZ=msan CC=clang && CXX=clang++
       os: linux
-      compiler: clang-7
+      compiler: clang
+      dist: bionic
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
           packages:
-            - clang-7
             - libpcap-dev
             - libgcrypt20-dev
             - autogen

--- a/src/lib/protocols/dnp3.c
+++ b/src/lib/protocols/dnp3.c
@@ -21,13 +21,12 @@
  */
 
 #include "ndpi_protocol_ids.h"
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_DNP3
 #include "ndpi_api.h"
 
 /*
   https://www.ixiacom.com/company/blog/scada-distributed-network-protocol-dnp3
 */
-
-#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_DNP3
 
 /* ******************************************************** */
 

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -286,7 +286,9 @@ static gcry_error_t hkdf_expand(int hashalgo, const uint8_t *prk, uint32_t prk_l
       gcry_md_write(h, lastoutput, hash_len); /* T(1..N) */
     }
     gcry_md_write(h, info, info_len);                   /* info */
-    gcry_md_putc(h, (uint8_t) (offset / hash_len + 1));  /* constant 0x01..N */
+
+    uint8_t c = offset / hash_len + 1;
+    gcry_md_write(h, &c, sizeof(c));                    /* constant 0x01..N */
 
     memcpy(lastoutput, gcry_md_read(h, hashalgo), hash_len);
     memcpy(out + offset, lastoutput, MIN(hash_len, out_len - offset));


### PR DESCRIPTION
* Fixed broken Travis YAML file. (indentation matters!)
* Fixed warning caused by a too-late `NDPI_CURRENT_PROTO` define.
* Investigated MSAN errors reported by fuzzm job (either related to libgcrypt bug or MSAN false-positive(s)) and deicded to upgrade to Ubuntu bionic for the fuzzm job.