### PR TITLE
Mining: lru cache is ipv4 only (for the time being)

### DIFF
--- a/src/lib/protocols/mining.c
+++ b/src/lib/protocols/mining.c
@@ -61,7 +61,8 @@ void ndpi_search_mining_udp(struct ndpi_detection_module_struct *ndpi_struct,
     else {
       snprintf(flow->flow_extra_info, sizeof(flow->flow_extra_info), "%s", "ETH");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MINING, NDPI_PROTOCOL_UNKNOWN);
-      cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
+      if(packet->iph) /* TODO: ipv6 */
+        cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
       return;
     }
   }
@@ -96,7 +97,8 @@ void ndpi_search_mining_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       if((*to_match == magic) || (*to_match == magic1)) {
 	snprintf(flow->flow_extra_info, sizeof(flow->flow_extra_info), "%s", "ETH");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MINING, NDPI_PROTOCOL_UNKNOWN);
-	cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
+	if(packet->iph) /* TODO: ipv6 */
+	  cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
 	return;
       }
     }
@@ -108,7 +110,8 @@ void ndpi_search_mining_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       if(isEthPort(ntohs(packet->tcp->dest)) /* Ethereum port */) {
 	snprintf(flow->flow_extra_info, sizeof(flow->flow_extra_info), "%s", "ETH");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MINING, NDPI_PROTOCOL_UNKNOWN);
-	cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
+	if(packet->iph) /* TODO: ipv6 */
+	  cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
 	return;
       } else
 	flow->guessed_protocol_id = NDPI_PROTOCOL_MINING;
@@ -128,7 +131,8 @@ void ndpi_search_mining_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       */
       snprintf(flow->flow_extra_info, sizeof(flow->flow_extra_info), "%s", "ETH");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MINING, NDPI_PROTOCOL_UNKNOWN);
-      cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
+      if(packet->iph) /* TODO: ipv6 */
+        cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
       return;
     } else if(ndpi_strnstr((const char *)packet->payload, "{", packet->payload_packet_len)
 	      && (ndpi_strnstr((const char *)packet->payload, "\"method\":", packet->payload_packet_len)
@@ -151,7 +155,8 @@ void ndpi_search_mining_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       */
       snprintf(flow->flow_extra_info, sizeof(flow->flow_extra_info), "%s", "ZCash/Monero");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MINING, NDPI_PROTOCOL_UNKNOWN);
-      cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
+      if(packet->iph) /* TODO: ipv6 */
+        cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
       return;
     }
   }


### PR DESCRIPTION
Fix memory error with ipv6 traffic.

It is a simple workaround until the cache supports ipv6 keys too