### PR TITLE
Fix a global-buffer-overflow when loading Azure list

### DIFF
--- a/src/lib/ndpi_azure_match.c.inc
+++ b/src/lib/ndpi_azure_match.c.inc
@@ -39285,4 +39285,7 @@ static ndpi_network ndpi_protocol_microsoft_azure_protocol_list[] = {
  { 0xD5C7B460 /* 213.199.180.96/27 */, 27, NDPI_PROTOCOL_MICROSOFT_AZURE },
  { 0xD5C7B4C0 /* 213.199.180.192/27 */, 27, NDPI_PROTOCOL_MICROSOFT_AZURE },
  { 0xD5C7B700 /* 213.199.183.0/24 */, 24, NDPI_PROTOCOL_MICROSOFT_AZURE },
+
+ /* End */
+ { 0x0, 0, 0 }
 };

--- a/utils/ipaddr2list.py
+++ b/utils/ipaddr2list.py
@@ -55,5 +55,6 @@ with open(sys.argv[1]) as fp:
             if(ipaddr != ""):
                 print(" { 0x"+socket.inet_aton(ipaddr).hex().upper()+" /* "+ipaddr+"/"+cidr+" */, "+cidr+", "+proto+" },")
 
-
+print(" /* End */")
+print(" { 0x0, 0, 0 }")
 print("};")


### PR DESCRIPTION
```
==59998==ERROR: AddressSanitizer: global-buffer-overflow on address 0x000000e17b40 at pc 0x00000078cd69 bp 0x7ffd6364e6f0 sp 0x7ffd6364e6e8
READ of size 4 at 0x000000e17b40 thread T0
    #0 0x78cd68 in ndpi_init_ptree_ipv4 /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:2094:27
    #1 0x789d2b in ndpi_init_detection_module /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:2362:5
    #2 0x60a30f in dgaUnitTest /home/ivan/svnrepos/nDPI/example/ndpiReader.c:3735:51
    #3 0x51a368 in main /home/ivan/svnrepos/nDPI/example/ndpiReader.c:4467:7
    #4 0x7f83aa57b0b2 in __libc_start_main /build/glibc-YbNSs7/glibc-2.31/csu/../csu/libc-start.c:308:16
    #5 0x41f71d in _start (/home/ivan/svnrepos/nDPI/example/ndpiReader+0x41f71d) (BuildId: 3a2b3b10cf419d92eacb686559d284d1e01f8369)

0x000000e17b40 is located 0 bytes to the right of global variable 'ndpi_protocol_microsoft_azure_protocol_list' defined in './ndpi_azure_match.c.inc:23:21' (0xdcb040) of size 314112
SUMMARY: AddressSanitizer: global-buffer-overflow /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:2094:27 in ndpi_init_ptree_ipv4
...
````