### PR TITLE
Improve IPv6 support, enabling IPv6 traffic on (almost) all dissectors.

### DIFF
--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -87,10 +87,6 @@ extern "C" {
   extern u_int16_t ndpi_check_for_email_address(struct ndpi_detection_module_struct *ndpi_struct,
 						struct ndpi_flow_struct *flow, u_int16_t counter);
 
-  extern void ndpi_int_change_protocol(struct ndpi_detection_module_struct *ndpi_struct,
-				       struct ndpi_flow_struct *flow,
-				       u_int16_t upper_detected_protocol,
-				       u_int16_t lower_detected_protocol);
   extern void ndpi_int_change_category(struct ndpi_detection_module_struct *ndpi_struct,
 				       struct ndpi_flow_struct *flow,
 				       ndpi_protocol_category_t protocol_category);

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -121,6 +121,8 @@ static void addDefaultPort(struct ndpi_detection_module_struct *ndpi_str, ndpi_p
 
 static int removeDefaultPort(ndpi_port_range *range, ndpi_proto_defaults_t *def, ndpi_default_ports_tree_node_t **root);
 static void ndpi_reset_packet_line_info(struct ndpi_packet_struct *packet);
+static void ndpi_int_change_protocol(struct ndpi_detection_module_struct *ndpi_str, struct ndpi_flow_struct *flow,
+				     u_int16_t upper_detected_protocol, u_int16_t lower_detected_protocol);
 
 /* ****************************************** */
 
@@ -4959,7 +4961,7 @@ ndpi_protocol ndpi_detection_giveup(struct ndpi_detection_module_struct *ndpi_st
       }
 
       *protocol_was_guessed = 1;
-      ndpi_int_change_protocol(ndpi_str, flow, guessed_host_protocol_id, guessed_protocol_id);
+      ndpi_set_detected_protocol(ndpi_str, flow, guessed_host_protocol_id, guessed_protocol_id);
     }
   }
 
