### PR TITLE
Fix return value of ndpi_match_string_subprotocol()

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6682,7 +6682,7 @@ int ndpi_match_string_subprotocol(struct ndpi_detection_module_struct *ndpi_str,
   rc = ndpi_match_string_common(((AC_AUTOMATA_t *) automa->ac_automa),
 		  string_to_match,string_to_match_len, &ret_match->protocol_id,
 		  &ret_match->protocol_category, &ret_match->protocol_breed);
-  return rc < 0 ? rc : ret_match->protocol_id;
+  return rc < 0 ? NDPI_PROTOCOL_UNKNOWN : ret_match->protocol_id;
 }
 
 /* **************************************** */


### PR DESCRIPTION
Fix memory corruption:
```
ivan@ivan-Latitude-E6540:~/svnrepos/nDPI(dev)$ ./example/ndpiReader -i ~/ndpi_match_string_subprotocol__error.pcapng
[...]
Running thread 0...
ndpi_main.c:4488:53: runtime error: index 65534 out of bounds for type 'ndpi_proto_defaults_t [512]'
ndpi_main.c:5419:44: runtime error: index 65534 out of bounds for type 'ndpi_proto_defaults_t [512]'
AddressSanitizer:DEADLYSIGNAL
=================================================================
==58924==ERROR: AddressSanitizer: SEGV on unknown address 0x626000080138 (pc 0x55eaeb3bffea bp 0x7ffdcb459470 sp 0x7ffdcb4593a0 T0)
==58924==The signal is caused by a READ memory access.
    #0 0x55eaeb3bffea in node_proto_guess_walker /home/ivan/svnrepos/nDPI/example/ndpiReader.c:1589
    #1 0x55eaeb4d3abb in ndpi_trecurse /home/ivan/svnrepos/nDPI/src/lib/ndpi_utils.c:161
    #2 0x55eaeb4d3d4e in ndpi_twalk /home/ivan/svnrepos/nDPI/src/lib/ndpi_utils.c:181
    #3 0x55eaeb460379 in printResults /home/ivan/svnrepos/nDPI/example/ndpiReader.c:2896
    #4 0x55eaeb46f886 in test_lib /home/ivan/svnrepos/nDPI/example/ndpiReader.c:3519
    #5 0x55eaeb478f1b in main /home/ivan/svnrepos/nDPI/example/ndpiReader.c:4358
    #6 0x7f2abe1550b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #7 0x55eaeb3af4ad in _start (/home/ivan/svnrepos/nDPI/example/ndpiReader+0x83b4ad)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/ivan/svnrepos/nDPI/example/ndpiReader.c:1589 in node_proto_guess_walker

```
[ndpi_match_string_subprotocol__error.pcapng.gz](https://github.com/ntop/nDPI/files/6765520/ndpi_match_string_subprotocol__error.pcapng.gz)
