### PR TITLE
Fix some warnings

### DIFF
--- a/src/include/ndpi_api.h.in
+++ b/src/include/ndpi_api.h.in
@@ -1501,7 +1501,7 @@ extern "C" {
   void ndpi_serialize_risk(ndpi_serializer *serializer, struct ndpi_flow_struct *flow);
 
   const char* ndpi_risk2str(ndpi_risk_enum risk);
-  const ndpi_risk_severity ndpi_risk2severity(ndpi_risk_enum risk);
+  ndpi_risk_severity ndpi_risk2severity(ndpi_risk_enum risk);
   
   /* ******************************* */
 

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -1788,7 +1788,7 @@ const char* ndpi_risk2str(ndpi_risk_enum risk) {
 
 /* ******************************************************************** */
 
-const ndpi_risk_severity ndpi_risk2severity(ndpi_risk_enum risk) {
+ndpi_risk_severity ndpi_risk2severity(ndpi_risk_enum risk) {
   switch(risk) {
   case NDPI_NO_RISK:
   case NDPI_MAX_RISK:
@@ -1831,6 +1831,10 @@ const ndpi_risk_severity ndpi_risk2severity(ndpi_risk_enum risk) {
   case NDPI_BINARY_APPLICATION_TRANSFER:
     return(NDPI_RISK_SEVERE);
   }
+
+  /* We have added all possible ndpi_risk_enum values in the switch,
+     but the compiler complains anyway... Try to silence it */
+  return(NDPI_RISK_LOW);
 }
 
 /* ******************************************************************** */


### PR DESCRIPTION
```
In file included from protocols/fasttrack.c:29:
../include/ndpi_api.h:1504:3: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
 1504 |   const ndpi_risk_severity ndpi_risk2severity(ndpi_risk_enum risk);
      |   ^~~~~
In file included from protocols/amazon_video.c:28:
../include/ndpi_api.h:1504:3: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
 1504 |   const ndpi_risk_severity ndpi_risk2severity(ndpi_risk_enum risk);
      |   ^~~~~

...

ndpi_utils.c: In function ‘ndpi_risk2severity’:
ndpi_utils.c:1834:1: warning: control reaches end of non-void function [-Wreturn-type]
 1834 | }
      | ^
```