### PR TITLE
Remove `struct ndpi_packet_struct` from `struct ndpi_flow_struct`

### DIFF
--- a/python/ndpi.py
+++ b/python/ndpi.py
@@ -645,6 +645,14 @@ struct ndpi_flow_udp_struct {
   /* NDPI_PROTOCOL_WIREGUARD */
   uint8_t wireguard_stage;
   uint32_t wireguard_peer_index[2];
+
+  /* NDPI_PROTOCOL_QUIC */
+  u_int8_t *quic_reasm_buf;
+  u_int32_t quic_reasm_buf_len;
+
+  /* NDPI_PROTOCOL_CSGO */
+  uint8_t csgo_strid[18],csgo_state,csgo_s2;
+  uint32_t csgo_id2;
 };
 
 struct ndpi_int_one_line_struct {
@@ -941,6 +949,9 @@ struct ndpi_detection_module_struct {
 
   uint8_t direction_detect_disable:1, /* disable internal detection of packet direction */
     _pad:7;
+
+  /* Current packet */
+  struct ndpi_packet_struct packet;
 };
 
 #define NDPI_CIPHER_SAFE                        0
@@ -1163,15 +1174,13 @@ struct ndpi_flow_struct {
   uint8_t ovpn_session_id[8];
   uint8_t ovpn_counter;
 
+  /* Flow key used to search a match into the mining cache */
+  u_int32_t key_mining_cache;
+
   /* NDPI_PROTOCOL_TINC */
   uint8_t tinc_state;
   struct tinc_cache_entry tinc_cache_entry;
 
-  /* NDPI_PROTOCOL_CSGO */
-  uint8_t csgo_strid[18],csgo_state,csgo_s2;
-  uint32_t csgo_id2;
-  /* internal structures to save functions calls */
-  struct ndpi_packet_struct packet;
   struct ndpi_id_struct *src;
   struct ndpi_id_struct *dst;
 };

--- a/python/ndpi_typestruct.py
+++ b/python/ndpi_typestruct.py
@@ -276,11 +276,9 @@ NDPIDetectionModuleStruct._fields_ = [
     ("tinc_cache", POINTER(Cache)),
     ("proto_defaults", NDPIProtoDefaultsT * (ndpi.ndpi_wrap_ndpi_max_supported_protocols() +
                                              ndpi.ndpi_wrap_ndpi_max_num_custom_protocols())),
-    ("http_dont_dissect_response", c_uint8, 1),
-    ("dns_dont_dissect_response", c_uint8, 1),
     ("direction_detect_disable", c_uint8, 1),
-    ("disable_metadata_export", c_uint8, 1),
-    ("hyperscan", c_void_p)
+    ('_pad', c_uint8, 7),
+    ('packet', NDPIPacketStruct),
 ]
 
 
@@ -408,6 +406,12 @@ class NDPIFlowUdpStruct(Structure):
         ('memcached_matches', c_uint8),
         ('wireguard_stage', c_uint8),
         ('wireguard_peer_index', c_uint32 * 2),
+        ('quic_reasm_buf', POINTER(c_uint8)),
+        ('quic_reasm_buf_len', c_uint32),
+        ('csgo_strid', c_uint8 * 18),
+        ('csgo_state', c_uint8),
+        ('csgo_s2', c_uint8),
+        ('csgo_id2', c_uint32),
     ]
 
 
@@ -735,15 +739,9 @@ NDPIFlowStruct._fields_ = [
     ('starcraft_udp_stage', c_uint8, 3),
     ('ovpn_session_id', c_uint8 * 8),
     ('ovpn_counter', c_uint8),
+    ('key_mining_cache', c_uint32),
     ('tinc_state', c_uint8),
     ('TincCacheEntry', TincCacheEntry),
-    ('csgo_strid', c_uint8 * 18),
-    ('csgo_state', c_uint8),
-    ('csgo_s2', c_uint8),
-    ('csgo_id2', c_uint32),
-    ('kxun_counter', c_uint16),
-    ('iqiyi_counter', c_uint16),
-    ('packet', NDPIPacketStruct),
     ('src', POINTER(NDPIIdStruct)),
     ('dst', POINTER(NDPIIdStruct))
 ]

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1175,6 +1175,9 @@ struct ndpi_detection_module_struct {
   MMDB_s mmdb_city, mmdb_as;
   u_int8_t mmdb_city_loaded, mmdb_as_loaded;
 #endif
+
+  /* Current packet */
+  struct ndpi_packet_struct packet;
 };
 
 #endif /* NDPI_LIB_COMPILATION */
@@ -1423,12 +1426,13 @@ struct ndpi_flow_struct {
   u_int8_t ovpn_session_id[8];
   u_int8_t ovpn_counter;
 
+  /* Flow key used to search a match into the mining cache */
+  u_int32_t key_mining_cache;
+
   /* NDPI_PROTOCOL_TINC */
   u_int8_t tinc_state;
   struct tinc_cache_entry tinc_cache_entry;
 
-  /* internal structures to save functions calls */
-  struct ndpi_packet_struct packet;
   struct ndpi_id_struct *src;
   struct ndpi_id_struct *dst;
 };

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -2101,9 +2101,9 @@ static void ndpi_handle_risk_exceptions(struct ndpi_detection_module_struct *ndp
   }
 
   /* TODO: add IPv6 support */
