### PR TITLE
Fix setting of flow risks on 32 bit machines

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3724,7 +3724,9 @@ static void hllUnitTest() {
 
 static void bitmapUnitTest() {
   u_int32_t val, i, j;
+  u_int64_t val64;
 
+  /* With a 32 bit integer */
   for(i=0; i<32; i++) {
     NDPI_ZERO_BIT(val);
     NDPI_SET_BIT(val, i);
@@ -3734,6 +3736,20 @@ static void bitmapUnitTest() {
     for(j=0; j<32; j++) {
       if(j != i) {
 	assert(!NDPI_ISSET_BIT(val, j));
+      }
+    }
+  }
+
+  /* With a 64 bit integer */
+  for(i=0; i<64; i++) {
+    NDPI_ZERO_BIT(val64);
+    NDPI_SET_BIT(val64, i);
+
+    assert(NDPI_ISSET_BIT(val64, i));
+
+    for(j=0; j<64; j++) {
+      if(j != i) {
+	assert(!NDPI_ISSET_BIT(val64, j));
       }
     }
   }

--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -282,10 +282,10 @@
 #define NDPI_BITMASK_SET_ALL(a)   NDPI_ONE(&a)
 #define NDPI_BITMASK_SET(a, b)    { memcpy(&a, &b, sizeof(NDPI_PROTOCOL_BITMASK)); }
 
-#define NDPI_SET_BIT(num, n)    num |= 1UL << ( n )
-#define NDPI_CLR_BIT(num, n)    num &= ~(1UL << ( n ))
-#define NDPI_CLR_BIT(num, n)    num &= ~(1UL << ( n ))
-#define NDPI_ISSET_BIT(num, n)  (num & (1UL << ( n )))
+#define NDPI_SET_BIT(num, n)    num |= 1ULL << ( n )
+#define NDPI_CLR_BIT(num, n)    num &= ~(1ULL << ( n ))
+#define NDPI_CLR_BIT(num, n)    num &= ~(1ULL << ( n ))
+#define NDPI_ISSET_BIT(num, n)  (num & (1ULL << ( n )))
 #define NDPI_ZERO_BIT(num)      num = 0
 
 /* this is a very very tricky macro *g*,


### PR DESCRIPTION
Since 19a29e1e (`NDPI_TLS_CERT_VALIDITY_TOO_LONG` is 32), unit tests are
failing on 32 bit machines (i.e Raspberry 4)