### PR TITLE
HTTP: fix user-agent parsing

### DIFF
--- a/python/ndpi.py
+++ b/python/ndpi.py
@@ -1068,6 +1068,8 @@ struct ndpi_flow_struct {
     uint8_t num_request_headers, num_response_headers;
     uint8_t request_version; /* 0=1.0 and 1=1.1. Create an enum for this? */
     uint16_t response_status_code; /* 200, 404, etc. */
+    uint8_t detected_os[32]; /* Via HTTP/QUIC User-Agent */
+
   } http;
 
   /* 
@@ -1145,8 +1147,6 @@ struct ndpi_flow_struct {
     } ubntac2;
 
     struct {
-      /* Via HTTP User-Agent */
-      uint8_t detected_os[32];
       /* Via HTTP X-Forwarded-For */
       uint8_t nat_ip[24];
     } http;

--- a/python/ndpi_typestruct.py
+++ b/python/ndpi_typestruct.py
@@ -456,6 +456,7 @@ class Http(Structure):
         ("num_response_headers", c_uint8),
         ("request_version", c_uint8),
         ("response_status_code", c_uint16),
+        ("detected_os", c_char * 32),
     ]
 
 
@@ -535,7 +536,6 @@ class Ubntac2(Structure):
 
 class Http2(Structure):
     _fields_ = [
-        ("detected_os", c_char * 32),
         ("nat_ip", c_char * 24)
     ]
 

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1224,6 +1224,7 @@ struct ndpi_flow_struct {
     u_int8_t num_request_headers, num_response_headers;
     u_int8_t request_version; /* 0=1.0 and 1=1.1. Create an enum for this? */
     u_int16_t response_status_code; /* 200, 404, etc. */
+    u_char detected_os[32]; /* Via HTTP/QUIC User-Agent */
   } http;
 
   /* 
@@ -1300,8 +1301,6 @@ struct ndpi_flow_struct {
     } ubntac2;
 
     struct {
-      /* Via HTTP User-Agent */
-      u_char detected_os[32];
       /* Via HTTP X-Forwarded-For */
       u_char nat_ip[24];
     } http;

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -342,8 +342,8 @@ static void setHttpUserAgent(struct ndpi_detection_module_struct *ndpi_struct,
   /* Good reference for future implementations:
    * https://github.com/ua-parser/uap-core/blob/master/regexes.yaml */
 
-  snprintf((char*)flow->protos.http.detected_os,
-	   sizeof(flow->protos.http.detected_os), "%s", ua);
+  snprintf((char*)flow->http.detected_os,
+	   sizeof(flow->http.detected_os), "%s", ua);
 }
 
 /* ************************************************************* */


### PR DESCRIPTION
User-agent information is used to try to detect the user OS; since the
UA is extracted for QUIC traffic too, the "detected_os" field must be
generic and not associated to HTTP flows only.

Otherwise, you might overwrite some "tls_quic_stun" fields (SNI...) with
random data.

Strangely enough, the "detected_os" field is never used: it is never
logged, or printed, or exported...

You can easily trigger this behavior with this hand-crafted trace, where there is not the SNI 
[os_detected.pcapng.gz](https://github.com/ntop/nDPI/files/5900090/os_detected.pcapng.gz)

```
ivan@ivan:~/svnrepos/nDPI(detected_os)$ ./example/ndpiReader -t -i os_detected.pcapng -v2
[..]
1    UDP 192.168.1.128:39821 -> 8.8.8.8:443 ... [Risk: ** SNI TLS extension was missing **] ...  <--- OK!
[...]
ivan@ivan:~/svnrepos/nDPI(dev)$ ./example/ndpiReader -t -i os_detected.pcapng -v2
[...]
1    UDP 192.168.1.128:39821 -> 8.8.8.8:443 ... [Client: 003] ...   <-- KO!!!
[...]
```