### PR TITLE
Added fuzzy targets conditional in tests/do.sh.in which prevents the …

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -23,6 +23,7 @@ AS_IF([test "${with_mipsel+set}" = set],[
 
 AC_ARG_WITH(sanitizer,     AS_HELP_STRING([--with-sanitizer], [Build with support for address, undefined and leak sanitizer]))
 AC_ARG_ENABLE(fuzztargets, AS_HELP_STRING([--enable-fuzztargets], [Enable fuzz targets]),[enable_fuzztargets=$enableval],[enable_fuzztargets=no])
+AS_IF([test "x$enable_fuzztargets" = "xyes"], [BUILD_FUZZTARGETS=1], [BUILD_FUZZTARGETS=0])
 AM_CONDITIONAL([BUILD_FUZZTARGETS], [test "x$enable_fuzztargets" = "xyes"])
 
 AS_IF([test "${with_sanitizer+set}" = set],[
@@ -240,6 +241,7 @@ AC_SUBST(CUSTOM_NDPI)
 AC_SUBST(NDPI_API_VERSION)
 AC_SUBST(EXTRA_TARGETS)
 AC_SUBST(BUILD_MINGW)
+AC_SUBST(BUILD_FUZZTARGETS)
 AC_SUBST(JSONC_CFLAGS)
 AC_SUBST(JSONC_LIBS)
 AC_SUBST(GCRYPT_ENABLED)

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -136,8 +136,11 @@ void *ndpi_realloc(void *ptr, size_t old_size, size_t new_size) {
   if(!ret)
     return(ret);
   else {
-    memcpy(ret, ptr, old_size);
-    ndpi_free(ptr);
+    if (ptr != NULL)
+    {
+      memcpy(ret, ptr, old_size);
+      ndpi_free(ptr);
+    }
     return(ret);
   }
 }

--- a/tests/do.sh.in
+++ b/tests/do.sh.in
@@ -2,6 +2,8 @@
 
 cd "$(dirname "${0}")"
 
+FUZZY_TESTING_ENABLED=@BUILD_FUZZTARGETS@
+
 GCRYPT_ENABLED=@GCRYPT_ENABLED@
 GCRYPT_PCAPS="gquic.pcap quic-23.pcap quic-24.pcap quic-27.pcap quic-28.pcap quic-29.pcap quic-mvfst-22.pcap quic-mvfst-27.pcap quic-mvfst-exp.pcap quic_q50.pcap quic_t50.pcap quic_t51.pcap quic_0RTT.pcap quic_interop_V.pcapng quic-33.pcapng doq.pcapng doq_adguard.pcapng dlt_ppp.pcap"
 READER="../example/ndpiReader -p ../example/protos.txt -c ../example/categories.txt"
@@ -67,7 +69,9 @@ check_results() {
     done
 }
 
-fuzzy_testing
+if [ $FUZZY_TESTING_ENABLED -eq 1 ]; then
+    fuzzy_testing
+fi
 build_results
 check_results
 


### PR DESCRIPTION
…fuzzer from running if nDPI was configured previously --enable-fuzztargets but not for the current config (may produce invalid results).

 * fixed possible NULL pointer dereference for memcpy(), src pointer should never be NULL

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>