### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -76,7 +76,10 @@ if test -d ".git" || test -f ".git" ; then :
 else
      GIT_RELEASE="${PACKAGE_VERSION}"
      GIT_DATE=`date -u -r CHANGELOG.md`
-     NDPI_API_VERSION=`date +%s | cut -c7-10`
+     if test -z "$SOURCE_DATE_EPOCH" ; then :
+         SOURCE_DATE_EPOCH=`date +%s`
+     fi
+     NDPI_API_VERSION=`echo $SOURCE_DATE_EPOCH | cut -c7-10`
 fi
 
 NDPI_API_VERSION=`echo $NDPI_API_VERSION | sed 's/^0*//'`


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

While this patch works, there are probably better ways to
deterministically generate the `NDPI_API_VERSION` value
by hashing relevant inputs.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).