### PR TITLE
Fix for #1230

### DIFF
--- a/src/include/ndpi_api.h.in
+++ b/src/include/ndpi_api.h.in
@@ -425,7 +425,9 @@ extern "C" {
    * @par    string_to_match_len = the length of the string
    * @par    ret_match           = completed returned match information
    * @par    is_host_match       = value of the second field of struct ndpi_automa
-   * @return the ID of the matched subprotocol
+   * @return the ID of the matched subprotocol;
+   *         -1 if automa is not finalized;
+   *         -2 if automa==NULL or string_to_match==NULL or empty string_to_match
    *
    */
   int ndpi_match_string_subprotocol(struct ndpi_detection_module_struct *ndpi_struct,

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6682,7 +6682,7 @@ int ndpi_match_string_subprotocol(struct ndpi_detection_module_struct *ndpi_str,
   rc = ndpi_match_string_common(((AC_AUTOMATA_t *) automa->ac_automa),
 		  string_to_match,string_to_match_len, &ret_match->protocol_id,
 		  &ret_match->protocol_category, &ret_match->protocol_breed);
-  return rc < 0 ? NDPI_PROTOCOL_UNKNOWN : ret_match->protocol_id;
+  return rc < 0 ? rc : ret_match->protocol_id;
 }
 
 /* **************************************** */

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6709,11 +6709,14 @@ static u_int16_t ndpi_automa_match_string_subprotocol(struct ndpi_detection_modu
 						      struct ndpi_flow_struct *flow, char *string_to_match,
 						      u_int string_to_match_len, u_int16_t master_protocol_id,
 						      ndpi_protocol_match_result *ret_match, u_int8_t is_host_match) {
-  uint16_t matching_protocol_id;
+  int matching_protocol_id;
   struct ndpi_packet_struct *packet = &flow->packet;
 
   matching_protocol_id =
     ndpi_match_string_subprotocol(ndpi_str, string_to_match, string_to_match_len, ret_match, is_host_match);
+
+  if(matching_protocol_id < 0)
+	  return NDPI_PROTOCOL_UNKNOWN;
 
 #ifdef DEBUG
   {

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -658,7 +658,7 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
       }
     }    
     
-    if(flow->http_detected) {
+    if(flow->http_detected && packet->content_line.ptr && *(char*)packet->content_line.ptr) {
       ndpi_protocol_match_result ret_match;
 
       ndpi_match_content_subprotocol(ndpi_struct, flow,


### PR DESCRIPTION
Handling errors returned by the ndpi_match_string_subprotocol() function.