### PR TITLE
Fixed off-by-one memory error for TLS-JA3.

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1849,7 +1849,11 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		       duplicate_found);
 #endif
 
-		ja3.client.signature_algorithms[i*2] = '\0';
+		if (i == tot_signature_algorithms_len) {
+		  ja3.client.signature_algorithms[i*2 - 1] = '\0';
+		} else {
+		  ja3.client.signature_algorithms[i*2] = '\0';
+		}
 
 #ifdef DEBUG_TLS
 		printf("Client TLS [SIGNATURE_ALGORITHMS: %s]\n", ja3.client.signature_algorithms);


### PR DESCRIPTION
Happens if `(i == tot_signature_algorithms_len == 128) * 2` which resulting value **256** will later used as index for buffer `ja3.client.signature_algorithms[256]`.

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>