### PR TITLE
Fix a memory leak on fuzzing code

### DIFF
--- a/fuzz/fuzz_ndpi_reader.c
+++ b/fuzz/fuzz_ndpi_reader.c
@@ -151,6 +151,7 @@ int main(int argc, char ** argv)
   if (fread(pcap_buffer, sizeof(*pcap_buffer), pcap_file_size, pcap_file) != pcap_file_size) {
     perror("fread failed");
     fclose(pcap_file);
+    free(pcap_buffer);
     return 1;
   }
 


### PR DESCRIPTION
After allocation of pcap_buffer it is necessary to free it