### PR TITLE
CAPWAP tunnel decoding fix

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1942,9 +1942,8 @@ struct ndpi_proto ndpi_workflow_process_packet(struct ndpi_workflow * workflow,
 
 	    offset += msg_len;
 
-	    if((offset + 32 < header->caplen) && (packet[offset] == 0x02)) {
+	    if((offset + 32 < header->caplen)) {
 	      /* IEEE 802.11 Data */
-
 	      offset += 24;
 	      /* LLC header is 8 bytes */
 	      type = ntohs((u_int16_t)*((u_int16_t*)&packet[offset+6]));

--- a/tests/result/capwap.pcap.out
+++ b/tests/result/capwap.pcap.out
@@ -1,8 +1,15 @@
 DNS	2	166	1
-CAPWAP	393	98074	4
+DHCP	5	2090	1
+IGMP	1	122	1
+ICMPV6	5	790	3
+CAPWAP	222	64441	3
 
 	1	UDP 192.168.10.9:5246 <-> 192.168.10.10:12380 [proto: 247/CAPWAP][cat: Network/14][106 pkts/26144 bytes <-> 111 pkts/37530 bytes][Goodput ratio: 83/88][169.10 sec][bytes ratio: -0.179 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 1421/1619 21349/21721 4110/4711][Pkt Len c2s/s2c min/avg/max/stddev: 106/115 247/338 1499/1499 292/381][PLAIN TEXT (Cisco Systems)][Plen Bins: 0,0,30,47,2,6,0,0,2,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,1,0,0]
-	2	UDP 192.168.10.10:12380 <-> 192.168.10.9:5247 [proto: 247/CAPWAP][cat: Network/14][170 pkts/33465 bytes <-> 1 pkts/168 bytes][Goodput ratio: 79/75][157.99 sec][bytes ratio: 0.990 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 961/0 3999/0 1217/0][Pkt Len c2s/s2c min/avg/max/stddev: 93/168 197/168 470/168 78/0][Plen Bins: 0,0,21,27,11,19,4,8,4,0,0,2,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	2	UDP 0.0.0.0:68 -> 255.255.255.255:67 [proto: CAPWAP:18/DHCP][cat: Network/14][5 pkts/2090 bytes -> 0 pkts/0 bytes][Goodput ratio: 72/0][59.44 sec][Host: kawai-ipad3][DHCP Fingerprint: 1,3,6,15,119,252][Plen Bins: 0,0,0,0,0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 	3	UDP 192.168.10.10:12380 -> 255.255.255.255:5246 [proto: 247/CAPWAP][cat: Network/14][4 pkts/660 bytes -> 0 pkts/0 bytes][Goodput ratio: 74/0][130.41 sec][PLAIN TEXT (838.61f)][Plen Bins: 0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-	4	UDP 192.168.10.10:49259 -> 255.255.255.255:53 [proto: 5/DNS][cat: Network/14][2 pkts/166 bytes -> 0 pkts/0 bytes][Goodput ratio: 49/0][3.00 sec][Host: cisco-capwap-controller][::][PLAIN TEXT (CAPWAP)][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-	5	UDP 192.168.10.9:5246 -> 192.168.10.10:12379 [proto: 247/CAPWAP][cat: Network/14][1 pkts/107 bytes -> 0 pkts/0 bytes][Goodput ratio: 60/0][< 1 sec][Plen Bins: 0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	4	ICMPV6 [fe80::fd:7a4c:8d72:7710]:0 -> [ff02::16]:0 [proto: CAPWAP:102/ICMPV6][cat: Network/14][2 pkts/352 bytes -> 0 pkts/0 bytes][Goodput ratio: 22/0][4.56 sec][Plen Bins: 50,50,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	5	ICMPV6 [fe80::fd:7a4c:8d72:7710]:0 -> [ff02::2]:0 [proto: CAPWAP:102/ICMPV6][cat: Network/14][2 pkts/284 bytes -> 0 pkts/0 bytes][Goodput ratio: 3/0][8.33 sec][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	6	UDP 192.168.10.10:49259 -> 255.255.255.255:53 [proto: 5/DNS][cat: Network/14][2 pkts/166 bytes -> 0 pkts/0 bytes][Goodput ratio: 49/0][3.00 sec][Host: cisco-capwap-controller][::][PLAIN TEXT (CAPWAP)][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	7	ICMPV6 [::]:0 -> [ff02::1:ff72:7710]:0 [proto: CAPWAP:102/ICMPV6][cat: Network/14][1 pkts/154 bytes -> 0 pkts/0 bytes][Goodput ratio: 10/0][< 1 sec][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	8	IGMP 169.254.87.121:0 -> 224.0.0.251:0 [proto: CAPWAP:82/IGMP][cat: Network/14][1 pkts/122 bytes -> 0 pkts/0 bytes][Goodput ratio: 0/0][< 1 sec][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	9	UDP 192.168.10.9:5246 -> 192.168.10.10:12379 [proto: 247/CAPWAP][cat: Network/14][1 pkts/107 bytes -> 0 pkts/0 bytes][Goodput ratio: 60/0][< 1 sec][Plen Bins: 0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]


### PR DESCRIPTION
This PR fix CAPWAP tunnel processing.
Currently, CAPWAP tunnel decoding has some issues. When set to True, we observe 3 passes per packet without effect.
After investigation, this is fixed by removing the **packet[offset] == 0x02** check.
The resulting file is updated and as illustrated now DHCP and other protocols on top of CAPWAP are correctly handled.
Note that when there is no IP layer on top of it (pure WiFI 801.11 management), packets are discarded.

BR,
Zied