### PR TITLE
TLS: fix a memory error in JA3 code

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1849,7 +1849,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		       duplicate_found);
 #endif
 
-		if (i == tot_signature_algorithms_len) {
+		if (i >= tot_signature_algorithms_len) {
 		  ja3.client.signature_algorithms[i*2 - 1] = '\0';
 		} else {
 		  ja3.client.signature_algorithms[i*2] = '\0';


### PR DESCRIPTION
protocols/tls.c:1856:5: runtime error: index 256 out of bounds for type 'char [256]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior protocols/tls.c:1856:5