### PR TITLE
Do not re-define libc functions for mingw builds.

### DIFF
--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -234,7 +234,7 @@ u_int8_t ndpi_ips_match(u_int32_t src, u_int32_t dst,
 
 /* ****************************************** */
 
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 /* http://opensource.apple.com/source/Libc/Libc-186/string.subproj/strcasecmp.c */
 
 /*


### PR DESCRIPTION
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>