### PR TITLE
Added a new API function `ndpi_free_flow_data' which free's all membe…

### DIFF
--- a/src/include/ndpi_api.h.in
+++ b/src/include/ndpi_api.h.in
@@ -201,9 +201,17 @@ extern "C" {
   void ndpi_finalize_initalization(struct ndpi_detection_module_struct *ndpi_str);
 
   /**
-   * Frees the memory allocated in the specified flow
+   * Frees the dynamic memory allocated members in the specified flow
    *
-   * @par flow  = the flow to deallocate
+   * @par flow  = the flow struct which dynamic allocated members should be deallocated
+   *
+   */
+  void ndpi_free_flow_data(struct ndpi_flow_struct *flow);
+
+  /**
+   * Frees the dynamic memory allocated members in the specified flow and the flow struct itself
+   *
+   * @par flow  = the flow struct and its dynamic allocated members that should be deallocated
    *
    */
   void ndpi_free_flow(struct ndpi_flow_struct *flow);

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6310,7 +6310,7 @@ int ndpi_match_bigram(struct ndpi_detection_module_struct *ndpi_str,
 
 /* ****************************************************** */
 
-void ndpi_free_flow(struct ndpi_flow_struct *flow) {
+void ndpi_free_flow_data(struct ndpi_flow_struct *flow) {
   if(flow) {
     u_int is_quic = flow_is_proto(flow, NDPI_PROTOCOL_QUIC);
     
@@ -6355,7 +6355,12 @@ void ndpi_free_flow(struct ndpi_flow_struct *flow) {
       if(flow->l4.tcp.tls.message.buffer)
 	ndpi_free(flow->l4.tcp.tls.message.buffer);
     }
+  }
+}
 
+void ndpi_free_flow(struct ndpi_flow_struct *flow) {
+  if (flow) {
+    ndpi_free_flow_data(flow);
     ndpi_free(flow);
   }
 }


### PR DESCRIPTION
…rs of ndpi_flow_struct but not the struct itself.

This function is necessary for all who integrated nDPI's `struct ndpi_flow_struct` into another struct  (as struct, not pointer to struct) to reduce the amount of dynamic memory allocations.

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>