+  struct ndpi_packet_struct *packet = &ndpi_str->packet;
   if(!flow->ip_risk_mask_evaluated) {
-    if(flow->packet.iph) {
-      struct ndpi_packet_struct *packet = &flow->packet;
+    if(packet->iph) {
       struct in_addr pin;
 
       pin.s_addr = packet->iph->saddr;

--- a/src/lib/protocols/afp.c
+++ b/src/lib/protocols/afp.c
@@ -43,7 +43,7 @@ static void ndpi_int_afp_add_connection(struct ndpi_detection_module_struct *ndp
 
 void ndpi_search_afp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search AFP\n");
 

--- a/src/lib/protocols/aimini.c
+++ b/src/lib/protocols/aimini.c
@@ -39,7 +39,7 @@ static void ndpi_int_aimini_add_connection(struct ndpi_detection_module_struct *
 
 void ndpi_search_aimini(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
 	NDPI_LOG_DBG(ndpi_struct, "search aimini\n");
 

--- a/src/lib/protocols/ajp.c
+++ b/src/lib/protocols/ajp.c
@@ -73,7 +73,7 @@ static void set_ajp_detected(struct ndpi_detection_module_struct *ndpi_struct,
 static void ndpi_check_ajp(struct ndpi_detection_module_struct *ndpi_struct,
 			   struct ndpi_flow_struct *flow) {
   struct ajp_header ajp_hdr;
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if (packet->payload_packet_len < sizeof(ajp_hdr)) {
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);

--- a/src/lib/protocols/amazon_video.c
+++ b/src/lib/protocols/amazon_video.c
@@ -29,7 +29,7 @@
 
 static void ndpi_check_amazon_video(struct ndpi_detection_module_struct *ndpi_struct,
 				    struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search Amazon Prime\n");
 

--- a/src/lib/protocols/among_us.c
+++ b/src/lib/protocols/among_us.c
@@ -33,7 +33,7 @@ static void ndpi_int_among_us_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_among_us(struct ndpi_detection_module_struct *ndpi_struct,
                           struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct * const packet = &flow->packet;
+  struct ndpi_packet_struct * const packet = &ndpi_struct->packet;
 
   /* handshake packet */
   if (packet->payload_packet_len > 9 &&

--- a/src/lib/protocols/amqp.c
+++ b/src/lib/protocols/amqp.c
@@ -40,7 +40,7 @@ static void ndpi_int_amqp_add_connection(struct ndpi_detection_module_struct *nd
 }
 
 void ndpi_search_amqp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
 	NDPI_LOG_DBG(ndpi_struct, "search amqp\n");
 

--- a/src/lib/protocols/apple_push.c
+++ b/src/lib/protocols/apple_push.c
@@ -29,7 +29,7 @@
 
 static void ndpi_check_apple_push(struct ndpi_detection_module_struct *ndpi_struct,
 				  struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if(packet->iph) {
     /* https://support.apple.com/en-us/HT203609 */

--- a/src/lib/protocols/applejuice.c
+++ b/src/lib/protocols/applejuice.c
@@ -38,7 +38,7 @@ static void ndpi_int_applejuice_add_connection(struct ndpi_detection_module_stru
 void ndpi_search_applejuice_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 				struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
 	NDPI_LOG_DBG(ndpi_struct, "search applejuice\n");
 

--- a/src/lib/protocols/armagetron.c
+++ b/src/lib/protocols/armagetron.c
@@ -37,7 +37,7 @@ static void ndpi_int_armagetron_add_connection(struct ndpi_detection_module_stru
 
 void ndpi_search_armagetron_udp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search armagetron\n");
 

--- a/src/lib/protocols/avast_securedns.c
+++ b/src/lib/protocols/avast_securedns.c
@@ -34,7 +34,7 @@ static void ndpi_int_avast_securedns_add_connection(struct ndpi_detection_module
 static void ndpi_search_avast_securedns(struct ndpi_detection_module_struct *ndpi_struct,
                                         struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct * packet = &flow->packet;
+  struct ndpi_packet_struct * packet = &ndpi_struct->packet;
 
   if (packet->payload_packet_len < 34 ||
       ntohl(get_u_int32_t(packet->payload, 11)) != 0x00013209 ||

--- a/src/lib/protocols/ayiya.c
+++ b/src/lib/protocols/ayiya.c
@@ -42,7 +42,7 @@ struct ayiya {
 
 void ndpi_search_ayiya(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search AYIYA\n");
 
@@ -57,7 +57,7 @@ void ndpi_search_ayiya(struct ndpi_detection_module_struct *ndpi_struct, struct 
       u_int32_t epoch = ntohl(a->epoch), now;
       u_int32_t fiveyears = 86400 * 365 * 5;
 
-      now = flow->packet.current_time_ms;
+      now = packet->current_time_ms;
 
       if((epoch >= (now - fiveyears)) && (epoch <= (now+86400 /* 1 day */))) {
 	NDPI_LOG_INFO(ndpi_struct, "found AYIYA\n");

--- a/src/lib/protocols/bgp.c
+++ b/src/lib/protocols/bgp.c
@@ -31,7 +31,7 @@
 /* this detection also works asymmetrically */
 void ndpi_search_bgp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t bgp_port = htons(179);
 
   NDPI_LOG_DBG(ndpi_struct, "search BGP\n");

--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -63,19 +63,21 @@ static void ndpi_add_connection_as_bittorrent(struct ndpi_detection_module_struc
 					      int bt_offset, int check_hash,
 					      const u_int8_t save_detection, const u_int8_t encrypted_connection)
 {
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
+
   if(check_hash) {
     const char *bt_hash = NULL; /* 20 bytes long */
     
     if(bt_offset == -1) {
-      const char *bt_magic = ndpi_strnstr((const char *)flow->packet.payload,
-					  "BitTorrent protocol", flow->packet.payload_packet_len);
+      const char *bt_magic = ndpi_strnstr((const char *)packet->payload,
+					  "BitTorrent protocol", packet->payload_packet_len);
 
       if(bt_magic)
 	bt_hash = &bt_magic[19];
     } else
-      bt_hash = (const char*)&flow->packet.payload[28];
+      bt_hash = (const char*)&packet->payload[28];
 
-    if(bt_hash && (flow->packet.payload_packet_len >= (20 + (bt_hash-(const char*)flow->packet.payload))))
+    if(bt_hash && (packet->payload_packet_len >= (20 + (bt_hash-(const char*)packet->payload))))
       memcpy(flow->protos.bittorrent.hash, bt_hash, 20);
   }
 
@@ -85,7 +87,7 @@ static void ndpi_add_connection_as_bittorrent(struct ndpi_detection_module_struc
 static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module_struct
 						    *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t a = 0;
 
   if(packet->payload_packet_len == 1 && packet->payload[0] == 0x13) {
@@ -359,7 +361,7 @@ static u_int8_t ndpi_int_search_bittorrent_tcp_zero(struct ndpi_detection_module
 /*Search for BitTorrent commands*/
 static void ndpi_int_search_bittorrent_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if(packet->payload_packet_len == 0) {
     return;
@@ -384,7 +386,7 @@ static u_int8_t is_port(u_int16_t a, u_int16_t b, u_int16_t what) {
   
 void ndpi_search_bittorrent(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   char *bt_proto = NULL;
 
   /* This is broadcast */

--- a/src/lib/protocols/bjnp.c
+++ b/src/lib/protocols/bjnp.c
@@ -14,7 +14,7 @@ static void ndpi_int_bjnp_add_connection(struct ndpi_detection_module_struct *nd
 
 static void ndpi_check_bjnp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   if(packet->udp != NULL) {

--- a/src/lib/protocols/capwap.c
+++ b/src/lib/protocols/capwap.c
@@ -38,7 +38,7 @@ static void ndpi_int_capwap_add_connection(struct ndpi_detection_module_struct *
 
 static void ndpi_search_setup_capwap(struct ndpi_detection_module_struct *ndpi_struct,
 				     struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t sport, dport;
    
   if(!packet->iph) {
@@ -104,7 +104,7 @@ static void ndpi_search_setup_capwap(struct ndpi_detection_module_struct *ndpi_s
 
 void ndpi_search_capwap(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if(packet->udp && (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN))
     ndpi_search_setup_capwap(ndpi_struct, flow);

--- a/src/lib/protocols/cassandra.c
+++ b/src/lib/protocols/cassandra.c
@@ -103,7 +103,7 @@ static bool ndpi_check_valid_cassandra_opcode(uint8_t opcode)
 void ndpi_search_cassandra(struct ndpi_detection_module_struct *ndpi_struct,
                            struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if (packet->tcp) {
     if (packet->payload_packet_len >= CASSANDRA_HEADER_LEN &&

--- a/src/lib/protocols/checkmk.c
+++ b/src/lib/protocols/checkmk.c
@@ -38,7 +38,7 @@ static void ndpi_int_checkmk_add_connection(struct ndpi_detection_module_struct 
 void ndpi_search_checkmk(struct ndpi_detection_module_struct *ndpi_struct,
 			 struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if (packet->payload_packet_len >= 15) {
 

--- a/src/lib/protocols/ciscovpn.c
+++ b/src/lib/protocols/ciscovpn.c
@@ -37,7 +37,7 @@ static void ndpi_int_ciscovpn_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_ciscovpn(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t udport = 0, usport = 0;
   u_int16_t tdport = 0, tsport = 0;
 

--- a/src/lib/protocols/citrix.c
+++ b/src/lib/protocols/citrix.c
@@ -32,7 +32,7 @@
 
 static void ndpi_check_citrix(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   if(packet->tcp != NULL) {

--- a/src/lib/protocols/coap.c
+++ b/src/lib/protocols/coap.c
@@ -106,7 +106,7 @@ static int isCoAPport(u_int16_t port) {
 void ndpi_search_coap (struct ndpi_detection_module_struct *ndpi_struct,
 		       struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   struct ndpi_coap_hdr * h = (struct ndpi_coap_hdr*) packet->payload;
 
   if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
@@ -115,8 +115,8 @@ void ndpi_search_coap (struct ndpi_detection_module_struct *ndpi_struct,
 
   // search for udp packet
   if(packet->udp != NULL) {
-    u_int16_t s_port = ntohs(flow->packet.udp->source);
-    u_int16_t d_port = ntohs(flow->packet.udp->dest);
+    u_int16_t s_port = ntohs(packet->udp->source);
+    u_int16_t d_port = ntohs(packet->udp->dest);
 
     if((!isCoAPport(s_port) && !isCoAPport(d_port))
        || (packet->payload_packet_len < 4) ) {   // header too short

--- a/src/lib/protocols/collectd.c
+++ b/src/lib/protocols/collectd.c
@@ -28,7 +28,7 @@
 
 void ndpi_search_collectd(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int len = 0;
 
   NDPI_LOG_DBG(ndpi_struct, "search collectd\n");

--- a/src/lib/protocols/corba.c
+++ b/src/lib/protocols/corba.c
@@ -31,7 +31,7 @@ static void ndpi_int_corba_add_connection(struct ndpi_detection_module_struct
 }
 void ndpi_search_corba(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search for CORBA\n");
   if(packet->tcp != NULL) {

--- a/src/lib/protocols/cpha.c
+++ b/src/lib/protocols/cpha.c
@@ -31,7 +31,7 @@
 
 
 void ndpi_search_cpha(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   const u_int16_t cpha_port = htons(8116);
   
   NDPI_LOG_DBG(ndpi_struct, "search CPHA\n");

--- a/src/lib/protocols/crossfire.c
+++ b/src/lib/protocols/crossfire.c
@@ -37,7 +37,7 @@ static void ndpi_int_crossfire_add_connection(struct ndpi_detection_module_struc
 
 void ndpi_search_crossfire_tcp_udp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
 	NDPI_LOG_DBG(ndpi_struct, "search crossfire\n");
 

--- a/src/lib/protocols/csgo.c
+++ b/src/lib/protocols/csgo.c
@@ -27,7 +27,7 @@
 #include "ndpi_api.h"
 
 void ndpi_search_csgo(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow) {
-  struct ndpi_packet_struct* packet = &flow->packet;
+  struct ndpi_packet_struct* packet = &ndpi_struct->packet;
 
   if(packet->udp != NULL) {
     if(packet->payload_packet_len < sizeof(uint32_t)) {

--- a/src/lib/protocols/dcerpc.c
+++ b/src/lib/protocols/dcerpc.c
@@ -79,7 +79,7 @@ bool is_connectionless_dcerpc(struct ndpi_packet_struct *packet, struct ndpi_flo
 
 void ndpi_search_dcerpc(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search DCERPC\n");
   if (is_connection_oriented_dcerpc(packet, flow) || is_connectionless_dcerpc(packet, flow)) {

--- a/src/lib/protocols/dhcp.c
+++ b/src/lib/protocols/dhcp.c
@@ -60,7 +60,7 @@ static void ndpi_int_dhcp_add_connection(struct ndpi_detection_module_struct *nd
 
 void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search DHCP\n");
 

--- a/src/lib/protocols/dhcpv6.c
+++ b/src/lib/protocols/dhcpv6.c
@@ -38,7 +38,7 @@ static void ndpi_int_dhcpv6_add_connection(struct ndpi_detection_module_struct *
 
 void ndpi_search_dhcpv6_udp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 	NDPI_LOG_DBG(ndpi_struct, "search DHCPv6\n");
 

--- a/src/lib/protocols/diameter.c
+++ b/src/lib/protocols/diameter.c
@@ -93,7 +93,7 @@ int is_diameter(struct ndpi_packet_struct *packet, int size_payload)
 void ndpi_search_diameter(struct ndpi_detection_module_struct *ndpi_struct,
 			  struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   // Diameter is on TCP
   if(packet->tcp) {

--- a/src/lib/protocols/directconnect.c
+++ b/src/lib/protocols/directconnect.c
@@ -78,7 +78,7 @@ static void ndpi_int_directconnect_add_connection(struct ndpi_detection_module_s
 						  const u_int8_t connection_type)
 {
 
-  struct ndpi_packet_struct *packet = &flow->packet;	
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
 
@@ -123,7 +123,7 @@ static void ndpi_int_directconnect_add_connection(struct ndpi_detection_module_s
 
 static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 					  struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
@@ -311,7 +311,7 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
 static void ndpi_search_directconnect_udp(struct ndpi_detection_module_struct
 					  *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
@@ -397,7 +397,7 @@ static void ndpi_search_directconnect_udp(struct ndpi_detection_module_struct
 void ndpi_search_directconnect(struct ndpi_detection_module_struct
 			       *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
 

--- a/src/lib/protocols/directdownloadlink.c
+++ b/src/lib/protocols/directdownloadlink.c
@@ -50,7 +50,7 @@ static void ndpi_int_direct_download_link_add_connection(struct ndpi_detection_m
 */
 u_int8_t search_ddl_domains(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t filename_start = 0;
   u_int16_t i = 1;
   u_int16_t host_line_len_without_port;

--- a/src/lib/protocols/dnp3.c
+++ b/src/lib/protocols/dnp3.c
@@ -32,7 +32,7 @@
 
 void ndpi_search_dnp3_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 			  struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search DNP3\n");
     

--- a/src/lib/protocols/dnscrypt.c
+++ b/src/lib/protocols/dnscrypt.c
@@ -33,7 +33,7 @@ static void ndpi_int_dnscrypt_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_dnscrypt(struct ndpi_detection_module_struct *ndpi_struct,
                           struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   static char const * const dnscrypt_initial = "2\rdnscrypt";
 
   NDPI_LOG_DBG(ndpi_struct, "search dnscrypt\n");

--- a/src/lib/protocols/dofus.c
+++ b/src/lib/protocols/dofus.c
@@ -36,7 +36,7 @@ static void ndpi_dofus_add_connection(struct ndpi_detection_module_struct *ndpi_
 
 void ndpi_search_dofus(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search dofus\n");
 

--- a/src/lib/protocols/drda.c
+++ b/src/lib/protocols/drda.c
@@ -36,7 +36,7 @@ struct ndpi_drda_hdr {
 void ndpi_search_drda(struct ndpi_detection_module_struct *ndpi_struct,
 		      struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct * packet = &flow->packet;
+  struct ndpi_packet_struct * packet = &ndpi_struct->packet;
   u_int16_t payload_len = packet->payload_packet_len;
   u_int count = 0; // prevent integer overflow
 

--- a/src/lib/protocols/dropbox.c
+++ b/src/lib/protocols/dropbox.c
@@ -39,7 +39,7 @@ static void ndpi_int_dropbox_add_connection(struct ndpi_detection_module_struct 
 
 static void ndpi_check_dropbox(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;  
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
 

--- a/src/lib/protocols/eaq.c
+++ b/src/lib/protocols/eaq.c
@@ -45,7 +45,7 @@ void ndpi_search_eaq(struct ndpi_detection_module_struct *ndpi_struct, struct nd
     return;
   }
 
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   if (!packet) {
     return;
   }

--- a/src/lib/protocols/edonkey.c
+++ b/src/lib/protocols/edonkey.c
@@ -156,7 +156,7 @@ static int ndpi_edonkey_payload_check(const u_int8_t *data, u_int32_t len) {
 }
 
 static void ndpi_check_edonkey(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
  
   /* Break after 20 packets. */

--- a/src/lib/protocols/fasttrack.c
+++ b/src/lib/protocols/fasttrack.c
@@ -37,7 +37,7 @@ static void ndpi_int_fasttrack_add_connection(struct ndpi_detection_module_struc
 
 void ndpi_search_fasttrack_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   NDPI_LOG_DBG(ndpi_struct, "search FASTTRACK\n");
 

--- a/src/lib/protocols/fiesta.c
+++ b/src/lib/protocols/fiesta.c
@@ -36,7 +36,7 @@ static void ndpi_int_fiesta_add_connection(struct ndpi_detection_module_struct *
 
 void ndpi_search_fiesta(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
 	NDPI_LOG_DBG(ndpi_struct, "search fiesta\n");
 

--- a/src/lib/protocols/fix.c
+++ b/src/lib/protocols/fix.c
@@ -30,7 +30,7 @@
 
 void ndpi_search_fix(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search FIX\n");
   if(packet->tcp && packet->payload_packet_len > 5) {

--- a/src/lib/protocols/florensia.c
+++ b/src/lib/protocols/florensia.c
@@ -36,7 +36,7 @@ static void ndpi_florensia_add_connection(struct ndpi_detection_module_struct *n
 
 void ndpi_search_florensia(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 	NDPI_LOG_DBG(ndpi_struct, "search florensia\n");
 

--- a/src/lib/protocols/ftp_control.c
+++ b/src/lib/protocols/ftp_control.c
@@ -581,7 +581,7 @@ static int ndpi_ftp_control_check_response(struct ndpi_flow_struct *flow,
 
 static void ndpi_check_ftp_control(struct ndpi_detection_module_struct *ndpi_struct,
 				   struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   /* Check connection over TCP */

--- a/src/lib/protocols/ftp_data.c
+++ b/src/lib/protocols/ftp_data.c
@@ -34,7 +34,7 @@ static void ndpi_int_ftp_data_add_connection(struct ndpi_detection_module_struct
 }
 
 static int ndpi_match_ftp_data_port(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   /* Check connection over TCP */
   if(packet->tcp) {
@@ -46,7 +46,7 @@ static int ndpi_match_ftp_data_port(struct ndpi_detection_module_struct *ndpi_st
 }
 
 static int ndpi_match_ftp_data_directory(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   if(payload_len > 10) {
@@ -70,7 +70,7 @@ static int ndpi_match_ftp_data_directory(struct ndpi_detection_module_struct *nd
 }
 
 static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   /* A FTP packet is pretty long so 256 is a bit conservative but it should be OK */
@@ -226,7 +226,7 @@ static int ndpi_match_file_header(struct ndpi_detection_module_struct *ndpi_stru
 }
 
 static void ndpi_check_ftp_data(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   /*
     Make sure we see the beginning of the connection as otherwise we might have

--- a/src/lib/protocols/genshin_impact.c
+++ b/src/lib/protocols/genshin_impact.c
@@ -35,7 +35,7 @@ static void ndpi_int_genshin_impact_add_connection(
 static void ndpi_search_genshin_impact(struct ndpi_detection_module_struct *ndpi_struct,
                                        struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct * packet = &flow->packet;
+  struct ndpi_packet_struct * packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search genshin-impact\n");
 

--- a/src/lib/protocols/git.c
+++ b/src/lib/protocols/git.c
@@ -30,7 +30,7 @@
 void ndpi_search_git(struct ndpi_detection_module_struct *ndpi_struct,
 		     struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct * packet = &flow->packet;
+  struct ndpi_packet_struct * packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search Git\n");
 

--- a/src/lib/protocols/gnutella.c
+++ b/src/lib/protocols/gnutella.c
@@ -33,7 +33,7 @@ static void ndpi_int_gnutella_add_connection(struct ndpi_detection_module_struct
 					     struct ndpi_flow_struct *flow/* , */
 					     /* ndpi_protocol_type_t protocol_type */)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
 
@@ -64,7 +64,7 @@ static void ndpi_int_gnutella_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;

--- a/src/lib/protocols/gtp.c
+++ b/src/lib/protocols/gtp.c
@@ -64,7 +64,7 @@ struct gtp_header_generic {
 
 static void ndpi_check_gtp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   if((packet->udp != NULL) && (payload_len > sizeof(struct gtp_header_generic))) {

--- a/src/lib/protocols/guildwars.c
+++ b/src/lib/protocols/guildwars.c
@@ -36,7 +36,7 @@ static void ndpi_int_guildwars_add_connection(struct ndpi_detection_module_struc
 
 void ndpi_search_guildwars_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
 	NDPI_LOG_DBG(ndpi_struct, "search guildwars\n");
 

--- a/src/lib/protocols/h323.c
+++ b/src/lib/protocols/h323.c
@@ -33,7 +33,7 @@ struct tpkt {
 
 void ndpi_search_h323(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t dport = 0, sport = 0;
 
   NDPI_LOG_DBG(ndpi_struct, "search H323\n");

--- a/src/lib/protocols/halflife2_and_mods.c
+++ b/src/lib/protocols/halflife2_and_mods.c
@@ -37,7 +37,7 @@ static void ndpi_int_halflife2_add_connection(struct ndpi_detection_module_struc
 
 void ndpi_search_halflife2(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 	NDPI_LOG_DBG(ndpi_struct, "search halflife2\n");
 

--- a/src/lib/protocols/hangout.c
+++ b/src/lib/protocols/hangout.c
@@ -27,7 +27,7 @@
 #include "ndpi_api.h"
 
 /* stun.c */
-extern u_int32_t get_stun_lru_key(struct ndpi_flow_struct *flow, u_int8_t rev);
+extern u_int32_t get_stun_lru_key(struct ndpi_packet_struct *packet, u_int8_t rev);
 
 /* https://support.google.com/a/answer/1279090?hl=en */
 #define HANGOUT_UDP_LOW_PORT  19302
@@ -63,7 +63,7 @@ static u_int8_t google_ptree_match(struct ndpi_detection_module_struct *ndpi_str
 
 static u_int8_t is_google_flow(struct ndpi_detection_module_struct *ndpi_struct,
 			       struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   
   if(packet->iph) {
     struct in_addr saddr, daddr;
@@ -83,7 +83,7 @@ static u_int8_t is_google_flow(struct ndpi_detection_module_struct *ndpi_struct,
 
 void ndpi_search_hangout(struct ndpi_detection_module_struct *ndpi_struct,
 			 struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct * packet = &flow->packet;
+  struct ndpi_packet_struct * packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search Hangout\n");
 
@@ -101,9 +101,9 @@ void ndpi_search_hangout(struct ndpi_detection_module_struct *ndpi_struct,
       if(ndpi_struct->stun_cache == NULL)
 	ndpi_struct->stun_cache = ndpi_lru_cache_init(1024);
 
-      if(ndpi_struct->stun_cache && flow->packet.iph && flow->packet.udp) {
-	u_int32_t key = get_stun_lru_key(flow, !matched_src);
-	
+      if(ndpi_struct->stun_cache && packet->iph && packet->udp) {
+	u_int32_t key = get_stun_lru_key(packet, !matched_src);
+
 #ifdef DEBUG_LRU
 	printf("[LRU] ADDING %u / %u.%u\n", key, NDPI_PROTOCOL_STUN, NDPI_PROTOCOL_HANGOUT_DUO);
 #endif

--- a/src/lib/protocols/hpvirtgrp.c
+++ b/src/lib/protocols/hpvirtgrp.c
@@ -35,7 +35,7 @@ static void ndpi_int_hpvirtgrp_add_connection(
 static void ndpi_search_hpvirtgrp(struct ndpi_detection_module_struct *ndpi_struct,
                                   struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct * packet = &flow->packet;
+  struct ndpi_packet_struct * packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search hpvirtgrp\n");
 

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -139,7 +139,7 @@ static void ndpi_http_check_human_redeable_content(struct ndpi_detection_module_
 
 static void ndpi_validate_http_content(struct ndpi_detection_module_struct *ndpi_struct,
 				       struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   const u_int8_t *double_ret = (const u_int8_t *)ndpi_strnstr((const char *)packet->payload, "\r\n\r\n", packet->payload_packet_len);
 
   NDPI_LOG_DBG(ndpi_struct, "==>>> [len: %u] ", packet->payload_packet_len);
@@ -174,7 +174,7 @@ static void ndpi_validate_http_content(struct ndpi_detection_module_struct *ndpi
 /* https://www.freeformatter.com/mime-types-list.html */
 static ndpi_protocol_category_t ndpi_http_check_content(struct ndpi_detection_module_struct *ndpi_struct,
 							struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if(packet->content_line.len > 0) {
     u_int app_len = sizeof("application");
@@ -314,7 +314,7 @@ static void ndpi_int_http_add_connection(struct ndpi_detection_module_struct *nd
 static void rtsp_parse_packet_acceptline(struct ndpi_detection_module_struct
 					 *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if((packet->accept_line.len >= 28)
      && (memcmp(packet->accept_line.ptr, "application/x-rtsp-tunnelled", 28) == 0)) {
@@ -499,7 +499,7 @@ static void ndpi_check_http_url(struct ndpi_detection_module_struct *ndpi_struct
 */
 static void check_content_type_and_change_protocol(struct ndpi_detection_module_struct *ndpi_struct,
 						   struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   int ret;
 
   if(flow->http_detected && (flow->http.response_status_code != 0))
@@ -524,8 +524,8 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
       ndpi_check_http_url(ndpi_struct, flow, &flow->http.url[packet->host_line.len]);
     }
 
-    flow->http.method = ndpi_http_str2method((const char*)flow->packet.http_method.ptr,
-					     (u_int16_t)flow->packet.http_method.len);
+    flow->http.method = ndpi_http_str2method((const char*)packet->http_method.ptr,
+					     (u_int16_t)packet->http_method.len);
   }
 
   if(packet->server_line.ptr != NULL && (packet->server_line.len > 7)) {
@@ -723,7 +723,7 @@ static const char *http_fs = "CDGHOPR";
 
 static u_int16_t http_request_url_offset(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   unsigned int i;
 
   NDPI_LOG_DBG2(ndpi_struct, "====>>>> HTTP: %c%c%c%c [len: %u]\n",
@@ -794,7 +794,7 @@ static int is_a_suspicious_header(const char* suspicious_headers[], struct ndpi_
 static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_struct,
 				   struct ndpi_flow_struct *flow) {
   u_int32_t i;
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   for(i=0; (i < packet->parsed_lines)
 	&& (packet->line[i].ptr != NULL)
@@ -862,7 +862,7 @@ static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_str
 
 static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 				struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t filename_start; /* the filename in the request method line, e.g., "GET filename_start..."*/
 
   packet->packet_lines_parsed_complete = 0;

--- a/src/lib/protocols/iax.c
+++ b/src/lib/protocols/iax.c
@@ -39,7 +39,7 @@ static void ndpi_int_iax_add_connection(struct ndpi_detection_module_struct *ndp
 
 static void ndpi_search_setup_iax(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int8_t i;
   u_int16_t packet_len;
 
@@ -87,7 +87,7 @@ static void ndpi_search_setup_iax(struct ndpi_detection_module_struct *ndpi_stru
 
 void ndpi_search_iax(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if(packet->udp 
      && (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN))

--- a/src/lib/protocols/icecast.c
+++ b/src/lib/protocols/icecast.c
@@ -35,7 +35,7 @@ static void ndpi_int_icecast_add_connection(struct ndpi_detection_module_struct 
 
 void ndpi_search_icecast_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t i;
 
   NDPI_LOG_DBG(ndpi_struct, "search icecast\n");

--- a/src/lib/protocols/iec60870-5-104.c
+++ b/src/lib/protocols/iec60870-5-104.c
@@ -30,7 +30,7 @@
 
 void ndpi_search_iec60870_tcp(struct ndpi_detection_module_struct *ndpi_struct,
                             struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   /* Check connection over TCP */
   NDPI_LOG_DBG(ndpi_struct, "search IEC60870\n");

--- a/src/lib/protocols/imo.c
+++ b/src/lib/protocols/imo.c
@@ -33,7 +33,7 @@ static void ndpi_int_imo_add_connection(struct ndpi_detection_module_struct
 }
 
 void ndpi_search_imo(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search IMO\n");
 

--- a/src/lib/protocols/ipp.c
+++ b/src/lib/protocols/ipp.c
@@ -37,7 +37,7 @@ static void ndpi_int_ipp_add_connection(struct ndpi_detection_module_struct *ndp
 
 void ndpi_search_ipp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;	
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	u_int8_t i;
 
 	NDPI_LOG_DBG(ndpi_struct, "search ipp\n");

--- a/src/lib/protocols/irc.c
+++ b/src/lib/protocols/irc.c
@@ -64,7 +64,7 @@ u_int8_t ndpi_is_duplicate(struct ndpi_id_struct *id_t, u_int16_t port)
 static u_int8_t ndpi_check_for_NOTICE_or_PRIVMSG(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   //
   u_int16_t i;
   u_int8_t number_of_lines_to_be_searched_for = 0;
@@ -88,7 +88,7 @@ static u_int8_t ndpi_check_for_NOTICE_or_PRIVMSG(struct ndpi_detection_module_st
 
 static u_int8_t ndpi_check_for_Nickname(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t i, packetl = packet->payload_packet_len;
 
   if (packetl < 4) {
@@ -110,7 +110,7 @@ static u_int8_t ndpi_check_for_Nickname(struct ndpi_detection_module_struct *ndp
 
 static u_int8_t ndpi_check_for_cmd(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t i;
 
   if (packet->payload_packet_len < 4) {
@@ -150,7 +150,7 @@ static u_int8_t ndpi_check_for_IRC_traces(const u_int8_t * ptr, u_int16_t len)
 u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 
   NDPI_LOG_DBG(ndpi_struct, "start fast detect\n");
@@ -367,7 +367,7 @@ u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_det
 
 void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;

--- a/src/lib/protocols/jabber.c
+++ b/src/lib/protocols/jabber.c
@@ -49,7 +49,7 @@ static void ndpi_int_jabber_add_connection(struct ndpi_detection_module_struct *
 static void check_content_type_and_change_protocol(struct ndpi_detection_module_struct *ndpi_struct,
 						   struct ndpi_flow_struct *flow, u_int16_t x)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   int i, left = packet->payload_packet_len-x;
 
   if(left <= 0) return;
@@ -64,7 +64,7 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 
 void ndpi_search_jabber_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
   u_int16_t x;

--- a/src/lib/protocols/kakaotalk_voice.c
+++ b/src/lib/protocols/kakaotalk_voice.c
@@ -32,7 +32,7 @@
 
 
 void ndpi_search_kakaotalk_voice(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   
   NDPI_LOG_DBG(ndpi_struct, "search kakaotalk_voice\n");
 

--- a/src/lib/protocols/kerberos.c
+++ b/src/lib/protocols/kerberos.c
@@ -42,7 +42,7 @@ static void ndpi_int_kerberos_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_kerberos(struct ndpi_detection_module_struct *ndpi_struct,
 			  struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t sport = packet->tcp ? ntohs(packet->tcp->source) : ntohs(packet->udp->source);
   u_int16_t dport = packet->tcp ? ntohs(packet->tcp->dest) : ntohs(packet->udp->dest);
   const u_int8_t *original_packet_payload = NULL;

--- a/src/lib/protocols/kontiki.c
+++ b/src/lib/protocols/kontiki.c
@@ -39,7 +39,7 @@ static void ndpi_int_kontiki_add_connection(struct ndpi_detection_module_struct 
 
 void ndpi_search_kontiki(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 	NDPI_LOG_DBG(ndpi_struct, "search Kontiki\n");
 

--- a/src/lib/protocols/ldap.c
+++ b/src/lib/protocols/ldap.c
@@ -37,7 +37,7 @@ static void ndpi_int_ldap_add_connection(struct ndpi_detection_module_struct *nd
 
 void ndpi_search_ldap(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 	NDPI_LOG_DBG(ndpi_struct, "search ldap\n");
 

--- a/src/lib/protocols/lisp.c
+++ b/src/lib/protocols/lisp.c
@@ -38,7 +38,7 @@ static void ndpi_int_lisp_add_connection(struct ndpi_detection_module_struct *nd
 static void ndpi_check_lisp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 
-  struct ndpi_packet_struct *packet = &flow->packet;  
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if(packet->udp != NULL) {
 

--- a/src/lib/protocols/lotus_notes.c
+++ b/src/lib/protocols/lotus_notes.c
@@ -29,7 +29,7 @@
 static void ndpi_check_lotus_notes(struct ndpi_detection_module_struct *ndpi_struct, 
 				   struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;  
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
 

--- a/src/lib/protocols/mail_imap.c
+++ b/src/lib/protocols/mail_imap.c
@@ -37,7 +37,7 @@ static void ndpi_int_mail_imap_add_connection(struct ndpi_detection_module_struc
 
 void ndpi_search_mail_imap_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;       
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t i = 0;
   u_int16_t space_pos = 0;
   u_int16_t command_start = 0;

--- a/src/lib/protocols/mail_pop.c
+++ b/src/lib/protocols/mail_pop.c
@@ -58,7 +58,7 @@ static void popInitExtraPacketProcessing(struct ndpi_flow_struct *flow);
 
 static int ndpi_int_mail_pop_check_for_client_commands(struct ndpi_detection_module_struct
 						       *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   if(packet->payload_packet_len > 4) {
     if((packet->payload[0] == 'A' || packet->payload[0] == 'a')
@@ -147,7 +147,7 @@ static int ndpi_int_mail_pop_check_for_client_commands(struct ndpi_detection_mod
 void ndpi_search_mail_pop_tcp(struct ndpi_detection_module_struct
 			      *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int8_t a = 0;
   u_int8_t bit_count = 0;
 

--- a/src/lib/protocols/mail_smtp.c
+++ b/src/lib/protocols/mail_smtp.c
@@ -67,7 +67,7 @@ static void smtpInitExtraPacketProcessing(struct ndpi_flow_struct *flow);
 
 void ndpi_search_mail_smtp_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 			       struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search mail_smtp\n");
 

--- a/src/lib/protocols/maplestory.c
+++ b/src/lib/protocols/maplestory.c
@@ -36,7 +36,7 @@ static void ndpi_int_maplestory_add_connection(struct ndpi_detection_module_stru
 
 void ndpi_search_maplestory(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 	NDPI_LOG_DBG(ndpi_struct, "search maplestory\n");
 

--- a/src/lib/protocols/megaco.c
+++ b/src/lib/protocols/megaco.c
@@ -28,7 +28,7 @@
 void ndpi_search_megaco(struct ndpi_detection_module_struct *ndpi_struct,
 			struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   
   NDPI_LOG_DBG(ndpi_struct, "search for MEGACO\n");
   

--- a/src/lib/protocols/memcached.c
+++ b/src/lib/protocols/memcached.c
@@ -103,7 +103,7 @@ void ndpi_search_memcached(
 			   struct ndpi_detection_module_struct *ndpi_struct,
 			   struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   const u_int8_t *offset = packet->payload;
   u_int16_t length = packet->payload_packet_len;
   u_int8_t *matches;

--- a/src/lib/protocols/mgcp.c
+++ b/src/lib/protocols/mgcp.c
@@ -37,7 +37,7 @@ static void ndpi_int_mgcp_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_mgcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   u_int16_t pos = 5;
 

--- a/src/lib/protocols/mining.c
+++ b/src/lib/protocols/mining.c
@@ -38,7 +38,7 @@ static void cacheMiningHostTwins(struct ndpi_detection_module_struct *ndpi_struc
 
 void ndpi_search_mining_udp(struct ndpi_detection_module_struct *ndpi_struct,
 			    struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t source = ntohs(packet->udp->source);
   u_int16_t dest = ntohs(packet->udp->dest);
 
@@ -62,7 +62,7 @@ void ndpi_search_mining_udp(struct ndpi_detection_module_struct *ndpi_struct,
       snprintf(flow->flow_extra_info, sizeof(flow->flow_extra_info), "%s", "ETH");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MINING, NDPI_PROTOCOL_UNKNOWN);
       if(packet->iph) /* TODO: ipv6 */
-        cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
+        cacheMiningHostTwins(ndpi_struct, packet->iph->saddr + packet->iph->daddr);
       return;
     }
   }
@@ -80,7 +80,7 @@ static u_int8_t isEthPort(u_int16_t dport) {
 
 void ndpi_search_mining_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 			    struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search MINING TCP\n");
 
@@ -98,7 +98,7 @@ void ndpi_search_mining_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	snprintf(flow->flow_extra_info, sizeof(flow->flow_extra_info), "%s", "ETH");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MINING, NDPI_PROTOCOL_UNKNOWN);
 	if(packet->iph) /* TODO: ipv6 */
-	  cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
+	  cacheMiningHostTwins(ndpi_struct, packet->iph->saddr + packet->iph->daddr);
 	return;
       }
     }
@@ -111,7 +111,7 @@ void ndpi_search_mining_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	snprintf(flow->flow_extra_info, sizeof(flow->flow_extra_info), "%s", "ETH");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MINING, NDPI_PROTOCOL_UNKNOWN);
 	if(packet->iph) /* TODO: ipv6 */
-	  cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
+	  cacheMiningHostTwins(ndpi_struct, packet->iph->saddr + packet->iph->daddr);
 	return;
       } else
 	flow->guessed_protocol_id = NDPI_PROTOCOL_MINING;
@@ -132,7 +132,7 @@ void ndpi_search_mining_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       snprintf(flow->flow_extra_info, sizeof(flow->flow_extra_info), "%s", "ETH");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MINING, NDPI_PROTOCOL_UNKNOWN);
       if(packet->iph) /* TODO: ipv6 */
-        cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
+        cacheMiningHostTwins(ndpi_struct, packet->iph->saddr + packet->iph->daddr);
       return;
     } else if(ndpi_strnstr((const char *)packet->payload, "{", packet->payload_packet_len)
 	      && (ndpi_strnstr((const char *)packet->payload, "\"method\":", packet->payload_packet_len)
@@ -156,7 +156,7 @@ void ndpi_search_mining_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       snprintf(flow->flow_extra_info, sizeof(flow->flow_extra_info), "%s", "ZCash/Monero");
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MINING, NDPI_PROTOCOL_UNKNOWN);
       if(packet->iph) /* TODO: ipv6 */
-        cacheMiningHostTwins(ndpi_struct, flow->packet.iph->saddr + flow->packet.iph->daddr);
+        cacheMiningHostTwins(ndpi_struct, packet->iph->saddr + packet->iph->daddr);
       return;
     }
   }

--- a/src/lib/protocols/modbus.c
+++ b/src/lib/protocols/modbus.c
@@ -29,7 +29,7 @@
 
 void ndpi_search_modbus_tcp(struct ndpi_detection_module_struct *ndpi_struct,
                             struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   NDPI_LOG_DBG(ndpi_struct, "search Modbus\n");
   u_int16_t modbus_port = htons(502); // port used by modbus
 

--- a/src/lib/protocols/mongodb.c
+++ b/src/lib/protocols/mongodb.c
@@ -66,7 +66,7 @@ static void set_mongodb_detected(struct ndpi_detection_module_struct *ndpi_struc
 static void ndpi_check_mongodb(struct ndpi_detection_module_struct *ndpi_struct,
 			       struct ndpi_flow_struct *flow) {
   struct mongo_message_header mongodb_hdr;
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if (packet->payload_packet_len <= sizeof(mongodb_hdr)) {
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);

--- a/src/lib/protocols/mpegts.c
+++ b/src/lib/protocols/mpegts.c
@@ -27,7 +27,7 @@
 
 void ndpi_search_mpegts(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search MPEGTS\n");
 

--- a/src/lib/protocols/mqtt.c
+++ b/src/lib/protocols/mqtt.c
@@ -68,7 +68,7 @@ void ndpi_search_mqtt (struct ndpi_detection_module_struct *ndpi_struct,
 	u_int8_t rl,pt,flags;
 
 	NDPI_LOG_DBG(ndpi_struct, "search Mqtt\n");
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
 		return;
 	}

--- a/src/lib/protocols/mssql_tds.c
+++ b/src/lib/protocols/mssql_tds.c
@@ -46,7 +46,7 @@ static void ndpi_int_mssql_tds_add_connection(struct ndpi_detection_module_struc
 
 void ndpi_search_mssql_tds(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   struct tds_packet_header *h = (struct tds_packet_header*) packet->payload;
 
   NDPI_LOG_DBG(ndpi_struct, "search mssql_tds\n");

--- a/src/lib/protocols/mysql.c
+++ b/src/lib/protocols/mysql.c
@@ -30,7 +30,7 @@
 #include "ndpi_api.h"
 
 void ndpi_search_mysql_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search MySQL\n");
 	

--- a/src/lib/protocols/nats.c
+++ b/src/lib/protocols/nats.c
@@ -40,7 +40,7 @@ static const char* commands[] =
 
 void ndpi_search_nats_tcp(struct ndpi_detection_module_struct *ndpi_struct,
                             struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   /* Check connection over TCP */
   NDPI_LOG_DBG(ndpi_struct, "search NATS\n");
@@ -49,14 +49,14 @@ void ndpi_search_nats_tcp(struct ndpi_detection_module_struct *ndpi_struct,
     int i;
 
     for(i=0; commands[i] != NULL; i++) {
-      char *match = ndpi_strnstr((const char *)flow->packet.payload,
+      char *match = ndpi_strnstr((const char *)packet->payload,
 				 commands[i],
-				 flow->packet.payload_packet_len);
+				 packet->payload_packet_len);
 
       if(!match) continue;
 
       if(ndpi_strnstr((const char *)match, "\r\n",
-		      flow->packet.payload_packet_len - ((size_t)match - (size_t)flow->packet.payload)) != NULL) {
+		      packet->payload_packet_len - ((size_t)match - (size_t)packet->payload)) != NULL) {
 	NDPI_LOG_INFO(ndpi_struct, "found NATS\n");
 
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_NATS, NDPI_PROTOCOL_UNKNOWN);

--- a/src/lib/protocols/nest_log_sink.c
+++ b/src/lib/protocols/nest_log_sink.c
@@ -37,7 +37,7 @@ void ndpi_search_nest_log_sink(
         struct ndpi_detection_module_struct *ndpi_struct,
         struct ndpi_flow_struct *flow)
 {
-    struct ndpi_packet_struct *packet = &flow->packet;
+    struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
     NDPI_LOG_DBG(ndpi_struct, "search nest_log_sink\n");
 

--- a/src/lib/protocols/netbios.c
+++ b/src/lib/protocols/netbios.c
@@ -94,12 +94,14 @@ int ndpi_netbios_name_interpret(u_char *in, u_int in_len, u_char *out, u_int out
 static void ndpi_int_netbios_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					    struct ndpi_flow_struct *flow,
 					    u_int16_t sub_protocol) {
-  unsigned char name[64];
-  u_int off = flow->packet.payload[12] == 0x20 ? 12 : 14;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
-  if((off < flow->packet.payload_packet_len)
-     && ndpi_netbios_name_interpret((unsigned char*)&flow->packet.payload[off],
-		 (u_int)(flow->packet.payload_packet_len - off), name, sizeof(name)-1) > 0) {
+  unsigned char name[64];
+  u_int off = packet->payload[12] == 0x20 ? 12 : 14;
+
+  if((off < packet->payload_packet_len)
+     && ndpi_netbios_name_interpret((unsigned char*)&packet->payload[off],
+		 (u_int)(packet->payload_packet_len - off), name, sizeof(name)-1) > 0) {
       snprintf((char*)flow->host_server_name, sizeof(flow->host_server_name)-1, "%s", name);
 
       ndpi_check_dga_name(ndpi_struct, flow, (char*)flow->host_server_name, 1);
@@ -115,7 +117,7 @@ static void ndpi_int_netbios_add_connection(struct ndpi_detection_module_struct 
 
 void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct,
 			 struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t dport;
 
   NDPI_LOG_DBG(ndpi_struct, "search netbios\n");

--- a/src/lib/protocols/netflow.c
+++ b/src/lib/protocols/netflow.c
@@ -99,7 +99,7 @@ struct flow_ver7_rec {
 
 void ndpi_search_netflow(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
   time_t now;

--- a/src/lib/protocols/nfs.c
+++ b/src/lib/protocols/nfs.c
@@ -38,7 +38,7 @@ static void ndpi_int_nfs_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_nfs(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 	NDPI_LOG_DBG(ndpi_struct, "search NFS\n");
 

--- a/src/lib/protocols/nintendo.c
+++ b/src/lib/protocols/nintendo.c
@@ -35,7 +35,7 @@ static void ndpi_int_nintendo_add_connection(struct ndpi_detection_module_struct
 
 
 void ndpi_search_nintendo(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   if(packet->udp != NULL) {

--- a/src/lib/protocols/noe.c
+++ b/src/lib/protocols/noe.c
@@ -39,7 +39,7 @@ static void ndpi_int_noe_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_noe(struct ndpi_detection_module_struct *ndpi_struct,
 		     struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   
   NDPI_LOG_DBG(ndpi_struct, "search NOE\n");
   

--- a/src/lib/protocols/non_tcp_udp.c
+++ b/src/lib/protocols/non_tcp_udp.c
@@ -40,7 +40,7 @@
 void ndpi_search_in_non_tcp_udp(struct ndpi_detection_module_struct
 				*ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if (packet->iph == NULL) {
     if (packet->iphv6 == NULL)

--- a/src/lib/protocols/ntp.c
+++ b/src/lib/protocols/ntp.c
@@ -36,7 +36,7 @@ static void ndpi_int_ntp_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_ntp_udp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   
   NDPI_LOG_DBG(ndpi_struct, "search NTP\n");
 

--- a/src/lib/protocols/ookla.c
+++ b/src/lib/protocols/ookla.c
@@ -28,7 +28,7 @@ const u_int16_t ookla_port = 8080;
 /* ************************************************************* */
 
 void ndpi_search_ookla(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow) {
-  struct ndpi_packet_struct* packet = &flow->packet;
+  struct ndpi_packet_struct* packet = &ndpi_struct->packet;
   u_int32_t addr = 0;
   u_int16_t sport, dport;
     

--- a/src/lib/protocols/openft.c
+++ b/src/lib/protocols/openft.c
@@ -37,7 +37,7 @@ static void ndpi_int_openft_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_openft_tcp(struct ndpi_detection_module_struct
 							  *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 	if (packet->payload_packet_len > 5 && memcmp(packet->payload, "GET /", 5) == 0) {
 		NDPI_LOG_DBG2(ndpi_struct, "HTTP packet detected\n");

--- a/src/lib/protocols/openvpn.c
+++ b/src/lib/protocols/openvpn.c
@@ -81,7 +81,7 @@ int8_t check_pkid_and_detect_hmac_size(const u_int8_t * payload) {
 
 void ndpi_search_openvpn(struct ndpi_detection_module_struct* ndpi_struct,
                          struct ndpi_flow_struct* flow) {
-  struct ndpi_packet_struct* packet = &flow->packet;
+  struct ndpi_packet_struct* packet = &ndpi_struct->packet;
   const u_int8_t * ovpn_payload = packet->payload;
   const u_int8_t * session_remote;
   u_int8_t opcode;

--- a/src/lib/protocols/oracle.c
+++ b/src/lib/protocols/oracle.c
@@ -33,7 +33,7 @@ static void ndpi_int_oracle_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_oracle(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t dport = 0, sport = 0;
 
   NDPI_LOG_DBG(ndpi_struct, "search ORACLE\n");

--- a/src/lib/protocols/postgres.c
+++ b/src/lib/protocols/postgres.c
@@ -39,7 +39,7 @@ static void ndpi_int_postgres_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_postgres_tcp(struct ndpi_detection_module_struct
 								*ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	u_int16_t size;
 
 	if (flow->l4.tcp.postgres_stage == 0) {

--- a/src/lib/protocols/ppstream.c
+++ b/src/lib/protocols/ppstream.c
@@ -41,7 +41,7 @@ static void ndpi_int_ppstream_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_ppstream(struct ndpi_detection_module_struct
 			  *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search PPStream\n");
   /**

--- a/src/lib/protocols/pptp.c
+++ b/src/lib/protocols/pptp.c
@@ -37,7 +37,7 @@ static void ndpi_int_pptp_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_pptp(struct ndpi_detection_module_struct
 						*ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 	NDPI_LOG_DBG(ndpi_struct, "search pptp\n");
 

--- a/src/lib/protocols/qq.c
+++ b/src/lib/protocols/qq.c
@@ -39,7 +39,7 @@ static void ndpi_int_qq_add_connection(struct ndpi_detection_module_struct *ndpi
 
 void ndpi_search_qq(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search QQ\n");
 

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -929,7 +929,7 @@ static uint8_t *decrypt_initial_packet(struct ndpi_detection_module_struct *ndpi
 				       uint32_t *clear_payload_len)
 {
   uint64_t token_length, payload_length, packet_number;
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   uint8_t first_byte;
   uint32_t pkn32, pn_offset, pkn_len, offset;
   quic_ciphers ciphers; /* Client initial ciphers */
@@ -1235,7 +1235,7 @@ static uint8_t *get_clear_payload(struct ndpi_detection_module_struct *ndpi_stru
 				  struct ndpi_flow_struct *flow,
 				  uint32_t version, uint32_t *clear_payload_len)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int8_t *clear_payload;
   u_int8_t dest_conn_id_len;
 #ifdef HAVE_LIBGCRYPT
@@ -1286,7 +1286,7 @@ static void process_tls(struct ndpi_detection_module_struct *ndpi_struct,
 			const u_int8_t *crypto_data, uint32_t crypto_data_len,
 			uint32_t version)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   /* Overwriting packet payload */
   u_int16_t p_len;
@@ -1409,7 +1409,7 @@ static int may_be_initial_pkt(struct ndpi_detection_module_struct *ndpi_struct,
 			      struct ndpi_flow_struct *flow,
 			      uint32_t *version)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int8_t first_byte;
   u_int8_t pub_bit1, pub_bit2, pub_bit3, pub_bit4, pub_bit5, pub_bit7, pub_bit8;
   u_int8_t dest_conn_id_len, source_conn_id_len;
@@ -1529,7 +1529,7 @@ static void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
 static int ndpi_search_quic_extra(struct ndpi_detection_module_struct *ndpi_struct,
 				  struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   /* We are elaborating a packet following the initial CHLO/ClientHello.
      Two cases:

--- a/src/lib/protocols/radius.c
+++ b/src/lib/protocols/radius.c
@@ -33,7 +33,7 @@ struct radius_header {
 
 static void ndpi_check_radius(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
 

--- a/src/lib/protocols/rdp.c
+++ b/src/lib/protocols/rdp.c
@@ -36,7 +36,7 @@ static void ndpi_int_rdp_add_connection(struct ndpi_detection_module_struct *ndp
 
 void ndpi_search_rdp(struct ndpi_detection_module_struct *ndpi_struct,
 		     struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   NDPI_LOG_DBG(ndpi_struct, "search RDP\n");
 

--- a/src/lib/protocols/redis_net.c
+++ b/src/lib/protocols/redis_net.c
@@ -31,7 +31,7 @@ static void ndpi_int_redis_add_connection(struct ndpi_detection_module_struct *n
 
 
 static void ndpi_check_redis(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;  
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
   
   if(payload_len == 0) return; /* Shouldn't happen */

--- a/src/lib/protocols/rsync.c
+++ b/src/lib/protocols/rsync.c
@@ -33,7 +33,7 @@ static void ndpi_int_rsync_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_rsync(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search RSYNC\n");
 

--- a/src/lib/protocols/rtcp.c
+++ b/src/lib/protocols/rtcp.c
@@ -20,7 +20,7 @@ static void ndpi_int_rtcp_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_rtcp(struct ndpi_detection_module_struct *ndpi_struct,
 		      struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t dport = 0, sport = 0;
 
   NDPI_LOG_DBG(ndpi_struct, "search RTCP\n");

--- a/src/lib/protocols/rtmp.c
+++ b/src/lib/protocols/rtmp.c
@@ -37,7 +37,7 @@ static void ndpi_int_rtmp_add_connection(struct ndpi_detection_module_struct *nd
 
 static void ndpi_check_rtmp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;  
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
   
   /* Break after 20 packets. */

--- a/src/lib/protocols/rtp.c
+++ b/src/lib/protocols/rtp.c
@@ -77,7 +77,7 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
 			    struct ndpi_flow_struct *flow,
 			    const u_int8_t * payload, const u_int16_t payload_len) {
   u_int8_t payloadType, payload_type;
-  u_int16_t d_port = ntohs(flow->packet.udp->dest);
+  u_int16_t d_port = ntohs(ndpi_struct->packet.udp->dest);
   
   NDPI_LOG_DBG(ndpi_struct, "search RTP\n");
 
@@ -122,7 +122,7 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
 
 void ndpi_search_rtp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t source = ntohs(packet->udp->source);
   u_int16_t dest = ntohs(packet->udp->dest);
   

--- a/src/lib/protocols/rtsp.c
+++ b/src/lib/protocols/rtsp.c
@@ -40,7 +40,7 @@ static void ndpi_int_rtsp_add_connection(struct ndpi_detection_module_struct *nd
 void ndpi_search_rtsp_tcp_udp(struct ndpi_detection_module_struct
 			      *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search RTSP\n");
 

--- a/src/lib/protocols/rx.c
+++ b/src/lib/protocols/rx.c
@@ -78,7 +78,7 @@ struct ndpi_rx_header {
 void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
                    struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   NDPI_LOG_DBG2(ndpi_struct, "RX: pck: %d, dir[0]: %d, dir[1]: %d\n",

--- a/src/lib/protocols/s7comm.c
+++ b/src/lib/protocols/s7comm.c
@@ -26,7 +26,7 @@
 
 void ndpi_search_s7comm_tcp(struct ndpi_detection_module_struct *ndpi_struct,
                             struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   NDPI_LOG_DBG(ndpi_struct, "search S7\n");
   u_int16_t s7comm_port = htons(102); 
   if(packet->tcp) {

--- a/src/lib/protocols/sflow.c
+++ b/src/lib/protocols/sflow.c
@@ -26,7 +26,7 @@
 
 void ndpi_search_sflow(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;  
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
 

--- a/src/lib/protocols/shoutcast.c
+++ b/src/lib/protocols/shoutcast.c
@@ -37,7 +37,7 @@ static void ndpi_int_shoutcast_add_connection(struct ndpi_detection_module_struc
 void ndpi_search_shoutcast_tcp(struct ndpi_detection_module_struct
 								 *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 
 	NDPI_LOG_DBG(ndpi_struct, "search shoutcast\n");

--- a/src/lib/protocols/sip.c
+++ b/src/lib/protocols/sip.c
@@ -44,7 +44,7 @@ __forceinline static
 void ndpi_search_sip_handshake(struct ndpi_detection_module_struct
 			       *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
 

--- a/src/lib/protocols/skinny.c
+++ b/src/lib/protocols/skinny.c
@@ -32,7 +32,7 @@ static void ndpi_int_skinny_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_skinny(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t dport = 0, sport = 0;
   const char pattern_9_bytes[9] = { 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
   const char pattern_8_bytes[8] = { 0x38, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };

--- a/src/lib/protocols/skype.c
+++ b/src/lib/protocols/skype.c
@@ -28,7 +28,7 @@ static int is_port(u_int16_t a, u_int16_t b, u_int16_t c) {
 }
 
 static int ndpi_check_skype_udp_again(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
   int i;
   const uint8_t id_flags_iv_crc_len = 11;
@@ -67,7 +67,7 @@ static int ndpi_check_skype_udp_again(struct ndpi_detection_module_struct *ndpi_
 }
 
 static void ndpi_check_skype(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
 

--- a/src/lib/protocols/smb.c
+++ b/src/lib/protocols/smb.c
@@ -27,7 +27,7 @@
 
 void ndpi_search_smb_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search SMB\n");
 

--- a/src/lib/protocols/smpp.c
+++ b/src/lib/protocols/smpp.c
@@ -41,9 +41,10 @@ static  u_int8_t ndpi_check_overflow(u_int32_t current_length, u_int32_t total_l
 void ndpi_search_smpp_tcp(struct ndpi_detection_module_struct* ndpi_struct, 
                           struct ndpi_flow_struct* flow)
 {
+  struct ndpi_packet_struct* packet = &ndpi_struct->packet;
+
   NDPI_LOG_DBG(ndpi_struct, "search SMPP\n");
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SMPP){
-    struct ndpi_packet_struct* packet = &flow->packet;
     // min SMPP packet length = 16 bytes
     if (packet->payload_packet_len < 16) {
       NDPI_EXCLUDE_PROTO(ndpi_struct, flow);

--- a/src/lib/protocols/snmp_proto.c
+++ b/src/lib/protocols/snmp_proto.c
@@ -32,7 +32,7 @@ static void ndpi_int_snmp_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_snmp(struct ndpi_detection_module_struct *ndpi_struct,
 		      struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t snmp_port = htons(161), trap_port = htons(162);
   
   if((packet->payload_packet_len <= 32)

--- a/src/lib/protocols/soap.c
+++ b/src/lib/protocols/soap.c
@@ -33,7 +33,7 @@ static void ndpi_int_soap_add_connection(struct ndpi_detection_module_struct *nd
 void ndpi_search_soap(struct ndpi_detection_module_struct *ndpi_struct,
                       struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search soap\n");
 

--- a/src/lib/protocols/socks45.c
+++ b/src/lib/protocols/socks45.c
@@ -36,7 +36,7 @@ static void ndpi_int_socks_add_connection(struct ndpi_detection_module_struct *n
 
 static void ndpi_check_socks4(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   /* Break after 20 packets. */
@@ -77,7 +77,7 @@ static void ndpi_check_socks4(struct ndpi_detection_module_struct *ndpi_struct, 
 
 static void ndpi_check_socks5(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   /* Break after 20 packets. */

--- a/src/lib/protocols/someip.c
+++ b/src/lib/protocols/someip.c
@@ -101,7 +101,7 @@ static u_int32_t someip_data_cover_32(const u_int8_t *data)
 void ndpi_search_someip (struct ndpi_detection_module_struct *ndpi_struct,
 			 struct ndpi_flow_struct *flow)
 {
-  const struct ndpi_packet_struct *packet = &flow->packet;
+  const struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   
   if (packet->payload_packet_len < 16) {
     NDPI_LOG(NDPI_PROTOCOL_SOMEIP, ndpi_struct, NDPI_LOG_DEBUG,

--- a/src/lib/protocols/sopcast.c
+++ b/src/lib/protocols/sopcast.c
@@ -101,7 +101,7 @@ static void ndpi_search_sopcast_tcp(struct ndpi_detection_module_struct
 				    *ndpi_struct, struct ndpi_flow_struct *flow)
 {
 
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   if (flow->packet_counter == 1 && packet->payload_packet_len == 54 && get_u_int16_t(packet->payload, 0) == ntohs(0x0036)) {
     if (ndpi_int_is_sopcast_tcp(packet->payload, packet->payload_packet_len)) {
@@ -118,7 +118,7 @@ static void ndpi_search_sopcast_tcp(struct ndpi_detection_module_struct
 static void ndpi_search_sopcast_udp(struct ndpi_detection_module_struct
 				    *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   NDPI_LOG_DBG(ndpi_struct, "search sopcast.  \n");
 
@@ -202,7 +202,7 @@ static void ndpi_search_sopcast_udp(struct ndpi_detection_module_struct
 void ndpi_search_sopcast(struct ndpi_detection_module_struct
 			 *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if (packet->udp != NULL)
     ndpi_search_sopcast_udp(ndpi_struct, flow);

--- a/src/lib/protocols/soulseek.c
+++ b/src/lib/protocols/soulseek.c
@@ -37,7 +37,7 @@
 void ndpi_search_soulseek_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 			      struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;

--- a/src/lib/protocols/spotify.c
+++ b/src/lib/protocols/spotify.c
@@ -38,7 +38,7 @@ static void ndpi_int_spotify_add_connection(struct ndpi_detection_module_struct 
 
 static void ndpi_check_spotify(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
 

--- a/src/lib/protocols/ssdp.c
+++ b/src/lib/protocols/ssdp.c
@@ -38,7 +38,7 @@ static void ndpi_int_ssdp_add_connection(struct ndpi_detection_module_struct
 /* this detection also works asymmetrically */
 void ndpi_search_ssdp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   NDPI_LOG_DBG(ndpi_struct, "search ssdp\n");
   if (packet->udp != NULL) {

--- a/src/lib/protocols/ssh.c
+++ b/src/lib/protocols/ssh.c
@@ -401,7 +401,7 @@ static void ndpi_ssh_zap_cr(char *str, int len) {
 /* ************************************************************************ */
 
 static void ndpi_search_ssh_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
 #ifdef SSH_DEBUG
   printf("[SSH] %s()\n", __FUNCTION__);

--- a/src/lib/protocols/starcraft.c
+++ b/src/lib/protocols/starcraft.c
@@ -49,10 +49,12 @@ u_int8_t sc2_match_logon_ip(struct ndpi_packet_struct* packet)
 */
 u_int8_t ndpi_check_starcraft_tcp(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow)
 {
-  if (sc2_match_logon_ip(&flow->packet)
-      && flow->packet.tcp->dest == htons(1119)	//bnetgame port
-      && (ndpi_match_strprefix(flow->packet.payload, flow->packet.payload_packet_len, "\x4a\x00\x00\x0a\x66\x02\x0a\xed\x2d\x66") 
-	  || ndpi_match_strprefix(flow->packet.payload, flow->packet.payload_packet_len, "\x49\x00\x00\x0a\x66\x02\x0a\xed\x2d\x66")))
+  struct ndpi_packet_struct* packet = &ndpi_struct->packet;
+
+  if (sc2_match_logon_ip(packet)
+      && packet->tcp->dest == htons(1119)	//bnetgame port
+      && (ndpi_match_strprefix(packet->payload, packet->payload_packet_len, "\x4a\x00\x00\x0a\x66\x02\x0a\xed\x2d\x66") 
+	  || ndpi_match_strprefix(packet->payload, packet->payload_packet_len, "\x49\x00\x00\x0a\x66\x02\x0a\xed\x2d\x66")))
     return 1;
   else
     return -1;
@@ -66,7 +68,7 @@ u_int8_t ndpi_check_starcraft_tcp(struct ndpi_detection_module_struct* ndpi_stru
 */
 u_int8_t ndpi_check_starcraft_udp(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow)
 {
-  struct ndpi_packet_struct* packet = &flow->packet;
+  struct ndpi_packet_struct* packet = &ndpi_struct->packet;
 
   /* First off, filter out any traffic not using port 1119, removing the chance of any false positive if we assume that non allowed protocols don't use the port */
   if (packet->udp->source != htons(1119) && packet->udp->dest != htons(1119))
@@ -114,9 +116,10 @@ u_int8_t ndpi_check_starcraft_udp(struct ndpi_detection_module_struct* ndpi_stru
 
 void ndpi_search_starcraft(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow)
 {
+  struct ndpi_packet_struct* packet = &ndpi_struct->packet;
+
   NDPI_LOG_DBG(ndpi_struct, "search Starcraft\n");
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_STARCRAFT) {
-    struct ndpi_packet_struct* packet = &flow->packet;
     int8_t result = 0;
 
     if (packet->udp != NULL) {

--- a/src/lib/protocols/stealthnet.c
+++ b/src/lib/protocols/stealthnet.c
@@ -38,7 +38,7 @@ static void ndpi_int_stealthnet_add_connection(struct ndpi_detection_module_stru
 void ndpi_search_stealthnet(struct ndpi_detection_module_struct
 			    *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   NDPI_LOG_DBG(ndpi_struct, "search stealthnet\n");
 

--- a/src/lib/protocols/steam.c
+++ b/src/lib/protocols/steam.c
@@ -35,7 +35,7 @@ static void ndpi_int_steam_add_connection(struct ndpi_detection_module_struct *n
 }
 
 static void ndpi_check_steam_http(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   NDPI_PARSE_PACKET_LINE_INFO(ndpi_struct, flow, packet);
   if (packet->user_agent_line.ptr != NULL 
@@ -47,7 +47,7 @@ static void ndpi_check_steam_http(struct ndpi_detection_module_struct *ndpi_stru
 }
 
 static void ndpi_check_steam_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 	
   if (flow->steam_stage == 0) {
@@ -104,7 +104,7 @@ static void ndpi_check_steam_tcp(struct ndpi_detection_module_struct *ndpi_struc
 }
 
 static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 	
   if (ndpi_match_strprefix(packet->payload, payload_len, "VS01")) {
@@ -185,7 +185,7 @@ static void ndpi_check_steam_udp1(struct ndpi_detection_module_struct *ndpi_stru
 }
 
 static void ndpi_check_steam_udp2(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   /* Check if we so far detected the protocol in the request or not. */
@@ -220,7 +220,7 @@ static void ndpi_check_steam_udp2(struct ndpi_detection_module_struct *ndpi_stru
 }
 
 static void ndpi_check_steam_udp3(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
   /* Check if we so far detected the protocol in the request or not. */
@@ -255,8 +255,9 @@ static void ndpi_check_steam_udp3(struct ndpi_detection_module_struct *ndpi_stru
 }
 
 void ndpi_search_steam(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
-  if(flow->packet.udp != NULL) {
+  if(packet->udp != NULL) {
     if(flow->packet_counter > 5) {
       NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
       return;

--- a/src/lib/protocols/syslog.c
+++ b/src/lib/protocols/syslog.c
@@ -37,7 +37,7 @@ static void ndpi_int_syslog_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_syslog(struct ndpi_detection_module_struct
 			*ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int8_t i;
 
   NDPI_LOG_DBG(ndpi_struct, "search syslog\n");

--- a/src/lib/protocols/targus_getdata.c
+++ b/src/lib/protocols/targus_getdata.c
@@ -29,7 +29,7 @@
 
 static void ndpi_check_targus_getdata(struct ndpi_detection_module_struct *ndpi_struct,
 				  struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if(packet->iph) {
     u_int16_t targus_getdata_port       = ntohs(5201);

--- a/src/lib/protocols/tcp_udp.c
+++ b/src/lib/protocols/tcp_udp.c
@@ -55,7 +55,7 @@ void ndpi_search_tcp_or_udp(struct ndpi_detection_module_struct *ndpi_struct, st
 {
   u_int16_t sport, dport;
   u_int proto;
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if(flow->host_server_name[0] != '\0')
     return;
@@ -72,8 +72,8 @@ void ndpi_search_tcp_or_udp(struct ndpi_detection_module_struct *ndpi_struct, st
   if(packet->iph /* IPv4 Only: we need to support packet->iphv6 at some point */) {
     proto = ndpi_search_tcp_or_udp_raw(ndpi_struct,
 				       flow,
-				       flow->packet.iph ? flow->packet.iph->protocol :
-				       flow->packet.iphv6->ip6_hdr.ip6_un1_nxt,
+				       packet->iph ? packet->iph->protocol :
+				       packet->iphv6->ip6_hdr.ip6_un1_nxt,
 				       ntohl(packet->iph->saddr), 
 				       ntohl(packet->iph->daddr),
 				       sport, dport);

--- a/src/lib/protocols/teamspeak.c
+++ b/src/lib/protocols/teamspeak.c
@@ -32,7 +32,7 @@ static void ndpi_int_teamspeak_add_connection(struct ndpi_detection_module_struc
 
 void ndpi_search_teamspeak(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search teamspeak\n");
 

--- a/src/lib/protocols/teamviewer.c
+++ b/src/lib/protocols/teamviewer.c
@@ -39,7 +39,7 @@ static void ndpi_int_teamview_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_teamview(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search teamwiewer\n");
   /*
@@ -48,9 +48,9 @@ void ndpi_search_teamview(struct ndpi_detection_module_struct *ndpi_struct, stru
 
     http://myip.ms/view/ip_owners/144885/Teamviewer_Gmbh.html
   */
-  if(flow->packet.iph) {
-    u_int32_t src = ntohl(flow->packet.iph->saddr);
-    u_int32_t dst = ntohl(flow->packet.iph->daddr);
+  if(packet->iph) {
+    u_int32_t src = ntohl(packet->iph->saddr);
+    u_int32_t dst = ntohl(packet->iph->daddr);
 
     /* 95.211.37.195 - 95.211.37.203 */
     if(((src >= 1607673283) && (src <= 1607673291))

--- a/src/lib/protocols/telegram.c
+++ b/src/lib/protocols/telegram.c
@@ -45,7 +45,7 @@ static u_int8_t is_telegram_port_range(u_int16_t port) {
 
 void ndpi_search_telegram(struct ndpi_detection_module_struct *ndpi_struct,
 			  struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search telegram\n");
 

--- a/src/lib/protocols/telnet.c
+++ b/src/lib/protocols/telnet.c
@@ -35,7 +35,7 @@
 
 static int search_telnet_again(struct ndpi_detection_module_struct *ndpi_struct,
 			       struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   int i;
 
 #ifdef TELNET_DEBUG
@@ -130,7 +130,7 @@ __forceinline static
 #endif
 u_int8_t search_iac(struct ndpi_detection_module_struct *ndpi_struct,
 		    struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   u_int16_t a;
 

--- a/src/lib/protocols/teredo.c
+++ b/src/lib/protocols/teredo.c
@@ -27,7 +27,7 @@
 /* https://en.wikipedia.org/wiki/Teredo_tunneling */
 void ndpi_search_teredo(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct,"search teredo\n");
   if(packet->udp

--- a/src/lib/protocols/tftp.c
+++ b/src/lib/protocols/tftp.c
@@ -39,7 +39,7 @@ static void ndpi_int_tftp_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_tftp(struct ndpi_detection_module_struct
 		      *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search TFTP\n");
 

--- a/src/lib/protocols/thunder.c
+++ b/src/lib/protocols/thunder.c
@@ -32,7 +32,7 @@
 static void ndpi_int_thunder_add_connection(struct ndpi_detection_module_struct *ndpi_struct, 
 					    struct ndpi_flow_struct *flow/* , ndpi_protocol_type_t protocol_type */)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
 
@@ -58,7 +58,7 @@ __forceinline static
 void ndpi_int_search_thunder_udp(struct ndpi_detection_module_struct
 				 *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   if (packet->payload_packet_len > 8 && packet->payload[0] >= 0x30
       && packet->payload[0] < 0x40 && packet->payload[1] == 0 && packet->payload[2] == 0 && packet->payload[3] == 0) {
@@ -89,7 +89,7 @@ __forceinline static
 void ndpi_int_search_thunder_tcp(struct ndpi_detection_module_struct
 				 *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   if (packet->payload_packet_len > 8 && packet->payload[0] >= 0x30
       && packet->payload[0] < 0x40 && packet->payload[1] == 0 && packet->payload[2] == 0 && packet->payload[3] == 0) {
@@ -145,7 +145,7 @@ __forceinline static
 void ndpi_int_search_thunder_http(struct ndpi_detection_module_struct
 				  *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
 
@@ -195,7 +195,7 @@ void ndpi_int_search_thunder_http(struct ndpi_detection_module_struct
 
 void ndpi_search_thunder(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   //
   //struct ndpi_id_struct *src = flow->src;
   //struct ndpi_id_struct *dst = flow->dst;

--- a/src/lib/protocols/tinc.c
+++ b/src/lib/protocols/tinc.c
@@ -28,7 +28,7 @@
 
 static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
   

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -105,7 +105,7 @@ static void ndpi_int_tls_add_connection(struct ndpi_detection_module_struct *ndp
 
 static u_int32_t ndpi_tls_refine_master_protocol(struct ndpi_detection_module_struct *ndpi_struct,
 						 struct ndpi_flow_struct *flow, u_int32_t protocol) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   // protocol = NDPI_PROTOCOL_TLS;
 
@@ -138,7 +138,7 @@ static u_int32_t ndpi_tls_refine_master_protocol(struct ndpi_detection_module_st
 
 void ndpi_search_tls_tcp_memory(struct ndpi_detection_module_struct *ndpi_struct,
 				struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int avail_bytes;
 
   /* TCP */
@@ -284,11 +284,13 @@ static int extractRDNSequence(struct ndpi_packet_struct *packet,
 
 static void checkTLSSubprotocol(struct ndpi_detection_module_struct *ndpi_struct,
 				struct ndpi_flow_struct *flow) {
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
+
   if(flow->detected_protocol_stack[1] == NDPI_PROTOCOL_UNKNOWN) {
     /* Subprotocol not yet set */
 
-    if(ndpi_struct->tls_cert_cache && flow->packet.iph && flow->packet.tcp) {
-      u_int32_t key = flow->packet.iph->daddr + flow->packet.tcp->dest;
+    if(ndpi_struct->tls_cert_cache && packet->iph && packet->tcp) {
+      u_int32_t key = packet->iph->daddr + packet->tcp->dest;
       u_int16_t cached_proto;
 
       if(ndpi_lru_find_cache(ndpi_struct->tls_cert_cache, key,
@@ -311,7 +313,7 @@ static void checkTLSSubprotocol(struct ndpi_detection_module_struct *ndpi_struct
 static void processCertificateElements(struct ndpi_detection_module_struct *ndpi_struct,
 				       struct ndpi_flow_struct *flow,
 				       u_int16_t p_offset, u_int16_t certificate_len) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t num_found = 0, i;
   char buffer[64] = { '\0' }, rdnSeqBuf[2048];
   u_int rdn_len = 0;
@@ -431,7 +433,7 @@ static void processCertificateElements(struct ndpi_detection_module_struct *ndpi
 	  offset += 2;
 
 	  if((offset+len) < packet->payload_packet_len) {
-	    u_int32_t time_sec = flow->packet.current_time_ms / 1000;
+	    u_int32_t time_sec = packet->current_time_ms / 1000;
 #ifdef DEBUG_TLS
 	    u_int j;
 
@@ -601,8 +603,8 @@ static void processCertificateElements(struct ndpi_detection_module_struct *ndpi
 	if(ndpi_struct->tls_cert_cache == NULL)
 	  ndpi_struct->tls_cert_cache = ndpi_lru_cache_init(1024);
 
-	if(ndpi_struct->tls_cert_cache && flow->packet.iph) {
-	  u_int32_t key = flow->packet.iph->daddr + flow->packet.tcp->dest;
+	if(ndpi_struct->tls_cert_cache && packet->iph) {
+	  u_int32_t key = packet->iph->daddr + packet->tcp->dest;
 
 	  ndpi_lru_add_to_cache(ndpi_struct->tls_cert_cache, key, proto_id);
 	}
@@ -624,7 +626,7 @@ static void processCertificateElements(struct ndpi_detection_module_struct *ndpi
 /* See https://blog.catchpoint.com/2017/05/12/dissecting-tls-using-wireshark/ */
 int processCertificate(struct ndpi_detection_module_struct *ndpi_struct,
 		       struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   int is_dtls = packet->udp ? 1 : 0;
   u_int32_t certificates_length, length = (packet->payload[1] << 16) + (packet->payload[2] << 8) + packet->payload[3];
   u_int32_t certificates_offset = 7 + (is_dtls ? 8 : 0);
@@ -749,7 +751,7 @@ int processCertificate(struct ndpi_detection_module_struct *ndpi_struct,
 
 static int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
 			   struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   int ret;
 
 #ifdef DEBUG_TL
@@ -812,7 +814,7 @@ static void ndpi_looks_like_tls(struct ndpi_detection_module_struct *ndpi_struct
 
 static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 			       struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int8_t something_went_wrong = 0;
 
 #ifdef DEBUG_TLS_MEMORY
@@ -971,7 +973,7 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 
 static int ndpi_search_tls_udp(struct ndpi_detection_module_struct *ndpi_struct,
 			       struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t handshake_len;
   u_int16_t p_len, processed;
   const u_int8_t *p;
@@ -1069,11 +1071,13 @@ static int ndpi_search_tls_udp(struct ndpi_detection_module_struct *ndpi_struct,
 
 static void tlsInitExtraPacketProcessing(struct ndpi_detection_module_struct *ndpi_struct,
 					 struct ndpi_flow_struct *flow) {
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
+
   flow->check_extra_packets = 1;
 
   /* At most 12 packets should almost always be enough to find the server certificate if it's there */
   flow->max_extra_packets_to_check = 12 + (ndpi_struct->num_tls_blocks_to_follow*4);
-  flow->extra_packets_func = (flow->packet.udp != NULL) ? ndpi_search_tls_udp : ndpi_search_tls_tcp;
+  flow->extra_packets_func = (packet->udp != NULL) ? ndpi_search_tls_udp : ndpi_search_tls_tcp;
 }
 
 /* **************************************** */
@@ -1108,11 +1112,13 @@ static void tlsCheckUncommonALPN(struct ndpi_detection_module_struct *ndpi_struc
 
 static void ndpi_int_tls_add_connection(struct ndpi_detection_module_struct *ndpi_struct,
 					struct ndpi_flow_struct *flow, u_int32_t protocol) {
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
+
 #if DEBUG_TLS
   printf("[TLS] %s()\n", __FUNCTION__);
 #endif
 
-  if((flow->packet.udp != NULL) && (protocol == NDPI_PROTOCOL_TLS))
+  if((packet->udp != NULL) && (protocol == NDPI_PROTOCOL_TLS))
     protocol = NDPI_PROTOCOL_DTLS;
 
   if((flow->detected_protocol_stack[0] == protocol)
@@ -1138,7 +1144,7 @@ static void checkExtensions(struct ndpi_detection_module_struct *ndpi_struct,
 			    struct ndpi_flow_struct * const flow, int is_dtls,
                             u_int16_t extension_id, u_int16_t extension_len, u_int16_t extension_payload_offset)
 {
-  struct ndpi_packet_struct const * const packet = &flow->packet;
+  struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
 
   if (extension_payload_offset + extension_len > packet->payload_packet_len)
   {
@@ -1206,7 +1212,7 @@ static void checkExtensions(struct ndpi_detection_module_struct *ndpi_struct,
 
 int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 			     struct ndpi_flow_struct *flow, uint32_t quic_version) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   union ja3_info ja3;
   u_int8_t invalid_ja3 = 0;
   u_int16_t tls_version, ja3_str_len;
@@ -2266,7 +2272,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 
 static void ndpi_search_tls_wrapper(struct ndpi_detection_module_struct *ndpi_struct,
 				    struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
 #ifdef DEBUG_TLS
   printf("==>> %s() %u [len: %u][version: %u]\n",

--- a/src/lib/protocols/tvuplayer.c
+++ b/src/lib/protocols/tvuplayer.c
@@ -37,7 +37,7 @@ static void ndpi_int_tvuplayer_add_connection(struct ndpi_detection_module_struc
 
 void ndpi_search_tvuplayer(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 
   NDPI_LOG_DBG(ndpi_struct, "search tvuplayer.  \n");

--- a/src/lib/protocols/ubntac2.c
+++ b/src/lib/protocols/ubntac2.c
@@ -33,7 +33,7 @@ static void ndpi_int_ubntac2_add_connection(struct ndpi_detection_module_struct 
 
 void ndpi_search_ubntac2(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search ubntac2\n");
   NDPI_LOG_DBG2(ndpi_struct, "UBNTAC2 detection... plen:%i %i:%i\n", packet->payload_packet_len, ntohs(packet->udp->source), ntohs(packet->udp->dest));

--- a/src/lib/protocols/usenet.c
+++ b/src/lib/protocols/usenet.c
@@ -40,7 +40,7 @@ static void ndpi_int_usenet_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_usenet_tcp(struct ndpi_detection_module_struct
 							  *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-	struct ndpi_packet_struct *packet = &flow->packet;
+	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
 	NDPI_LOG_DBG(ndpi_struct, "search usenet\n");
 

--- a/src/lib/protocols/vhua.c
+++ b/src/lib/protocols/vhua.c
@@ -38,7 +38,7 @@ static void ndpi_int_vhua_add_connection(struct ndpi_detection_module_struct *nd
 
 
 static void ndpi_check_vhua(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
   u_char p0[] =  { 0x05, 0x14, 0x3a, 0x05, 0x08, 0xf8, 0xa1, 0xb1, 0x03 };
 

--- a/src/lib/protocols/viber.c
+++ b/src/lib/protocols/viber.c
@@ -27,7 +27,7 @@
 
 void ndpi_search_viber(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   
   NDPI_LOG_DBG(ndpi_struct, "search for VIBER\n");
   

--- a/src/lib/protocols/vmware.c
+++ b/src/lib/protocols/vmware.c
@@ -26,7 +26,7 @@
 
 void ndpi_search_vmware(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search vmware\n");
   /* Check whether this is an VMWARE flow */

--- a/src/lib/protocols/vnc.c
+++ b/src/lib/protocols/vnc.c
@@ -28,7 +28,7 @@
 
 void ndpi_search_vnc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search vnc\n");
   /* search over TCP */

--- a/src/lib/protocols/warcraft3.c
+++ b/src/lib/protocols/warcraft3.c
@@ -37,7 +37,7 @@ static void ndpi_int_warcraft3_add_connection(struct ndpi_detection_module_struc
 void ndpi_search_warcraft3(struct ndpi_detection_module_struct
 			   *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   u_int16_t l; /* 
 		  Leave it as u_int32_t because otherwise 'u_int16_t temp' 

--- a/src/lib/protocols/websocket.c
+++ b/src/lib/protocols/websocket.c
@@ -61,7 +61,7 @@ static void set_websocket_detected(struct ndpi_detection_module_struct *ndpi_str
 
 static void ndpi_check_websocket(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-    struct ndpi_packet_struct *packet = &flow->packet;
+    struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
     if (packet->payload_packet_len < sizeof(u_int16_t))
     {

--- a/src/lib/protocols/whatsapp.c
+++ b/src/lib/protocols/whatsapp.c
@@ -25,7 +25,7 @@
 
 void ndpi_search_whatsapp(struct ndpi_detection_module_struct *ndpi_struct,
 			  struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   static u_int8_t whatsapp_sequence[] = {
     0x45, 0x44, 0x0, 0x01, 0x0, 0x0, 0x02, 0x08,
     0x0, 0x57, 0x41, 0x02, 0x0, 0x0, 0x0

--- a/src/lib/protocols/whoisdas.c
+++ b/src/lib/protocols/whoisdas.c
@@ -27,7 +27,7 @@
 
 void ndpi_search_whois_das(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search WHOIS/DAS\n");
   if(packet->tcp != NULL) {

--- a/src/lib/protocols/wireguard.c
+++ b/src/lib/protocols/wireguard.c
@@ -42,7 +42,7 @@ enum wg_message_type {
 void ndpi_search_wireguard(struct ndpi_detection_module_struct
 			   *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   const u_int8_t *payload = packet->payload;
   u_int8_t message_type = payload[0];
 

--- a/src/lib/protocols/world_of_kung_fu.c
+++ b/src/lib/protocols/world_of_kung_fu.c
@@ -35,7 +35,7 @@ static void ndpi_int_world_of_kung_fu_add_connection(struct ndpi_detection_modul
 
 void ndpi_search_world_of_kung_fu(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   NDPI_LOG_DBG(ndpi_struct, "search world_of_kung_fu\n");
 

--- a/src/lib/protocols/world_of_warcraft.c
+++ b/src/lib/protocols/world_of_warcraft.c
@@ -54,7 +54,7 @@ u_int8_t ndpi_int_is_wow_port(const u_int16_t port)
 void ndpi_search_worldofwarcraft(struct ndpi_detection_module_struct
 				 *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;

--- a/src/lib/protocols/wsd.c
+++ b/src/lib/protocols/wsd.c
@@ -30,7 +30,7 @@
 
 void ndpi_search_wsd(struct ndpi_detection_module_struct *ndpi_struct,
 		      struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   NDPI_LOG_DBG(ndpi_struct, "search wsd\n");
 

--- a/src/lib/protocols/xbox.c
+++ b/src/lib/protocols/xbox.c
@@ -35,7 +35,7 @@ static void ndpi_int_xbox_add_connection(struct ndpi_detection_module_struct
 
 void ndpi_search_xbox(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   /*
    * XBOX UDP DETCTION ONLY

--- a/src/lib/protocols/xdmcp.c
+++ b/src/lib/protocols/xdmcp.c
@@ -38,7 +38,7 @@ static void ndpi_int_xdmcp_add_connection(struct ndpi_detection_module_struct
 void ndpi_search_xdmcp(struct ndpi_detection_module_struct
 		       *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   NDPI_LOG_DBG(ndpi_struct, "search xdmcp\n");
 

--- a/src/lib/protocols/z3950.c
+++ b/src/lib/protocols/z3950.c
@@ -87,7 +87,7 @@ static int z3950_parse_sequences(struct ndpi_packet_struct const * const packet,
 
 static void ndpi_search_z3950(struct ndpi_detection_module_struct *ndpi_struct,
                               struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct * packet = &flow->packet;
+  struct ndpi_packet_struct * packet = &ndpi_struct->packet;
   int const minimum_expected_sequences = 6;
 
   NDPI_LOG_DBG(ndpi_struct, "search z39.50\n");

--- a/src/lib/protocols/zabbix.c
+++ b/src/lib/protocols/zabbix.c
@@ -36,7 +36,7 @@ static void ndpi_int_zabbix_add_connection(struct ndpi_detection_module_struct *
 
 void ndpi_search_zabbix(struct ndpi_detection_module_struct *ndpi_struct,
 			struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int8_t tomatch[] = { 'Z', 'B', 'X', 'D', 0x1 };
 
   NDPI_LOG_DBG(ndpi_struct, "search Zabbix\n");

--- a/src/lib/protocols/zattoo.c
+++ b/src/lib/protocols/zattoo.c
@@ -35,8 +35,10 @@ __forceinline static
 #endif
 u_int8_t ndpi_int_zattoo_user_agent_set(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  if(flow->packet.user_agent_line.ptr != NULL && flow->packet.user_agent_line.len == 111) {
-    if(memcmp(flow->packet.user_agent_line.ptr + flow->packet.user_agent_line.len - 25, "Zattoo/4", sizeof("Zattoo/4") - 1) == 0) {
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
+
+  if(packet->user_agent_line.ptr != NULL && packet->user_agent_line.len == 111) {
+    if(memcmp(packet->user_agent_line.ptr + packet->user_agent_line.len - 25, "Zattoo/4", sizeof("Zattoo/4") - 1) == 0) {
       NDPI_LOG_DBG(ndpi_struct, "found zattoo useragent\n");
       return 1;
     }
@@ -54,7 +56,7 @@ u_int8_t ndpi_int_zattoo_user_agent_set(struct ndpi_detection_module_struct *ndp
 
 void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   struct ndpi_id_struct *src = flow->src;
   struct ndpi_id_struct *dst = flow->dst;
 

--- a/src/lib/protocols/zeromq.c
+++ b/src/lib/protocols/zeromq.c
@@ -31,7 +31,7 @@ static void ndpi_int_zmq_add_connection(struct ndpi_detection_module_struct *ndp
 
 static void ndpi_check_zmq(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
 
-  struct ndpi_packet_struct *packet = &flow->packet;
+  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
   u_char p0[] =  { 0x00, 0x00, 0x00, 0x05, 0x01, 0x66, 0x6c, 0x6f, 0x77 };
   u_char p1[] =  { 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x7f };


### PR DESCRIPTION
There are no real reasons to embed `struct ndpi_packet_struct` (i.e. "packet")
in `struct ndpi_flow_struct` (i.e. "flow"). In other words, we can avoid
saving dissection information of "current packet" into the "flow" state,
i.e. in the flow management table.

The nDPI detection module processes only one packet at the time, so it is
safe to save packet dissection information in `struct ndpi_detection_module_struct`,
reusing always the same "packet" instance and saving a huge amount of memory.
Bottom line: we need only one copy of "packet" (for detection module),
not one for each "flow".

It is not clear how/why "packet" ended up in "flow" in the first place.
It has been there since the beginning of the GIT history, but in the original
OpenDPI code `struct ipoque_packet_struct` was embedded in
`struct ipoque_detection_module_struct`, i.e. there was the same exact
situation this commit wants to achieve.

Most of the changes in this PR are some boilerplate to update something
like "flow->packet" into something like "module->packet" throughout the code.
Some attention has been paid to update `ndpi_init_packet()` since we need
to reset some "packet" fields before starting to process another packet.

There has been one important change, though, in ndpi_detection_giveup().
Nothing changed for the applications/users, but this function can't access
"packet" anymore.
The reason is that this function can be called "asynchronously" with respect
to the data processing, i.e in context where there is no valid notion of
"current packet"; for example ndpiReader calls it after having processed all
the traffic, iterating the entire session table.

Mining LRU stuff seems a bit odd (even before this patch): probably we need
to rethink it, as a follow-up.