### PR TITLE
Fix/packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,15 @@ matrix:
       compiler: clang
 
     - os: linux
+      env: BUILD_DPKG_PACKAGE=y
       compiler: gcc
       dist: bionic
       addons:
         apt:
           packages:
+            - fakeroot
+            - debhelper
+            - dpkg-dev
             - libpcap-dev
             - libgcrypt20-dev
             - libjson-c-dev
@@ -189,7 +193,10 @@ before_script:
 #  - lcov --directory . --zerocounters
 
 script:
-  - if [ -n "$QA_FUZZ" ]; then ./configure --enable-fuzztargets ; else ./configure ; fi
+  - if [ -n "$QA_FUZZ" ]; then ./configure --enable-fuzztargets ; else
+    ./configure ; fi
+  - if [ -n "$BUILD_DPKG_PACKAGE" ]; then cd ./packages/ubuntu ;
+    ./configure && dpkg-buildpackage -b -us -uc ; cd ../.. ; fi
   - make
   - make -C example ndpiSimpleIntegration
   - make dist

--- a/packages/openwrt/Makefile
+++ b/packages/openwrt/Makefile
@@ -1,57 +1,93 @@
 #
-# Copyright (C) 2018-20 - ntop.org
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libndpi
-PKG_VERSION:=17022020
+PKG_VERSION:=3.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/ntop/nDPI.git
-PKG_SOURCE_VERSION:=1f921562d1d7962f1d23ca5b59c25f9b65073460
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://codeload.github.com/ntop/nDPI/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=dc9b291c7fde94edb45fb0f222e0d93c93f8d6d37f4efba20ebd9c655bfcedf9
+PKG_BUILD_DIR:=$(BUILD_DIR)/nDPI-$(PKG_VERSION)
 
-PKG_MAINTAINER:=Luca Deri <deri@ntop.org>
-PKG_LICENSE:=GPL3
-PKG_BUILD_DEPENDS:=
+PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>, Toni Uhlig <matzeton@googlemail.com>
+PKG_LICENSE:=LGPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
+PKG_REMOVE_FILES:=autogen.sh
+PKG_BUILD_DEPENDS:=libpcap
 PKG_BUILD_PARALLEL:=1
 
-# autogen fix
-PKG_FIXUP:=autoreconf
-
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
+ifeq ($(CONFIG_LIBNDPI_GCRYPT),)
+CONFIGURE_ARGS += --disable-gcrypt
+endif
+
 define Package/libndpi
-  SECTION:=network
-  CATEGORY:=Network
-  TITLE:=nDPI Deep Packet Inspection Library
-  URL:=https://www.ntop.org
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Library for deep-packet inspection
+  URL:=https://github.com/ntop/nDPI
+  DEPENDS:=$(CXX_DEPENDS) +LIBNDPI_GCRYPT:libgcrypt +libpcap +libjson-c
 endef
 
 define Package/libndpi/description
- Open and Extensible GPLv3 Deep Packet Inspection Library
+  nDPI is an open source LGPLv3 library for deep-packet inspection.
+  Based on OpenDPI it includes ntop extensions.
 endef
 
-CONFIGURE_ARGS += \
-	--with-only-libndpi
+define Package/libndpi/config
+config LIBNDPI_GCRYPT
+	bool "GCrypt support"
+	depends on PACKAGE_libndpi
+	default n
+	help
+	  This option enables QUIC client hello decryption.
+	  Disabled by default.
+endef
 
 define Build/Prepare
