### PR TITLE
Fix access to some TLS fields in flow structure

### DIFF
--- a/example/ndpiSimpleIntegration.c
+++ b/example/ndpiSimpleIntegration.c
@@ -914,7 +914,7 @@ static void ndpi_process_packet(uint8_t * const args,
 	  flow_to_process->detected_l7_protocol.app_protocol == NDPI_PROTOCOL_TLS)
         {
 	  if (flow_to_process->tls_client_hello_seen == 0 &&
-	      flow_to_process->ndpi_flow->l4.tcp.tls.hello_processed != 0)
+	      flow_to_process->ndpi_flow->protos.tls_quic_stun.tls_quic.hello_processed != 0)
             {
 	      uint8_t unknown_tls_version = 0;
 	      printf("[%8llu, %d, %4d][TLS-CLIENT-HELLO] version: %s | sni: %s | alpn: %s\n",

--- a/python/ndpi.py
+++ b/python/ndpi.py
@@ -597,7 +597,7 @@ struct ndpi_flow_tcp_struct {
     void* srv_cert_fingerprint_ctx; /* SHA-1 */
 
     /* NDPI_PROTOCOL_TLS */
-    uint8_t hello_processed:1, certificate_processed:1, subprotocol_detected:1, fingerprint_set:1, _pad:4; 
+    uint8_t certificate_processed:1, fingerprint_set:1, _pad:6;
     uint8_t sha1_certificate_fingerprint[20], num_tls_blocks;
     int16_t tls_application_blocks_len[NDPI_MAX_NUM_TLS_APPL_BLOCKS];
   } tls;
@@ -1117,6 +1117,8 @@ struct ndpi_flow_struct {
       uint32_t notBefore, notAfter;
       char ja3_client[33], ja3_server[33];
       uint16_t server_cipher;
+      u_int8_t sha1_certificate_fingerprint[20];
+      u_int8_t hello_processed:1, subprotocol_detected:1, _pad:6;
       struct {
         uint16_t cipher_suite;
         char *esni;

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -726,8 +726,7 @@ struct ndpi_flow_tcp_struct {
     void* srv_cert_fingerprint_ctx; /* SHA-1 */
 
     /* NDPI_PROTOCOL_TLS */
-    u_int8_t hello_processed:1, certificate_processed:1, subprotocol_detected:1,
-	fingerprint_set:1, _pad:4;
+    u_int8_t certificate_processed:1, fingerprint_set:1, _pad:6;
     u_int8_t num_tls_blocks;
     int16_t tls_application_blocks_len[NDPI_MAX_NUM_TLS_APPL_BLOCKS]; /* + = src->dst, - = dst->src */
   } tls;
@@ -1366,6 +1365,7 @@ struct ndpi_flow_struct {
 	char ja3_client[33], ja3_server[33];
 	u_int16_t server_cipher;
 	u_int8_t sha1_certificate_fingerprint[20];
+	u_int8_t hello_processed:1, subprotocol_detected:1, _pad:6;
 
 #ifdef TLS_HANDLE_SIGNATURE_ALGORITMS
 	/* Under #ifdef to save memory for those who do not need them */

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4834,13 +4834,13 @@ ndpi_protocol ndpi_detection_giveup(struct ndpi_detection_module_struct *ndpi_st
       *protocol_was_guessed = 1;
       ndpi_set_detected_protocol(ndpi_str, flow, flow->guessed_protocol_id, NDPI_PROTOCOL_UNKNOWN);
     }
-    else if((flow->l4.tcp.tls.hello_processed == 1) &&
+    else if((flow->protos.tls_quic_stun.tls_quic.hello_processed == 1) &&
 	    (flow->protos.tls_quic_stun.tls_quic.client_requested_server_name[0] != '\0')) {
       *protocol_was_guessed = 1;
       ndpi_set_detected_protocol(ndpi_str, flow, NDPI_PROTOCOL_TLS, NDPI_PROTOCOL_UNKNOWN);
     } else if(enable_guess) {
       if((flow->guessed_protocol_id == NDPI_PROTOCOL_UNKNOWN) && (flow->packet.l4_protocol == IPPROTO_TCP) &&
-	 flow->l4.tcp.tls.hello_processed)
+	 flow->protos.tls_quic_stun.tls_quic.hello_processed)
 	flow->guessed_protocol_id = NDPI_PROTOCOL_TLS;
 
       guessed_protocol_id = flow->guessed_protocol_id, guessed_host_protocol_id = flow->guessed_host_protocol_id;
@@ -5138,7 +5138,7 @@ void ndpi_fill_protocol_category(struct ndpi_detection_module_struct *ndpi_str, 
       }
     }
 
-    if(flow->l4.tcp.tls.hello_processed == 1 &&
+    if(flow->protos.tls_quic_stun.tls_quic.hello_processed == 1 &&
        flow->protos.tls_quic_stun.tls_quic.client_requested_server_name[0] != '\0') {
       u_int32_t id;
       int rc = ndpi_match_custom_category(ndpi_str, (char *) flow->protos.tls_quic_stun.tls_quic.client_requested_server_name,

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -856,7 +856,7 @@ static const char* ndpi_get_flow_info_by_proto_id(struct ndpi_flow_struct const 
         return (char const *)flow->host_server_name;
     case NDPI_PROTOCOL_QUIC:
     case NDPI_PROTOCOL_TLS:
-        if (flow->l4.tcp.tls.hello_processed != 0)
+        if (flow->protos.tls_quic_stun.tls_quic.hello_processed != 0)
         {
           return flow->protos.tls_quic_stun.tls_quic.client_requested_server_name;
         }

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1297,7 +1297,7 @@ static void process_tls(struct ndpi_detection_module_struct *ndpi_struct,
   packet->payload_packet_len = crypto_data_len;
 
   processClientServerHello(ndpi_struct, flow, version);
-  flow->l4.tcp.tls.hello_processed = 1; /* Allow matching of custom categories */
+  flow->protos.tls_quic_stun.tls_quic.hello_processed = 1; /* Allow matching of custom categories */
 
   /* Restore */
   packet->payload = p;
@@ -1368,7 +1368,7 @@ static void process_chlo(struct ndpi_detection_module_struct *ndpi_struct,
                                   (char *)flow->protos.tls_quic_stun.tls_quic.client_requested_server_name,
                                   strlen((const char*)flow->protos.tls_quic_stun.tls_quic.client_requested_server_name),
                                   &ret_match, NDPI_PROTOCOL_QUIC);
-      flow->l4.tcp.tls.hello_processed = 1; /* Allow matching of custom categories */
+      flow->protos.tls_quic_stun.tls_quic.hello_processed = 1; /* Allow matching of custom categories */
 
       ndpi_check_dga_name(ndpi_struct, flow,
                           flow->protos.tls_quic_stun.tls_quic.client_requested_server_name, 1);

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -558,9 +558,9 @@ static void processCertificateElements(struct ndpi_detection_module_struct *ndpi
 		    }
 		  }
 
-		  if(!flow->l4.tcp.tls.subprotocol_detected)
+		  if(!flow->protos.tls_quic_stun.tls_quic.subprotocol_detected)
 		    if(ndpi_match_hostname_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TLS, dNSName, len))
-		      flow->l4.tcp.tls.subprotocol_detected = 1;
+		      flow->protos.tls_quic_stun.tls_quic.subprotocol_detected = 1;
 
 		  i += len;
 		} else {
@@ -763,7 +763,7 @@ static int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
   case 0x01: /* Client Hello */
   case 0x02: /* Server Hello */
     processClientServerHello(ndpi_struct, flow, 0);
-    flow->l4.tcp.tls.hello_processed = 1;
+    flow->protos.tls_quic_stun.tls_quic.hello_processed = 1;
     ndpi_int_tls_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_TLS);
 
 #ifdef DEBUG_TLS
@@ -783,7 +783,7 @@ static int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
   case 0x0b: /* Certificate */
     /* Important: populate the tls union fields only after
      * ndpi_int_tls_add_connection has been called */
-    if(flow->l4.tcp.tls.hello_processed) {
+    if(flow->protos.tls_quic_stun.tls_quic.hello_processed) {
       ret = processCertificate(ndpi_struct, flow);
       if (ret != 1) {
 #ifdef DEBUG_TLS
@@ -1693,10 +1693,10 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 
 		    if(!is_quic) {
 		      if(ndpi_match_hostname_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TLS, buffer, strlen(buffer)))
-		        flow->l4.tcp.tls.subprotocol_detected = 1;
+		        flow->protos.tls_quic_stun.tls_quic.subprotocol_detected = 1;
 		    } else {
 		      if(ndpi_match_hostname_protocol(ndpi_struct, flow, NDPI_PROTOCOL_QUIC, buffer, strlen(buffer)))
-		        flow->l4.tcp.tls.subprotocol_detected = 1;
+		        flow->protos.tls_quic_stun.tls_quic.subprotocol_detected = 1;
 		    }
 
 		    if(ndpi_check_dga_name(ndpi_struct, flow,


### PR DESCRIPTION
Fields `tls.hello_processed` and `tls.subprotocol_detected` are used by
QUIC (i.e UDP...), too.