### PR TITLE
Added nDPI pkg-config file to Debian / Ubuntu ndpi-dev packaging.

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -224,7 +224,7 @@ AC_ARG_ENABLE([gcrypt],
   [AS_HELP_STRING([--disable-gcrypt], [Avoid compiling with libgcrypt/libgpg-error, even if they are present. QUIC sub-classification may be missing])],
   [GCRYPT_ENABLED=0],
   [AC_CHECK_LIB(gcrypt, gcry_cipher_checktag)])
-AS_IF([test "x$enable_gcrypt" = "xyes"], [
+AS_IF([test ${GCRYPT_ENABLED} -eq 1], [
   if test "x$ac_cv_lib_gcrypt_gcry_cipher_checktag" = xyes; then :
     ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lgcrypt"
   else
@@ -233,6 +233,8 @@ AS_IF([test "x$enable_gcrypt" = "xyes"], [
     AC_CHECK_LIB(gcrypt, gcry_cipher_checktag)
     if test "x$ac_cv_lib_gcrypt_gcry_cipher_checktag" = xyes -a "x$ac_cv_lib_gpg_error_gpg_strerror_r" = xyes; then :
       ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lgcrypt -lgpg-error"
+    else
+      GCRYPT_ENABLED=0
     fi
   fi
 ])

--- a/packages/ubuntu/Makefile.in
+++ b/packages/ubuntu/Makefile.in
@@ -13,7 +13,7 @@ ndpi:
 	cp $(NDPI_HOME)/src/lib/libndpi.a ./debian/ndpi-dev-tmp/usr/lib/
 	cp $(NDPI_HOME)/example/ndpiReader ./debian/ndpi-tmp/usr/bin/
 	cp $(NDPI_HOME)/src/include/*.h ./debian/ndpi-dev-tmp/usr/include/ndpi/
-	cp $(NDPI_HOME)/libndpi.pc ./debian/ndpi-dev-tmp/usr/lib/pkgconfig
+	cp $(NDPI_HOME)/libndpi.pc ./debian/ndpi-dev-tmp/usr/lib/pkgconfig/
 	-rm -fr ./debian/ndpi-dev-tmp/usr/include/ndpi/ndpi_win32.h*
 	@echo
 	@find ./debian/ndpi-tmp -name "*~" -exec /bin/rm {} ';'

--- a/packages/ubuntu/Makefile.in
+++ b/packages/ubuntu/Makefile.in
@@ -5,7 +5,7 @@ ndpi:
 	\rm -rf ./debian/ndpi-tmp ./debian/ndpi-dev-tmp ./debian/ndpi ./debian/ndpi-dev
 	mkdir -p ./debian/ndpi-tmp ./debian/ndpi-dev-tmp
 	mkdir -p  ./debian/ndpi-tmp/usr/lib ./debian/ndpi-tmp/usr/bin 
-	mkdir -p ./debian/ndpi-dev-tmp/usr/lib ./debian/ndpi-dev-tmp/usr/include/ndpi
+	mkdir -p ./debian/ndpi-dev-tmp/usr/lib ./debian/ndpi-dev-tmp/usr/include/ndpi ./debian/ndpi-dev-tmp/usr/lib/pkgconfig
 	cd ${NDPI_HOME}; ./autogen.sh; ./configure; make
 	cp $(NDPI_HOME)/src/lib/libndpi.so.@NDPI_VERS@ ./debian/ndpi-tmp/usr/lib/
 	cd ./debian/ndpi-tmp/usr/lib/; ln -s libndpi.so.@NDPI_VERS@ libndpi.so; cd -
@@ -13,6 +13,7 @@ ndpi:
 	cp $(NDPI_HOME)/src/lib/libndpi.a ./debian/ndpi-dev-tmp/usr/lib/
 	cp $(NDPI_HOME)/example/ndpiReader ./debian/ndpi-tmp/usr/bin/
 	cp $(NDPI_HOME)/src/include/*.h ./debian/ndpi-dev-tmp/usr/include/ndpi/
+	cp $(NDPI_HOME)/libndpi.pc ./debian/ndpi-dev-tmp/usr/lib/pkgconfig
 	-rm -fr ./debian/ndpi-dev-tmp/usr/include/ndpi/ndpi_win32.h*
 	@echo
 	@find ./debian/ndpi-tmp -name "*~" -exec /bin/rm {} ';'


### PR DESCRIPTION
 * fixed missing gcrypt library dependency in libndpi.pc

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

While searching for the needle in the haystack (finding endian issues), I've stumbled on another build system related *D'oh!* and a missing Debian / Ubuntu packaging file aka *libndpi.pc*. All other packaging build seem to be aware of that file. Should we instrument the CI for the packaging process as well?