### PR TITLE
Increase SNI host name buffer length to 256.

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1259,8 +1259,8 @@ struct ndpi_flow_struct {
       struct {
         char ssl_version_str[12];
 	u_int16_t ssl_version, server_names_len;
-	char client_requested_server_name[64], *server_names,
-	  *alpn, *tls_supported_versions, *issuerDN, *subjectDN;
+	char client_requested_server_name[256], /* SNI hostname length: RFC 4366 */
+	  *server_names, *alpn, *tls_supported_versions, *issuerDN, *subjectDN;
 	u_int32_t notBefore, notAfter;
 	char ja3_client[33], ja3_server[33];
 	u_int16_t server_cipher;


### PR DESCRIPTION
According to RFC 4366, SNI host names can be up to 255 bytes.
Previous size of 64 resulted in failed application matches due to truncation.

For example:
 0976e041e65b1aece3e720df36ac6bd7.safeframe.googlesyndication.co|m

Signed-off-by: Darryl Sokoloski <darryl@sokoloski.ca>