### PR TITLE
QUIC: fix old GQUIC versions on big-endian machines

### DIFF
--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -385,6 +385,46 @@
 
 #endif /* __APPLE__ */
 
+
+#if defined(__MINGW32__)
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+
+#define htobe16(x) htons(x)
+#define htole16(x) (x)
+#define be16toh(x) ntohs(x)
+#define le16toh(x) (x)
+#define htobe32(x) htonl(x)
+#define htole32(x) (x)
+#define be32toh(x) ntohl(x)
+#define le32toh(x) (x)
+#define htobe64(x) htonll(x)
+#define htole64(x) (x)
+#define be64toh(x) ntohll(x)
+#define le64toh(x) (x)
+
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+
+#define htobe16(x) (x)
+#define htole16(x) __builtin_bswap16(x)
+#define be16toh(x) (x)
+#define le16toh(x) __builtin_bswap16(x)
+#define htobe32(x) (x)
+#define htole32(x) __builtin_bswap32(x)
+#define be32toh(x) (x)
+#define le32toh(x) __builtin_bswap32(x)
+#define htobe64(x) (x)
+#define htole64(x) __builtin_bswap64(x)
+#define be64toh(x) (x)
+#define le64toh(x) __builtin_bswap64(x)
+
+#else
+#error Unexpected __BYTE_ORDER__
+
+#endif /* __BYTE_ORDER__ */
+#endif /* __MINGW32__ */
+
+
 #ifndef ETH_ARP
 #define ETH_ARP                0x0806
 #endif

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1343,7 +1343,7 @@ static void process_chlo(struct ndpi_detection_module_struct *ndpi_struct,
 #endif
     return;
   }
-  num_tags = (*(uint16_t *)&crypto_data[4]);
+  num_tags = le16toh(*(uint16_t *)&crypto_data[4]);
 
   tag_offset_start = 8 + 8 * num_tags;
   prev_offset = 0;
@@ -1351,7 +1351,7 @@ static void process_chlo(struct ndpi_detection_module_struct *ndpi_struct,
     if(8 + 8 * i + 8 >= crypto_data_len)
       break;
     tag = &crypto_data[8 + 8 * i];
-    offset = *((u_int32_t *)&crypto_data[8 + 8 * i + 4]);
+    offset = le32toh(*((u_int32_t *)&crypto_data[8 + 8 * i + 4]));
     if(prev_offset > offset)
       break;
     len = offset - prev_offset;


### PR DESCRIPTION
Not sure if now the QUIC core code is completely correct on big-endian machines: these were the easy fixes, though.