### PR TITLE
Update the list of default ports for QUIC protocol

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -1434,7 +1434,7 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
   ndpi_set_proto_defaults(ndpi_str, 0 /* encrypted */, NDPI_PROTOCOL_ACCEPTABLE, NDPI_PROTOCOL_QUIC,
 			  "QUIC", NDPI_PROTOCOL_CATEGORY_WEB,
 			  ndpi_build_default_ports(ports_a, 0, 0, 0, 0, 0) /* TCP */,
-			  ndpi_build_default_ports(ports_b, 443, 80, 0, 0, 0) /* UDP */);
+			  ndpi_build_default_ports(ports_b, 443, 0, 0, 0, 0) /* UDP */);
   ndpi_set_proto_subprotocols(ndpi_str, NDPI_PROTOCOL_QUIC,
 			      NDPI_PROTOCOL_MATCHED_BY_CONTENT,
 			      NDPI_PROTOCOL_NO_MORE_SUBPROTOCOLS); /* NDPI_PROTOCOL_QUIC can have (content-matched) subprotocols */

--- a/tests/result/NTPv2.pcap.out
+++ b/tests/result/NTPv2.pcap.out
@@ -4,4 +4,4 @@ DPI Packets (UDP):	1	(1.00 pkts/flow)
 
 NTP	1	410	1
 
-	1	UDP 208.104.95.10:123 -> 78.46.76.2:80 [proto: 9/NTP][ClearText][cat: System/18][1 pkts/410 bytes -> 0 pkts/0 bytes][Goodput ratio: 90/0][< 1 sec][Risk: ** Known protocol on non standard port **][Risk Score: 10][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	1	UDP 208.104.95.10:123 -> 78.46.76.2:80 [proto: 9/NTP][ClearText][cat: System/18][1 pkts/410 bytes -> 0 pkts/0 bytes][Goodput ratio: 90/0][< 1 sec][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

--- a/tests/result/NTPv3.pcap.out
+++ b/tests/result/NTPv3.pcap.out
@@ -4,4 +4,4 @@ DPI Packets (UDP):	1	(1.00 pkts/flow)
 
 NTP	1	90	1
 
-	1	UDP 175.144.140.29:123 -> 78.46.76.2:80 [proto: 9/NTP][ClearText][cat: System/18][1 pkts/90 bytes -> 0 pkts/0 bytes][Goodput ratio: 53/0][< 1 sec][Risk: ** Known protocol on non standard port **][Risk Score: 10][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	1	UDP 175.144.140.29:123 -> 78.46.76.2:80 [proto: 9/NTP][ClearText][cat: System/18][1 pkts/90 bytes -> 0 pkts/0 bytes][Goodput ratio: 53/0][< 1 sec][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]


### PR DESCRIPTION
There are no reasons to register UDP/80 as a default port for QUIC