### PR TITLE
Get rid of `configure.seed` as it comes with some disadvantages.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,7 @@ jobs:
         if: startsWith(matrix.os, 'macOS') && startsWith(matrix.arch, 'x86_64')
         run: |
           brew install autoconf automake libtool pkg-config gettext json-c
+          brew install coreutils
       - name: Install MacOS Prerequisites (libgcrypt)
         if: startsWith(matrix.os, 'macOS') && startsWith(matrix.arch, 'x86_64') && !startsWith(matrix.gcrypt, '--disable-gcrypt')
         run: |
@@ -171,11 +172,13 @@ jobs:
         if: startsWith(matrix.arch, 'x86_64')
         run: |
           make all
-          cd example
-          make ndpiSimpleIntegration
-          cd ../python
-          make
-          cd ..
+          make -C example ndpiSimpleIntegration
+          make -C python
+      - name: Install nDPI
+        if: startsWith(matrix.arch, 'x86_64')
+        run: |
+          make install DESTDIR=$(realpath _install)
+          ls -alhHR _install
       - name: Test nDPI [DIFF]
         if: startsWith(matrix.arch, 'x86_64')
         run: |
@@ -215,13 +218,10 @@ jobs:
             apt-get -y install git autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev libgcrypt20-dev libpcre3-dev libmaxminddb-dev &&
             env CC=gcc CFLAGS='-Werror' ./autogen.sh --enable-debug-messages ${{ matrix.gcrypt }} ${{ matrix.msan }} ${{ matrix.pcre }} ${{ matrix.maxminddb }} &&
             make all &&
-            cd example &&
-            make ndpiSimpleIntegration &&
-            cd ../python &&
-            make &&
-            cd ../tests &&
-            ./do.sh &&
-            ./do-unit.sh
+            make -C example ndpiSimpleIntegration &&
+            make -C python &&
+            ./tests/do.sh &&
+            ./tests/do-unit.sh
             "
       - name: Display qemu specified architecture (armhf - little endian)
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 'armhf')
@@ -242,13 +242,10 @@ jobs:
             apt-get -y install git autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev libgcrypt20-dev libpcre3-dev libmaxminddb-dev &&
             env CC=gcc CFLAGS='-Werror' ./autogen.sh --enable-debug-messages ${{ matrix.gcrypt }} ${{ matrix.msan }} ${{ matrix.pcre }} ${{ matrix.maxminddb }} &&
             make all &&
-            cd example &&
-            make ndpiSimpleIntegration &&
-            cd ../python &&
-            make &&
-            cd ../tests &&
-            ./do.sh &&
-            ./do-unit.sh
+            make -C example ndpiSimpleIntegration &&
+            make -C python &&
+            ./tests/do.sh &&
+            ./tests/do-unit.sh
             "
       - name: Display qemu specified architecture (s390x - big endian)
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 's390x')
@@ -269,11 +266,8 @@ jobs:
             apt-get -y install git autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev libgcrypt20-dev libpcre3-dev libmaxminddb-dev &&
             env CC=gcc CFLAGS='-Werror' ./autogen.sh --enable-debug-messages ${{ matrix.gcrypt }} ${{ matrix.msan }} ${{ matrix.pcre }} ${{ matrix.maxminddb }} &&
             make all &&
-            cd example &&
-            make ndpiSimpleIntegration &&
-            cd ../python &&
-            make &&
-            cd ../tests &&
-            ./do.sh &&
-            ./do-unit.sh
+            make -C example ndpiSimpleIntegration &&
+            make -C python &&
+            ./tests/do.sh &&
+            ./tests/do-unit.sh
             "

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ compile
 /config.status
 /config.sub
 /configure
-/configure.ac
 /configure.tmp
 .cproject
 /depcomp

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-NDPI_MAJOR="4"
-NDPI_MINOR="1"
-NDPI_PATCH="0"
-NDPI_VERSION_SHORT="$NDPI_MAJOR.$NDPI_MINOR.$NDPI_PATCH"
-
 rm -f configure config.h config.h.in
 
 AUTOCONF=$(command -v autoconf)
@@ -13,16 +8,10 @@ LIBTOOL=$(command -v libtool)
 LIBTOOLIZE=$(command -v libtoolize)
 AUTORECONF=$(command -v autoreconf)
 PKG_CONFIG=$(command -v pkg-config)
-FUZZY=
 
 if test -z $AUTOCONF; then
     echo "autoconf is missing: please install it and try again"
     exit
-else
-    V=`autoconf --version | head -1 | cut -d ' ' -f 4`
-    if [ "$V" = '2.63' ]; then
-        FUZZY="dnl> "
-    fi
 fi
 
 if test -z $AUTOMAKE; then
@@ -45,17 +34,7 @@ if test -z $PKG_CONFIG; then
     exit
 fi
 
-cat configure.seed | sed \
-    -e "s/@NDPI_MAJOR@/$NDPI_MAJOR/g" \
-    -e "s/@NDPI_MINOR@/$NDPI_MINOR/g" \
-    -e "s/@NDPI_PATCH@/$NDPI_PATCH/g" \
-    -e "s/@NDPI_VERSION_SHORT@/$NDPI_VERSION_SHORT/g" \
-    -e "s/@FUZZY@/$FUZZY/g" \
-    > configure.ac
-
 autoreconf -ivf
