### PR TITLE
Zattoo: fix Null-dereference READ with ipv6 traffic

### DIFF
--- a/src/lib/protocols/zattoo.c
+++ b/src/lib/protocols/zattoo.c
@@ -100,7 +100,7 @@ void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct, struct
       ndpi_parse_packet_line_info(ndpi_struct, flow);
 
       // test for unique character of the zattoo header
-      if(packet->parsed_lines == 4 && packet->host_line.ptr != NULL) {
+      if(packet->parsed_lines == 4 && packet->host_line.ptr != NULL && packet->iph) {
 	u_int32_t ip;
 	u_int16_t bytes_read = 0;
 


### PR DESCRIPTION
Fix: 20b5f6d7
Detected by oss-fux:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43700