### PR TITLE
XBox, Diameter: fix dissectors initialization

### DIFF
--- a/src/lib/protocols/xbox.c
+++ b/src/lib/protocols/xbox.c
@@ -80,12 +80,17 @@ void ndpi_search_xbox(struct ndpi_detection_module_struct *ndpi_struct, struct n
       NDPI_LOG_DBG(ndpi_struct, "maybe xbox\n");
       flow->l4.udp.xbox_stage++;
       return;
-    } else if ((dport == 3075 || dport == 3076 || dport == 3077 || dport == 3078) ||
+    }
+/* Disable this code. These checks are quite weak and these ports are not mentioned at
+   https://support.xbox.com/en-US/help/hardware-network/connect-network/network-ports-used-xbox-live */
+#if 0
+    else if ((dport == 3075 || dport == 3076 || dport == 3077 || dport == 3078) ||
           (sport == 3075 || sport == 3076 || sport == 3077 || sport == 3078)) {
 	ndpi_int_xbox_add_connection(ndpi_struct, flow);
 	NDPI_LOG_INFO(ndpi_struct, "found xbox udp port connection detected\n");
 	return;
     }
+#endif
 
     /* exclude here all non matched udp traffic, exclude here tcp only if http has been excluded, because xbox could use http */
     if(NDPI_COMPARE_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_HTTP) != 0) {
@@ -102,7 +107,7 @@ void init_xbox_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int
 				      NDPI_PROTOCOL_XBOX,
 				      ndpi_search_xbox,
 				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
+				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 
   *id += 1;

--- a/tests/result/diameter.pcap.out
+++ b/tests/result/diameter.pcap.out
@@ -1,8 +1,8 @@
-Guessed flow protos:	1
+Guessed flow protos:	0
 
-DPI Packets (TCP):	6	(6.00 pkts/flow)
-Confidence Match by port    : 1 (flows)
+DPI Packets (TCP):	1	(1.00 pkts/flow)
+Confidence DPI              : 1 (flows)
 
 Diameter	6	1980	1
 
-	1	TCP 10.201.9.245:50957 <-> 10.201.9.11:3868 [proto: 237/Diameter][ClearText][Confidence: Match by port][cat: Network/14][3 pkts/1174 bytes <-> 3 pkts/806 bytes][Goodput ratio: 86/80][0.09 sec][bytes ratio: 0.186 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 13/12 39/32 65/51 26/20][Pkt Len c2s/s2c min/avg/max/stddev: 362/226 391/269 414/290 22/30][PLAIN TEXT (1263278878147)][Plen Bins: 0,0,0,0,0,16,0,34,0,16,16,16,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	1	TCP 10.201.9.245:50957 <-> 10.201.9.11:3868 [proto: 237/Diameter][ClearText][Confidence: DPI][cat: Network/14][3 pkts/1174 bytes <-> 3 pkts/806 bytes][Goodput ratio: 86/80][0.09 sec][bytes ratio: 0.186 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 13/12 39/32 65/51 26/20][Pkt Len c2s/s2c min/avg/max/stddev: 362/226 391/269 414/290 22/30][PLAIN TEXT (1263278878147)][Plen Bins: 0,0,0,0,0,16,0,34,0,16,16,16,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]


### PR DESCRIPTION
These dissectors have *never* been triggered because their registration
functions use the wrong parameter/bitmask.
Diameter code is buggy since the origianl commit (1d108234), while
XBox code since 5266c726.

Fix some false positives in Xbox code.