### PR TITLE
Generate NDPI_API_VERSION based on git commands.

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -46,7 +46,9 @@ AC_DEFINE_UNQUOTED(NDPI_MAJOR_RELEASE, "${NDPI_MAJOR}", [nDPI major release])
 AC_DEFINE_UNQUOTED(NDPI_MINOR_RELEASE, "${NDPI_MINOR}", [nDPI minor release])
 AC_DEFINE_UNQUOTED(NDPI_PATCH_LEVEL,   "${NDPI_PATCH}", [nDPI patch level])
 
-if test -d ".git"; then :
+# .git as directory in a cloned repo
+# .git as file in submodule based integration
+if test -d ".git" || test -f ".git" ; then :
      GIT_TAG=`git log -1 --format=%h`
      GIT_DATE=`git log -1 --format=%cd`
      #


### PR DESCRIPTION
https://github.com/ntop/PF_RING/issues/668

Check for .git directory works in case of usual clone of nDPI repo.
But if you integrate is as submodule then .git is a file.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>