### PR TITLE
ndpiReader: add statistics about nDPI performance

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -893,6 +893,12 @@ static struct ndpi_flow_info *get_ndpi_flow_info(struct ndpi_workflow * workflow
 
       ndpi_tsearch(newflow, &workflow->ndpi_flows_root[idx], ndpi_workflow_node_cmp); /* Add */
       workflow->stats.ndpi_flow_count++;
+      if(*proto == IPPROTO_TCP)
+        workflow->stats.flow_count[0]++;
+      else if(*proto == IPPROTO_UDP)
+        workflow->stats.flow_count[1]++;
+      else
+        workflow->stats.flow_count[2]++;
 
       *src = newflow->src_id, *dst = newflow->dst_id;
       newflow->entropy.src2dst_pkt_len[newflow->entropy.src2dst_pkt_count] = l4_data_len;
@@ -1510,6 +1516,13 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
 #if 0
     printf("%s()\n", __FUNCTION__);
 #endif
+
+    if(proto == IPPROTO_TCP)
+      workflow->stats.dpi_packet_count[0]++;
+    else if(proto == IPPROTO_UDP)
+      workflow->stats.dpi_packet_count[1]++;
+    else
+      workflow->stats.dpi_packet_count[2]++;
 
     flow->detected_protocol = ndpi_detection_process_packet(workflow->ndpi_struct, ndpi_flow,
 							    iph ? (uint8_t *)iph : (uint8_t *)iph6,

--- a/example/reader_util.h
+++ b/example/reader_util.h
@@ -256,10 +256,12 @@ typedef struct ndpi_stats {
   u_int64_t protocol_counter_bytes[NDPI_MAX_SUPPORTED_PROTOCOLS + NDPI_MAX_NUM_CUSTOM_PROTOCOLS + 1];
   u_int32_t protocol_flows[NDPI_MAX_SUPPORTED_PROTOCOLS + NDPI_MAX_NUM_CUSTOM_PROTOCOLS + 1];
   u_int32_t ndpi_flow_count;
+  u_int32_t flow_count[3];
   u_int64_t tcp_count, udp_count;
   u_int64_t mpls_count, pppoe_count, vlan_count, fragmented_count;
   u_int64_t packet_len[6];
   u_int16_t max_packet_len;
+  u_int64_t dpi_packet_count[3];
 } ndpi_stats_t;
 
 

--- a/tests/result/1kxun.pcap.out
+++ b/tests/result/1kxun.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	27
+
+DPI Packets (TCP):	284	(9.47 pkts/flow)
+DPI Packets (UDP):	120	(1.21 pkts/flow)
+
 Unknown	24	6428	14
 DNS	5	638	2
 HTTP	945	530967	19

--- a/tests/result/443-chrome.pcap.out
+++ b/tests/result/443-chrome.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	1	(1.00 pkts/flow)
+
 TLS	1	1506	1
 
 	1	TCP 178.62.197.130:443 -> 192.168.1.13:53059 [proto: 91/TLS][cat: Web/5][1 pkts/1506 bytes -> 0 pkts/0 bytes][Goodput ratio: 96/0][< 1 sec][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,100,0,0]

--- a/tests/result/443-curl.pcap.out
+++ b/tests/result/443-curl.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	7	(7.00 pkts/flow)
+
 ntop	109	73982	1
 
 JA3 Host Stats: 

--- a/tests/result/443-firefox.pcap.out
+++ b/tests/result/443-firefox.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	7	(7.00 pkts/flow)
+
 ntop	667	458067	1
 
 JA3 Host Stats: 

--- a/tests/result/443-git.pcap.out
+++ b/tests/result/443-git.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	7	(7.00 pkts/flow)
+
 Github	70	37189	1
 
 JA3 Host Stats: 

--- a/tests/result/443-opvn.pcap.out
+++ b/tests/result/443-opvn.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	6	(6.00 pkts/flow)
+
 OpenVPN	46	11573	1
 
 	1	TCP 192.168.1.84:52973 <-> 192.12.192.103:1194 [proto: 159/OpenVPN][cat: VPN/2][25 pkts/5636 bytes <-> 21 pkts/5937 bytes][Goodput ratio: 70/77][8.96 sec][bytes ratio: -0.026 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 443/427 3959/4015 926/1024][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 225/283 1506/1506 330/399][PLAIN TEXT (Registro.it)][Plen Bins: 4,41,4,8,0,0,0,0,0,4,4,0,0,0,4,0,0,4,0,8,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,8,0,0]

--- a/tests/result/443-safari.pcap.out
+++ b/tests/result/443-safari.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	7	(7.00 pkts/flow)
+
 ntop	41	19929	1
 
 JA3 Host Stats: 

--- a/tests/result/4in4tunnel.pcap.out
+++ b/tests/result/4in4tunnel.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (UDP):	5	(5.00 pkts/flow)
+
 Unknown	5	850	1
 
 

--- a/tests/result/4in6tunnel.pcap.out
+++ b/tests/result/4in6tunnel.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	4	(4.00 pkts/flow)
+
 Microsoft	4	2188	1
 
 JA3 Host Stats: 

--- a/tests/result/6in4tunnel.pcap.out
+++ b/tests/result/6in4tunnel.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	2
+
+DPI Packets (TCP):	29	(5.80 pkts/flow)
+DPI Packets (UDP):	4	(2.00 pkts/flow)
+DPI Packets (other):	3	(1.00 pkts/flow)
+
 HTTP	10	1792	1
 IMAPS	4	516	2
 TLS	28	15397	1

--- a/tests/result/6in6tunnel.pcap.out
+++ b/tests/result/6in6tunnel.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (UDP):	2	(2.00 pkts/flow)
+
 Unknown	2	212	1
 
 

--- a/tests/result/BGP_Cisco_hdlc_slarp.pcap.out
+++ b/tests/result/BGP_Cisco_hdlc_slarp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	4	(4.00 pkts/flow)
+
 BGP	14	969	1
 
 	1	TCP 100.16.1.2:18324 <-> 100.16.1.1:179 [proto: 13/BGP][cat: Network/14][7 pkts/388 bytes <-> 7 pkts/581 bytes][Goodput ratio: 20/46][50.10 sec][bytes ratio: -0.199 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 10014/9944 50028/49681 20007/19868][Pkt Len c2s/s2c min/avg/max/stddev: 44/44 55/83 101/195 20/49][Plen Bins: 57,28,0,0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/BGP_redist.pcap.out
+++ b/tests/result/BGP_redist.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	2	(1.00 pkts/flow)
+
 BGP	2	322	2
 
 	1	TCP 2.2.2.2:179 -> 4.4.4.4:63535 [proto: 13/BGP][cat: Network/14][1 pkts/163 bytes -> 0 pkts/0 bytes][Goodput ratio: 70/0][< 1 sec][Plen Bins: 0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/EAQ.pcap.out
+++ b/tests/result/EAQ.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	12	(6.00 pkts/flow)
+DPI Packets (UDP):	116	(4.00 pkts/flow)
+
 Google	23	11743	2
 EAQ	174	10092	29
 

--- a/tests/result/IEC104.pcap.out
+++ b/tests/result/IEC104.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	4	(2.00 pkts/flow)
+
 IEC60870	15	1431	2
 
 	1	TCP 10.175.211.1:2404 <-> 10.119.105.26:54768 [proto: 245/IEC60870][cat: IoT-Scada/31][7 pkts/987 bytes <-> 5 pkts/270 bytes][Goodput ratio: 61/0][2.00 sec][bytes ratio: 0.570 (Upload)][IAT c2s/s2c min/avg/max/stddev: 36/199 360/521 935/935 313/307][Pkt Len c2s/s2c min/avg/max/stddev: 60/54 141/54 306/54 90/0][Plen Bins: 51,0,0,16,0,16,0,16,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/KakaoTalk_chat.pcap.out
+++ b/tests/result/KakaoTalk_chat.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	10
+
+DPI Packets (TCP):	174	(9.16 pkts/flow)
+DPI Packets (UDP):	36	(2.00 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 DNS	2	217	1
 HTTP	1	56	1
 ICMP	1	147	1

--- a/tests/result/KakaoTalk_talk.pcap.out
+++ b/tests/result/KakaoTalk_talk.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	12
+
+DPI Packets (TCP):	89	(5.93 pkts/flow)
+DPI Packets (UDP):	6	(1.20 pkts/flow)
+
 HTTP	5	280	1
 QQ	15	1727	1
 RTP	2991	398751	2

--- a/tests/result/NTPv2.pcap.out
+++ b/tests/result/NTPv2.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 NTP	1	410	1
 
 	1	UDP 208.104.95.10:123 -> 78.46.76.2:80 [proto: 9/NTP][cat: System/18][1 pkts/410 bytes -> 0 pkts/0 bytes][Goodput ratio: 90/0][< 1 sec][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/NTPv3.pcap.out
+++ b/tests/result/NTPv3.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 NTP	1	90	1
 
 	1	UDP 175.144.140.29:123 -> 78.46.76.2:80 [proto: 9/NTP][cat: System/18][1 pkts/90 bytes -> 0 pkts/0 bytes][Goodput ratio: 53/0][< 1 sec][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/NTPv4.pcap.out
+++ b/tests/result/NTPv4.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 NTP	1	90	1
 
 	1	UDP 85.22.62.120:123 -> 78.46.76.11:123 [proto: 9/NTP][cat: System/18][1 pkts/90 bytes -> 0 pkts/0 bytes][Goodput ratio: 53/0][< 1 sec][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/Oscar.pcap.out
+++ b/tests/result/Oscar.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	71	(71.00 pkts/flow)
+
 TLS	71	9386	1
 
 	1	TCP 10.30.29.3:63357 <-> 178.237.24.249:443 [proto: 91/TLS][cat: Web/5][38 pkts/3580 bytes <-> 33 pkts/5806 bytes][Goodput ratio: 42/68][72.45 sec][bytes ratio: -0.237 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 2392/2607 58175/58215 10382/11142][Pkt Len c2s/s2c min/avg/max/stddev: 54/60 94/176 369/1414 75/257][PLAIN TEXT (Adium/1.5.10)][Plen Bins: 7,58,5,5,0,0,5,2,2,7,0,0,0,0,2,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0]

--- a/tests/result/WebattackRCE.pcap.out
+++ b/tests/result/WebattackRCE.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	797
+
+DPI Packets (TCP):	797	(1.00 pkts/flow)
+
 HTTP	797	191003	797
 
 	1	TCP 127.0.0.1:51184 -> 127.0.0.1:8080 [proto: 131.7/HTTP_Proxy.HTTP][cat: Web/5][1 pkts/651 bytes -> 0 pkts/0 bytes][Goodput ratio: 90/0][< 1 sec][Host: 127.0.0.1][URL: 127.0.0.1/vbulletin/ajax/api/hook/decodeArguments?arguments=O%3A12%3A%22vB_dB_Result%22%3A2%3A%7Bs%3A5%3A%22%00%2A%00db%22%3BO%3A17%3A%22vB_Database_MySQL%22%3A1%3A%7Bs%3A9%3A%22functions%22%3Ba%3A1%3A%7Bs%3A11%3A%22free_result%22%3Bs%3A6%3A%22assert%22%3][StatusCode: 0][Req Content-Type: application/x-www-form-urlencoded][User-Agent: Mozilla/5.00 (Nikto/2.1.6) (Evasions:None) (Test:007058)][Risk: ** Known protocol on non standard port **** HTTP Numeric IP Address **][Risk Score: 20][PLAIN TEXT (GET /vbulletin/ajax/api/hook/de)][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/WebattackSQLinj.pcap.out
+++ b/tests/result/WebattackSQLinj.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	54	(6.00 pkts/flow)
+
 HTTP	94	30008	9
 
 	1	TCP 172.16.0.1:36212 <-> 192.168.10.50:80 [proto: 7/HTTP][cat: Web/5][7 pkts/1070 bytes <-> 5 pkts/4487 bytes][Goodput ratio: 56/92][5.01 sec][Host: 205.174.165.68][bytes ratio: -0.615 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 1002/3 5000/10 1999/5][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 153/897 666/2767 210/1090][URL: 205.174.165.68/dv/vulnerabilities/sqli/?id=1%27+and+1%3D1+union+select+null%2C+table_name+from+information_schema.tables%23&Submit=Submit][StatusCode: 200][Content-Type: text/html][User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0][Risk: ** SQL injection **** HTTP Numeric IP Address **][Risk Score: 260][PLAIN TEXT (GET /dv/vulnerabilities/sqli/)][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,33,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,33,0,33]

--- a/tests/result/WebattackXSS.pcap.out
+++ b/tests/result/WebattackXSS.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	639
+
+DPI Packets (TCP):	3972	(6.01 pkts/flow)
+
 HTTP	9374	4721148	661
 
 	1	TCP 172.16.0.1:59042 <-> 192.168.10.50:80 [proto: 7/HTTP][cat: Web/5][214 pkts/62915 bytes <-> 107 pkts/190654 bytes][Goodput ratio: 78/96][68.07 sec][Host: 205.174.165.68][bytes ratio: -0.504 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 340/680 4821/4822 530/629][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 294/1782 651/1935 251/393][URL: 205.174.165.68/dv/vulnerabilities/xss_r/][StatusCode: 200][Content-Type: text/html][User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0][Risk: ** HTTP Numeric IP Address **][Risk Score: 10][PLAIN TEXT (GET /dv/vulnerabilities/xss)][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,25,0,0,0,0,0,0,24,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,49]

--- a/tests/result/aimini-http.pcap.out
+++ b/tests/result/aimini-http.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	33	(8.25 pkts/flow)
+
 HTTP	133	86722	4
 
 	1	TCP 10.101.0.2:28501 <-> 10.102.0.2:80 [proto: 99.7/Aimini.HTTP][cat: Web/5][38 pkts/36756 bytes <-> 34 pkts/28010 bytes][Goodput ratio: 94/93][0.00 sec][Host: www.aimini.net][bytes ratio: 0.135 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 0/0 1/0 0/0][Pkt Len c2s/s2c min/avg/max/stddev: 60/60 967/824 1514/1514 664/699][URL: www.aimini.net/member/signup/][StatusCode: 0][User-Agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.17) Gecko/20110420 Firefox/3.6.17][PLAIN TEXT (GET /member/signup/ HTTP/1.1)][Plen Bins: 0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,4,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,83,0,0]

--- a/tests/result/ajp.pcap.out
+++ b/tests/result/ajp.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	2
+
+DPI Packets (TCP):	8	(4.00 pkts/flow)
+DPI Packets (other):	6	(3.00 pkts/flow)
+
 Unknown	6	2200	2
 AJP	26	4446	2
 

--- a/tests/result/alexa-app.pcapng.out
+++ b/tests/result/alexa-app.pcapng.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	68
+
+DPI Packets (TCP):	1780	(14.71 pkts/flow)
+DPI Packets (UDP):	64	(1.94 pkts/flow)
+DPI Packets (other):	6	(1.00 pkts/flow)
+
 DNS	4	400	2
 DHCP	3	1056	2
 ICMP	2	188	1

--- a/tests/result/among_us.pcap.out
+++ b/tests/result/among_us.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 AmongUs	1	57	1
 
 	1	UDP 10.0.0.1:64260 -> 172.105.251.170:22023 [proto: 69/AmongUs][cat: Game/8][1 pkts/57 bytes -> 0 pkts/0 bytes][Goodput ratio: 26/0][< 1 sec][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/amqp.pcap.out
+++ b/tests/result/amqp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	9	(3.00 pkts/flow)
+
 AMQP	160	23514	3
 
 	1	TCP 127.0.0.1:44205 <-> 127.0.1.1:5672 [proto: 192/AMQP][cat: RPC/16][54 pkts/10859 bytes <-> 54 pkts/3564 bytes][Goodput ratio: 67/0][4.12 sec][bytes ratio: 0.506 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 85/85 2001/2001 341/341][Pkt Len c2s/s2c min/avg/max/stddev: 103/66 201/66 395/66 103/0][PLAIN TEXT (celeryev)][Plen Bins: 0,33,0,33,0,0,9,0,9,5,9,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/android.pcap.out
+++ b/tests/result/android.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	11
+
+DPI Packets (TCP):	175	(6.25 pkts/flow)
+DPI Packets (UDP):	52	(1.68 pkts/flow)
+DPI Packets (other):	4	(1.00 pkts/flow)
+
 DNS	4	390	2
 MDNS	2	174	2
 SSDP	2	336	2

--- a/tests/result/anyconnect-vpn.pcap.out
+++ b/tests/result/anyconnect-vpn.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	17
+
+DPI Packets (TCP):	175	(7.95 pkts/flow)
+DPI Packets (UDP):	90	(2.43 pkts/flow)
+DPI Packets (other):	10	(1.00 pkts/flow)
+
 Unknown	19	1054	2
 DNS	32	3655	16
 HTTP	50	11137	5

--- a/tests/result/anydesk-2.pcap.out
+++ b/tests/result/anydesk-2.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	13	(6.50 pkts/flow)
+DPI Packets (UDP):	4	(2.00 pkts/flow)
+
 AnyDesk	2083	346113	4
 
 JA3 Host Stats: 

--- a/tests/result/anydesk.pcap.out
+++ b/tests/result/anydesk.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	28	(14.00 pkts/flow)
+
 AnyDesk	6963	2795460	2
 
 JA3 Host Stats: 

--- a/tests/result/bad-dns-traffic.pcap.out
+++ b/tests/result/bad-dns-traffic.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	11	(3.67 pkts/flow)
+
 DNS	382	99374	3
 
 	1	UDP 192.168.43.91:56354 <-> 4.2.2.4:53 [proto: 5/DNS][cat: Network/14][203 pkts/51588 bytes <-> 146 pkts/43285 bytes][Goodput ratio: 83/86][92.47 sec][Host: c75900fdf525320021636f6d6d616e64202873697276696d65732900.skullseclabs.org][::][bytes ratio: 0.088 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 6/15 482/284 1046/2080 456/471][Pkt Len c2s/s2c min/avg/max/stddev: 95/95 254/296 290/325 74/65][Risk: ** Suspicious DGA domain name **][Risk Score: 100][PLAIN TEXT (8244300)][Plen Bins: 0,5,5,0,0,0,0,50,39,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/bitcoin.pcap.out
+++ b/tests/result/bitcoin.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	6
+
+DPI Packets (TCP):	370	(61.67 pkts/flow)
+
 Mining	637	581074	6
 
 	1	TCP 192.168.1.142:55328 <-> 69.118.54.122:8333 [proto: 42/Mining][cat: Mining/99][2 pkts/281 bytes <-> 137 pkts/191029 bytes][Goodput ratio: 53/95][330.56 sec][bytes ratio: -0.997 (Download)][IAT c2s/s2c min/avg/max/stddev: 141657/0 141657/2644 141657/76010 0/11325][Pkt Len c2s/s2c min/avg/max/stddev: 110/86 140/1394 171/1514 30/378][PLAIN TEXT (version)][Plen Bins: 0,6,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,92,0,0]

--- a/tests/result/bittorrent.pcap.out
+++ b/tests/result/bittorrent.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	24	(1.00 pkts/flow)
+
 BitTorrent	299	305728	24
 
 	1	TCP 192.168.1.3:52915 <-> 198.100.146.9:60163 [proto: 37/BitTorrent][cat: FileTransfer/7][17 pkts/2745 bytes <-> 193 pkts/282394 bytes][Goodput ratio: 59/95][5.77 sec][bytes ratio: -0.981 (Download)][IAT c2s/s2c min/avg/max/stddev: 12/0 319/30 779/919 241/95][Pkt Len c2s/s2c min/avg/max/stddev: 83/80 161/1463 242/1506 58/218][BT Hash: dcfcdccfb9e670ccc3dd40c78c161f2bea243126][PLAIN TEXT (BitTorrent protocol)][Plen Bins: 2,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,93,0,0]

--- a/tests/result/bittorrent_ip.pcap.out
+++ b/tests/result/bittorrent_ip.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	2
+
+DPI Packets (TCP):	129	(64.50 pkts/flow)
+
 BitTorrent	479	508018	2
 
 	1	TCP 77.222.174.20:2866 <-> 10.0.0.14:46610 [proto: 37/BitTorrent][cat: FileTransfer/7][305 pkts/461770 bytes <-> 126 pkts/8316 bytes][Goodput ratio: 96/0][2.45 sec][bytes ratio: 0.965 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 5/6 879/56 54/10][Pkt Len c2s/s2c min/avg/max/stddev: 1514/66 1514/66 1514/66 0/0][PLAIN TEXT (n.m Hh)][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,100,0,0]

--- a/tests/result/bittorrent_utp.pcap.out
+++ b/tests/result/bittorrent_utp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 BitTorrent	86	41489	1
 
 	1	UDP 82.243.113.43:64969 <-> 192.168.1.5:40959 [proto: 37/BitTorrent][cat: FileTransfer/7][47 pkts/36653 bytes <-> 39 pkts/4836 bytes][Goodput ratio: 95/66][19.22 sec][bytes ratio: 0.767 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/11 223/425 4392/4641 701/934][Pkt Len c2s/s2c min/avg/max/stddev: 62/62 780/124 1514/519 609/123][PLAIN TEXT (hash20)][Plen Bins: 52,1,2,4,0,1,1,1,0,0,5,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,6,0,0,0,6,0,0,0,8,0]

--- a/tests/result/bt_search.pcap.out
+++ b/tests/result/bt_search.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 BitTorrent	2	322	1
 
 	1	UDP 192.168.0.102:6771 -> 239.192.152.143:6771 [proto: 37/BitTorrent][cat: FileTransfer/7][2 pkts/322 bytes -> 0 pkts/0 bytes][Goodput ratio: 74/0][300.03 sec][PLAIN TEXT (SEARCH )][Plen Bins: 0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/capwap.pcap.out
+++ b/tests/result/capwap.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	1
+
+DPI Packets (UDP):	6	(1.20 pkts/flow)
+DPI Packets (other):	4	(1.00 pkts/flow)
+
 DNS	2	166	1
 DHCP	5	2090	1
 IGMP	1	122	1

--- a/tests/result/check_mk_new.pcap.out
+++ b/tests/result/check_mk_new.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	4	(4.00 pkts/flow)
+
 CHECKMK	98	20242	1
 
 	1	TCP 192.168.100.22:58998 <-> 192.168.100.50:6556 [proto: 138/CHECKMK][cat: DataTransfer/4][49 pkts/3242 bytes <-> 49 pkts/17000 bytes][Goodput ratio: 0/81][0.04 sec][bytes ratio: -0.680 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 1/0 4/4 1/1][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 66/347 74/4162 1/758][PLAIN TEXT (k@Version)][Plen Bins: 73,0,4,0,0,4,0,2,2,0,0,0,2,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,2,0,0,0,0,0,0,6]

--- a/tests/result/chrome.pcap.out
+++ b/tests/result/chrome.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	36	(6.00 pkts/flow)
+
 TLS	5633	4985157	6
 
 JA3 Host Stats: 

--- a/tests/result/coap_mqtt.pcap.out
+++ b/tests/result/coap_mqtt.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	7	(1.75 pkts/flow)
+DPI Packets (UDP):	12	(1.00 pkts/flow)
+
 COAP	19	1614	8
 Dropbox	800	80676	4
 MQTT	7695	668291	4

--- a/tests/result/cpha.pcap.out
+++ b/tests/result/cpha.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 CPHA	1	96	1
 
 	1	UDP 0.0.0.0:8116 -> 172.21.3.0:8116 [VLAN: 21][proto: 53/CPHA][cat: Network/14][1 pkts/96 bytes -> 0 pkts/0 bytes][Goodput ratio: 52/0][< 1 sec][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/dcerpc.pcap.out
+++ b/tests/result/dcerpc.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	4	(1.00 pkts/flow)
+
 DCE_RPC	16	6866	4
 
 	1	UDP 192.168.1.11:49155 -> 192.168.1.20:34964 [proto: 127/DCE_RPC][cat: RPC/16][6 pkts/3706 bytes -> 0 pkts/0 bytes][Goodput ratio: 93/0][0.05 sec][bytes ratio: 1.000 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 10/0 32/0 13/0][Pkt Len c2s/s2c min/avg/max/stddev: 174/0 618/0 995/0 338/0][PLAIN TEXT (mrpdomain)][Plen Bins: 0,0,0,0,33,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,33,0,0,0,0,0,0,0,0,33,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/diameter.pcap.out
+++ b/tests/result/diameter.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	6	(6.00 pkts/flow)
+
 Diameter	6	1980	1
 
 	1	TCP 10.201.9.245:50957 <-> 10.201.9.11:3868 [proto: 237/Diameter][cat: Network/14][3 pkts/1174 bytes <-> 3 pkts/806 bytes][Goodput ratio: 86/80][0.09 sec][bytes ratio: 0.186 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 13/12 39/32 65/51 26/20][Pkt Len c2s/s2c min/avg/max/stddev: 362/226 391/269 414/290 22/30][PLAIN TEXT (1263278878147)][Plen Bins: 0,0,0,0,0,16,0,34,0,16,16,16,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/dlt_ppp.pcap.out
+++ b/tests/result/dlt_ppp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 QUIC	1	1230	1
 
 JA3 Host Stats: 

--- a/tests/result/dnp3.pcap.out
+++ b/tests/result/dnp3.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	80	(10.00 pkts/flow)
+
 DNP3	543	38754	8
 
 	1	TCP 10.0.0.8:2828 <-> 10.0.0.3:20000 [proto: 244/DNP3][cat: IoT-Scada/31][60 pkts/4041 bytes <-> 78 pkts/7164 bytes][Goodput ratio: 17/38][121.83 sec][bytes ratio: -0.279 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 421/302 13044/8439 1926/1115][Pkt Len c2s/s2c min/avg/max/stddev: 60/60 67/92 79/145 5/37][Plen Bins: 64,3,32,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/dns-tunnel-iodine.pcap.out
+++ b/tests/result/dns-tunnel-iodine.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	2	(2.00 pkts/flow)
+
 DNS	434	70252	1
 
 	1	UDP 10.0.2.30:44639 <-> 10.0.2.20:53 [proto: 5/DNS][cat: Network/14][222 pkts/26136 bytes <-> 212 pkts/44116 bytes][Goodput ratio: 64/80][24.49 sec][Host: vaaaakardli.pirate.sea][::][bytes ratio: -0.256 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 127/88 4005/4005 543/524][Pkt Len c2s/s2c min/avg/max/stddev: 82/93 118/208 323/1512 67/175][Risk: ** Suspicious DNS traffic **][Risk Score: 50][PLAIN TEXT (vaaaakardli)][Plen Bins: 0,40,1,15,29,3,0,1,8,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/dns_ambiguous_names.pcap.out
+++ b/tests/result/dns_ambiguous_names.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	20	(2.00 pkts/flow)
+
 QQ	2	212	1
 Google	2	208	1
 Instagram	2	220	1

--- a/tests/result/dns_doh.pcap.out
+++ b/tests/result/dns_doh.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	6	(6.00 pkts/flow)
+
 DoH_DoT	142	20362	1
 
 JA3 Host Stats: 

--- a/tests/result/dns_dot.pcap.out
+++ b/tests/result/dns_dot.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	6	(6.00 pkts/flow)
+
 DoH_DoT	24	5869	1
 
 JA3 Host Stats: 

--- a/tests/result/dns_exfiltration.pcap.out
+++ b/tests/result/dns_exfiltration.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	2	(2.00 pkts/flow)
+
 DNS	300	73545	1
 
 	1	UDP 192.168.220.56:56373 <-> 192.168.203.167:53 [proto: 5/DNS][cat: Network/14][150 pkts/32419 bytes <-> 150 pkts/41126 bytes][Goodput ratio: 81/85][59.99 sec][Host: dnscat.546b03f50000000000a6023ed4df184d6ac5c2628b47714fdee584fed739.5a03b5b1e1aa8f8fdb1bbe8d5e04952141f7d4f82c7e3b06dcc8b87fad7a.19e4d098dc8c618f8d81cfeb02][::][bytes ratio: -0.118 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 1/1 398/397 1035/1015 491/489][Pkt Len c2s/s2c min/avg/max/stddev: 101/148 216/274 300/386 97/97][Risk: ** Suspicious DGA domain name **][Risk Score: 100][PLAIN TEXT (dnscat)][Plen Bins: 0,24,0,23,0,0,0,0,26,26,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/dns_long_domainname.pcap.out
+++ b/tests/result/dns_long_domainname.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	2	(2.00 pkts/flow)
+
 Google	2	262	1
 
 	1	UDP 192.168.1.168:65311 <-> 8.8.8.8:53 [proto: 5.126/DNS.Google][cat: Web/5][1 pkts/103 bytes <-> 1 pkts/159 bytes][Goodput ratio: 59/73][0.02 sec][Host: gmr02c.16.0.fhkfhsdkfhsk.tunnel.example.com][::][PLAIN TEXT (fhkfhsdkfhsk)][Plen Bins: 0,50,0,50,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/dnscrypt-v1-and-resolver-pings.pcap.out
+++ b/tests/result/dnscrypt-v1-and-resolver-pings.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	256	(1.04 pkts/flow)
+
 Amazon	12	7560	6
 DNScrypt	476	302002	239
 

--- a/tests/result/dnscrypt-v2-doh.pcap.out
+++ b/tests/result/dnscrypt-v2-doh.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	70	(2.06 pkts/flow)
+
 DoH_DoT	577	216583	34
 
 JA3 Host Stats: 

--- a/tests/result/doq.pcapng.out
+++ b/tests/result/doq.pcapng.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 ICMPV6	6	1170	1
 DoH_DoT	14	4788	1
 

--- a/tests/result/doq_adguard.pcapng.out
+++ b/tests/result/doq_adguard.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 DoH_DoT	296	44445	1
 
 JA3 Host Stats: 

--- a/tests/result/dos_win98_smb_netbeui.pcap.out
+++ b/tests/result/dos_win98_smb_netbeui.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	3	(1.00 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 NetBIOS	46	5060	2
 SMBv1	15	3447	1
 ICMP	1	60	1

--- a/tests/result/drda_db2.pcap.out
+++ b/tests/result/drda_db2.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	4	(4.00 pkts/flow)
+
 DRDA	38	6691	1
 
 	1	TCP 192.168.106.1:4847 <-> 192.168.106.128:50000 [proto: 227/DRDA][cat: Database/11][20 pkts/3169 bytes <-> 18 pkts/3522 bytes][Goodput ratio: 66/72][38.46 sec][bytes ratio: -0.053 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 1/0 2371/2905 17828/17986 5833/6422][Pkt Len c2s/s2c min/avg/max/stddev: 54/54 158/196 717/684 169/193][PLAIN TEXT (@@@@@@@@@@@)][Plen Bins: 25,20,4,4,0,4,0,8,8,0,4,0,8,0,4,0,0,0,0,4,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/dropbox.pcap.out
+++ b/tests/result/dropbox.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	27	(1.80 pkts/flow)
+
 Dropbox	848	90532	15
 
 	1	UDP 192.168.56.1:50318 <-> 192.168.56.101:17500 [proto: 121/Dropbox][cat: Cloud/13][100 pkts/13960 bytes <-> 100 pkts/6260 bytes][Goodput ratio: 70/33][11.19 sec][bytes ratio: 0.381 (Upload)][IAT c2s/s2c min/avg/max/stddev: 103/103 113/112 150/151 11/11][Pkt Len c2s/s2c min/avg/max/stddev: 136/59 140/63 143/66 2/2][PLAIN TEXT (messageType)][Plen Bins: 50,0,13,36,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/dtls.pcap.out
+++ b/tests/result/dtls.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (UDP):	2	(2.00 pkts/flow)
+
 DTLS	2	394	1
 
 JA3 Host Stats: 

--- a/tests/result/dtls2.pcap.out
+++ b/tests/result/dtls2.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	4	(4.00 pkts/flow)
+
 DTLS	30	4991	1
 
 JA3 Host Stats: 

--- a/tests/result/dtls_certificate_fragments.pcap.out
+++ b/tests/result/dtls_certificate_fragments.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	4	(4.00 pkts/flow)
+
 DTLS	20	5978	1
 
 JA3 Host Stats: 

--- a/tests/result/dtls_session_id_and_coockie_both.pcap.out
+++ b/tests/result/dtls_session_id_and_coockie_both.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	4	(4.00 pkts/flow)
+
 DTLS	4	604	1
 
 JA3 Host Stats: 

--- a/tests/result/encrypted_sni.pcap.out
+++ b/tests/result/encrypted_sni.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	3
+
+DPI Packets (TCP):	3	(1.00 pkts/flow)
+
 Cloudflare	3	2310	3
 
 JA3 Host Stats: 

--- a/tests/result/ethereum.pcap.out
+++ b/tests/result/ethereum.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	3
+
+DPI Packets (TCP):	217	(3.88 pkts/flow)
+DPI Packets (UDP):	18	(1.00 pkts/flow)
+
 Mining	1939	208480	70
 Amazon	61	7631	4
 

--- a/tests/result/exe_download.pcap.out
+++ b/tests/result/exe_download.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	6	(6.00 pkts/flow)
+
 HTTP	703	717463	1
 
 	1	TCP 10.9.25.101:49165 <-> 144.91.69.195:80 [proto: 7/HTTP][cat: FileTransfer/7][203 pkts/11127 bytes <-> 500 pkts/706336 bytes][Goodput ratio: 1/96][5.18 sec][Host: 144.91.69.195][bytes ratio: -0.969 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 23/9 319/365 49/37][Pkt Len c2s/s2c min/avg/max/stddev: 54/54 55/1413 207/1514 11/134][URL: 144.91.69.195/solar.php][StatusCode: 200][Content-Type: application/octet-stream][User-Agent: pwtyyEKzNtGatwnJjmCcBLbOveCVpc][Risk: ** Binary application transfer **** HTTP Numeric IP Address **][Risk Score: 260][PLAIN TEXT (GET /solar.php HTTP/1.1)][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,2,0,0,7,0,0,63,0,0,24,0,0]

--- a/tests/result/exe_download_as_png.pcap.out
+++ b/tests/result/exe_download_as_png.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	6	(6.00 pkts/flow)
+
 HTTP	534	529449	1
 
 	1	TCP 10.9.25.101:49197 <-> 185.98.87.185:80 [proto: 7/HTTP][cat: Web/5][163 pkts/9113 bytes <-> 371 pkts/520336 bytes][Goodput ratio: 3/96][69.52 sec][Host: 185.98.87.185][bytes ratio: -0.966 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 623/25 60010/4824 5733/276][Pkt Len c2s/s2c min/avg/max/stddev: 54/54 56/1403 204/1514 16/164][URL: 185.98.87.185/tablone.png][StatusCode: 200][Content-Type: image/png][User-Agent: WinHTTP loader/1.0][Risk: ** Binary application transfer **** HTTP Numeric IP Address **][Risk Score: 260][PLAIN TEXT (GET /tablone.png HTTP/1.1)][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,10,0,0,71,0,0,16,0,0]

--- a/tests/result/facebook.pcap.out
+++ b/tests/result/facebook.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	51	(25.50 pkts/flow)
+
 Facebook	60	30511	2
 
 JA3 Host Stats: 

--- a/tests/result/firefox.pcap.out
+++ b/tests/result/firefox.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	36	(6.00 pkts/flow)
+
 TLS	5441	4952732	6
 
 JA3 Host Stats: 

--- a/tests/result/fix.pcap.out
+++ b/tests/result/fix.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	12	(1.00 pkts/flow)
+
 FIX	1261	115514	12
 
 	1	TCP 208.245.107.3:4000 <-> 192.168.0.20:45578 [proto: 230/FIX][cat: RPC/16][228 pkts/26333 bytes <-> 228 pkts/13920 bytes][Goodput ratio: 53/2][22.80 sec][bytes ratio: 0.308 (Upload)][IAT c2s/s2c min/avg/max/stddev: 3/0 100/100 850/850 127/126][Pkt Len c2s/s2c min/avg/max/stddev: 54/60 115/61 511/140 54/9][PLAIN TEXT (FIX.4.1)][Plen Bins: 35,41,10,8,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/forticlient.pcap.out
+++ b/tests/result/forticlient.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	35	(7.00 pkts/flow)
+
 FortiClient	2000	430931	5
 
 JA3 Host Stats: 

--- a/tests/result/ftp.pcap.out
+++ b/tests/result/ftp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	97	(32.33 pkts/flow)
+
 Unknown	1115	1122198	1
 FTP_CONTROL	68	5571	1
 FTP_DATA	9	1819	1

--- a/tests/result/ftp_failed.pcap.out
+++ b/tests/result/ftp_failed.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	18	(18.00 pkts/flow)
+
 FTP_CONTROL	18	1700	1
 
 	1	TCP [2a00:d40:1:3:192:12:193:11]:44724 <-> [2a00:800:1010::1]:21 [proto: 1/FTP_CONTROL][cat: FileTransfer/7][10 pkts/892 bytes <-> 8 pkts/808 bytes][Goodput ratio: 3/14][7.24 sec][User: hello][Pwd: ][Auth Failed][bytes ratio: 0.049 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 896/1442 5304/5318 1757/2052][Pkt Len c2s/s2c min/avg/max/stddev: 86/86 89/101 98/126 4/15][PLAIN TEXT (vsFTPd 3.0.3)][Plen Bins: 71,28,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/fuzz-2006-06-26-2594.pcap.out
+++ b/tests/result/fuzz-2006-06-26-2594.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	169
+
+DPI Packets (TCP):	48	(2.29 pkts/flow)
+DPI Packets (UDP):	367	(1.63 pkts/flow)
+DPI Packets (other):	5	(1.00 pkts/flow)
+
 Unknown	30	3356	30
 FTP_CONTROL	36	2569	12
 DNS	301	26612	159

--- a/tests/result/fuzz-2006-09-29-28586.pcap.out
+++ b/tests/result/fuzz-2006-09-29-28586.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	38
+
+DPI Packets (TCP):	112	(2.87 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 Unknown	3	655	3
 HTTP	117	27855	36
 Cloudflare	1	854	1

--- a/tests/result/fuzz-2020-02-16-11740.pcap.out
+++ b/tests/result/fuzz-2020-02-16-11740.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	15
+
+DPI Packets (UDP):	70	(1.00 pkts/flow)
+DPI Packets (other):	7	(1.00 pkts/flow)
+
 Unknown	12	3985	12
 VRRP	1	725	1
 Radius	302	145773	64

--- a/tests/result/genshin-impact.pcap.out
+++ b/tests/result/genshin-impact.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	3	(1.00 pkts/flow)
+
 GenshinImpact	45	10832	3
 
 	1	UDP 192.168.2.100:58766 <-> 47.245.143.85:22101 [proto: 257/GenshinImpact][cat: Game/8][7 pkts/1369 bytes <-> 8 pkts/3568 bytes][Goodput ratio: 78/91][1.63 sec][bytes ratio: -0.445 (Download)][IAT c2s/s2c min/avg/max/stddev: 9/0 312/266 818/750 343/309][Pkt Len c2s/s2c min/avg/max/stddev: 62/62 196/446 648/1223 192/449][Plen Bins: 20,13,0,6,13,20,0,0,0,6,0,0,0,0,0,0,0,0,6,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,13,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/git.pcap.out
+++ b/tests/result/git.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	4	(4.00 pkts/flow)
+
 Git	90	74005	1
 
 	1	TCP 192.168.0.77:47991 <-> 5.153.231.21:9418 [proto: 226/Git][cat: Collaborative/15][41 pkts/3319 bytes <-> 49 pkts/70686 bytes][Goodput ratio: 18/95][1.11 sec][bytes ratio: -0.910 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 31/25 558/607 98/96][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 81/1443 593/2946 82/706][PLAIN TEXT (0045git)][Plen Bins: 4,0,2,0,0,0,2,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,75,0,12]

--- a/tests/result/google_ssl.pcap.out
+++ b/tests/result/google_ssl.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	28	(28.00 pkts/flow)
+
 Google	28	9108	1
 
 	1	TCP 172.31.3.224:42835 <-> 216.58.212.100:443 [proto: 91.126/TLS.Google][cat: Web/5][16 pkts/1512 bytes <-> 12 pkts/7596 bytes][Goodput ratio: 43/91][6.67 sec][bytes ratio: -0.668 (Download)][IAT c2s/s2c min/avg/max/stddev: 76/66 422/544 1185/1213 376/402][Pkt Len c2s/s2c min/avg/max/stddev: 54/60 94/633 368/1484 87/622][PLAIN TEXT (@zgsiP)][Plen Bins: 8,8,0,8,0,8,0,0,0,25,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,33,0,0,0]

--- a/tests/result/googledns_android10.pcap.out
+++ b/tests/result/googledns_android10.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	2
+
+DPI Packets (TCP):	117	(16.71 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 Google	12	896	3
 DoH_DoT	520	131998	5
 

--- a/tests/result/gquic.pcap.out
+++ b/tests/result/gquic.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 Google	1	1392	1
 
 	1	UDP 10.44.5.25:61097 -> 216.58.213.163:443 [proto: 188.126/QUIC.Google][cat: Web/5][1 pkts/1392 bytes -> 0 pkts/0 bytes][Goodput ratio: 97/0][< 1 sec][User-Agent: canary Chrome/85.0.4169.0 Windows NT 10.0; Win64; x64][Client: www.gstatic.com][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,100,0,0,0,0,0]

--- a/tests/result/h323-overflow.pcap.out
+++ b/tests/result/h323-overflow.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	1	(1.00 pkts/flow)
+
 HTTP	1	58	1
 
 	1	TCP 192.168.1.1:31337 -> 192.168.1.2:80 [proto: 7/HTTP][cat: Web/5][1 pkts/58 bytes -> 0 pkts/0 bytes][Goodput ratio: 7/0][< 1 sec][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/hangout.pcap.out
+++ b/tests/result/hangout.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 GoogleHangoutDuo	19	2774	1
 
 	1	UDP 74.125.134.127:19305 -> 10.89.61.13:56406 [proto: 78.201/STUN.GoogleHangoutDuo][cat: VoIP/10][19 pkts/2774 bytes -> 0 pkts/0 bytes][Goodput ratio: 71/0][18.02 sec][bytes ratio: 1.000 (Upload)][IAT c2s/s2c min/avg/max/stddev: 993/0 1000/0 1010/0 5/0][Pkt Len c2s/s2c min/avg/max/stddev: 146/0 146/0 146/0 0/0][Risk: ** Known protocol on non standard port **][Risk Score: 10][PLAIN TEXT (sdiKGkw)][Plen Bins: 0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/hpvirtgrp.pcap.out
+++ b/tests/result/hpvirtgrp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	37	(4.11 pkts/flow)
+
 HP Virtual Machine Group Management	135	12739	9
 
 	1	TCP 192.168.2.100:40152 <-> 160.44.194.66:5223 [proto: 256/HP Virtual Machine Group Management][cat: Network/14][7 pkts/1019 bytes <-> 8 pkts/613 bytes][Goodput ratio: 61/26][1.18 sec][bytes ratio: 0.249 (Upload)][IAT c2s/s2c min/avg/max/stddev: 1/0 92/192 380/409 144/135][Pkt Len c2s/s2c min/avg/max/stddev: 54/60 146/77 217/106 74/17][Plen Bins: 0,50,0,0,12,37,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/http-crash-content-disposition.pcap.out
+++ b/tests/result/http-crash-content-disposition.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	8	(8.00 pkts/flow)
+
 Amazon	9	3328	1
 
 	1	TCP 192.168.0.103:51171 <-> 174.129.0.10:80 [proto: 7.178/HTTP.Amazon][cat: Web/5][4 pkts/691 bytes <-> 5 pkts/2637 bytes][Goodput ratio: 69/90][0.31 sec][Host: khu.sh][bytes ratio: -0.585 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 48/50 125/145 55/59][Pkt Len c2s/s2c min/avg/max/stddev: 52/52 173/527 480/1492 178/601][URL: khu.sh/imessages.php?songify_a=3h248fIbwJ&new][StatusCode: 200][Content-Type: text/html][User-Agent: Apache-HttpClient/UNAVAILABLE (java 1.4)][PLAIN TEXT (POST /imessages.php)][Plen Bins: 0,25,0,0,0,0,0,0,0,0,0,0,0,25,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,25,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,25,0,0]

--- a/tests/result/http-lines-split.pcap.out
+++ b/tests/result/http-lines-split.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	8	(8.00 pkts/flow)
+
 HTTP	14	2503	1
 
 	1	TCP 192.168.0.1:39236 <-> 192.168.0.20:31337 [proto: 7/HTTP][cat: Web/5][7 pkts/481 bytes <-> 7 pkts/2022 bytes][Goodput ratio: 14/81][0.00 sec][Host: toni.lan][bytes ratio: -0.616 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 0/0 0/1 0/0][Pkt Len c2s/s2c min/avg/max/stddev: 60/54 69/289 92/1514 12/503][URL: toni.lan:31337/][StatusCode: 200][User-Agent: uclient-fetch][Risk: ** Known protocol on non standard port **][Risk Score: 10][PLAIN TEXT (GET / HTTP/1.1)][Plen Bins: 40,20,0,0,20,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,20,0,0]

--- a/tests/result/http_ipv6.pcap.out
+++ b/tests/result/http_ipv6.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	8
+
+DPI Packets (TCP):	86	(6.62 pkts/flow)
+DPI Packets (UDP):	4	(2.00 pkts/flow)
+
 Unknown	3	502	1
 ntop	80	36401	4
 TLS	26	3245	7

--- a/tests/result/iec60780-5-104.pcap.out
+++ b/tests/result/iec60780-5-104.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	24	(4.00 pkts/flow)
+
 IEC60870	147	9033	6
 
 	1	TCP 172.27.248.109:1578 <-> 172.27.248.79:2404 [proto: 245/IEC60870][cat: IoT-Scada/31][28 pkts/1758 bytes <-> 19 pkts/1297 bytes][Goodput ratio: 9/20][235.18 sec][bytes ratio: 0.151 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 1/4 9106/11905 32485/32516 10297/10287][Pkt Len c2s/s2c min/avg/max/stddev: 60/54 63/68 76/118 5/15][Plen Bins: 96,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/imaps.pcap.out
+++ b/tests/result/imaps.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	7	(7.00 pkts/flow)
+
 ntop	20	5196	1
 
 JA3 Host Stats: 

--- a/tests/result/instagram.pcap.out
+++ b/tests/result/instagram.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	18
+
+DPI Packets (TCP):	499	(16.63 pkts/flow)
+DPI Packets (UDP):	10	(1.43 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 Unknown	1	66	1
 HTTP	116	91784	6
 ICMP	5	510	1

--- a/tests/result/ip_fragmented_garbage.pcap.out
+++ b/tests/result/ip_fragmented_garbage.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	29	(29.00 pkts/flow)
+
 Unknown	29	1566	1
 
 

--- a/tests/result/iphone.pcap.out
+++ b/tests/result/iphone.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	3
+
+DPI Packets (TCP):	107	(7.13 pkts/flow)
+DPI Packets (UDP):	55	(1.77 pkts/flow)
+DPI Packets (other):	5	(1.00 pkts/flow)
+
 Unknown	2	120	1
 MDNS	17	7012	5
 SSDP	2	336	2

--- a/tests/result/ipv6_in_gtp.pcap.out
+++ b/tests/result/ipv6_in_gtp.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	1
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 Unknown	1	150	1
 IPsec	1	166	1
 

--- a/tests/result/irc.pcap.out
+++ b/tests/result/irc.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	7	(7.00 pkts/flow)
+
 IRC	29	8945	1
 
 	1	TCP 10.180.156.249:45921 <-> 38.229.70.20:8000 [proto: 65/IRC][cat: Chat/9][14 pkts/1046 bytes <-> 15 pkts/7899 bytes][Goodput ratio: 11/87][14.57 sec][bytes ratio: -0.766 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 1314/1206 8864/8864 2852/2736][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 75/527 107/1514 14/611][Risk: ** Unsafe Protocol **][Risk Score: 10][PLAIN TEXT (USER xx)][Plen Bins: 13,41,6,0,0,0,0,0,6,0,0,0,0,0,0,0,0,6,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,26,0,0]

--- a/tests/result/ja3_lots_of_cipher_suites.pcap.out
+++ b/tests/result/ja3_lots_of_cipher_suites.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	7	(7.00 pkts/flow)
+
 TLS	11	5132	1
 
 JA3 Host Stats: 

--- a/tests/result/ja3_lots_of_cipher_suites_2_anon.pcap.out
+++ b/tests/result/ja3_lots_of_cipher_suites_2_anon.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	7	(7.00 pkts/flow)
+
 TLS	27	6966	1
 
 JA3 Host Stats: 

--- a/tests/result/kerberos.pcap.out
+++ b/tests/result/kerberos.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	33
+
+DPI Packets (TCP):	77	(2.14 pkts/flow)
+
 Unknown	9	3031	2
 SMBv23	6	1914	3
 Kerberos	48	19194	24

--- a/tests/result/long_tls_certificate.pcap.out
+++ b/tests/result/long_tls_certificate.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	12	(12.00 pkts/flow)
+
 TLS	47	14812	1
 
 JA3 Host Stats: 

--- a/tests/result/malformed_dns.pcap.out
+++ b/tests/result/malformed_dns.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	2	(2.00 pkts/flow)
+
 DNS	6	5860	1
 
 	1	UDP 127.0.0.1:50435 <-> 127.0.0.1:53 [proto: 5/DNS][cat: Network/14][2 pkts/140 bytes <-> 4 pkts/5720 bytes][Goodput ratio: 40/97][5.03 sec][Host: www.xt.com][0.0.0.0][bytes ratio: -0.952 (Download)][IAT c2s/s2c min/avg/max/stddev: 4999/13 4999/1670 4999/4983 0/2343][Pkt Len c2s/s2c min/avg/max/stddev: 70/1430 70/1430 70/1430 0/0][Risk: ** Malformed packet **][Risk Score: 10][PLAIN TEXT (AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)][Plen Bins: 33,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,66,0,0,0,0]

--- a/tests/result/malformed_icmp.pcap.out
+++ b/tests/result/malformed_icmp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 ICMP	1	42	1
 
 	1	ICMP 218.152.179.213:0 -> 218.152.179.54:0 [proto: 81/ICMP][cat: Network/14][1 pkts/42 bytes -> 0 pkts/0 bytes][Goodput ratio: 0/0][< 1 sec][Risk: ** Malformed packet **][Risk Score: 10][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/malware.pcap.out
+++ b/tests/result/malware.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	2
+
+DPI Packets (TCP):	13	(4.33 pkts/flow)
+DPI Packets (UDP):	2	(2.00 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 DNS	2	216	1
 HTTP	1	66	1
 ICMP	1	98	1

--- a/tests/result/modbus.pcap.out
+++ b/tests/result/modbus.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	1	(1.00 pkts/flow)
+
 Modbus	102	6681	1
 
 	1	TCP 192.168.110.131:2074 <-> 192.168.110.138:502 [proto: 44/Modbus][cat: IoT-Scada/31][51 pkts/3366 bytes <-> 51 pkts/3315 bytes][Goodput ratio: 18/17][23.11 sec][bytes ratio: 0.008 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 477/477 1073/1074 501/501][Pkt Len c2s/s2c min/avg/max/stddev: 66/65 66/65 66/65 0/0][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/monero.pcap.out
+++ b/tests/result/monero.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	8	(4.00 pkts/flow)
+
 Mining	319	166676	2
 
 	1	TCP 192.168.2.148:46838 <-> 94.23.199.191:3333 [proto: 42/Mining][cat: Mining/99][159 pkts/143155 bytes <-> 113 pkts/13204 bytes][Goodput ratio: 93/43][1091.42 sec][ZCash/Monero][bytes ratio: 0.831 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 7234/8131 71734/71815 15224/15291][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 900/117 1514/376 709/99][Risk: ** Unsafe Protocol **][Risk Score: 10][PLAIN TEXT (method)][Plen Bins: 28,2,0,1,0,0,0,0,0,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,29,29,0,0]

--- a/tests/result/mongodb.pcap.out
+++ b/tests/result/mongodb.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	3
+
+DPI Packets (TCP):	27	(3.38 pkts/flow)
+
 Unknown	3	230	1
 MongoDB	24	2510	7
 

--- a/tests/result/mpeg.pcap.out
+++ b/tests/result/mpeg.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	6	(6.00 pkts/flow)
+
 ntop	19	10643	1
 
 	1	TCP 192.168.80.160:55804 <-> 46.101.157.119:80 [proto: 7.26/HTTP.ntop][cat: Media/1][9 pkts/754 bytes <-> 10 pkts/9889 bytes][Goodput ratio: 20/93][0.18 sec][Host: luca.ntop.org][bytes ratio: -0.858 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 25/6 77/41 28/14][Pkt Len c2s/s2c min/avg/max/stddev: 66/68 84/989 214/1502 46/649][URL: luca.ntop.org/0.mp3][StatusCode: 200][Content-Type: audio/mpeg][User-Agent: Wget/1.16.3 (darwin14.1.0)][PLAIN TEXT (GET /0.mp)][Plen Bins: 0,0,0,0,12,0,0,0,0,0,0,0,0,0,0,0,0,0,12,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,75,0,0,0]

--- a/tests/result/mpegts.pcap.out
+++ b/tests/result/mpegts.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 MPEG_TS	1	1362	1
 
 	1	UDP 10.1.16.48:40737 -> 230.200.201.23:1234 [VLAN: 3359][proto: 198/MPEG_TS][cat: Media/1][1 pkts/1362 bytes -> 0 pkts/0 bytes][Goodput ratio: 97/0][< 1 sec][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,100,0,0,0,0,0,0]

--- a/tests/result/mssql_tds.pcap.out
+++ b/tests/result/mssql_tds.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	18	(1.50 pkts/flow)
+
 MsSQL-TDS	38	16260	12
 
 	1	TCP 10.111.111.111:6666 -> 10.0.0.1:1433 [proto: 114/MsSQL-TDS][cat: Database/11][7 pkts/8717 bytes -> 0 pkts/0 bytes][Goodput ratio: 96/0][< 1 sec][bytes ratio: 1.000 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 0/0 0/0 0/0][Pkt Len c2s/s2c min/avg/max/stddev: 393/0 1245/0 1514/0 436/0][Plen Bins: 0,0,0,0,0,0,0,0,0,0,14,0,0,0,0,0,0,0,0,0,0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,71,0,0]

--- a/tests/result/mysql-8.pcap.out
+++ b/tests/result/mysql-8.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	4	(4.00 pkts/flow)
+
 MySQL	4	367	1
 
 	1	TCP 192.168.1.105:8738 <-> 10.42.18.198:3306 [proto: 20/MySQL][cat: Database/11][2 pkts/140 bytes <-> 2 pkts/227 bytes][Goodput ratio: 0/38][0.00 sec][PLAIN TEXT (DDDDDD)][Plen Bins: 0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/nats.pcap.out
+++ b/tests/result/nats.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	10	(5.00 pkts/flow)
+
 Nats	27	2460	2
 
 	1	TCP 127.0.0.1:54821 <-> 127.0.0.1:4222 [proto: 68/Nats][cat: RPC/16][7 pkts/545 bytes <-> 7 pkts/725 bytes][Goodput ratio: 26/44][2.20 sec][bytes ratio: -0.142 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 1/1 3/3 1/1][Pkt Len c2s/s2c min/avg/max/stddev: 56/56 78/104 191/365 46/107][PLAIN TEXT (rINFO )][Plen Bins: 60,0,0,0,20,0,0,0,0,20,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/ndpi_match_string_subprotocol__error.pcapng.out
+++ b/tests/result/ndpi_match_string_subprotocol__error.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	3	(3.00 pkts/flow)
+
 HTTP	13	2935	1
 
 	1	TCP 10.3.9.19:40632 <-> 10.68.137.118:8091 [proto: 7/HTTP][cat: Web/5][7 pkts/1546 bytes <-> 6 pkts/1389 bytes][Goodput ratio: 73/76][3438.13 sec][Host: 10.68.137.118][bytes ratio: 0.053 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 7/29 687620/24940 3382709/49851 1347715/24911][Pkt Len c2s/s2c min/avg/max/stddev: 60/54 221/232 1180/739 392/263][URL: 10.68.137.118:8091/Apcn/ApcRemoteService][StatusCode: 200][User-Agent: Jakarta Commons-HttpClient/3.0.1][Risk: ** Known protocol on non standard port **** HTTP Numeric IP Address **][Risk Score: 20][PLAIN TEXT (POST /Apcn/ApcRemoteService HTT)][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,33,0,0,0,0,0,0,0,0,0,33,0,0,0,0,0,0,0,0,0,0,0,0,0,33,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/nest_log_sink.pcap.out
+++ b/tests/result/nest_log_sink.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	176	(13.54 pkts/flow)
+DPI Packets (UDP):	2	(2.00 pkts/flow)
+
 DNS	15	1612	1
 NestLogSink	457	44483	6
 Google	302	72365	7

--- a/tests/result/netbios.pcap.out
+++ b/tests/result/netbios.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	2	(2.00 pkts/flow)
+DPI Packets (UDP):	14	(1.00 pkts/flow)
+
 NetBIOS	258	24196	13
 SMBv1	2	486	2
 

--- a/tests/result/netbios_wildcard_dns_query.pcap.out
+++ b/tests/result/netbios_wildcard_dns_query.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 DNS	1	92	1
 
 	1	UDP 10.1.67.250:41335 -> 10.1.66.20:53 [proto: 5/DNS][cat: Network/14][1 pkts/92 bytes -> 0 pkts/0 bytes][Goodput ratio: 54/0][< 1 sec][Host: ckaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa][::][PLAIN TEXT ( CKAAAAAAAAAAAAAAAAAAAAAAAAAAAA)][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/netflix.pcap.out
+++ b/tests/result/netflix.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	6
+
+DPI Packets (TCP):	393	(8.36 pkts/flow)
+DPI Packets (UDP):	27	(2.08 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 DNS	4	386	2
 SSDP	16	2648	1
 IGMP	1	60	1

--- a/tests/result/netflow-fritz.pcap.out
+++ b/tests/result/netflow-fritz.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 NetFlow	1	222	1
 
 	1	UDP 192.168.0.1:23384 -> 192.168.1.1:2055 [proto: 128/NetFlow][cat: Network/14][1 pkts/222 bytes -> 0 pkts/0 bytes][Goodput ratio: 81/0][< 1 sec][Plen Bins: 0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/netflowv9.pcap.out
+++ b/tests/result/netflowv9.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 NetFlow	10	13888	1
 
 	1	UDP 192.168.2.134:48629 -> 192.168.2.222:2057 [proto: 128/NetFlow][cat: Network/14][10 pkts/13888 bytes -> 0 pkts/0 bytes][Goodput ratio: 97/0][0.00 sec][bytes ratio: 1.000 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 0/0 0/0 0/0][Pkt Len c2s/s2c min/avg/max/stddev: 1362/0 1389/0 1418/0 23/0][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,50,30,20,0,0,0,0]

--- a/tests/result/nintendo.pcap.out
+++ b/tests/result/nintendo.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	7
+
+DPI Packets (TCP):	70	(17.50 pkts/flow)
+DPI Packets (UDP):	35	(2.33 pkts/flow)
+DPI Packets (other):	2	(1.00 pkts/flow)
+
 ICMP	30	2100	2
 Nintendo	887	319888	11
 Amazon	79	11165	8

--- a/tests/result/no_sni.pcap.out
+++ b/tests/result/no_sni.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	51	(6.38 pkts/flow)
+
 DoH_DoT	268	31882	1
 Cloudflare	917	562254	7
 

--- a/tests/result/ocs.pcap.out
+++ b/tests/result/ocs.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	18
+
+DPI Packets (TCP):	266	(22.17 pkts/flow)
+DPI Packets (UDP):	8	(1.00 pkts/flow)
+
 Unknown	6	360	1
 HTTP	13	1019	2
 Google	30	3390	6

--- a/tests/result/ookla.pcap.out
+++ b/tests/result/ookla.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	24	(12.00 pkts/flow)
+
 Ookla	5086	4689745	2
 
 	1	TCP 192.168.1.7:51215 <-> 46.44.253.187:8080 [proto: 191/Ookla][cat: Network/14][2202 pkts/1032520 bytes <-> 2864 pkts/3652905 bytes][Goodput ratio: 86/95][40.14 sec][bytes ratio: -0.559 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 15/11 2086/2226 59/54][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 469/1275 1506/1506 642/527][PLAIN TEXT ( 6HELLO 2.4 2016)][Plen Bins: 28,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,70,0,0]

--- a/tests/result/openvpn.pcap.out
+++ b/tests/result/openvpn.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	6	(6.00 pkts/flow)
+DPI Packets (UDP):	5	(2.50 pkts/flow)
+
 OpenVPN	298	57111	3
 
 	1	UDP 192.168.43.18:13680 <-> 139.59.151.137:13680 [proto: 159/OpenVPN][cat: VPN/2][62 pkts/11508 bytes <-> 58 pkts/16664 bytes][Goodput ratio: 77/85][19.24 sec][bytes ratio: -0.183 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 289/106 3994/2456 764/365][Pkt Len c2s/s2c min/avg/max/stddev: 84/92 186/287 1214/1287 193/325][PLAIN TEXT (160727093158Z)][Plen Bins: 0,33,19,9,29,0,0,2,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,1,1,0,0,0,0,0,0,0,0,0]

--- a/tests/result/os_detected.pcapng.out
+++ b/tests/result/os_detected.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 Google	1	1294	1
 
 JA3 Host Stats: 

--- a/tests/result/pinterest.pcap.out
+++ b/tests/result/pinterest.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	17
+
+DPI Packets (TCP):	261	(7.05 pkts/flow)
+
 TLS	979	1924858	20
 Facebook	242	237988	2
 Google	634	607243	5

--- a/tests/result/pps.pcap.out
+++ b/tests/result/pps.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	44
+
+DPI Packets (TCP):	159	(2.52 pkts/flow)
+DPI Packets (UDP):	201	(4.57 pkts/flow)
+
 Unknown	990	378832	34
 HTTP	1502	1849543	62
 SSDP	63	17143	10

--- a/tests/result/ps_vue.pcap.out
+++ b/tests/result/ps_vue.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	8
+
+DPI Packets (TCP):	97	(12.12 pkts/flow)
+
 PS_VUE	1724	2198169	1
 TLS	11	1401	5
 Amazon	5	1380	2

--- a/tests/result/quic-23.pcap.out
+++ b/tests/result/quic-23.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 QUIC	20	7191	1
 
 JA3 Host Stats: 

--- a/tests/result/quic-24.pcap.out
+++ b/tests/result/quic-24.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 QUIC	15	8000	1
 
 JA3 Host Stats: 

--- a/tests/result/quic-27.pcap.out
+++ b/tests/result/quic-27.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 Google	20	12887	1
 
 JA3 Host Stats: 

--- a/tests/result/quic-28.pcap.out
+++ b/tests/result/quic-28.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 Cloudflare	253	246793	1
 
 JA3 Host Stats: 

--- a/tests/result/quic-29.pcap.out
+++ b/tests/result/quic-29.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 QUIC	15	9386	1
 
 JA3 Host Stats: 

--- a/tests/result/quic-33.pcapng.out
+++ b/tests/result/quic-33.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 QUIC	992	1340722	1
 
 JA3 Host Stats: 

--- a/tests/result/quic-mvfst-22.pcap.out
+++ b/tests/result/quic-mvfst-22.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 Facebook	490	288303	1
 
 JA3 Host Stats: 

--- a/tests/result/quic-mvfst-22_decryption_error.pcap.out
+++ b/tests/result/quic-mvfst-22_decryption_error.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 QUIC	353	400490	1
 
 	1	UDP 10.230.40.168:62196 <-> 94.97.225.146:443 [proto: 188/QUIC][cat: Web/5][43 pkts/13029 bytes <-> 310 pkts/387461 bytes][Goodput ratio: 91/98][0.20 sec][bytes ratio: -0.935 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 1/0 15/43 3/3][Pkt Len c2s/s2c min/avg/max/stddev: 59/66 303/1250 1260/1280 452/176][PLAIN TEXT (FSboeS)][Plen Bins: 4,4,1,0,0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,85,0,0,0,0,0,0,0,0]

--- a/tests/result/quic-mvfst-27.pcapng.out
+++ b/tests/result/quic-mvfst-27.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 Facebook	20	11399	1
 
 JA3 Host Stats: 

--- a/tests/result/quic-mvfst-exp.pcap.out
+++ b/tests/result/quic-mvfst-exp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 Facebook	30	26309	1
 
 JA3 Host Stats: 

--- a/tests/result/quic.pcap.out
+++ b/tests/result/quic.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (UDP):	12	(1.20 pkts/flow)
+
 GMail	413	254874	1
 YouTube	85	76193	5
 Google	14	10427	3

--- a/tests/result/quic046.pcap.out
+++ b/tests/result/quic046.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 YouTube	100	91297	1
 
 	1	UDP 192.168.1.236:50587 <-> 216.58.206.86:443 [proto: 188.124/QUIC.YouTube][cat: Media/1][37 pkts/6724 bytes <-> 63 pkts/84573 bytes][Goodput ratio: 77/97][0.05 sec][bytes ratio: -0.853 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 0/0 1/5 0/1][Pkt Len c2s/s2c min/avg/max/stddev: 70/62 182/1342 1392/1392 304/222][User-Agent: Chrome/80.0.3987.132 Windows NT 6.3; Win64; x64][Client: i.ytimg.com][PLAIN TEXT (i.ytimg.com)][Plen Bins: 26,1,1,0,5,2,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,61,0,0,0,0,0]

--- a/tests/result/quic_0RTT.pcap.out
+++ b/tests/result/quic_0RTT.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 QUIC	2	2588	1
 
 JA3 Host Stats: 

--- a/tests/result/quic_frags_ch_in_multiple_packets.pcapng.out
+++ b/tests/result/quic_frags_ch_in_multiple_packets.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (UDP):	4	(4.00 pkts/flow)
+
 QUIC	4	3998	1
 
 JA3 Host Stats: 

--- a/tests/result/quic_frags_ch_out_of_order_same_packet_craziness.pcapng.out
+++ b/tests/result/quic_frags_ch_out_of_order_same_packet_craziness.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	113
+
+DPI Packets (UDP):	179	(1.58 pkts/flow)
+
 Google	6	8352	2
 QUIC	169	235248	110
 GoogleServices	4	5568	1

--- a/tests/result/quic_interop_V.pcapng.out
+++ b/tests/result/quic_interop_V.pcapng.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	63	(1.00 pkts/flow)
+DPI Packets (other):	14	(1.00 pkts/flow)
+
 ICMP	21	7436	9
 ICMPV6	10	10642	5
 QUIC	195	201384	60

--- a/tests/result/quic_q39.pcap.out
+++ b/tests/result/quic_q39.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 YouTube	60	24185	1
 
 	1	UDP 170.216.16.209:38620 <-> 21.157.183.227:443 [proto: 188.124/QUIC.YouTube][cat: Media/1][27 pkts/20099 bytes <-> 33 pkts/4086 bytes][Goodput ratio: 94/66][48.95 sec][bytes ratio: 0.662 (Upload)][IAT c2s/s2c min/avg/max/stddev: 1/0 2239/1370 14326/14805 3925/3576][Pkt Len c2s/s2c min/avg/max/stddev: 65/60 744/124 1392/1392 569/228][User-Agent: com.google.android.youtube Cronet/63.0.3223.7][Client: s.youtube.com][PLAIN TEXT (s.youtube.com)][Plen Bins: 24,47,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,1,5,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,16,0,0,0,0,0]

--- a/tests/result/quic_q43.pcap.out
+++ b/tests/result/quic_q43.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 DoH_DoT	2	1464	1
 
 	1	UDP 51.120.20.202:49241 <-> 72.119.217.29:443 [proto: 188.196/QUIC.DoH_DoT][cat: Network/14][1 pkts/1392 bytes <-> 1 pkts/72 bytes][Goodput ratio: 97/41][0.05 sec][Client: dns.google.com][PLAIN TEXT (dns.google.com)][Plen Bins: 50,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,50,0,0,0,0,0]

--- a/tests/result/quic_q46.pcap.out
+++ b/tests/result/quic_q46.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 Google	20	21241	1
 
 	1	UDP 172.29.42.236:38292 <-> 153.20.183.203:443 [proto: 188.126/QUIC.Google][cat: Web/5][5 pkts/1675 bytes <-> 15 pkts/19566 bytes][Goodput ratio: 87/97][0.31 sec][bytes ratio: -0.842 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 6/20 17/224 8/59][Pkt Len c2s/s2c min/avg/max/stddev: 70/78 335/1304 1392/1392 529/328][User-Agent: Chrome/74.0.3729.157 Android 8.0.0; BND-L21][Client: play.google.com][PLAIN TEXT (play.google.comL)][Plen Bins: 20,5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,75,0,0,0,0,0]

--- a/tests/result/quic_q46_b.pcap.out
+++ b/tests/result/quic_q46_b.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 YouTubeUpload	20	7020	1
 
 	1	UDP 172.27.69.216:45530 <-> 110.231.134.35:443 [proto: 188.136/QUIC.YouTubeUpload][cat: Media/1][6 pkts/2916 bytes <-> 14 pkts/4104 bytes][Goodput ratio: 81/69][3.09 sec][bytes ratio: -0.169 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 24/0 200/218 384/1017 128/277][Pkt Len c2s/s2c min/avg/max/stddev: 118/106 486/293 1440/1440 466/345][User-Agent: com.google.android.youtube Cronet/76.0.3809.0][Client: upload.youtube.com][PLAIN TEXT (upload.youtube.comx)][Plen Bins: 45,15,0,0,0,0,0,0,0,0,20,0,0,0,10,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,10,0,0,0,0,0]

--- a/tests/result/quic_q50.pcap.out
+++ b/tests/result/quic_q50.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 QUIC	20	20434	1
 
 	1	UDP 248.144.129.147:39203 <-> 184.151.193.237:443 [proto: 188/QUIC][cat: Web/5][6 pkts/3579 bytes <-> 14 pkts/16855 bytes][Goodput ratio: 93/97][0.47 sec][bytes ratio: -0.650 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 85/27 210/221 80/63][Pkt Len c2s/s2c min/avg/max/stddev: 75/67 596/1204 1392/1392 588/461][User-Agent: Chrome/83.0.4103.101 Android 8.0.0; LDN-L21][Client: www.googletagmanager.com][PLAIN TEXT (x.GdrZY)][Plen Bins: 5,20,0,0,0,0,0,0,0,0,0,0,0,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,70,0,0,0,0,0]

--- a/tests/result/quic_t50.pcap.out
+++ b/tests/result/quic_t50.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 GoogleServices	12	8420	1
 
 JA3 Host Stats: 

--- a/tests/result/quic_t51.pcap.out
+++ b/tests/result/quic_t51.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 Google	642	573718	1
 
 JA3 Host Stats: 

--- a/tests/result/quickplay.pcap.out
+++ b/tests/result/quickplay.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	10
+
+DPI Packets (TCP):	150	(7.14 pkts/flow)
+
 HTTP	133	96179	11
 QQ	12	4781	5
 Facebook	6	1740	3

--- a/tests/result/rdp.pcap.out
+++ b/tests/result/rdp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	4	(4.00 pkts/flow)
+
 RDP	2010	622743	1
 
 	1	TCP 172.16.2.185:52494 <-> 192.168.2.142:3389 [proto: 88/RDP][cat: RemoteAccess/12][936 pkts/58890 bytes <-> 1074 pkts/563853 bytes][Goodput ratio: 30/92][7.55 sec][bytes ratio: -0.811 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 6/5 850/850 40/38][Pkt Len c2s/s2c min/avg/max/stddev: 44/44 63/525 622/1317 44/511][Risk: ** Desktop/File Sharing Session **][Risk Score: 10][PLAIN TEXT (192.168.2.142)][Plen Bins: 1,63,22,5,1,0,0,0,0,0,0,1,0,0,1,1,0,1,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0]

--- a/tests/result/reasm_crash_anon.pcapng.out
+++ b/tests/result/reasm_crash_anon.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	81	(81.00 pkts/flow)
+
 Unknown	200	20067	1
 
 

--- a/tests/result/reasm_segv_anon.pcapng.out
+++ b/tests/result/reasm_segv_anon.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	81	(81.00 pkts/flow)
+
 HTTP	82	77940	1
 
 	1	TCP 172.17.36.21:57619 <-> 63.190.145.43:80 [proto: GTP:7/HTTP][cat: Web/5][28 pkts/3184 bytes <-> 54 pkts/74756 bytes][Goodput ratio: 0/93][15.67 sec][bytes ratio: -0.918 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 448/205 1615/2133 476/518][Pkt Len c2s/s2c min/avg/max/stddev: 94/90 114/1384 130/1490 9/330][PLAIN TEXT (.iJoJJ)][Plen Bins: 0,0,0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,0,0,1,0,0,92,0,0,0,0]

--- a/tests/result/reddit.pcap.out
+++ b/tests/result/reddit.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	445	(7.42 pkts/flow)
+
 TLS	612	384211	15
 Twitter	863	686585	3
 YouTube	881	966947	3

--- a/tests/result/rtsp_setup_http.pcapng.out
+++ b/tests/result/rtsp_setup_http.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	1	(1.00 pkts/flow)
+
 RTSP	1	233	1
 
 	1	TCP 172.28.5.170:63840 -> 172.28.4.26:8554 [proto: 50/RTSP][cat: Media/1][1 pkts/233 bytes -> 0 pkts/0 bytes][Goodput ratio: 76/0][< 1 sec][PLAIN TEXT (SETUP rtsp)][Plen Bins: 0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/rx.pcap.out
+++ b/tests/result/rx.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	5	(1.00 pkts/flow)
+
 RX	132	26475	5
 
 	1	UDP 131.114.219.168:7001 <-> 192.167.206.241:7000 [proto: 223/RX][cat: RPC/16][48 pkts/6808 bytes <-> 31 pkts/5568 bytes][Goodput ratio: 70/77][20.45 sec][bytes ratio: 0.100 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 509/13 19828/65 3094/18][Pkt Len c2s/s2c min/avg/max/stddev: 70/74 142/180 510/782 117/123][PLAIN TEXT (UZ.SNS.IT)][Plen Bins: 2,26,41,0,17,6,0,0,0,0,0,0,2,0,3,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/s7comm.pcap.out
+++ b/tests/result/s7comm.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	1	(1.00 pkts/flow)
+
 s7comm	55	5260	1
 
 	1	TCP 192.168.1.10:4185 <-> 192.168.1.40:102 [proto: 249/s7comm][cat: Network/14][36 pkts/3146 bytes <-> 19 pkts/2114 bytes][Goodput ratio: 38/51][0.14 sec][bytes ratio: 0.196 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/3 3/6 8/12 3/3][Pkt Len c2s/s2c min/avg/max/stddev: 61/74 87/111 301/275 54/44][PLAIN TEXT (TestHMI00040)][Plen Bins: 53,32,9,0,0,0,1,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/safari.pcap.out
+++ b/tests/result/safari.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	421	(60.14 pkts/flow)
+
 TLS	6019	5570309	7
 
 JA3 Host Stats: 

--- a/tests/result/selfsigned.pcap.out
+++ b/tests/result/selfsigned.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	7	(7.00 pkts/flow)
+
 ntop	20	3766	1
 
 JA3 Host Stats: 

--- a/tests/result/signal.pcap.out
+++ b/tests/result/signal.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	3
+
+DPI Packets (TCP):	110	(7.33 pkts/flow)
+DPI Packets (UDP):	5	(1.67 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 DNS	2	186	1
 DHCP	4	1368	1
 Signal	512	282327	11

--- a/tests/result/simple-dnscrypt.pcap.out
+++ b/tests/result/simple-dnscrypt.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	47	(11.75 pkts/flow)
+
 DNScrypt	111	44676	4
 
 JA3 Host Stats: 

--- a/tests/result/sip.pcap.out
+++ b/tests/result/sip.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	4	(1.00 pkts/flow)
+
 RTP	9	1926	1
 SIP	102	47087	2
 RTCP	1	146	1

--- a/tests/result/skype-conference-call.pcap.out
+++ b/tests/result/skype-conference-call.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 SkypeCall	200	39687	1
 
 	1	UDP 192.168.2.20:49282 <-> 104.46.40.49:60642 [proto: 78.38/STUN.SkypeCall][cat: VoIP/10][133 pkts/24845 bytes <-> 67 pkts/14842 bytes][Goodput ratio: 78/81][1.50 sec][bytes ratio: 0.252 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 10/8 147/120 22/27][Pkt Len c2s/s2c min/avg/max/stddev: 74/77 187/222 957/957 244/233][Risk: ** Known protocol on non standard port **][Risk Score: 10][Plen Bins: 0,41,17,28,1,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,9,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/skype.pcap.out
+++ b/tests/result/skype.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	124
+
+DPI Packets (TCP):	1760	(18.14 pkts/flow)
+DPI Packets (UDP):	366	(1.92 pkts/flow)
+DPI Packets (other):	5	(1.00 pkts/flow)
+
 Unknown	718	73876	35
 DNS	2	267	1
 MDNS	8	1736	2

--- a/tests/result/skype_no_unknown.pcap.out
+++ b/tests/result/skype_no_unknown.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	95
+
+DPI Packets (TCP):	1233	(16.22 pkts/flow)
+DPI Packets (UDP):	310	(1.67 pkts/flow)
+DPI Packets (other):	5	(1.00 pkts/flow)
+
 Unknown	392	39230	26
 DNS	2	267	1
 MDNS	3	400	2

--- a/tests/result/skype_udp.pcap.out
+++ b/tests/result/skype_udp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	2	(2.00 pkts/flow)
+
 Skype_Teams	5	339	1
 
 	1	UDP 192.168.1.2:35990 <-> 24.224.190.149:39262 [proto: 125/Skype_Teams][4 pkts/279 bytes <-> 1 pkts/60 bytes][Goodput ratio: 40/30][72.51 sec][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/smb_deletefile.pcap.out
+++ b/tests/result/smb_deletefile.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	1	(1.00 pkts/flow)
+
 SMBv23	101	30748	1
 
 	1	TCP 192.168.1.118:56848 <-> 192.168.1.187:445 [proto: 10.41/NetBIOS.SMBv23][cat: System/18][62 pkts/14382 bytes <-> 39 pkts/16366 bytes][Goodput ratio: 77/87][2.38 sec][bytes ratio: -0.065 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 46/80 2157/2158 299/394][Pkt Len c2s/s2c min/avg/max/stddev: 54/60 232/420 530/1514 194/299][Plen Bins: 0,0,4,7,1,0,1,1,0,1,7,9,20,21,6,13,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,1,0,0]

--- a/tests/result/smbv1.pcap.out
+++ b/tests/result/smbv1.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	3	(3.00 pkts/flow)
+
 SMBv1	7	1197	1
 
 	1	TCP 172.16.156.130:50927 <-> 10.128.0.243:445 [proto: 10.16/NetBIOS.SMBv1][cat: System/18][4 pkts/669 bytes <-> 3 pkts/528 bytes][Goodput ratio: 68/69][0.10 sec][bytes ratio: 0.118 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 27/34 32/35 37/36 4/1][Pkt Len c2s/s2c min/avg/max/stddev: 136/114 167/176 194/243 26/53][Risk: ** Known protocol on non standard port **** SMB Insecure Version **** Unsafe Protocol **][Risk Score: 70][PLAIN TEXT (PC NETWORK PROGRAM 1.0)][Plen Bins: 0,14,28,14,28,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/smpp_in_general.pcap.out
+++ b/tests/result/smpp_in_general.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	4	(4.00 pkts/flow)
+
 SMPP	17	1144	1
 
 	1	TCP 10.226.202.118:1770 <-> 10.226.202.53:9000 [proto: 207/SMPP][cat: FileTransfer/7][10 pkts/670 bytes <-> 7 pkts/474 bytes][Goodput ratio: 18/16][30.95 sec][bytes ratio: 0.171 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 3848/7230 28802/28906 9451/12515][Pkt Len c2s/s2c min/avg/max/stddev: 54/60 67/68 104/79 17/7][PLAIN TEXT (password)][Plen Bins: 75,25,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/snapchat.pcap.out
+++ b/tests/result/snapchat.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	3
+
+DPI Packets (TCP):	56	(18.67 pkts/flow)
+
 Google	22	2879	1
 Snapchat	34	7320	2
 

--- a/tests/result/snapchat_call.pcapng.out
+++ b/tests/result/snapchat_call.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	20	(20.00 pkts/flow)
+
 SnapchatCall	50	12772	1
 
 	1	UDP 192.168.12.169:42083 <-> 18.184.138.142:443 [proto: 188.255/QUIC.SnapchatCall][cat: Web/5][25 pkts/5295 bytes <-> 25 pkts/7477 bytes][Goodput ratio: 80/86][8.29 sec][bytes ratio: -0.171 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 288/246 1313/1315 376/342][Pkt Len c2s/s2c min/avg/max/stddev: 65/62 212/299 1392/1392 365/419][Risk: ** SNI TLS extension was missing **][Risk Score: 50][PLAIN TEXT (AESGCC20)][Plen Bins: 28,44,0,2,2,0,0,2,4,4,0,0,2,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,10,0,0,0,0,0]

--- a/tests/result/ssdp-m-search.pcap.out
+++ b/tests/result/ssdp-m-search.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 SSDP	19	1197	1
 
 	1	UDP 192.168.242.8:42253 -> 192.168.242.255:32412 [proto: 12/SSDP][cat: System/18][19 pkts/1197 bytes -> 0 pkts/0 bytes][Goodput ratio: 33/0][90.00 sec][bytes ratio: 1.000 (Upload)][IAT c2s/s2c min/avg/max/stddev: 4999/0 4999/0 5000/0 0/0][Pkt Len c2s/s2c min/avg/max/stddev: 63/0 63/0 63/0 0/0][PLAIN TEXT (SEARCH )][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/ssh.pcap.out
+++ b/tests/result/ssh.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	10	(10.00 pkts/flow)
+
 SSH	258	35546	1
 
 	1	TCP 172.16.238.1:58395 <-> 172.16.238.168:22 [proto: 92/SSH][cat: RemoteAccess/12][159 pkts/15615 bytes <-> 99 pkts/19931 bytes][Goodput ratio: 33/67][248.48 sec][bytes ratio: -0.121 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 1846/2934 166223/166224 14794/19692][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 98/201 970/1346 83/283][Risk: ** SSH Obsolete Client Version/Cipher **** SSH Obsolete Server Version/Cipher **][Risk Score: 100][Client: SSH-2.0-OpenSSH_5.3][HASSH-C: 21B457A327CE7A2D4FCE5EF2C42400BD][Server: SSH-2.0-OpenSSH_5.6][HASSH-S: B1C6C0D56317555B85C7005A3DE29325][Plen Bins: 2,76,12,2,3,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,1,0,0,0,0,0,0,0]

--- a/tests/result/ssl-cert-name-mismatch.pcap.out
+++ b/tests/result/ssl-cert-name-mismatch.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	10	(10.00 pkts/flow)
+
 Google	21	5412	1
 
 JA3 Host Stats: 

--- a/tests/result/starcraft_battle.pcap.out
+++ b/tests/result/starcraft_battle.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	24
+
+DPI Packets (TCP):	182	(4.79 pkts/flow)
+DPI Packets (UDP):	36	(2.77 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 DNS	26	2848	7
 HTTP	450	294880	19
 SSDP	11	4984	1

--- a/tests/result/steam.pcap.out
+++ b/tests/result/steam.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	55	(1.00 pkts/flow)
+
 Steam	104	9020	55
 
 	1	UDP 192.168.188.149:45665 <-> 72.165.61.188:27018 [proto: 74/Steam][cat: Game/8][5 pkts/846 bytes <-> 6 pkts/608 bytes][Goodput ratio: 75/58][0.69 sec][bytes ratio: 0.164 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 50/0 149/124 298/289 107/116][Pkt Len c2s/s2c min/avg/max/stddev: 78/78 169/101 366/158 117/28][PLAIN TEXT (H@VS01)][Plen Bins: 0,63,9,9,0,0,9,0,0,0,9,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/synscan.pcap.out
+++ b/tests/result/synscan.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1990
+
+DPI Packets (TCP):	2011	(1.01 pkts/flow)
+
 Unknown	1874	108700	1870
 FTP_CONTROL	2	116	2
 POP3	2	116	2

--- a/tests/result/teams.pcap.out
+++ b/tests/result/teams.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	23
+
+DPI Packets (TCP):	793	(18.88 pkts/flow)
+DPI Packets (UDP):	87	(2.17 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 Unknown	4	456	1
 DNS	14	1902	7
 DHCP	7	2323	2

--- a/tests/result/teamspeak3.pcap.out
+++ b/tests/result/teamspeak3.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 TeamSpeak	13	1911	1
 
 	1	UDP 10.0.0.1:53187 -> 10.0.0.2:9987 [proto: 162/TeamSpeak][cat: VoIP/10][13 pkts/1911 bytes -> 0 pkts/0 bytes][Goodput ratio: 71/0][37.01 sec][bytes ratio: 1.000 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 387/0 1301/0 449/0][Pkt Len c2s/s2c min/avg/max/stddev: 76/0 147/0 230/0 77/0][PLAIN TEXT (DDDDDDffffff)][Plen Bins: 0,53,0,0,0,46,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/telegram.pcap.out
+++ b/tests/result/telegram.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	6
+
+DPI Packets (UDP):	105	(2.19 pkts/flow)
+
 Unknown	304	72496	2
 DNS	8	716	4
 MDNS	282	60976	9

--- a/tests/result/teredo.pcap.out
+++ b/tests/result/teredo.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	5	(1.00 pkts/flow)
+
 Teredo	24	2574	5
 
 	1	UDP 10.112.16.67:51812 <-> 194.136.28.76:3544 [proto: 214/Teredo][cat: Network/14][10 pkts/930 bytes <-> 4 pkts/374 bytes][Goodput ratio: 55/55][17.48 sec][bytes ratio: 0.426 (Upload)][IAT c2s/s2c min/avg/max/stddev: 42/10 2184/2486 8524/4963 2528/2476][Pkt Len c2s/s2c min/avg/max/stddev: 82/90 93/94 95/95 4/2][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/tftp_rrq.pcap.out
+++ b/tests/result/tftp_rrq.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (UDP):	3	(1.50 pkts/flow)
+
 STUN	1	62	1
 TFTP	98	29793	1
 

--- a/tests/result/tinc.pcap.out
+++ b/tests/result/tinc.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	19	(9.50 pkts/flow)
+DPI Packets (UDP):	2	(1.00 pkts/flow)
+
 TINC	317	352291	4
 
 	1	UDP 185.83.218.112:55656 <-> 131.114.168.27:55656 [proto: 209/TINC][cat: VPN/2][29 pkts/30038 bytes <-> 105 pkts/139726 bytes][Goodput ratio: 96/97][35.82 sec][bytes ratio: -0.646 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 244/335 1049/2670 434/517][Pkt Len c2s/s2c min/avg/max/stddev: 158/118 1036/1331 1502/1510 544/412][PLAIN TEXT (E@zUIs1)][Plen Bins: 0,0,2,7,1,0,0,0,0,1,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,2,2,3,1,0,2,73,0,0]

--- a/tests/result/tk.pcap.out
+++ b/tests/result/tk.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	6	(2.00 pkts/flow)
+
 DNS	6	566	3
 
 	1	UDP 192.168.1.178:53820 <-> 192.168.1.1:53 [proto: 5/DNS][cat: Network/14][1 pkts/72 bytes <-> 1 pkts/131 bytes][Goodput ratio: 41/67][0.05 sec][Host: whois.dot.tk][::][Risk: ** Risky domain name **][Risk Score: 50][PLAIN TEXT (freenom)][Plen Bins: 50,0,50,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/tls-esni-fuzzed.pcap.out
+++ b/tests/result/tls-esni-fuzzed.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	3
+
+DPI Packets (TCP):	3	(1.00 pkts/flow)
+
 Cloudflare	3	2310	3
 
 JA3 Host Stats: 

--- a/tests/result/tls-rdn-extract.pcap.out
+++ b/tests/result/tls-rdn-extract.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	6	(6.00 pkts/flow)
+
 Microsoft	6	7205	1
 
 JA3 Host Stats: 

--- a/tests/result/tls_esni_sni_both.pcap.out
+++ b/tests/result/tls_esni_sni_both.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	12	(6.00 pkts/flow)
+
 Cloudflare	38	15899	2
 
 JA3 Host Stats: 

--- a/tests/result/tls_invalid_reads.pcap.out
+++ b/tests/result/tls_invalid_reads.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	3
+
+DPI Packets (TCP):	11	(3.67 pkts/flow)
+
 TLS	8	1891	2
 Amazon	3	560	1
 

--- a/tests/result/tls_long_cert.pcap.out
+++ b/tests/result/tls_long_cert.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	9	(9.00 pkts/flow)
+
 TLS	182	117601	1
 
 JA3 Host Stats: 

--- a/tests/result/tls_verylong_certificate.pcap.out
+++ b/tests/result/tls_verylong_certificate.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	11	(11.00 pkts/flow)
+
 TLS	48	22229	1
 
 JA3 Host Stats: 

--- a/tests/result/tor.pcap.out
+++ b/tests/result/tor.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	43	(5.38 pkts/flow)
+DPI Packets (UDP):	3	(1.00 pkts/flow)
+
 SMBv1	1	252	1
 TLS	2029	1601968	5
 DHCPV6	6	906	1

--- a/tests/result/trickbot.pcap.out
+++ b/tests/result/trickbot.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	8	(8.00 pkts/flow)
+
 HTTP	74	62002	1
 
 	1	TCP 10.12.29.101:61318 <-> 82.118.225.196:7080 [proto: 7/HTTP][cat: Web/5][28 pkts/2801 bytes <-> 46 pkts/59201 bytes][Goodput ratio: 46/96][8.40 sec][Host: 82.118.225.196][bytes ratio: -0.910 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 327/167 1000/1000 339/292][Pkt Len c2s/s2c min/avg/max/stddev: 54/54 100/1287 982/1514 182/426][URL: 82.118.225.196:7080/OK21pqJAtyyGBEo00sk][StatusCode: 200][Req Content-Type: application/x-www-form-urlencoded][Content-Type: text/html][User-Agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E)][Risk: ** Known protocol on non standard port **** HTTP Numeric IP Address **** HTTP suspicious content **][Risk Score: 70][PLAIN TEXT (POST /OK21p)][Plen Bins: 0,0,0,0,0,0,0,2,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,2,0,0,0,0,4,0,0,6,2,0,35,0,0,44,0,0]

--- a/tests/result/tumblr.pcap.out
+++ b/tests/result/tumblr.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	38
+
+DPI Packets (TCP):	586	(12.47 pkts/flow)
+
 Yahoo	31	9933	1
 Tumblr	1733	1208864	2
 TLS	22811	22990118	42

--- a/tests/result/ubntac2.pcap.out
+++ b/tests/result/ubntac2.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	8	(1.00 pkts/flow)
+
 UBNTAC2	8	1736	8
 
 	1	UDP 192.168.1.1:34085 -> 255.255.255.255:10001 [proto: 31/UBNTAC2][cat: Network/14][1 pkts/217 bytes -> 0 pkts/0 bytes][Goodput ratio: 80/0][< 1 sec][UniFiSecurityGateway.ER-e120.v4][PLAIN TEXT (UniFiSecurityGateway.ER)][Plen Bins: 0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/upnp.pcap.out
+++ b/tests/result/upnp.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	2
+
+DPI Packets (UDP):	14	(7.00 pkts/flow)
+
 WSD	14	9912	2
 
 	1	UDP [fe80::3441:3d24:6d30:a807]:58932 -> [ff02::c]:3702 [proto: 153/WSD][cat: Network/14][7 pkts/5026 bytes -> 0 pkts/0 bytes][Goodput ratio: 91/0][5.63 sec][bytes ratio: 1.000 (Upload)][IAT c2s/s2c min/avg/max/stddev: 118/0 938/0 2000/0 752/0][Pkt Len c2s/s2c min/avg/max/stddev: 718/0 718/0 718/0 0/0][PLAIN TEXT (xml version)][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/viber.pcap.out
+++ b/tests/result/viber.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	8
+
+DPI Packets (TCP):	172	(17.20 pkts/flow)
+DPI Packets (UDP):	27	(1.93 pkts/flow)
+DPI Packets (other):	2	(1.00 pkts/flow)
+
 DNS	8	1267	4
 MDNS	4	412	1
 ICMP	2	3028	1

--- a/tests/result/vnc.pcap.out
+++ b/tests/result/vnc.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	10	(5.00 pkts/flow)
+
 VNC	4551	329158	2
 
 	1	TCP 95.237.48.208:59791 <-> 192.168.2.110:6900 [proto: 89/VNC][cat: RemoteAccess/12][2485 pkts/199101 bytes <-> 1058 pkts/57444 bytes][Goodput ratio: 32/1][16.52 sec][bytes ratio: 0.552 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 6/10 841/845 31/42][Pkt Len c2s/s2c min/avg/max/stddev: 60/54 80/54 89/88 5/3][Risk: ** Desktop/File Sharing Session **][Risk Score: 10][Plen Bins: 88,11,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/wa_video.pcap.out
+++ b/tests/result/wa_video.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	81	(81.00 pkts/flow)
+DPI Packets (UDP):	13	(1.00 pkts/flow)
+
 SSDP	8	1377	3
 DHCP	2	684	1
 WhatsAppCall	1421	937506	7

--- a/tests/result/wa_voice.pcap.out
+++ b/tests/result/wa_voice.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	5
+
+DPI Packets (TCP):	104	(17.33 pkts/flow)
+DPI Packets (UDP):	33	(1.57 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 Unknown	2	120	1
 MDNS	10	1188	2
 SSDP	8	1365	5

--- a/tests/result/waze.pcap.out
+++ b/tests/result/waze.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	12
+
+DPI Packets (TCP):	226	(7.06 pkts/flow)
+DPI Packets (UDP):	1	(1.00 pkts/flow)
+
 Unknown	10	786	1
 HTTP	65	64777	8
 NTP	2	180	1

--- a/tests/result/webex.pcap.out
+++ b/tests/result/webex.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	26
+
+DPI Packets (TCP):	515	(9.36 pkts/flow)
+DPI Packets (UDP):	17	(8.50 pkts/flow)
+
 HTTP	22	3182	2
 TLS	106	11841	8
 SIP	22	15356	1

--- a/tests/result/websocket.pcap.out
+++ b/tests/result/websocket.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	1	(1.00 pkts/flow)
+
 WebSocket	5	441	1
 
 	1	TCP 192.168.43.135:12345 <-> 192.168.43.1:50999 [proto: 251/WebSocket][cat: Web/5][3 pkts/294 bytes <-> 2 pkts/147 bytes][Goodput ratio: 45/26][77.63 sec][PLAIN TEXT (Welcome)][Plen Bins: 60,40,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/wechat.pcap.out
+++ b/tests/result/wechat.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	47
+
+DPI Packets (TCP):	531	(9.00 pkts/flow)
+DPI Packets (UDP):	124	(3.35 pkts/flow)
+DPI Packets (other):	7	(1.00 pkts/flow)
+
 DNS	13	1075	8
 HTTP	70	4620	8
 MDNS	116	10672	4

--- a/tests/result/weibo.pcap.out
+++ b/tests/result/weibo.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	28
+
+DPI Packets (TCP):	167	(5.57 pkts/flow)
+DPI Packets (UDP):	44	(3.14 pkts/flow)
+
 DNS	10	1059	5
 HTTP	19	2275	5
 TLS	15	1234	10

--- a/tests/result/whatsapp_login_call.pcap.out
+++ b/tests/result/whatsapp_login_call.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	25
+
+DPI Packets (TCP):	258	(9.56 pkts/flow)
+DPI Packets (UDP):	35	(1.21 pkts/flow)
+DPI Packets (other):	1	(1.00 pkts/flow)
+
 Unknown	180	24874	1
 HTTP	11	726	3
 MDNS	8	952	4

--- a/tests/result/whatsapp_login_chat.pcap.out
+++ b/tests/result/whatsapp_login_chat.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	4
+
+DPI Packets (TCP):	75	(25.00 pkts/flow)
+DPI Packets (UDP):	7	(1.17 pkts/flow)
+
 Unknown	30	2963	1
 MDNS	2	202	2
 DHCP	6	2052	1

--- a/tests/result/whatsapp_voice_and_message.pcap.out
+++ b/tests/result/whatsapp_voice_and_message.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	5
+
+DPI Packets (TCP):	217	(43.40 pkts/flow)
+DPI Packets (UDP):	8	(1.00 pkts/flow)
+
 WhatsAppCall	44	5916	8
 TLS	46	4990	1
 WhatsApp	171	17149	4

--- a/tests/result/whatsappfiles.pcap.out
+++ b/tests/result/whatsappfiles.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	89	(44.50 pkts/flow)
+
 WhatsAppFiles	620	452233	2
 
 JA3 Host Stats: 

--- a/tests/result/wireguard.pcap.out
+++ b/tests/result/wireguard.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	4	(4.00 pkts/flow)
+
 WireGuard	2399	734182	1
 
 	1	UDP 139.162.192.157:51820 <-> 192.168.0.14:36116 [proto: 206/WireGuard][cat: VPN/2][1362 pkts/518526 bytes <-> 1037 pkts/215656 bytes][Goodput ratio: 89/80][381.21 sec][bytes ratio: 0.413 (Upload)][IAT c2s/s2c min/avg/max/stddev: 0/0 269/314 10882/13538 1111/1204][Pkt Len c2s/s2c min/avg/max/stddev: 74/74 381/208 1404/1404 362/135][Plen Bins: 0,0,0,35,43,5,2,0,6,2,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0]

--- a/tests/result/youtube_quic.pcap.out
+++ b/tests/result/youtube_quic.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (UDP):	3	(1.00 pkts/flow)
+
 YouTube	258	178495	1
 Google	31	13144	2
 

--- a/tests/result/youtubeupload.pcap.out
+++ b/tests/result/youtubeupload.pcap.out
@@ -1,3 +1,8 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	8	(8.00 pkts/flow)
+DPI Packets (UDP):	2	(1.00 pkts/flow)
+
 YouTubeUpload	137	127038	3
 
 JA3 Host Stats: 

--- a/tests/result/z3950.pcapng.out
+++ b/tests/result/z3950.pcapng.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	1
+
+DPI Packets (TCP):	26	(13.00 pkts/flow)
+
 Z39.50	31	6308	2
 
 	1	TCP 192.168.2.100:58921 <-> 193.174.240.93:210 [proto: 260/Z39.50][cat: Network/14][7 pkts/623 bytes <-> 8 pkts/4374 bytes][Goodput ratio: 37/90][1.55 sec][bytes ratio: -0.751 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 293/29 1341/73 524/28][Pkt Len c2s/s2c min/avg/max/stddev: 54/60 89/547 170/1506 44/623][PLAIN TEXT (p.5.4.1 12b)][Plen Bins: 25,0,25,12,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,12,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,25,0,0]

--- a/tests/result/zabbix.pcap.out
+++ b/tests/result/zabbix.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	4	(4.00 pkts/flow)
+
 Zabbix	10	715	1
 
 	1	TCP 192.168.67.98:57162 <-> 192.168.67.25:10050 [proto: 248/Zabbix][cat: Network/14][5 pkts/361 bytes <-> 5 pkts/354 bytes][Goodput ratio: 6/5][0.01 sec][bytes ratio: 0.010 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 1/1 1/2 4/4 2/2][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 72/71 89/82 9/6][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/zcash.pcap.out
+++ b/tests/result/zcash.pcap.out
@@ -1,3 +1,7 @@
+Guessed flow protos:	0
+
+DPI Packets (TCP):	4	(4.00 pkts/flow)
+
 Mining	145	20644	1
 
 	1	TCP 192.168.2.92:55190 <-> 178.32.196.217:9050 [proto: 42/Mining][cat: Mining/99][83 pkts/11785 bytes <-> 62 pkts/8859 bytes][Goodput ratio: 53/53][1154.54 sec][ZCash/Monero][bytes ratio: 0.142 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 0/0 15953/19141 60205/60205 20621/20751][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 142/143 326/369 91/88][Risk: ** Unsafe Protocol **][Risk Score: 10][PLAIN TEXT (method)][Plen Bins: 0,40,0,0,0,44,0,13,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/zoom.pcap.out
+++ b/tests/result/zoom.pcap.out
@@ -1,3 +1,9 @@
+Guessed flow protos:	7
+
+DPI Packets (TCP):	135	(9.64 pkts/flow)
+DPI Packets (UDP):	25	(1.47 pkts/flow)
+DPI Packets (other):	2	(1.00 pkts/flow)
+
 DNS	2	205	1
 MDNS	1	87	1
 NetBIOS	3	330	1


### PR DESCRIPTION
The goal is to have a (roughly) idea about how many packets nDPI needs
to properly classify a flow.

Log this information (and guessed flows number too) during unit tests,
to keep track of improvements/regressions across commits.