### PR TITLE
Bittorrent: fix a potential use-of-uninitialized-value error

### DIFF
--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -163,7 +163,7 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
     }
 
     /* this is a self built client, not possible to catch asymmetrically */
-    if((packet->parsed_lines == 10 || (packet->parsed_lines == 11 && packet->line[11].len == 0))
+    if((packet->parsed_lines == 10 || (packet->parsed_lines == 11 && packet->line[10].len == 0))
 	&& packet->user_agent_line.ptr != NULL
 	&& packet->user_agent_line.len > 12
 	&& memcmp(packet->user_agent_line.ptr, "Mozilla/4.0 ",


### PR DESCRIPTION
Not sure if this is the right fix (from a logical point-of-view): this
code hasn't changed since OpenDPI era (!) and I haven't found a trace
triggering this code path.
Anyway, the use-of-uninitialized-value error itself should be fixed.