### PR TITLE
Enable sanitizers on CIFuzz.

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -8,21 +8,21 @@ jobs:
       matrix:
         sanitizer: [address, undefined, memory]
     steps:
-    - name: Build Fuzzers - ${{ matrix.sanitizer }}
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-      with:
-        oss-fuzz-project-name: 'ndpi'
-        dry-run: false
-        sanitizer: ${{ matrix.sanitizer }}
-    - name: Run Fuzzers - ${{ matrix.sanitizer }}
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-      with:
-        oss-fuzz-project-name: 'ndpi'
-        fuzz-seconds: 600
-        dry-run: false
-        sanitizer: ${{ matrix.sanitizer }}
-    - name: Upload Crash
-      uses: actions/upload-artifact@v1
-      with:
-        name: ${{ matrix.sanitizer }}-artifacts
-        path: ./out/artifacts
+      - name: Build Fuzzers - ${{ matrix.sanitizer }}
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'ndpi'
+          dry-run: false
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run Fuzzers - ${{ matrix.sanitizer }}
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'ndpi'
+          fuzz-seconds: 600
+          dry-run: false
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Upload Crash
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.sanitizer }}-artifacts
+          path: ./out/artifacts

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -25,5 +25,5 @@ jobs:
      uses: actions/upload-artifact@v1
      if: failure()
      with:
-       name: artifacts
+       name: ${{ matrix.sanitizer }}-artifacts
        path: ./out/artifacts

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -23,7 +23,7 @@ jobs:
           sanitizer: ${{ matrix.sanitizer }}
       - name: Check artifacts presence
         run: |
-          ls .out/artifacts/
+          ls /github/workspace/out/artifacts/
       - name: Upload Crash
         uses: actions/upload-artifact@v1
         # if: failure() 

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -21,8 +21,14 @@ jobs:
           fuzz-seconds: 600
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
+      - name: Check artifacts presence
+        run: |
+          ls .out/artifacts/
       - name: Upload Crash
         uses: actions/upload-artifact@v1
+        # if: failure() 
+        # This is commented due to the fact that Run Fuzzers return success even when setting dry-run to false.
+        # A temporal workaround is to upload artifacts at each run.
         with:
           name: ${{ matrix.sanitizer }}-artifacts
           path: ./out/artifacts

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -3,19 +3,25 @@ on: [pull_request]
 jobs:
  Fuzzing:
    runs-on: ubuntu-latest
+   strategy:
+     fail-fast: false
+     matrix:
+       sanitizer: [address, undefined, memory]
    steps:
-   - name: Build Fuzzers
+   - name: Build Fuzzers (${{ matrix.sanitizer }})
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:
        oss-fuzz-project-name: 'ndpi'
        dry-run: false
