### PR TITLE
don't pass arguments to ./configure as 1 string

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -58,4 +58,4 @@ cat configure | sed "s/#define PACKAGE/#define NDPI_PACKAGE/g" | sed "s/#define 
 cat configure.tmp > configure
 
 chmod +x configure
-./configure "$*"
+./configure $@


### PR DESCRIPTION
this causes the following error if there are arguments after --host :
'checking host system type... config.sub: too many arguments'