### PR TITLE
Fix how some protocols handle tcp retransmissions

### DIFF
--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -406,8 +406,7 @@ void ndpi_search_bittorrent(struct ndpi_detection_module_struct *ndpi_struct, st
   if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_BITTORRENT) {
     /* check for tcp retransmission here */
 
-    if((packet->tcp != NULL)
-	&& (packet->tcp_retransmission == 0 || packet->num_retried_bytes)) {
+    if(packet->tcp != NULL) {
       ndpi_int_search_bittorrent_tcp(ndpi_struct, flow);
     } else if(packet->udp != NULL) {
       /* UDP */
@@ -505,7 +504,7 @@ void init_bittorrent_dissector(struct ndpi_detection_module_struct *ndpi_struct,
   ndpi_set_bitmask_protocol_detection("BitTorrent", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_BITTORRENT,
 				      ndpi_search_bittorrent,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP_WITHOUT_RETRANSMISSION,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
   *id += 1;

--- a/src/lib/protocols/bjnp.c
+++ b/src/lib/protocols/bjnp.c
@@ -36,15 +36,11 @@ static void ndpi_check_bjnp(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void ndpi_search_bjnp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search bjnp\n");
 
   /* skip marked packets */
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_BJNP) {
-    if (packet->tcp_retransmission == 0) {
-      ndpi_check_bjnp(ndpi_struct, flow);
-    }
+    ndpi_check_bjnp(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/dropbox.c
+++ b/src/lib/protocols/dropbox.c
@@ -72,15 +72,11 @@ static void ndpi_check_dropbox(struct ndpi_detection_module_struct *ndpi_struct,
 
 void ndpi_search_dropbox(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search dropbox\n");
 
   /* skip marked packets */
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_DROPBOX) {
-    if (packet->tcp_retransmission == 0) {
-      ndpi_check_dropbox(ndpi_struct, flow);
-    }
+    ndpi_check_dropbox(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/edonkey.c
+++ b/src/lib/protocols/edonkey.c
@@ -204,15 +204,11 @@ static void ndpi_check_edonkey(struct ndpi_detection_module_struct *ndpi_struct,
 }
 
 void ndpi_search_edonkey(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search EDONKEY\n");
 
   /* skip marked packets */
   if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_EDONKEY) {
-    if(packet->tcp_retransmission == 0) {
-      ndpi_check_edonkey(ndpi_struct, flow);
-    }
+    ndpi_check_edonkey(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/ftp_control.c
+++ b/src/lib/protocols/ftp_control.c
@@ -653,15 +653,11 @@ static void ndpi_check_ftp_control(struct ndpi_detection_module_struct *ndpi_str
 
 void ndpi_search_ftp_control(struct ndpi_detection_module_struct *ndpi_struct,
 			     struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search FTP_CONTROL\n");
 
   /* skip marked packets */
   if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_FTP_CONTROL) {
-    if(packet->tcp_retransmission == 0) {
-      ndpi_check_ftp_control(ndpi_struct, flow);
-    }
+    ndpi_check_ftp_control(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/redis_net.c
+++ b/src/lib/protocols/redis_net.c
@@ -77,15 +77,11 @@ static void ndpi_check_redis(struct ndpi_detection_module_struct *ndpi_struct, s
 }
 
 void ndpi_search_redis(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search Redis\n");
 
   /* skip marked packets */
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_REDIS) {
-    if (packet->tcp_retransmission == 0) {
-      ndpi_check_redis(ndpi_struct, flow);
-    }
+    ndpi_check_redis(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/rtmp.c
+++ b/src/lib/protocols/rtmp.c
@@ -78,15 +78,11 @@ static void ndpi_check_rtmp(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void ndpi_search_rtmp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search RTMP\n");
 
   /* skip marked packets */
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_RTMP) {
-    if (packet->tcp_retransmission == 0) {
-      ndpi_check_rtmp(ndpi_struct, flow);
-    }
+    ndpi_check_rtmp(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/sip.c
+++ b/src/lib/protocols/sip.c
@@ -178,8 +178,6 @@ void ndpi_search_sip_handshake(struct ndpi_detection_module_struct
 
 void ndpi_search_sip(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search sip\n");
 
   if(flow->packet_counter > 5)
@@ -187,9 +185,7 @@ void ndpi_search_sip(struct ndpi_detection_module_struct *ndpi_struct, struct nd
   else {
     /* skip marked packets */
     if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SIP) {
-      if(packet->tcp_retransmission == 0) {
-	ndpi_search_sip_handshake(ndpi_struct, flow);
-      }
+      ndpi_search_sip_handshake(ndpi_struct, flow);
     }
   }
 }
@@ -199,7 +195,7 @@ void init_sip_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int3
   ndpi_set_bitmask_protocol_detection("SIP", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_SIP,
 				      ndpi_search_sip,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD,/* Fix courtesy of Miguel Quesada <mquesadab@gmail.com> */
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,/* Fix courtesy of Miguel Quesada <mquesadab@gmail.com> */
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/socks45.c
+++ b/src/lib/protocols/socks45.c
@@ -119,18 +119,14 @@ static void ndpi_check_socks5(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void ndpi_search_socks(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search SOCKS\n");
 
   /* skip marked packets */
   if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS) {
-    if(packet->tcp_retransmission == 0) {
-      ndpi_check_socks4(ndpi_struct, flow);
+    ndpi_check_socks4(ndpi_struct, flow);
 
-      if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS)
-	ndpi_check_socks5(ndpi_struct, flow);
-    }
+    if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS)
+      ndpi_check_socks5(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/spotify.c
+++ b/src/lib/protocols/spotify.c
@@ -121,15 +121,11 @@ static void ndpi_check_spotify(struct ndpi_detection_module_struct *ndpi_struct,
 
 void ndpi_search_spotify(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search spotify\n");
 
   /* skip marked packets */
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SPOTIFY) {
-    if (packet->tcp_retransmission == 0) {
-      ndpi_check_spotify(ndpi_struct, flow);
-    }
+    ndpi_check_spotify(ndpi_struct, flow);
   }
 }
 
@@ -139,7 +135,7 @@ void init_spotify_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_
   ndpi_set_bitmask_protocol_detection("SPOTIFY", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_SPOTIFY,
 				      ndpi_search_spotify,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/steam.c
+++ b/src/lib/protocols/steam.c
@@ -255,8 +255,7 @@ static void ndpi_check_steam_udp3(struct ndpi_detection_module_struct *ndpi_stru
 }
 
 void ndpi_search_steam(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
-	
+
   if(flow->packet.udp != NULL) {
     if(flow->packet_counter > 5) {
       NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
@@ -281,11 +280,7 @@ void ndpi_search_steam(struct ndpi_detection_module_struct *ndpi_struct, struct 
       return;
     }
 
-    /* skip marked or retransmitted packets */
-    if(packet->tcp_retransmission != 0) {
-      return;
-    }
-
+    /* skip marked packets */
     if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_STEAM)
       return;   
 

--- a/src/lib/protocols/tinc.c
+++ b/src/lib/protocols/tinc.c
@@ -129,14 +129,10 @@ static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, st
 }
 
 void ndpi_search_tinc(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow) {
-  struct ndpi_packet_struct* packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "tinc detection\n");
 
   if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_TINC) {
-    if(packet->tcp_retransmission == 0) {
-      ndpi_check_tinc(ndpi_struct, flow);
-    }
+    ndpi_check_tinc(ndpi_struct, flow);
   }
 }
 
@@ -145,7 +141,7 @@ void init_tinc_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int
   ndpi_set_bitmask_protocol_detection("TINC", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_TINC,
 				      ndpi_search_tinc,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP_WITHOUT_RETRANSMISSION,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/zeromq.c
+++ b/src/lib/protocols/zeromq.c
@@ -84,15 +84,11 @@ static void ndpi_check_zmq(struct ndpi_detection_module_struct *ndpi_struct, str
 }
 
 void ndpi_search_zmq(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &flow->packet;
-
   NDPI_LOG_DBG(ndpi_struct, "search ZMQ\n");
 
   /* skip marked packets */
   if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_ZMQ) {
-    if(packet->tcp && packet->tcp_retransmission == 0) {
-      ndpi_check_zmq(ndpi_struct, flow);
-    }
+    ndpi_check_zmq(ndpi_struct, flow);
   }
 }
 


### PR DESCRIPTION
Most (all?) protocols don't care about (tcp) retransmissions.

If a protocol registers itself with a
NDPI_SELECTION_BITMASK_PROTOCOL_*_WITHOUT_RETRANSMISSION value, its
callback is never triggered with a retransmitted packet.