### PR TITLE
Remove `detected_protocol_stack` field from `ndpi_packet_struct`

### DIFF
--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -87,10 +87,6 @@ extern "C" {
   extern u_int16_t ndpi_check_for_email_address(struct ndpi_detection_module_struct *ndpi_struct,
 						struct ndpi_flow_struct *flow, u_int16_t counter);
 
-  extern void ndpi_int_change_packet_protocol(struct ndpi_detection_module_struct *ndpi_struct,
-					      struct ndpi_flow_struct *flow,
-					      u_int16_t upper_detected_protocol,
-					      u_int16_t lower_detected_protocol);
   extern void ndpi_int_change_protocol(struct ndpi_detection_module_struct *ndpi_struct,
 				       struct ndpi_flow_struct *flow,
 				       u_int16_t upper_detected_protocol,
@@ -109,7 +105,6 @@ extern "C" {
 				      ndpi_port_range *tcpDefPorts,
 				      ndpi_port_range *udpDefPorts);
 
-  extern void ndpi_int_reset_packet_protocol(struct ndpi_packet_struct *packet);
   extern void ndpi_int_reset_protocol(struct ndpi_flow_struct *flow);
 
   extern int ndpi_packet_src_ip_eql(const struct ndpi_packet_struct *packet, const ndpi_ip_addr_t * ip);

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -833,8 +833,6 @@ struct ndpi_packet_struct {
 
   u_int64_t current_time_ms;
 
-  u_int16_t detected_protocol_stack[NDPI_PROTOCOL_SIZE];
-
   struct ndpi_int_one_line_struct line[NDPI_MAX_PARSE_LINES_PER_PACKET];
   /* HTTP headers */
   struct ndpi_int_one_line_struct host_line;

--- a/src/lib/protocols/ajp.c
+++ b/src/lib/protocols/ajp.c
@@ -115,15 +115,13 @@ static void ndpi_check_ajp(struct ndpi_detection_module_struct *ndpi_struct,
 void ndpi_search_ajp(struct ndpi_detection_module_struct *ndpi_struct,
  struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   // Break after 20 packets.
   if(flow->packet_counter > 20) {
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
     return;
   }
 

--- a/src/lib/protocols/amazon_video.c
+++ b/src/lib/protocols/amazon_video.c
@@ -58,12 +58,10 @@ static void ndpi_check_amazon_video(struct ndpi_detection_module_struct *ndpi_st
 
 void ndpi_search_amazon_video(struct ndpi_detection_module_struct *ndpi_struct,
 			      struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search amazon_video\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_AMAZON_VIDEO)
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_AMAZON_VIDEO)
     ndpi_check_amazon_video(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/apple_push.c
+++ b/src/lib/protocols/apple_push.c
@@ -55,12 +55,10 @@ static void ndpi_check_apple_push(struct ndpi_detection_module_struct *ndpi_stru
 
 void ndpi_search_apple_push(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search apple_push\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_APPLE_PUSH)
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_APPLE_PUSH)
     ndpi_check_apple_push(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/attic/ftp.c
+++ b/src/lib/protocols/attic/ftp.c
@@ -407,7 +407,7 @@ void ndpi_search_ftp_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 
   if (src != NULL && ndpi_packet_dst_ip_eql(packet, &src->ftp_ip)
       && packet->tcp->syn != 0 && packet->tcp->ack == 0
-      && packet->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN
+      && flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN
       && NDPI_COMPARE_PROTOCOL_TO_BITMASK(src->detected_protocol_bitmask,
 					  NDPI_PROTOCOL_FTP) != 0 && src->ftp_timer_set != 0) {
     NDPI_LOG(NDPI_PROTOCOL_FTP, ndpi_struct, NDPI_LOG_DEBUG, "possible ftp data, src!= 0.\n");
@@ -425,7 +425,7 @@ void ndpi_search_ftp_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
 
   if (dst != NULL && ndpi_packet_src_ip_eql(packet, &dst->ftp_ip)
       && packet->tcp->syn != 0 && packet->tcp->ack == 0
-      && packet->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN
+      && flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN
       && NDPI_COMPARE_PROTOCOL_TO_BITMASK(dst->detected_protocol_bitmask,
 					  NDPI_PROTOCOL_FTP) != 0 && dst->ftp_timer_set != 0) {
     NDPI_LOG(NDPI_PROTOCOL_FTP, ndpi_struct, NDPI_LOG_DEBUG, "possible ftp data; dst!= 0.\n");
@@ -453,7 +453,7 @@ void ndpi_search_ftp_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
   /* skip excluded connections */
 
   // we test for FTP connection and search for passive mode
-  if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_FTP) {
+  if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_FTP) {
     NDPI_LOG(NDPI_PROTOCOL_FTP, ndpi_struct, NDPI_LOG_DEBUG,
 	     "detected ftp command mode. going to test data mode.\n");
     search_passive_ftp_mode(ndpi_struct, flow);
@@ -463,7 +463,7 @@ void ndpi_search_ftp_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
   }
 
 
-  if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN && search_ftp(ndpi_struct, flow) != 0) {
+  if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN && search_ftp(ndpi_struct, flow) != 0) {
     NDPI_LOG(NDPI_PROTOCOL_FTP, ndpi_struct, NDPI_LOG_DEBUG, "unknown. need next packet.\n");
 
     return;

--- a/src/lib/protocols/ayiya.c
+++ b/src/lib/protocols/ayiya.c
@@ -46,7 +46,7 @@ void ndpi_search_ayiya(struct ndpi_detection_module_struct *ndpi_struct, struct 
 
   NDPI_LOG_DBG(ndpi_struct, "search AYIYA\n");
 
-  if(packet->udp && (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN)) {
+  if(packet->udp && (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN)) {
     /* Ayiya is udp based, port 5072 */
     if ((packet->udp->source == htons(5072) || packet->udp->dest == htons(5072))
 	/* check for ayiya new packet */

--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -403,8 +403,7 @@ void ndpi_search_bittorrent(struct ndpi_detection_module_struct *ndpi_struct, st
       }
     }
   }
-
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_BITTORRENT) {
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_BITTORRENT) {
     /* check for tcp retransmission here */
 
     if((packet->tcp != NULL)

--- a/src/lib/protocols/bjnp.c
+++ b/src/lib/protocols/bjnp.c
@@ -41,7 +41,7 @@ void ndpi_search_bjnp(struct ndpi_detection_module_struct *ndpi_struct, struct n
   NDPI_LOG_DBG(ndpi_struct, "search bjnp\n");
 
   /* skip marked packets */
-  if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_BJNP) {
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_BJNP) {
     if (packet->tcp_retransmission == 0) {
       ndpi_check_bjnp(ndpi_struct, flow);
     }

--- a/src/lib/protocols/capwap.c
+++ b/src/lib/protocols/capwap.c
@@ -106,7 +106,7 @@ void ndpi_search_capwap(struct ndpi_detection_module_struct *ndpi_struct, struct
 {
   struct ndpi_packet_struct *packet = &flow->packet;
 
-  if(packet->udp && (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN))
+  if(packet->udp && (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN))
     ndpi_search_setup_capwap(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/citrix.c
+++ b/src/lib/protocols/citrix.c
@@ -73,12 +73,10 @@ static void ndpi_check_citrix(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void ndpi_search_citrix(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search citrix\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_CITRIX)
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_CITRIX)
     ndpi_check_citrix(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/coap.c
+++ b/src/lib/protocols/coap.c
@@ -109,7 +109,7 @@ void ndpi_search_coap (struct ndpi_detection_module_struct *ndpi_struct,
   struct ndpi_packet_struct *packet = &flow->packet;
   struct ndpi_coap_hdr * h = (struct ndpi_coap_hdr*) packet->payload;
 
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
     return;
   }
 

--- a/src/lib/protocols/directconnect.c
+++ b/src/lib/protocols/directconnect.c
@@ -403,7 +403,7 @@ void ndpi_search_directconnect(struct ndpi_detection_module_struct
 
   NDPI_LOG_DBG(ndpi_struct, "search DC\n");
 
-  if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_DIRECTCONNECT) {
+  if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_DIRECTCONNECT) {
     if(src != NULL && ((u_int32_t)
 			(packet->current_time_ms -
 			 src->directconnect_last_safe_access_time) <
@@ -416,7 +416,7 @@ void ndpi_search_directconnect(struct ndpi_detection_module_struct
 			       ndpi_struct->directconnect_connection_ip_tick_timeout)) {
       dst->directconnect_last_safe_access_time = packet->current_time_ms;
     } else {
-      packet->detected_protocol_stack[0] = NDPI_PROTOCOL_UNKNOWN;
+      flow->detected_protocol_stack[0] = NDPI_PROTOCOL_UNKNOWN;
       NDPI_LOG_DBG2(ndpi_struct, "skipping as unknown due to timeout\n");
     }
     return;

--- a/src/lib/protocols/directdownloadlink.c
+++ b/src/lib/protocols/directdownloadlink.c
@@ -702,10 +702,8 @@ u_int8_t search_ddl_domains(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void ndpi_search_direct_download_link_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   /* do not detect again if it is already ddl */
-  if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK) {
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_DIRECT_DOWNLOAD_LINK) {
     if (search_ddl_domains(ndpi_struct, flow) != 0) {
       return;
     }

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -308,8 +308,8 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
 	}
       }
 
-      if((flow->packet.detected_protocol_stack[0] == NDPI_PROTOCOL_DNS)
-	 || (flow->packet.detected_protocol_stack[1] == NDPI_PROTOCOL_DNS)) {
+      if((flow->detected_protocol_stack[0] == NDPI_PROTOCOL_DNS)
+	 || (flow->detected_protocol_stack[1] == NDPI_PROTOCOL_DNS)) {
 	/* Request already set the protocol */
 	// flow->extra_packets_func = NULL; /* Removed so the caller can keep dissecting DNS flows */
       } else {
@@ -500,7 +500,7 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
 		  );
 #endif
 
-    if(flow->packet.detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) {
+    if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) {
       /**
 	 Do not set the protocol with DNS if ndpi_match_host_subprotocol() has
 	 matched a subprotocol
@@ -508,8 +508,8 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
       NDPI_LOG_INFO(ndpi_struct, "found DNS\n");
       ndpi_set_detected_protocol(ndpi_struct, flow, ret.app_protocol, ret.master_protocol);
     } else {
-      if((flow->packet.detected_protocol_stack[0] == NDPI_PROTOCOL_DNS)
-	 || (flow->packet.detected_protocol_stack[1] == NDPI_PROTOCOL_DNS))
+      if((flow->detected_protocol_stack[0] == NDPI_PROTOCOL_DNS)
+	 || (flow->detected_protocol_stack[1] == NDPI_PROTOCOL_DNS))
 	;
       else
 	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
@@ -519,8 +519,8 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
   if(flow->packet_counter > 3)
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 
-  if((flow->packet.detected_protocol_stack[0] == NDPI_PROTOCOL_DNS)
-     || (flow->packet.detected_protocol_stack[1] == NDPI_PROTOCOL_DNS)) {
+  if((flow->detected_protocol_stack[0] == NDPI_PROTOCOL_DNS)
+     || (flow->detected_protocol_stack[1] == NDPI_PROTOCOL_DNS)) {
     /* TODO: add support to RFC6891 to avoid some false positives */
     if(flow->packet.udp != NULL && flow->packet.payload_packet_len > PKT_LEN_ALERT)
       ndpi_set_risk(ndpi_struct, flow, NDPI_DNS_LARGE_PACKET);

--- a/src/lib/protocols/dropbox.c
+++ b/src/lib/protocols/dropbox.c
@@ -77,7 +77,7 @@ void ndpi_search_dropbox(struct ndpi_detection_module_struct *ndpi_struct, struc
   NDPI_LOG_DBG(ndpi_struct, "search dropbox\n");
 
   /* skip marked packets */
-  if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_DROPBOX) {
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_DROPBOX) {
     if (packet->tcp_retransmission == 0) {
       ndpi_check_dropbox(ndpi_struct, flow);
     }

--- a/src/lib/protocols/edonkey.c
+++ b/src/lib/protocols/edonkey.c
@@ -209,7 +209,7 @@ void ndpi_search_edonkey(struct ndpi_detection_module_struct *ndpi_struct, struc
   NDPI_LOG_DBG(ndpi_struct, "search EDONKEY\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_EDONKEY) {
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_EDONKEY) {
     if(packet->tcp_retransmission == 0) {
       ndpi_check_edonkey(ndpi_struct, flow);
     }

--- a/src/lib/protocols/ftp_control.c
+++ b/src/lib/protocols/ftp_control.c
@@ -658,7 +658,7 @@ void ndpi_search_ftp_control(struct ndpi_detection_module_struct *ndpi_struct,
   NDPI_LOG_DBG(ndpi_struct, "search FTP_CONTROL\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_FTP_CONTROL) {
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_FTP_CONTROL) {
     if(packet->tcp_retransmission == 0) {
       ndpi_check_ftp_control(ndpi_struct, flow);
     }

--- a/src/lib/protocols/gnutella.c
+++ b/src/lib/protocols/gnutella.c
@@ -72,7 +72,7 @@ void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, stru
 
   NDPI_LOG_DBG(ndpi_struct, "search GNUTELLA\n");
 
-  if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_GNUTELLA) {
+  if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_GNUTELLA) {
     if (src != NULL && ((u_int32_t)
 			(packet->current_time_ms - src->gnutella_ts) < ndpi_struct->gnutella_timeout)) {
       NDPI_LOG_DBG2(ndpi_struct, "save src connection packet detected\n");

--- a/src/lib/protocols/gtp.c
+++ b/src/lib/protocols/gtp.c
@@ -115,12 +115,10 @@ static void ndpi_check_gtp(struct ndpi_detection_module_struct *ndpi_struct, str
 
 void ndpi_search_gtp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search gtp\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_GTP)
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_GTP)
     ndpi_check_gtp(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -21,6 +21,8 @@
  *
  */
 
+#include <assert.h>
+
 #include "ndpi_protocol_ids.h"
 
 #define NDPI_CURRENT_PROTO NDPI_PROTOCOL_HTTP
@@ -597,10 +599,10 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
     }
 
     if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
-      if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_HTTP) {
+      if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_HTTP) {
 	NDPI_LOG_INFO(ndpi_struct, "found HTTP/%s\n",
-		      ndpi_get_proto_name(ndpi_struct, packet->detected_protocol_stack[0]));
-	ndpi_int_http_add_connection(ndpi_struct, flow, packet->detected_protocol_stack[0], NDPI_PROTOCOL_CATEGORY_WEB);
+		      ndpi_get_proto_name(ndpi_struct, flow->detected_protocol_stack[0]));
+	ndpi_int_http_add_connection(ndpi_struct, flow, flow->detected_protocol_stack[0], NDPI_PROTOCOL_CATEGORY_WEB);
 	return; /* We have identified a sub-protocol so we're done */
       }
     }
@@ -674,7 +676,7 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 
   if (ndpi_get_http_method(ndpi_struct, flow) != NDPI_HTTP_METHOD_UNKNOWN)
   {
-    ndpi_int_http_add_connection(ndpi_struct, flow, packet->detected_protocol_stack[0], NDPI_PROTOCOL_CATEGORY_WEB);
+    ndpi_int_http_add_connection(ndpi_struct, flow, flow->detected_protocol_stack[0], NDPI_PROTOCOL_CATEGORY_WEB);
   }
 }
 

--- a/src/lib/protocols/iax.c
+++ b/src/lib/protocols/iax.c
@@ -90,7 +90,7 @@ void ndpi_search_iax(struct ndpi_detection_module_struct *ndpi_struct, struct nd
   struct ndpi_packet_struct *packet = &flow->packet;
 
   if(packet->udp 
-     && (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN))
+     && (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN))
     ndpi_search_setup_iax(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/irc.c
+++ b/src/lib/protocols/irc.c
@@ -391,7 +391,7 @@ void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struc
     return;
   }
 
-  if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_IRC) {
+  if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_IRC) {
     if (src != NULL && ((u_int32_t)
 			(packet->current_time_ms - src->irc_ts) < ndpi_struct->irc_timeout)) {
       NDPI_LOG_DBG2(ndpi_struct, "irc : save src connection packet detected\n");

--- a/src/lib/protocols/jabber.c
+++ b/src/lib/protocols/jabber.c
@@ -129,7 +129,7 @@ void ndpi_search_jabber_tcp(struct ndpi_detection_module_struct *ndpi_struct, st
 
 
   /* this part parses a packet and searches for port=. it works asymmetrically. */
-  if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_JABBER) {
+  if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_JABBER) {
     u_int16_t lastlen;
     u_int16_t j_port = 0;
     /* check for google jabber voip connections ... */

--- a/src/lib/protocols/lisp.c
+++ b/src/lib/protocols/lisp.c
@@ -62,12 +62,10 @@ static void ndpi_check_lisp(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void ndpi_search_lisp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search lisp\n");
 
   /* skip marked packets */
-  if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_LISP) {
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_LISP) {
  
       ndpi_check_lisp(ndpi_struct, flow);
    

--- a/src/lib/protocols/lotus_notes.c
+++ b/src/lib/protocols/lotus_notes.c
@@ -59,12 +59,10 @@ static void ndpi_check_lotus_notes(struct ndpi_detection_module_struct *ndpi_str
 
 void ndpi_search_lotus_notes(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search lotus_notes\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_LOTUS_NOTES)
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_LOTUS_NOTES)
     ndpi_check_lotus_notes(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/mongodb.c
+++ b/src/lib/protocols/mongodb.c
@@ -108,15 +108,13 @@ static void ndpi_check_mongodb(struct ndpi_detection_module_struct *ndpi_struct,
 void ndpi_search_mongodb(struct ndpi_detection_module_struct *ndpi_struct,
 			 struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   // Break after 6 packets.
   if(flow->packet_counter > 6) {
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
   }
 
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
     return;
   }
 

--- a/src/lib/protocols/mqtt.c
+++ b/src/lib/protocols/mqtt.c
@@ -69,7 +69,7 @@ void ndpi_search_mqtt (struct ndpi_detection_module_struct *ndpi_struct,
 
 	NDPI_LOG_DBG(ndpi_struct, "search Mqtt\n");
 	struct ndpi_packet_struct *packet = &flow->packet;
-	if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
+	if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
 		return;
 	}
 	if (flow->packet_counter > 10) {

--- a/src/lib/protocols/radius.c
+++ b/src/lib/protocols/radius.c
@@ -61,12 +61,10 @@ static void ndpi_check_radius(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void ndpi_search_radius(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search radius\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_RADIUS)
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_RADIUS)
     ndpi_check_radius(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/redis_net.c
+++ b/src/lib/protocols/redis_net.c
@@ -82,7 +82,7 @@ void ndpi_search_redis(struct ndpi_detection_module_struct *ndpi_struct, struct 
   NDPI_LOG_DBG(ndpi_struct, "search Redis\n");
 
   /* skip marked packets */
-  if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_REDIS) {
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_REDIS) {
     if (packet->tcp_retransmission == 0) {
       ndpi_check_redis(ndpi_struct, flow);
     }

--- a/src/lib/protocols/rtmp.c
+++ b/src/lib/protocols/rtmp.c
@@ -83,7 +83,7 @@ void ndpi_search_rtmp(struct ndpi_detection_module_struct *ndpi_struct, struct n
   NDPI_LOG_DBG(ndpi_struct, "search RTMP\n");
 
   /* skip marked packets */
-  if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_RTMP) {
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_RTMP) {
     if (packet->tcp_retransmission == 0) {
       ndpi_check_rtmp(ndpi_struct, flow);
     }

--- a/src/lib/protocols/rtsp.c
+++ b/src/lib/protocols/rtsp.c
@@ -57,7 +57,7 @@ void ndpi_search_rtsp_tcp_udp(struct ndpi_detection_module_struct
   }
 
   if (flow->rtsprdt_stage == 0
-      && !(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_RTCP)
+      && !(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_RTCP)
       ) {
     flow->rtsprdt_stage = 1 + packet->packet_direction;
     NDPI_LOG_DBG2(ndpi_struct, "maybe handshake 1; need next packet, return\n");
@@ -87,7 +87,7 @@ void ndpi_search_rtsp_tcp_udp(struct ndpi_detection_module_struct
     }
   }
 
-  if (packet->udp != NULL && packet->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN
+  if (packet->udp != NULL && flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN
       && ((NDPI_COMPARE_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RTP) == 0)
 	  || (NDPI_COMPARE_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_RTCP) == 0)
 	  )) {

--- a/src/lib/protocols/rx.c
+++ b/src/lib/protocols/rx.c
@@ -208,10 +208,8 @@ void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
 void ndpi_search_rx(struct ndpi_detection_module_struct *ndpi_struct,
                     struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search RX\n");
-  if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_RX) {
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_RX) {
     ndpi_check_rx(ndpi_struct, flow);
   }
 }

--- a/src/lib/protocols/shoutcast.c
+++ b/src/lib/protocols/shoutcast.c
@@ -50,7 +50,7 @@ void ndpi_search_shoutcast_tcp(struct ndpi_detection_module_struct
 			return;
 		}
 		if (flow->packet_counter < 3
-			&& packet->detected_protocol_stack[0] == NDPI_PROTOCOL_HTTP
+			&& flow->detected_protocol_stack[0] == NDPI_PROTOCOL_HTTP
 			) {
 			NDPI_LOG_DBG2(ndpi_struct,
 					"http detected, need next packet for shoutcast detection.\n");

--- a/src/lib/protocols/sip.c
+++ b/src/lib/protocols/sip.c
@@ -186,7 +186,7 @@ void ndpi_search_sip(struct ndpi_detection_module_struct *ndpi_struct, struct nd
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   else {
     /* skip marked packets */
-    if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_SIP) {
+    if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SIP) {
       if(packet->tcp_retransmission == 0) {
 	ndpi_search_sip_handshake(ndpi_struct, flow);
       }

--- a/src/lib/protocols/skype.c
+++ b/src/lib/protocols/skype.c
@@ -176,12 +176,10 @@ static void ndpi_check_skype(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void ndpi_search_skype(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search skype\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_SKYPE_TEAMS)
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SKYPE_TEAMS)
     ndpi_check_skype(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/smpp.c
+++ b/src/lib/protocols/smpp.c
@@ -42,7 +42,7 @@ void ndpi_search_smpp_tcp(struct ndpi_detection_module_struct* ndpi_struct,
                           struct ndpi_flow_struct* flow)
 {
   NDPI_LOG_DBG(ndpi_struct, "search SMPP\n");
-  if (flow->packet.detected_protocol_stack[0] != NDPI_PROTOCOL_SMPP){
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SMPP){
     struct ndpi_packet_struct* packet = &flow->packet;
     // min SMPP packet length = 16 bytes
     if (packet->payload_packet_len < 16) {

--- a/src/lib/protocols/socks45.c
+++ b/src/lib/protocols/socks45.c
@@ -124,11 +124,11 @@ void ndpi_search_socks(struct ndpi_detection_module_struct *ndpi_struct, struct 
   NDPI_LOG_DBG(ndpi_struct, "search SOCKS\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS) {
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS) {
     if(packet->tcp_retransmission == 0) {
       ndpi_check_socks4(ndpi_struct, flow);
 
-      if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS)
+      if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS)
 	ndpi_check_socks5(ndpi_struct, flow);
     }
   }

--- a/src/lib/protocols/someip.c
+++ b/src/lib/protocols/someip.c
@@ -114,7 +114,7 @@ void ndpi_search_someip (struct ndpi_detection_module_struct *ndpi_struct,
 
   NDPI_LOG_DBG(ndpi_struct, "search SOME/IP\n");
 
-  if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
     return;
   }
  

--- a/src/lib/protocols/soulseek.c
+++ b/src/lib/protocols/soulseek.c
@@ -44,7 +44,7 @@ void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 
   if(packet->tcp) {
 
-    if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_SOULSEEK) {
+    if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_SOULSEEK) {
       NDPI_LOG_DBG2(ndpi_struct, "packet marked as Soulseek\n");
       if(src != NULL)
 	NDPI_LOG_DBG2(ndpi_struct,

--- a/src/lib/protocols/spotify.c
+++ b/src/lib/protocols/spotify.c
@@ -67,7 +67,7 @@ static void ndpi_check_spotify(struct ndpi_detection_module_struct *ndpi_struct,
 
 
     if(packet->iph /* IPv4 Only: we need to support packet->iphv6 at some point */) {
-      /* if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) */ {
+      /* if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) */ {
 	/*
 	Spotify
 
@@ -126,7 +126,7 @@ void ndpi_search_spotify(struct ndpi_detection_module_struct *ndpi_struct, struc
   NDPI_LOG_DBG(ndpi_struct, "search spotify\n");
 
   /* skip marked packets */
-  if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_SPOTIFY) {
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SPOTIFY) {
     if (packet->tcp_retransmission == 0) {
       ndpi_check_spotify(ndpi_struct, flow);
     }

--- a/src/lib/protocols/starcraft.c
+++ b/src/lib/protocols/starcraft.c
@@ -115,7 +115,7 @@ u_int8_t ndpi_check_starcraft_udp(struct ndpi_detection_module_struct* ndpi_stru
 void ndpi_search_starcraft(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow)
 {
   NDPI_LOG_DBG(ndpi_struct, "search Starcraft\n");
-  if (flow->packet.detected_protocol_stack[0] != NDPI_PROTOCOL_STARCRAFT) {
+  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_STARCRAFT) {
     struct ndpi_packet_struct* packet = &flow->packet;
     int8_t result = 0;
 

--- a/src/lib/protocols/steam.c
+++ b/src/lib/protocols/steam.c
@@ -265,12 +265,12 @@ void ndpi_search_steam(struct ndpi_detection_module_struct *ndpi_struct, struct 
     
     ndpi_check_steam_udp1(ndpi_struct, flow);
 	
-    if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
+    if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
       return;   
 	
     ndpi_check_steam_udp2(ndpi_struct, flow);
 	
-    if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
+    if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
       return;   
 	
     ndpi_check_steam_udp3(ndpi_struct, flow);
@@ -286,18 +286,18 @@ void ndpi_search_steam(struct ndpi_detection_module_struct *ndpi_struct, struct 
       return;
     }
 
-    if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
+    if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
       return;   
 
     NDPI_LOG_DBG(ndpi_struct, "search STEAM\n");
     ndpi_check_steam_http(ndpi_struct, flow);
 	
-    if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
+    if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
       return;   
 
     ndpi_check_steam_tcp(ndpi_struct, flow);
 	
-    if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
+    if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
       return;   
   }
 }

--- a/src/lib/protocols/targus_getdata.c
+++ b/src/lib/protocols/targus_getdata.c
@@ -55,12 +55,10 @@ static void ndpi_check_targus_getdata(struct ndpi_detection_module_struct *ndpi_
 
 void ndpi_search_targus_getdata(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search targus getdata\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_TARGUS_GETDATA)
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_TARGUS_GETDATA)
     ndpi_check_targus_getdata(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/thunder.c
+++ b/src/lib/protocols/thunder.c
@@ -150,7 +150,7 @@ void ndpi_int_search_thunder_http(struct ndpi_detection_module_struct
   struct ndpi_id_struct *dst = flow->dst;
 
 
-  if (packet->detected_protocol_stack[0] == NDPI_PROTOCOL_THUNDER) {
+  if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_THUNDER) {
     if (src != NULL && ((u_int32_t)
 			(packet->current_time_ms - src->thunder_ts) < ndpi_struct->thunder_timeout)) {
       NDPI_LOG_DBG2(ndpi_struct,

--- a/src/lib/protocols/tinc.c
+++ b/src/lib/protocols/tinc.c
@@ -133,7 +133,7 @@ void ndpi_search_tinc(struct ndpi_detection_module_struct* ndpi_struct, struct n
 
   NDPI_LOG_DBG(ndpi_struct, "tinc detection\n");
 
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_TINC) {
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_TINC) {
     if(packet->tcp_retransmission == 0) {
       ndpi_check_tinc(ndpi_struct, flow);
     }

--- a/src/lib/protocols/vhua.c
+++ b/src/lib/protocols/vhua.c
@@ -55,12 +55,10 @@ static void ndpi_check_vhua(struct ndpi_detection_module_struct *ndpi_struct, st
 }
 
 void ndpi_search_vhua(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search VHUA\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_VHUA) {
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_VHUA) {
     ndpi_check_vhua(ndpi_struct, flow);
   }
 }

--- a/src/lib/protocols/websocket.c
+++ b/src/lib/protocols/websocket.c
@@ -98,8 +98,6 @@ static void ndpi_check_websocket(struct ndpi_detection_module_struct *ndpi_struc
 
 void ndpi_search_websocket(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-    struct ndpi_packet_struct *packet = &flow->packet;
-
     // Break after 6 packets.
     if (flow->packet_counter > 10)
     {
@@ -107,7 +105,7 @@ void ndpi_search_websocket(struct ndpi_detection_module_struct *ndpi_struct, str
         return;
     }
 
-    if (packet->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN)
+    if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN)
     {
         return;
     }

--- a/src/lib/protocols/zattoo.c
+++ b/src/lib/protocols/zattoo.c
@@ -62,7 +62,7 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
 
   NDPI_LOG_DBG(ndpi_struct, "search ZATTOO\n");
 
-  if(packet->detected_protocol_stack[0] == NDPI_PROTOCOL_ZATTOO) {
+  if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_ZATTOO) {
     if(src != NULL && ((u_int32_t) (packet->current_time_ms - src->zattoo_ts) < ndpi_struct->zattoo_connection_timeout))
       src->zattoo_ts = packet->current_time_ms;
     if (dst != NULL && ((u_int32_t) (packet->current_time_ms - dst->zattoo_ts) < ndpi_struct->zattoo_connection_timeout))

--- a/src/lib/protocols/zeromq.c
+++ b/src/lib/protocols/zeromq.c
@@ -89,7 +89,7 @@ void ndpi_search_zmq(struct ndpi_detection_module_struct *ndpi_struct, struct nd
   NDPI_LOG_DBG(ndpi_struct, "search ZMQ\n");
 
   /* skip marked packets */
-  if(packet->detected_protocol_stack[0] != NDPI_PROTOCOL_ZMQ) {
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_ZMQ) {
     if(packet->tcp && packet->tcp_retransmission == 0) {
       ndpi_check_zmq(ndpi_struct, flow);
     }


### PR DESCRIPTION
This field is an exact copy of `ndpi_flow_struct->detected_protocol_stack[2]`:
* at the very beginning of packet dissection, the value saved in
`flow->detected_protocol_stack` is copied in `packet->detected_protocol_stack`
(via `ndpi_detection_process_packet()` -> `ndpi_init_packet_header()`)

* every time we update `flow->detected_protocol_stack` we update
`packet->detected_protocol_stack` too (via `ndpi_int_change_protocol()`
-> `ndpi_int_change_packet_protocol()`)

These two fields are always in sync: keeping the same value in two
different places is useless.