@@ -6191,8 +6193,8 @@ void ndpi_int_change_flow_protocol(struct ndpi_detection_module_struct *ndpi_str
  * what it does is:
  * 1.update the flow protocol stack with the new protocol
  */
-void ndpi_int_change_protocol(struct ndpi_detection_module_struct *ndpi_str, struct ndpi_flow_struct *flow,
-			      u_int16_t upper_detected_protocol, u_int16_t lower_detected_protocol) {
+static void ndpi_int_change_protocol(struct ndpi_detection_module_struct *ndpi_str, struct ndpi_flow_struct *flow,
+				     u_int16_t upper_detected_protocol, u_int16_t lower_detected_protocol) {
   if((upper_detected_protocol == NDPI_PROTOCOL_UNKNOWN) && (lower_detected_protocol != NDPI_PROTOCOL_UNKNOWN))
     upper_detected_protocol = lower_detected_protocol;
 

--- a/src/lib/protocols/avast_securedns.c
+++ b/src/lib/protocols/avast_securedns.c
@@ -60,7 +60,7 @@ void init_avast_securedns_dissector(struct ndpi_detection_module_struct *ndpi_st
                                       ndpi_struct, detection_bitmask, *id,
                                       NDPI_PROTOCOL_AVAST_SECUREDNS,
                                       ndpi_search_avast_securedns,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                                       SAVE_DETECTION_BITMASK_AS_UNKNOWN,
                                       ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/ayiya.c
+++ b/src/lib/protocols/ayiya.c
@@ -77,7 +77,7 @@ void init_ayiya_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_in
   ndpi_set_bitmask_protocol_detection("Ayiya", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_AYIYA,
 				      ndpi_search_ayiya,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -122,7 +122,7 @@ static void ndpi_add_connection_as_bittorrent(struct ndpi_detection_module_struc
   if(check_hash)
     ndpi_search_bittorrent_hash(ndpi_struct, flow, bt_offset);
 
-  ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_BITTORRENT, NDPI_PROTOCOL_UNKNOWN);
+  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_BITTORRENT, NDPI_PROTOCOL_UNKNOWN);
   
   if(flow->protos.bittorrent.hash[0] == '\0') {
     /* This is necessary to inform the core to call this dissector again */

--- a/src/lib/protocols/bjnp.c
+++ b/src/lib/protocols/bjnp.c
@@ -50,7 +50,7 @@ void init_bjnp_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int
   ndpi_set_bitmask_protocol_detection("BJNP", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_BJNP,
 				      ndpi_search_bjnp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
   *id += 1;

--- a/src/lib/protocols/cpha.c
+++ b/src/lib/protocols/cpha.c
@@ -56,7 +56,7 @@ void init_cpha_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int
   ndpi_set_bitmask_protocol_detection("CPHA", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_CPHA,
 				      ndpi_search_cpha,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* TODO: ipv6 support? */
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/csgo.c
+++ b/src/lib/protocols/csgo.c
@@ -134,7 +134,7 @@ void init_csgo_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int
   ndpi_set_bitmask_protocol_detection("CSGO", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_CSGO,
 				      ndpi_search_csgo,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/directconnect.c
+++ b/src/lib/protocols/directconnect.c
@@ -166,7 +166,7 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
 	   src->directconnect_last_safe_access_time) < ndpi_struct->directconnect_connection_ip_tick_timeout) {
 	src->directconnect_last_safe_access_time = packet->current_time_ms;
 	NDPI_LOG_INFO(ndpi_struct, "found DC using port %d\n", ntohs(src->detected_directconnect_port));
-	ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
+	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
 	return;
       } else {
 	src->detected_directconnect_port = 0;
@@ -180,7 +180,7 @@ static void ndpi_search_directconnect_tcp(struct ndpi_detection_module_struct *n
 	   src->directconnect_last_safe_access_time) < ndpi_struct->directconnect_connection_ip_tick_timeout) {
 	src->directconnect_last_safe_access_time = packet->current_time_ms;
 	NDPI_LOG_INFO(ndpi_struct, "found DC using port %d\n", ntohs(src->detected_directconnect_ssl_port));
-	ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
+	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DIRECTCONNECT, NDPI_PROTOCOL_UNKNOWN);
 	return;
       } else {
 	src->detected_directconnect_ssl_port = 0;

--- a/src/lib/protocols/drda.c
+++ b/src/lib/protocols/drda.c
@@ -95,7 +95,7 @@ void init_drda_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int
   ndpi_set_bitmask_protocol_detection("DRDA", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_DRDA,
 				      ndpi_search_drda,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/dropbox.c
+++ b/src/lib/protocols/dropbox.c
@@ -86,7 +86,7 @@ void init_dropbox_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_
   ndpi_set_bitmask_protocol_detection("DROPBOX", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_DROPBOX,
 				      ndpi_search_dropbox,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
   *id += 1;

--- a/src/lib/protocols/genshin_impact.c
+++ b/src/lib/protocols/genshin_impact.c
@@ -65,7 +65,7 @@ void init_genshin_impact_dissector(struct ndpi_detection_module_struct *ndpi_str
                                       ndpi_struct, detection_bitmask, *id,
                                       NDPI_PROTOCOL_GENSHIN_IMPACT,
                                       ndpi_search_genshin_impact,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                                       SAVE_DETECTION_BITMASK_AS_UNKNOWN,
                                       ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/git.c
+++ b/src/lib/protocols/git.c
@@ -79,7 +79,7 @@ void init_git_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int3
   ndpi_set_bitmask_protocol_detection("Git", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_GIT,
 				      ndpi_search_git,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/hpvirtgrp.c
+++ b/src/lib/protocols/hpvirtgrp.c
@@ -63,7 +63,7 @@ void init_hpvirtgrp_dissector(struct ndpi_detection_module_struct *ndpi_struct, 
                                       ndpi_struct, detection_bitmask, *id,
                                       NDPI_PROTOCOL_HPVIRTGRP,
                                       ndpi_search_hpvirtgrp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_WITH_PAYLOAD,
+                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                                       SAVE_DETECTION_BITMASK_AS_UNKNOWN,
                                       ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/lisp.c
+++ b/src/lib/protocols/lisp.c
@@ -78,7 +78,7 @@ void init_lisp_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int
   ndpi_set_bitmask_protocol_detection("LISP", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_LISP,
 				      ndpi_search_lisp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
   *id += 1;

--- a/src/lib/protocols/megaco.c
+++ b/src/lib/protocols/megaco.c
@@ -54,7 +54,7 @@ void init_megaco_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_i
   ndpi_set_bitmask_protocol_detection("Megaco", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_MEGACO,
 				      ndpi_search_megaco,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/mpegts.c
+++ b/src/lib/protocols/mpegts.c
@@ -56,7 +56,7 @@ void init_mpegts_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_i
   ndpi_set_bitmask_protocol_detection("MPEG_TS", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_MPEGTS,
 				      ndpi_search_mpegts,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/netflow.c
+++ b/src/lib/protocols/netflow.c
@@ -186,7 +186,7 @@ void init_netflow_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_
   ndpi_set_bitmask_protocol_detection("NetFlow", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_NETFLOW,
 				      ndpi_search_netflow,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/nintendo.c
+++ b/src/lib/protocols/nintendo.c
@@ -59,7 +59,7 @@ void init_nintendo_dissector(struct ndpi_detection_module_struct *ndpi_struct,
   ndpi_set_bitmask_protocol_detection("Nintendo", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_NINTENDO,
 				      ndpi_search_nintendo,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
   *id += 1;

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1313,7 +1313,7 @@ static void process_tls(struct ndpi_detection_module_struct *ndpi_struct,
   if(flow->protos.tls_quic.alpn &&
      strncmp(flow->protos.tls_quic.alpn, "doq", 3) == 0) {
     NDPI_LOG_DBG(ndpi_struct, "Found DOQ (ALPN: [%s])\n", flow->protos.tls_quic.alpn);
-    ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DOH_DOT, NDPI_PROTOCOL_QUIC);
+    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_DOH_DOT, NDPI_PROTOCOL_QUIC);
   }
 }
 static void process_chlo(struct ndpi_detection_module_struct *ndpi_struct,
@@ -1565,7 +1565,7 @@ static int ndpi_search_quic_extra(struct ndpi_detection_module_struct *ndpi_stru
       packet->payload[1] == 200 || /* RTCP, Sender Report */
       is_valid_rtp_payload_type(packet->payload[1] & 0x7F)) /* RTP */) {
     NDPI_LOG_DBG(ndpi_struct, "Found RTP/RTCP over QUIC\n");
-    ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SNAPCHAT_CALL, NDPI_PROTOCOL_QUIC);
+    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SNAPCHAT_CALL, NDPI_PROTOCOL_QUIC);
   } else {
     /* Unexpected traffic pattern: we should investigate it... */
     NDPI_LOG_INFO(ndpi_struct, "To investigate...\n");

--- a/src/lib/protocols/radius.c
+++ b/src/lib/protocols/radius.c
@@ -74,7 +74,7 @@ void init_radius_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_i
   ndpi_set_bitmask_protocol_detection("Radius", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_RADIUS,
 				      ndpi_search_radius,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/rtp.c
+++ b/src/lib/protocols/rtp.c
@@ -403,7 +403,7 @@ void init_rtp_dissector(struct ndpi_detection_module_struct *ndpi_struct,
   ndpi_set_bitmask_protocol_detection("RTP", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_RTP,
 				      ndpi_search_rtp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/rx.c
+++ b/src/lib/protocols/rx.c
@@ -221,7 +221,7 @@ void init_rx_dissector(struct ndpi_detection_module_struct *ndpi_struct,
   ndpi_set_bitmask_protocol_detection("RX", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_RX,
 				      ndpi_search_rx,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/sflow.c
+++ b/src/lib/protocols/sflow.c
@@ -50,7 +50,7 @@ void init_sflow_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_in
   ndpi_set_bitmask_protocol_detection("sFlow", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_SFLOW,
 				      ndpi_search_sflow,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -221,7 +221,7 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
     printf("[STUN] Here we go\n");;
 #endif
 
-  if(ndpi_struct->stun_cache) {
+  if(ndpi_struct->stun_cache && packet->iph) { /* TODO: ipv6 */
     u_int16_t proto;
     u_int32_t key = get_stun_lru_key(packet, 0);
     int rc = ndpi_lru_find_cache(ndpi_struct->stun_cache, key, &proto,
@@ -471,10 +471,12 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
   printf("==>> NDPI_PROTOCOL_WHATSAPP_CALL\n");
 #endif
 
-  if(is_messenger_ip_address(ntohl(packet->iph->saddr)) || is_messenger_ip_address(ntohl(packet->iph->daddr)))      
-    flow->guessed_host_protocol_id = NDPI_PROTOCOL_MESSENGER;
-  else if(is_google_ip_address(ntohl(packet->iph->saddr)) || is_google_ip_address(ntohl(packet->iph->daddr)))
-    flow->guessed_host_protocol_id = NDPI_PROTOCOL_HANGOUT_DUO;
+  if(packet->iph) { /* TODO: ipv6 */
+    if(is_messenger_ip_address(ntohl(packet->iph->saddr)) || is_messenger_ip_address(ntohl(packet->iph->daddr)))
+      flow->guessed_host_protocol_id = NDPI_PROTOCOL_MESSENGER;
+    else if(is_google_ip_address(ntohl(packet->iph->saddr)) || is_google_ip_address(ntohl(packet->iph->daddr)))
+      flow->guessed_host_protocol_id = NDPI_PROTOCOL_HANGOUT_DUO;
+  }
   
   rc = (flow->stun.num_udp_pkts < MAX_NUM_STUN_PKTS) ? NDPI_IS_NOT_STUN : NDPI_IS_STUN;
 
@@ -543,7 +545,7 @@ void init_stun_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int
   ndpi_set_bitmask_protocol_detection("STUN", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_STUN,
 				      ndpi_search_stun,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/teredo.c
+++ b/src/lib/protocols/teredo.c
@@ -36,7 +36,7 @@ void ndpi_search_teredo(struct ndpi_detection_module_struct *ndpi_struct, struct
      && ((ntohs(packet->udp->source) == 3544) || (ntohs(packet->udp->dest) == 3544))
      && (packet->payload_packet_len >= 40 /* IPv6 header */)) {
     NDPI_LOG_INFO(ndpi_struct,"found teredo\n");
-    ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TEREDO, NDPI_PROTOCOL_UNKNOWN);
+    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TEREDO, NDPI_PROTOCOL_UNKNOWN);
   }  else {
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
@@ -48,6 +48,7 @@ void init_teredo_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_i
   ndpi_set_bitmask_protocol_detection("TEREDO", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_TEREDO,
 				      ndpi_search_teredo,
+				      /* Teredo is inherently IPV4 only */
 				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);

--- a/src/lib/protocols/ubntac2.c
+++ b/src/lib/protocols/ubntac2.c
@@ -87,7 +87,7 @@ void init_ubntac2_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_
   ndpi_set_bitmask_protocol_detection("UBNTAC2", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_UBNTAC2,
 				      ndpi_search_ubntac2,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
   *id += 1;

--- a/src/lib/protocols/vhua.c
+++ b/src/lib/protocols/vhua.c
@@ -69,7 +69,7 @@ void init_vhua_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int
   ndpi_set_bitmask_protocol_detection("VHUA", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_VHUA,
 				      ndpi_search_vhua,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
   *id += 1;

--- a/src/lib/protocols/viber.c
+++ b/src/lib/protocols/viber.c
@@ -55,7 +55,7 @@ void init_viber_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_in
   ndpi_set_bitmask_protocol_detection("VIBER", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_VIBER,
 				      ndpi_search_viber,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/src/lib/protocols/vmware.c
+++ b/src/lib/protocols/vmware.c
@@ -48,7 +48,7 @@ void init_vmware_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_i
   ndpi_set_bitmask_protocol_detection("VMWARE", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_VMWARE,
 				      ndpi_search_vmware,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
   

--- a/src/lib/protocols/wsd.c
+++ b/src/lib/protocols/wsd.c
@@ -44,8 +44,8 @@ void ndpi_search_wsd(struct ndpi_detection_module_struct *ndpi_struct,
      && (packet->payload_packet_len >= 40)
      && (strncmp((char*)packet->payload, "<?xml", 5) == 0)
      ) {
-    NDPI_LOG_INFO(ndpi_struct,"found teredo\n");
-    ndpi_int_change_protocol(ndpi_struct, flow, NDPI_PROTOCOL_WSD, NDPI_PROTOCOL_UNKNOWN);
+    NDPI_LOG_INFO(ndpi_struct,"found wsd\n");
+    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_WSD, NDPI_PROTOCOL_UNKNOWN);
   } else {
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }

--- a/src/lib/protocols/z3950.c
+++ b/src/lib/protocols/z3950.c
@@ -128,7 +128,7 @@ void init_z3950_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_in
                                       ndpi_struct, detection_bitmask, *id,
                                       NDPI_PROTOCOL_Z3950,
                                       ndpi_search_z3950,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_WITH_PAYLOAD,
+                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                                       SAVE_DETECTION_BITMASK_AS_UNKNOWN,
                                       ADD_TO_DETECTION_BITMASK);
 

--- a/tests/result/ipv6_in_gtp.pcap.out
+++ b/tests/result/ipv6_in_gtp.pcap.out
@@ -1,13 +1,10 @@
-Guessed flow protos:	1
+Guessed flow protos:	0
 
 DPI Packets (UDP):	1	(1.00 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 
-Unknown	1	150	1
 IPsec	1	166	1
+RTP	1	150	1
 
 	1	50 [2a01:4c8:c014:144e:1:2:945b:6761]:0 -> [2a01:4c8:f000:f49::4]:0 [VLAN: 2][proto: GTP:79/IPsec][Encrypted][cat: VPN/2][1 pkts/166 bytes -> 0 pkts/0 bytes][Goodput ratio: 0/0][< 1 sec][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-
-
-Undetected flows:
-	1	UDP [2607:fc20:4052:39e:490a:ea4d:17fe:e09c]:49120 -> [fd00:976a:bc67:193e::7]:25658 [VLAN: 5][proto: GTP:0/Unknown][ClearText][1 pkts/150 bytes -> 0 pkts/0 bytes][Goodput ratio: 29/0][< 1 sec][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	2	UDP [2607:fc20:4052:39e:490a:ea4d:17fe:e09c]:49120 -> [fd00:976a:bc67:193e::7]:25658 [VLAN: 5][proto: GTP:87/RTP][ClearText][cat: Media/1][1 pkts/150 bytes -> 0 pkts/0 bytes][Goodput ratio: 29/0][< 1 sec][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]


### PR DESCRIPTION
There are no valid reasons for a (generic) protocol to ignore IPv6
traffic.
Note that:
* I have not found the specifications of "CheckPoint High Availability
Protocol", so I don't know how/if it supports IPv6
* all LRU caches are still IPv4 only

Even if src_id/dst_id stuff is probably useless (see #1279), the right
way to update the protocol classification is via `ndpi_set_detected_protocol()`