### PR TITLE
Fix minimum packet length condition

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1613,7 +1613,8 @@ struct ndpi_proto ndpi_workflow_process_packet(struct ndpi_workflow * workflow,
 
 
  datalink_check:
-  if(header->caplen < eth_offset + 40)
+  // 20 for min iph and 8 for min UDP
+  if(header->caplen < eth_offset + 28)
     return(nproto); /* Too short */
 
   switch(datalink_type) {


### PR DESCRIPTION
Minor fix for minimum packet length to process.

Currently, it is 20 for minimum(iph) and 20 for minimum(tcph) resulting in 40.
Switched to 28 = 20 for minimum(iph) and 8 for minimum(udph).
This was found based on a subset of CAIDA datasets where traces are truncated with 29 snaplen for UDP and 40 for TCP.
ndpiReader does not generate any UDP flows due to this limit which we fix in this PR.

Regards,
Zied