### PR TITLE
QUIC: fix extra dissection

### DIFF
--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1541,7 +1541,10 @@ static int ndpi_search_quic_extra(struct ndpi_detection_module_struct *ndpi_stru
 
   if (is_ch_reassembler_pending(flow)) {
     ndpi_search_quic(ndpi_struct, flow);
-    return is_ch_reassembler_pending(flow);
+    if(is_ch_reassembler_pending(flow))
+      return 1;
+    flow->extra_packets_func = NULL;
+    return 0;
   }
 
   /* RTP/RTCP stuff */

--- a/tests/result/quic_frags_ch_in_multiple_packets.pcapng.out
+++ b/tests/result/quic_frags_ch_in_multiple_packets.pcapng.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	1
+Guessed flow protos:	0
 
-DPI Packets (UDP):	4	(4.00 pkts/flow)
+DPI Packets (UDP):	2	(2.00 pkts/flow)
 
 QUIC	4	3998	1
 


### PR DESCRIPTION
When we have fully reassembled the Client Hello, we need to stop extra
dissection.