-cat configure | sed "s/#define PACKAGE/#define NDPI_PACKAGE/g" | sed "s/#define VERSION/#define NDPI_VERSION/g"  > configure.tmp
-cat configure.tmp > configure
 
 echo "./configure $@"
 chmod +x configure

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libndpi], [@NDPI_VERSION_SHORT@])
+AC_INIT([libndpi], [4.1.0])
 
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_MACRO_DIR([m4])
@@ -43,10 +43,10 @@ dnl>  AC_PROG_CC
 fi
 AC_LANG_WERROR
 
-NDPI_VERSION_SHORT="@NDPI_VERSION_SHORT@"
-NDPI_MAJOR="@NDPI_MAJOR@"
-NDPI_MINOR="@NDPI_MINOR@"
-NDPI_PATCH="@NDPI_PATCH@"
+NDPI_MAJOR=`echo "${PACKAGE_VERSION}" | cut -d . -f 1`
+NDPI_MINOR=`echo "${PACKAGE_VERSION}" | cut -d . -f 2`
+NDPI_PATCH=`echo "${PACKAGE_VERSION}" | cut -d . -f 3`
+NDPI_VERSION_SHORT="$NDPI_MAJOR.$NDPI_MINOR.$NDPI_PATCH"
 
 AC_DEFINE_UNQUOTED(NDPI_MAJOR_RELEASE, "${NDPI_MAJOR}", [nDPI major release])
 AC_DEFINE_UNQUOTED(NDPI_MINOR_RELEASE, "${NDPI_MINOR}", [nDPI minor release])
@@ -185,35 +185,35 @@ AC_ARG_ENABLE([debug-messages],
     AS_HELP_STRING([--enable-debug-messages], [Define NDPI_ENABLE_DEBUG_MESSAGES=1]), [
 	AC_DEFINE(NDPI_ENABLE_DEBUG_MESSAGES, 1, [Enable ndpi_debug_messages]) ])
 
-@FUZZY@ AS_IF([test "x$enable_fuzztargets" = "xyes"], [
-@FUZZY@     AC_PROG_CXX
-@FUZZY@     AC_LANG_PUSH(C++)
-@FUZZY@     tmp_saved_flags=$[]_AC_LANG_PREFIX[]FLAGS
-@FUZZY@     AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer],,
-@FUZZY@         [AC_MSG_ERROR([--enable-fuzztargets requires -fsanitize=fuzzer which is only supported by LLVM])],
-@FUZZY@         [-Werror])
-@FUZZY@     AS_IF([test "x$LIB_FUZZING_ENGINE" = "x"], [
-@FUZZY@         LIB_FUZZING_ENGINE=-fsanitize=fuzzer
-@FUZZY@         AC_SUBST(LIB_FUZZING_ENGINE)
-@FUZZY@     ])
-@FUZZY@     _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $LIB_FUZZING_ENGINE"
-@FUZZY@     AC_MSG_CHECKING([whether $CXX accepts $LIB_FUZZING_ENGINE])
-@FUZZY@     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-@FUZZY@ #include <sys/types.h>
-@FUZZY@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char *Data, size_t Size);
-@FUZZY@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char *Data, size_t Size) {
-@FUZZY@ (void)Data;
-@FUZZY@ (void)Size;
-@FUZZY@ return 0;
-@FUZZY@ }
-@FUZZY@         ]])],
-@FUZZY@         [ AC_MSG_RESULT(yes)
-@FUZZY@           has_sanitizefuzzer=yes],
-@FUZZY@         [ AC_MSG_RESULT(no) ]
-@FUZZY@     )
-@FUZZY@     _AC_LANG_PREFIX[]FLAGS=$tmp_saved_flags
-@FUZZY@     AC_LANG_POP()
-@FUZZY@ ])
+AS_IF([test "x$enable_fuzztargets" = "xyes"], [
+    AC_PROG_CXX
+    AC_LANG_PUSH(C++)
+    tmp_saved_flags=$[]_AC_LANG_PREFIX[]FLAGS
+    AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer],,
+        [AC_MSG_ERROR([--enable-fuzztargets requires -fsanitize=fuzzer which is only supported by LLVM])],
+        [-Werror])
+    AS_IF([test "x$LIB_FUZZING_ENGINE" = "x"], [
+        LIB_FUZZING_ENGINE=-fsanitize=fuzzer
+        AC_SUBST(LIB_FUZZING_ENGINE)
+    ])
+    _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $LIB_FUZZING_ENGINE"
+    AC_MSG_CHECKING([whether $CXX accepts $LIB_FUZZING_ENGINE])
+    AC_LINK_IFELSE([AC_LANG_SOURCE([[
+#include <sys/types.h>
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char *Data, size_t Size);
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char *Data, size_t Size) {
+(void)Data;
+(void)Size;
+return 0;
+}
+        ]])],
+        [ AC_MSG_RESULT(yes)
+          has_sanitizefuzzer=yes],
+        [ AC_MSG_RESULT(no) ]
+    )
+    _AC_LANG_PREFIX[]FLAGS=$tmp_saved_flags
+    AC_LANG_POP()
+])
 AM_CONDITIONAL([HAS_FUZZLDFLAGS], [test "x$has_sanitizefuzzer" = "xyes"])
 
 AC_CHECK_LIB(pthread, pthread_setaffinity_np, AC_DEFINE_UNQUOTED(HAVE_PTHREAD_SETAFFINITY_NP, 1, [libc has pthread_setaffinity_np]))


### PR DESCRIPTION
 * using Autotools best-practices to achieve (hopefully) the same result

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

I know I will have hard times getting this PR merged. But this `autogen.sh <=> configure.seed` sed magic is not for what autotools was made for and does also break the configure/build system sometimes.
But now with a working CI it is possible to verify that it will work with MacOS. :smile: 