### PR TITLE
Add libgcrypt as part of macOS CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ matrix:
   include:
     - os: osx
       compiler: clang
+      addons:
+        homebrew:
+          packages:
+            - libgcrypt
+            - json-c
 
     - os: linux
       env: BUILD_DPKG_PACKAGE=y CFLAGS="-Werror"


### PR DESCRIPTION
For consistency reasons, macOS CI should integrate libgcrypt. (I added also json-c which I think is present by default)

Zied