### PR TITLE
Add issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Create a report to help us improve nDPI
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+### Obtained behavior
+A clear and concise description of what happening.
+
+## Environment (please complete the following information):
+* OS name: [e.g. Ubuntu].
+* OS version: [e.g. 18.04]
+* Architecture: [e.g. arm64]
+* nDPI version or commit hash: [e.g. 4.0-stable or 937357e4bc55610f116f66d15a8e0fc1e260c02c].
+* nDPI compilation flags used: if you are building from source [e.g. --with-pcre --disable-gcrypt].
+
+## How to reproduce the reported bug
+
+### Reproducible using ndpiReader?
+- [x] The reported bug is reproducible using ndpiReader.
+- [x] The reported bug is not reproducible using ndpiReader.
+
+### If applicable, the used ndpiReader options:
+
+``` shell
+ndpiReader -q -t -i wlo1 -T 20 -U 20
+```
+
+### If your bug is reproducible using a pcap, please attach a pcap file (or a valid link to download it)
+
+Example: test.pcap
+
+### Steps to reproduce the behavior:
+1. Run '...'
+2. Set '....'
+3. Do '....'
+4. See error
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -16,12 +16,13 @@ A clear and concise description of what you expected to happen.
 ### Obtained behavior
 A clear and concise description of what happening.
 
-## Environment (please complete the following information):
+## nDPI Environment (please complete the following information):
 * OS name: [e.g. Ubuntu].
 * OS version: [e.g. 18.04]
 * Architecture: [e.g. arm64]
 * nDPI version or commit hash: [e.g. 4.0-stable or 937357e4bc55610f116f66d15a8e0fc1e260c02c].
 * nDPI compilation flags used: if you are building from source [e.g. --with-pcre --disable-gcrypt].
+* Attach the `config.log` file generated after `./configure` ran (if you are building from source).
 
 ## How to reproduce the reported bug
 

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea or a feature for nDPI
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I always need to [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question_template.md
+++ b/.github/ISSUE_TEMPLATE/question_template.md
@@ -1,0 +1,10 @@
+---
+name: General question
+about: Ask a question about nDPI
+title: ''
+labels: 'question'
+assignees: ''
+
+---
+
+Type your question in a clear and concise way to help the community answering it.


### PR DESCRIPTION
This PR address https://github.com/ntop/nDPI/issues/1325.
Each time a user wants to create an issue, he will be asked to select between:
* Bug Report
* Feature request
* General question
* If none of these satisfies his request, he can still select a blank issue.

We provide a template for each of the three defined (bug, feature, question) and we focus especially on bug reporting one where we add several pieces of information needed to address the bug.

In addition, when the issue is created using these templates, it is automatically tagged which facilitates triage.
* Bug report tagged with bug,
* Feature request tagged with enhancement
* Question tagged with question.

Zied