### PR TITLE
Code cleanup.

### DIFF
--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -1887,17 +1887,17 @@ u_int32_t ndpi_quick_16_byte_hash(u_int8_t *in_16_bytes_long) {
 /* ******************************************************************** */
 
 ndpi_str_hash* ndpi_hash_alloc(u_int32_t max_num_entries) {
-  ndpi_str_hash *h = (ndpi_str_hash*)malloc(sizeof(ndpi_str_hash));
+  ndpi_str_hash *h = (ndpi_str_hash*)ndpi_malloc(sizeof(ndpi_str_hash));
 
   if(!h) return(NULL);
   if(max_num_entries < 1024) max_num_entries = 1024;
   if(max_num_entries > 10000000) max_num_entries = 10000000;
 
   h->max_num_entries = max_num_entries, h->num_buckets = max_num_entries/2;
-  h->buckets = (struct ndpi_str_hash_info**)calloc(sizeof(struct ndpi_str_hash_info*), h->num_buckets);
+  h->buckets = (struct ndpi_str_hash_info**)ndpi_calloc(sizeof(struct ndpi_str_hash_info*), h->num_buckets);
 
   if(h->buckets == NULL) {
-    free(h);
+    ndpi_free(h);
     return(NULL);
   } else
     return(h);
@@ -1914,14 +1914,14 @@ void ndpi_hash_free(ndpi_str_hash *h) {
     while(head != NULL) {
       struct ndpi_str_hash_info *next = head->next;
 
-      free(head->key);
-      free(head);
+      ndpi_free(head->key);
+      ndpi_free(head);
       head = next;
     }
   }
 
-  free(h->buckets);
-  free(h);
+  ndpi_free(h->buckets);
+  ndpi_free(h);
 }
 
 /* ******************************************************************** */
@@ -1970,12 +1970,12 @@ int ndpi_hash_add_entry(ndpi_str_hash *h, char *key, u_int8_t key_len, u_int8_t 
 
   if(rc == -1) {
     /* Not found */
-    struct ndpi_str_hash_info *e = (struct ndpi_str_hash_info*)malloc(sizeof(struct ndpi_str_hash_info));
+    struct ndpi_str_hash_info *e = (struct ndpi_str_hash_info*)ndpi_malloc(sizeof(struct ndpi_str_hash_info));
 
     if(e == NULL)
       return(-2);
-
-    if((e->key = (char*)malloc(key_len)) == NULL)
+    
+    if((e->key = (char*)ndpi_malloc(key_len)) == NULL)
       return(-3);
 
     memcpy(e->key, key, key_len);

--- a/src/lib/protocols/genshin_impact.c
+++ b/src/lib/protocols/genshin_impact.c
@@ -22,7 +22,6 @@
 
 #define NDPI_CURRENT_PROTO NDPI_PROTOCOL_GENSHIN_IMPACT
 
-#include <stdlib.h>
 #include "ndpi_api.h"
 
 

--- a/src/lib/protocols/git.c
+++ b/src/lib/protocols/git.c
@@ -22,7 +22,6 @@
 
 #define NDPI_CURRENT_PROTO NDPI_PROTOCOL_GIT
 
-#include <stdlib.h>
 #include "ndpi_api.h"
 
 

--- a/src/lib/protocols/hpvirtgrp.c
+++ b/src/lib/protocols/hpvirtgrp.c
@@ -22,7 +22,6 @@
 
 #define NDPI_CURRENT_PROTO NDPI_PROTOCOL_HPVIRTGRP
 
-#include <stdlib.h>
 #include "ndpi_api.h"
 
 

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -26,7 +26,6 @@
 #define NDPI_CURRENT_PROTO NDPI_PROTOCOL_HTTP
 
 #include "ndpi_api.h"
-#include <stdlib.h>
 
 static const char* binary_file_mimes_e[] = { "exe", NULL };
 static const char* binary_file_mimes_v[] = { "vnd.ms-cab-compressed", "vnd.microsoft.portable-executable", NULL };

--- a/src/lib/protocols/netbios.c
+++ b/src/lib/protocols/netbios.c
@@ -370,7 +370,7 @@ void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct,
 
 	  NDPI_LOG_DBG2(ndpi_struct, "found netbios with MSG-type 0x10,0x11,0x12,0x13,0x14,0x15 or 0x16\n");
 
-	  if(source_ip == ntohl(packet->iph->saddr)) {
+	  if(packet->iph && source_ip == ntohl(packet->iph->saddr)) {
 	    int16_t leftover = netbios_len - 82; /* NetBIOS len */
 
 	    NDPI_LOG_INFO(ndpi_struct, "found netbios with checked ip-address\n");

--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -475,10 +475,12 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
   printf("==>> NDPI_PROTOCOL_WHATSAPP_CALL\n");
 #endif
 
-  if(is_messenger_ip_address(ntohl(packet->iph->saddr)) || is_messenger_ip_address(ntohl(packet->iph->daddr)))      
-    flow->guessed_host_protocol_id = NDPI_PROTOCOL_MESSENGER;
-  else if(is_google_ip_address(ntohl(packet->iph->saddr)) || is_google_ip_address(ntohl(packet->iph->daddr)))
-    flow->guessed_host_protocol_id = NDPI_PROTOCOL_HANGOUT_DUO;
+  if(packet->iph) {
+    if(is_messenger_ip_address(ntohl(packet->iph->saddr)) || is_messenger_ip_address(ntohl(packet->iph->daddr)))      
+      flow->guessed_host_protocol_id = NDPI_PROTOCOL_MESSENGER;
+    else if(is_google_ip_address(ntohl(packet->iph->saddr)) || is_google_ip_address(ntohl(packet->iph->daddr)))
+      flow->guessed_host_protocol_id = NDPI_PROTOCOL_HANGOUT_DUO;
+  }
   
   rc = (flow->protos.tls_quic_stun.stun.num_udp_pkts < MAX_NUM_STUN_PKTS) ? NDPI_IS_NOT_STUN : NDPI_IS_STUN;
 

--- a/src/lib/protocols/tinc.c
+++ b/src/lib/protocols/tinc.c
@@ -33,7 +33,7 @@ static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, st
   u_int32_t payload_len = packet->payload_packet_len;
   
   if(packet->udp != NULL) {
-    if(ndpi_struct->tinc_cache != NULL) {
+    if(ndpi_struct->tinc_cache != NULL && packet->iph != NULL) {
       struct tinc_cache_entry tinc_cache_entry1 = {
         .src_address = packet->iph->saddr,
         .dst_address = packet->iph->daddr,
@@ -63,7 +63,7 @@ static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, st
     return;
   } else if(packet->tcp != NULL) {
     if(payload_len == 0) {
-      if(packet->tcp->syn == 1 && packet->tcp->ack == 0) {
+      if(packet->iph != NULL && packet->tcp->syn == 1 && packet->tcp->ack == 0) {
         flow->tinc_cache_entry.src_address = packet->iph->saddr;
         flow->tinc_cache_entry.dst_address = packet->iph->daddr;
         flow->tinc_cache_entry.dst_port = packet->tcp->dest;

--- a/src/lib/protocols/z3950.c
+++ b/src/lib/protocols/z3950.c
@@ -22,7 +22,6 @@
 
 #define NDPI_CURRENT_PROTO NDPI_PROTOCOL_Z3950
 
-#include <stdlib.h>
 #include "ndpi_api.h"
 
 /* https://github.com/wireshark/wireshark/blob/master/epan/dissectors/asn1/z3950/z3950.asn */

--- a/src/lib/protocols/zattoo.c
+++ b/src/lib/protocols/zattoo.c
@@ -119,7 +119,7 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
 	ip = ndpi_bytestream_to_ipv4(&packet->payload[12], packet->payload_packet_len, &bytes_read);
 	
 	// and now test the firt 5 bytes of the payload for zattoo pattern
-	if(ip == packet->iph->daddr
+	if(packet->iph && ip == packet->iph->daddr
 	   && packet->empty_line_position_set != 0
 	   && ((packet->payload_packet_len - packet->empty_line_position) > 10)
 	   && packet->payload[packet->empty_line_position + 2] ==


### PR DESCRIPTION
ndpi_utils.c: use ndpi_malloc,ndpi_calloc,ndpi_free
genshin_impact.c, git.c, hpvirtgrp.c, http.c, z3950.c: removed "#include stdlib.h"
Added packet->iph check before using it. I have a bug report about a
crash in the tinc protocol due to packet->iph == NULL.