### PR TITLE
Cassandra: fix compilation when "--enable-debug-messages" option is used

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ jobs:
         run: ./tests/do.sh
       - name: Test UNIT
         run: ./tests/unit/unit
+      - name: Configure (with debug logs)
+        run: make distclean && env CFLAGS='-Werror' ./autogen.sh --enable-debug-messages
+      - name: Build
+        run: make all
       - name: Configure ARM
         run: make distclean && env CFLAGS='-Werror' ./autogen.sh --host=arm-linux-gnueabihf --with-only-libndpi
       - name: Build ARM

--- a/src/lib/protocols/cassandra.c
+++ b/src/lib/protocols/cassandra.c
@@ -22,9 +22,9 @@
 
 #include <stdbool.h>
 #include "ndpi_protocol_ids.h"
+#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_CASSANDRA
 #include "ndpi_api.h"
 
-#define NDPI_CURRENT_PROTO NDPI_PROTOCOL_CASSANDRA
 #define CASSANDRA_HEADER_LEN 9
 #define CASSANDRA_MAX_BODY_SIZE 268435456 //256MB (256 * 1024^2)
 


### PR DESCRIPTION
Let's try adding a dedicated compilation in GitHub Actions to easily
detect this kind of errors in the future