### PR TITLE
Fixed memory leaks caused by conditional free'ing for some TLS connec…

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -812,7 +812,7 @@ static struct ndpi_flow_info *get_ndpi_flow_info(struct ndpi_workflow * workflow
       LOG(NDPI_LOG_ERROR,
 	       "maximum flow count (%u) has been exceeded\n",
 	       workflow->prefs.max_ndpi_flows);
-      exit(-1);
+      return NULL;
     } else {
       struct ndpi_flow_info *newflow = (struct ndpi_flow_info*)ndpi_malloc(sizeof(struct ndpi_flow_info));
 

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -15,8 +15,8 @@ fuzz_process_packet_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 
 fuzz_ndpi_reader_SOURCES = fuzz_ndpi_reader.c
 fuzz_ndpi_reader_CFLAGS = -I../example/
-fuzz_ndpi_reader_LDADD = ../src/lib/libndpi.a
-fuzz_ndpi_reader_LDFLAGS = ../example/libndpiReader.a $(PCAP_LIB) $(ADDITIONAL_LIBS) $(LIBS)
+fuzz_ndpi_reader_LDADD = ../example/libndpiReader.a ../src/lib/libndpi.a
+fuzz_ndpi_reader_LDFLAGS = $(PCAP_LIB) $(ADDITIONAL_LIBS) $(LIBS)
 if HAS_FUZZLDFLAGS
 fuzz_ndpi_reader_CFLAGS += $(LIB_FUZZING_ENGINE)
 fuzz_ndpi_reader_LDFLAGS += $(LIB_FUZZING_ENGINE)

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6425,8 +6425,6 @@ uint8_t ndpi_connection_tracking(struct ndpi_detection_module_struct *ndpi_str,
 
   void ndpi_free_flow_data(struct ndpi_flow_struct *flow) {
     if(flow) {
-      u_int is_quic = flow_is_proto(flow, NDPI_PROTOCOL_QUIC);
-    
       if(flow->http.url)
 	ndpi_free(flow->http.url);
 
@@ -6442,10 +6440,12 @@ uint8_t ndpi_connection_tracking(struct ndpi_detection_module_struct *ndpi_str,
       if(flow->kerberos_buf.pktbuf)
 	ndpi_free(flow->kerberos_buf.pktbuf);
 
-      if(is_quic
-	 || flow_is_proto(flow, NDPI_PROTOCOL_TLS)
-	 || flow_is_proto(flow, NDPI_PROTOCOL_DTLS)
-	 ) {
+	if (flow_is_proto(flow, NDPI_PROTOCOL_QUIC) ||
+        flow_is_proto(flow, NDPI_PROTOCOL_TLS) ||
+        flow_is_proto(flow, NDPI_PROTOCOL_DTLS) ||
+        flow_is_proto(flow, NDPI_PROTOCOL_MAIL_SMTPS) ||
+        flow_is_proto(flow, NDPI_PROTOCOL_MAIL_POPS) ||
+        flow_is_proto(flow, NDPI_PROTOCOL_MAIL_IMAPS)) {
 	if(flow->protos.tls_quic_stun.tls_quic.server_names)
 	  ndpi_free(flow->protos.tls_quic_stun.tls_quic.server_names);
 
@@ -6463,7 +6463,7 @@ uint8_t ndpi_connection_tracking(struct ndpi_detection_module_struct *ndpi_str,
       
 	if(flow->protos.tls_quic_stun.tls_quic.encrypted_sni.esni)
 	  ndpi_free(flow->protos.tls_quic_stun.tls_quic.encrypted_sni.esni);
-      }
+	}
 
       if(flow->l4_proto == IPPROTO_TCP) {
 	if(flow->l4.tcp.tls.message.buffer)


### PR DESCRIPTION
…tions.

 * Members of tls_quic struct should also free'd if the detected master protocol is IMAPS / POPS / SMTPS / etc.

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>