-	$(call Build/Prepare/Default)
-endef
-
-define Build/Configure
-	( cd $(PKG_BUILD_DIR); ./autogen.sh )
-	$(call Build/Configure/Default)
+	$(PKG_UNPACK)
+	$(Build/Patch)
+	mv $(PKG_BUILD_DIR)/configure.seed $(PKG_BUILD_DIR)/configure.ac
+	$(SED) "s/@NDPI_MAJOR@/3/g" \
+		-e "s/@NDPI_MINOR@/4/g" \
+		-e "s/@NDPI_PATCH@/0/g" \
+		-e "s/@NDPI_VERSION_SHORT@/3.4.0/g" \
+		-e "s/@FUZZY@/dnl> /g" \
+		$(PKG_BUILD_DIR)/configure.ac
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/local/include/libndpi
-	$(CP) $(PKG_BUILD_DIR)/src/include/* $(STAGING_DIR)/usr/local/include/libndpi
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/local/lib
-	$(CP) $(PKG_BUILD_DIR)/src/lib/libndpi.* $(STAGING_DIR)/usr/local/lib
+	$(INSTALL_DIR) $(1)/usr/include/ndpi
+	$(CP) $(PKG_BUILD_DIR)/src/include/*.h \
+		$(1)/usr/include/ndpi/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/src/lib/libndpi.so* \
+		$(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_BUILD_DIR)/libndpi.pc \
+		$(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libndpi/install
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/src/lib/libndpi.so* \
+		$(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(CP) $(PKG_BUILD_DIR)/example/ndpiReader \
+		$(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,libndpi))

--- a/packages/ubuntu/Makefile.in
+++ b/packages/ubuntu/Makefile.in
@@ -1,46 +1,17 @@
-#
-# Change it according to your setup
-#
 NDPI_HOME=$(PWD)/../..
-NDPI_BUILD=${NDPI_HOME}/packages/ubuntu
+NDPI_BUILD="$(realpath ${NDPI_HOME}/packages/ubuntu)"
 
 all: clean ndpi
 
 ndpi:
-	\rm -rf ./debian/ndpi-tmp ./debian/ndpi-dev-tmp ./debian/ndpi ./debian/ndpi-dev
-	mkdir -p ./debian/ndpi-tmp ./debian/ndpi-dev-tmp
-	mkdir -p  ./debian/ndpi-tmp/usr/lib ./debian/ndpi-tmp/usr/bin 
-	mkdir -p ./debian/ndpi-dev-tmp/usr/lib ./debian/ndpi-dev-tmp/usr/include/ndpi
-	cd ${NDPI_HOME}; ./autogen.sh; ./configure; make
-	cp $(NDPI_HOME)/src/lib/libndpi.so.@NDPI_VERS@ ./debian/ndpi-tmp/usr/lib/
-	cd ./debian/ndpi-tmp/usr/lib/; ln -s libndpi.so.@NDPI_VERS@ libndpi.so; cd -
-	cd ./debian/ndpi-tmp/usr/lib/; ln -s libndpi.so.@NDPI_VERS@ libndpi.so.@MAJOR_RELEASE@; cd -
-	cp $(NDPI_HOME)/src/lib/libndpi.a ./debian/ndpi-dev-tmp/usr/lib/
-	cp $(NDPI_HOME)/example/ndpiReader ./debian/ndpi-tmp/usr/bin/
-	cp $(NDPI_HOME)/src/include/*.h ./debian/ndpi-dev-tmp/usr/include/ndpi/
-	-rm -fr ./debian/ndpi-dev-tmp/usr/include/ndpi/ndpi_win32.h*
-	@echo
-	@find ./debian/ndpi-tmp -name "*~" -exec /bin/rm {} ';'
-	@find ./debian/ndpi-dev-tmp -name "*~" -exec /bin/rm {} ';'
-	dpkg-buildpackage -rfakeroot -d -us -uc
-	dpkg-sig --sign builder -k D1EB60BE ../ndpi*deb
-	@\rm -f ../ndpi*dsc ../ndpi*.gz ../ndpi*changes
-	@/bin/mv ../ndpi*deb .
-	@echo
-	@echo "Package built."
-	@/bin/ls ndpi*deb
-	@echo "-------------------------------"
-	-dpkg --contents ndpi_*.deb
-	@echo "-------------------------------"
-	@echo "-------------------------------"
-	-dpkg --contents ndpi-dev_*.deb
-	@echo "-------------------------------"
+	cd ${NDPI_HOME}; ./autogen.sh --prefix="/usr"; make
 
 distclean:
-	echo "dummy distclean"
+	-cd ${NDPI_HOME} && make distclean
 
 install:
-	echo "dummy install"
+	cd ${NDPI_HOME}; make install DESTDIR="${NDPI_BUILD}/debian/tmp" AM_UPDATE_INFO_DIR=no
 
 clean:
-	-rm -rf *~ *deb ./usr ./debian/ndpi ./debian/ndpi-dev ./debian/ndpi-tmp ./debian/ndpi-dev-tmp
+	-cd ${NDPI_HOME} && make clean
+	-rm -rf *~ *deb ./usr ./debian/ndpi ./debian/ndpi-dev ./debian/ndpi ./debian/ndpi-dev

--- a/packages/ubuntu/README
+++ b/packages/ubuntu/README
@@ -1,0 +1,12 @@
+Howto Build Debian packages
+---------------------------
+
+Initial configuration and debian/changelog generation:
+./configure
+
+Build a binary (GPG signed) nDPI package with:
+dpkg-buildpackage -b
+
+Or build a binary (unsigned) nDPI package with:
+dpkg-buildpackage -b -us -uc
+

--- a/packages/ubuntu/configure
+++ b/packages/ubuntu/configure
@@ -1705,9 +1705,9 @@ else
   fi
 fi
 
-NDPI_VERS=`../version.sh --release`
-MAJOR_RELEASE=`../version.sh --major-release`
-GIT_REVISION=`../version.sh --revision`
+NDPI_VERS=`$(dirname "${0}")/../version.sh --release`
+MAJOR_RELEASE=`$(dirname "${0}")/../version.sh --major-release`
+GIT_REVISION=`$(dirname "${0}")/../version.sh --revision`
 
 ac_config_files="$ac_config_files Makefile debian/changelog debian/files debian/control"
 

--- a/packages/ubuntu/configure.in
+++ b/packages/ubuntu/configure.in
@@ -24,9 +24,9 @@ else
   fi
 fi
 
-NDPI_VERS=`../version.sh --release`
-MAJOR_RELEASE=`../version.sh --major-release`
-GIT_REVISION=`../version.sh --revision`
+NDPI_VERS=`$(dirname "${0}")/../version.sh --release`
+MAJOR_RELEASE=`$(dirname "${0}")/../version.sh --major-release`
+GIT_REVISION=`$(dirname "${0}")/../version.sh --revision`
 
 AC_CONFIG_FILES([Makefile debian/changelog debian/files debian/control])
 

--- a/packages/ubuntu/debian/rules
+++ b/packages/ubuntu/debian/rules
@@ -19,6 +19,7 @@ ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 endif
 
 override_dh_installdocs:
+	# FIXME: nDPI does currently not have any up2date doc
 
 override_dh_auto_install:
 	make -j1 install DESTDIR="$(CURDIR)/debian/tmp" AM_UPDATE_INFO_DIR=no

--- a/packages/ubuntu/debian/rules
+++ b/packages/ubuntu/debian/rules
@@ -1,50 +1,34 @@
 #!/usr/bin/make -f
 
-# Uncomment this to turn on verbose mode.
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DH_VERBOSE=1
 
-package=ndpi
+DPKG_EXPORT_BUILDFLAGS = 1
 
-build: build-stamp
-build-stamp:
-	dh_testdir
+include /usr/share/dpkg/buildflags.mk
+include /usr/share/dpkg/pkg-info.mk
 
-clean:
-	dh_testdir
-	dh_testroot
-	dh_clean
 
-install: build
-	dh_testdir
-	dh_testroot
-	dh_clean -k
-	dh_installdirs
+%:
+	dh $@
 
-# Build architecture-independent files here.
-binary-indep: build install
-# We have nothing to do by default.
+override_dh_auto_test:
+ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
+	cd ../../tests && LD_LIBRARY_PATH=$(CURDIR)/src/lib ./do.sh
+	cd ../../tests && LD_LIBRARY_PATH=$(CURDIR)/src/lib ./do-unit.sh
+endif
 
-# Build architecture-dependent files here.
-binary-arch: build install
-	dh_testdir
-	dh_testroot
-	dh_prep
-	#dh_clean -k
-	dh_installdirs
-	dh_installinit
-	dh_installman
-	dh_link
-	dh_strip
-	dh_compress
-	dh_fixperms
-	dh_installdeb
-	mkdir -p ./debian/ndpi ./debian/ndpi-dev
-	cp -r ./debian/ndpi-tmp/*     ./debian/ndpi/
-	cp -r ./debian/ndpi-dev-tmp/* ./debian/ndpi-dev/
-	-find ./debian/ndpi -executable -type f | xargs strip
-	dh_gencontrol
-	dh_md5sums
-	dh_builddeb
+override_dh_installdocs:
 
-binary: binary-indep binary-arch
-.PHONY: build clean binary-indep binary-arch binary install
+override_dh_auto_install:
+	make -j1 install DESTDIR="$(CURDIR)/debian/tmp" AM_UPDATE_INFO_DIR=no
+	# ndpi package
+	mkdir -p "$(CURDIR)/debian/ndpi/usr/"
+	mv -v "$(CURDIR)/debian/tmp/usr/bin"   "$(CURDIR)/debian/ndpi/usr/"
+	mv -v "$(CURDIR)/debian/tmp/usr/lib"   "$(CURDIR)/debian/ndpi/usr/"
+	mv -v "$(CURDIR)/debian/tmp/usr/share" "$(CURDIR)/debian/ndpi/usr/"
+	# ndpi-dev package
+	mkdir -p "$(CURDIR)/debian/ndpi-dev/usr/include"
+	mv -v "$(CURDIR)/debian/tmp/usr/include/ndpi" "$(CURDIR)/debian/ndpi-dev/usr/include/"
+
+.PHONY: override_dh_auto_configure override_dh_installdocs override_dh_auto_install


### PR DESCRIPTION
Fixes packaging for Debian, Ubuntu and OpenWrt and adds a CI job for Ubuntu packaging.

I've just copy'n'pasted the nDPI OpenWrt build file from openwrt-packages.
The previous file was broken and I'm keeping OpenWrt's nDPI up2date anyway.