### PR TITLE
fix ahocorasick on big-endian machines

### DIFF
--- a/src/lib/third_party/src/ahocorasick.c
+++ b/src/lib/third_party/src/ahocorasick.c
@@ -849,7 +849,11 @@ xmemchr(char *s, char i,int n)
       mask = c * DUPC;
 
       while (n >= LBLOCKSIZE) {
-        unsigned long int nc = DETECTNULL((*(unsigned long int *)s) ^ mask);
+#if __SIZEOF_LONG__ == 4
+        unsigned long int nc = DETECTNULL(le32toh(*(unsigned long int *)s) ^ mask);
+#else
+        unsigned long int nc = DETECTNULL(le64toh(*(unsigned long int *)s) ^ mask);
+#endif
         if(nc)
             return s + (bsf(nc) >> 3);
         s += LBLOCKSIZE;


### PR DESCRIPTION
Fixes #1312 (partially).
In my tests, 74 pcap tests failed on a 64-bit big-endian machine.
After these changes, the number of failed tests was reduced to 18.
Maybe the remaining tests are failing due to a dissector-specific bug or there is another bug in ahocorasic lib.