-   - name: Run Fuzzers
+       sanitizer: ${{ matrix.sanitizer }
+   - name: Run Fuzzers (${{ matrix.sanitizer }})
      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
      with:
        oss-fuzz-project-name: 'ndpi'
        fuzz-seconds: 600
        dry-run: false
-   - name: Upload Crash
+       sanitizer: ${{ matrix.sanitizer }
+   - name: Upload Crash (${{ matrix.sanitizer }})
      uses: actions/upload-artifact@v1
      if: failure()
      with:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -23,7 +23,6 @@ jobs:
        sanitizer: ${{ matrix.sanitizer }}
    - name: Upload Crash
      uses: actions/upload-artifact@v1
-     if: failure()
      with:
        name: ${{ matrix.sanitizer }}-artifacts
        path: ./out/artifacts

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -21,12 +21,12 @@ jobs:
           fuzz-seconds: 600
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
-      - name: Check crash
+      - name: Check Crash (fails when a crash is detected)
         # Run Fuzzers return success even when setting dry-run to false.
         # A temporal workaround is to trigger failure manually if we fing crash files.
         run: |
           exit $(ls out/artifacts -l |wc -c)
-      - name: Upload Crash
+      - name: Upload Crash (upload detected crash as artifacts)
         uses: actions/upload-artifact@v1
         if: failure()
         with:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -8,20 +8,20 @@ jobs:
      matrix:
        sanitizer: [address, undefined, memory]
    steps:
-   - name: Build Fuzzers (${{ matrix.sanitizer }})
+   - name: Build Fuzzers - ${{ matrix.sanitizer }}
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:
        oss-fuzz-project-name: 'ndpi'
        dry-run: false
-       sanitizer: ${{ matrix.sanitizer }
-   - name: Run Fuzzers (${{ matrix.sanitizer }})
+       sanitizer: ${{ matrix.sanitizer }}
+   - name: Run Fuzzers - ${{ matrix.sanitizer }}
      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
      with:
        oss-fuzz-project-name: 'ndpi'
        fuzz-seconds: 600
        dry-run: false
-       sanitizer: ${{ matrix.sanitizer }
-   - name: Upload Crash (${{ matrix.sanitizer }})
+       sanitizer: ${{ matrix.sanitizer }}
+   - name: Upload Crash
      uses: actions/upload-artifact@v1
      if: failure()
      with:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -23,7 +23,7 @@ jobs:
           sanitizer: ${{ matrix.sanitizer }}
       - name: Check artifacts presence
         run: |
-          ls
+          ls out/artifacts
       - name: Upload Crash
         uses: actions/upload-artifact@v1
         # if: failure() 

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -21,14 +21,14 @@ jobs:
           fuzz-seconds: 600
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
-      - name: Check artifacts presence
+      - name: Check crash
+        # Run Fuzzers return success even when setting dry-run to false.
+        # A temporal workaround is to trigger failure manually if we fing crash files.
         run: |
-          ls out/artifacts
+          exit $(ls out/artifacts -l |wc -c)
       - name: Upload Crash
         uses: actions/upload-artifact@v1
-        # if: failure() 
-        # This is commented due to the fact that Run Fuzzers return success even when setting dry-run to false.
-        # A temporal workaround is to upload artifacts at each run.
+        if: failure()
         with:
           name: ${{ matrix.sanitizer }}-artifacts
           path: ./out/artifacts

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,28 +1,28 @@
 name: CIFuzz
 on: [pull_request]
 jobs:
- Fuzzing:
-   runs-on: ubuntu-latest
-   strategy:
-     fail-fast: false
-     matrix:
-       sanitizer: [address, undefined, memory]
-   steps:
-   - name: Build Fuzzers - ${{ matrix.sanitizer }}
-     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-     with:
-       oss-fuzz-project-name: 'ndpi'
-       dry-run: false
-       sanitizer: ${{ matrix.sanitizer }}
-   - name: Run Fuzzers - ${{ matrix.sanitizer }}
-     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-     with:
-       oss-fuzz-project-name: 'ndpi'
-       fuzz-seconds: 600
-       dry-run: false
-       sanitizer: ${{ matrix.sanitizer }}
-   - name: Upload Crash
-     uses: actions/upload-artifact@v1
-     with:
-       name: ${{ matrix.sanitizer }}-artifacts
-       path: ./out/artifacts
+  Fuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined, memory]
+    steps:
+    - name: Build Fuzzers - ${{ matrix.sanitizer }}
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'ndpi'
+        dry-run: false
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: Run Fuzzers - ${{ matrix.sanitizer }}
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'ndpi'
+        fuzz-seconds: 600
+        dry-run: false
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ matrix.sanitizer }}-artifacts
+        path: ./out/artifacts

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -23,7 +23,7 @@ jobs:
           sanitizer: ${{ matrix.sanitizer }}
       - name: Check artifacts presence
         run: |
-          ls /github/workspace/out/artifacts/
+          ls
       - name: Upload Crash
         uses: actions/upload-artifact@v1
         # if: failure() 


### PR DESCRIPTION
Current CI Fuzz runs with default sanitizer which is "address".
In this PR, we enable all available sanitizers as a matrix.

Zied
