### PR TITLE
Improved libm check via Autoconf.

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -32,6 +32,7 @@ AS_IF([test "${with_sanitizer+set}" = set],[
 ])
 
 LT_INIT
+LT_LIB_M
 
 SYSTEM=`uname -s`
 if test $SYSTEM = "Darwin"; then
@@ -97,7 +98,7 @@ CFLAGS="$CFLAGS $JSONC_CFLAGS"
 
 AC_CHECK_HEADERS([netinet/in.h stdint.h stdlib.h string.h unistd.h json.h])
 
-ADDITIONAL_LIBS=
+ADDITIONAL_LIBS="$LIBM"
 PCAP_HOME=$HOME/PF_RING/userland
 
 DPDK_TARGET=

--- a/example/Makefile.dpdk.in
+++ b/example/Makefile.dpdk.in
@@ -21,7 +21,7 @@ SRCS-y := reader_util.c intrusion_detection.c ndpiReader.c
 
 CFLAGS += -g
 CFLAGS += -Wno-strict-prototypes -Wno-missing-prototypes -Wno-missing-declarations -Wno-unused-parameter -I $(PWD)/../src/include @CFLAGS@ -DUSE_DPDK
-LDLIBS = $(LIBNDPI) @PCAP_LIB@ @LIBS@ -lpthread -lm @LDFLAGS@
+LDLIBS = $(LIBNDPI) @PCAP_LIB@ @LIBS@ @ADDITIONAL_LIBS@ -lpthread @LDFLAGS@
 
 include $(RTE_SDK)/mk/rte.extapp.mk
 

--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -4,7 +4,7 @@ BUILD_MINGW=@BUILD_MINGW@
 SRCHOME=../src
 CFLAGS=-g -fPIC -DPIC -I$(SRCHOME)/include @PCAP_INC@ @CFLAGS@
 LIBNDPI=$(SRCHOME)/lib/libndpi.a
-LDFLAGS=$(LIBNDPI) @PCAP_LIB@ @LIBS@ @ADDITIONAL_LIBS@ -lpthread -lm @LDFLAGS@
+LDFLAGS=$(LIBNDPI) @PCAP_LIB@ @LIBS@ @ADDITIONAL_LIBS@ -lpthread @LDFLAGS@
 HEADERS=intrusion_detection.h reader_util.h $(SRCHOME)/include/ndpi_api.h \
         $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
 OBJS=ndpiReader.o reader_util.o intrusion_detection.o

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -14,7 +14,7 @@ libdir     = ${prefix}/lib
 includedir = ${prefix}/include/ndpi
 CC         = @GNU_PREFIX@@CC@
 CFLAGS     += -fPIC -DPIC -I../include -Ithird_party/include -DNDPI_LIB_COMPILATION -Wall @CFLAGS@ @CUSTOM_NDPI@
-LDFLAGS    = @LDFLAGS@ @ADDITIONAL_LIBS@ @LIBS@ -lm
+LDFLAGS    = @LDFLAGS@ @ADDITIONAL_LIBS@ @LIBS@
 RANLIB     = @GNU_PREFIX@ranlib
 
 OBJECTS   = $(patsubst protocols/%.c, protocols/%.o, $(wildcard protocols/*.c)) $(patsubst third_party/src/%.c, third_party/src/%.o, $(wildcard third_party/src/*.c)) $(patsubst ./%.c, ./%.o, $(wildcard ./*.c))

--- a/tests/dga/Makefile.in
+++ b/tests/dga/Makefile.in
@@ -5,7 +5,7 @@ SRCHOME=../../src
 
 CFLAGS=-g -fPIC -DPIC -I$(SRCHOME)/include @JSONC_CFLAGS@ @PCAP_INC@ @CFLAGS@
 LIBNDPI=$(SRCHOME)/lib/libndpi.a
-LDFLAGS=$(LIBNDPI) @PCAP_LIB@ @LIBS@ @ADDITIONAL_LIBS@ @JSONC_LIBS@ -lpthread -lm @LDFLAGS@
+LDFLAGS=$(LIBNDPI) @PCAP_LIB@ @LIBS@ @ADDITIONAL_LIBS@ @JSONC_LIBS@ -lpthread @LDFLAGS@
 HEADERS=$(SRCHOME)/include/ndpi_api.h $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
 OBJS=dga_evaluate
 PREFIX?=@prefix@

--- a/tests/unit/Makefile.in
+++ b/tests/unit/Makefile.in
@@ -5,7 +5,7 @@ SRCHOME=../../src
 
 CFLAGS=-g -fPIC -DPIC -I$(SRCHOME)/include @JSONC_CFLAGS@ @PCAP_INC@ @CFLAGS@
 LIBNDPI=$(SRCHOME)/lib/libndpi.a
-LDFLAGS=$(LIBNDPI) @PCAP_LIB@ @LIBS@ @ADDITIONAL_LIBS@ @JSONC_LIBS@ -lpthread -lm @LDFLAGS@
+LDFLAGS=$(LIBNDPI) @PCAP_LIB@ @LIBS@ @ADDITIONAL_LIBS@ @JSONC_LIBS@ -lpthread @LDFLAGS@
 HEADERS=$(SRCHOME)/include/ndpi_api.h $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
 OBJS=unit
 PREFIX?=@prefix@


### PR DESCRIPTION
 * libm will now be part of @ADDITIONAL_LIBS@ (if required)

Not sure if the Autoconf macro `LT_LIB_M` will work for Darwin as well.
This fixes linking issues with pkg-config.

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>