### PR TITLE
Improved RTSP detection the second. (#1232)

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -876,7 +876,6 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
 			  ndpi_build_default_ports(ports_a, 80, 0 /* ntop */, 0, 0, 0) /* TCP */,
 			  ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
   ndpi_set_proto_subprotocols(ndpi_str, NDPI_PROTOCOL_HTTP,
-			      NDPI_PROTOCOL_RTSP,
 			      NDPI_PROTOCOL_AIMINI, NDPI_PROTOCOL_CROSSFIRE,
 			      NDPI_PROTOCOL_BITTORRENT, NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK, NDPI_PROTOCOL_GNUTELLA,
 			      NDPI_PROTOCOL_MAPLESTORY, NDPI_PROTOCOL_ZATTOO, NDPI_PROTOCOL_WORLDOFWARCRAFT,

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -499,8 +499,6 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
   struct ndpi_packet_struct *packet = &flow->packet;
   int ret;
 
-  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_HTTP, NDPI_PROTOCOL_UNKNOWN);
-
   if(flow->http_detected && (flow->http.response_status_code != 0))
     return;
 
@@ -667,7 +665,10 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
     }
   }
 
-  ndpi_int_http_add_connection(ndpi_struct, flow, packet->detected_protocol_stack[0], NDPI_PROTOCOL_CATEGORY_WEB);
+  if (ndpi_get_http_method(ndpi_struct, flow) != NDPI_HTTP_METHOD_UNKNOWN)
+  {
+    ndpi_int_http_add_connection(ndpi_struct, flow, packet->detected_protocol_stack[0], NDPI_PROTOCOL_CATEGORY_WEB);
+  }
 }
 
 /* ************************************************************* */

--- a/src/lib/protocols/rtsp.c
+++ b/src/lib/protocols/rtsp.c
@@ -47,8 +47,11 @@ void ndpi_search_rtsp_tcp_udp(struct ndpi_detection_module_struct
 
   NDPI_LOG_DBG(ndpi_struct, "search RTSP\n");
 
-  if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_HTTP &&
-      packet->parsed_lines > 0 &&
+  if (packet->parsed_lines == 0)
+  {
+    ndpi_parse_packet_line_info(ndpi_struct, flow);
+  }
+  if (packet->parsed_lines > 0 &&
       LINE_STARTS(packet->line[0], "SETUP rtsp://") != 0 &&
       LINE_ENDS(packet->line[0], "RTSP/1.0") != 0)
   {

--- a/tests/result/rtsp_setup_http.pcapng.out
+++ b/tests/result/rtsp_setup_http.pcapng.out
@@ -1,3 +1,3 @@
-HTTP	1	233	1
+RTSP	1	233	1
 
-	1	TCP 172.28.5.170:63840 -> 172.28.4.26:8554 [proto: 50.7/RTSP.HTTP][cat: Media/1][1 pkts/233 bytes -> 0 pkts/0 bytes][Goodput ratio: 76/0][< 1 sec][Risk: ** Known protocol on non standard port **][Risk Score: 10][PLAIN TEXT (SETUP rtsp)][Plen Bins: 0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	1	TCP 172.28.5.170:63840 -> 172.28.4.26:8554 [proto: 50/RTSP][cat: Media/1][1 pkts/233 bytes -> 0 pkts/0 bytes][Goodput ratio: 76/0][< 1 sec][PLAIN TEXT (SETUP rtsp)][Plen Bins: 0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]


### PR DESCRIPTION
 * RTSP is no subprotocol of HTTP (most of the time)
 * detection patterns should stay in rtsp.c
 * set detected HTTP protocol only if at least a valid HTTP method detected

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>