### PR TITLE
Check datalink during fuzzing to prevent console / logfile spam.

### DIFF
--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -1,7 +1,6 @@
 CC=@CC@
 CXX=@CXX@
 BUILD_MINGW=@BUILD_MINGW@
-BUILD_FUZZTARGETS=@BUILD_FUZZTARGETS@
 SRCHOME=../src
 CFLAGS=-g -fPIC -DPIC -I$(SRCHOME)/include @PCAP_INC@ @CFLAGS@
 LIBNDPI=$(SRCHOME)/lib/libndpi.a
@@ -10,10 +9,6 @@ HEADERS=intrusion_detection.h reader_util.h $(SRCHOME)/include/ndpi_api.h \
         $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
 OBJS=ndpiReader.o reader_util.o intrusion_detection.o
 PREFIX?=@prefix@
-
-ifneq ($(BUILD_FUZZTARGETS),)
-CFLAGS += -DBUILD_FUZZTARGETS=1
-endif
 
 ifneq ($(BUILD_MINGW),)
 all:

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1773,15 +1773,11 @@ struct ndpi_proto ndpi_workflow_process_packet(struct ndpi_workflow * workflow,
     break;
 
   default:
-#ifndef BUILD_FUZZTARGETS
     /*
      * We shoudn't be here, because we already checked that this datalink is supported.
      * Should ndpi_is_datalink_supported() be updated?
-     *
-     * NOTE (toni): We get here quite often during fuzzing and it spams consoles and logfiles. ;)
      */
     printf("Unknown datalink %d\n", datalink_type);
-#endif
     return(nproto);
   }
 

--- a/fuzz/fuzz_ndpi_reader.c
+++ b/fuzz/fuzz_ndpi_reader.c
@@ -66,6 +66,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     free(pcap_path);
     return 0;
   }
+  if (ndpi_is_datalink_supported(pcap_datalink(pkts)) == 0)
+  {
+    /* Do not fail if the datalink type is not supported (may happen often during fuzzing). */
+    pcap_close(pkts);
+    remove(pcap_path);
+    free(pcap_path);
+    return 0;
+  }
   struct ndpi_workflow * workflow = ndpi_workflow_init(prefs, pkts);
   // enable all protocols
   NDPI_BITMASK_SET_ALL(all);


### PR DESCRIPTION
As adviced by @IvanNardi in #1175 the fuzz reader checks now if the datalink is valid before processing any packets.

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>