### PR TITLE
Added protocols with HTTP patterns as possible HTTP subprotocols.

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -876,7 +876,10 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
 			  ndpi_build_default_ports(ports_a, 80, 0 /* ntop */, 0, 0, 0) /* TCP */,
 			  ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
   ndpi_set_proto_subprotocols(ndpi_str, NDPI_PROTOCOL_HTTP,
-			      NDPI_PROTOCOL_AIMINI,
+			      NDPI_PROTOCOL_AIMINI, NDPI_PROTOCOL_CROSSFIRE,
+			      NDPI_PROTOCOL_BITTORRENT, NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, NDPI_PROTOCOL_GNUTELLA,
+			      NDPI_PROTOCOL_MAPLESTORY, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_WORLDOFWARCRAFT,
+			      NDPI_PROTOCOL_THUNDER, NDPI_PROTOCOL_IRC,
 			      NDPI_PROTOCOL_MATCHED_BY_CONTENT,
 			      NDPI_PROTOCOL_NO_MORE_SUBPROTOCOLS); /* NDPI_PROTOCOL_HTTP can have (content-matched) subprotocols */
   ndpi_set_proto_defaults(ndpi_str, NDPI_PROTOCOL_ACCEPTABLE, NDPI_PROTOCOL_MDNS,


### PR DESCRIPTION
All of the (sub-)protocol detection patterns will be adjusted as done before for **aimini**.
One of the biggest issue here is the lack of pcap files for some protocols.
For those protocols, I can not verify if the detection improves unless I record pcap's myself (which I may do if possible, but may take some additional time).

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>