### PR TITLE
TLS: fix a use-of-uninitialized-value error

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1870,7 +1870,8 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		  printf("Client TLS Invalid len %u vs %u\n", s_offset+extension_len, total_len);
 #endif
 		}
-	      } else if(extension_id == 13 /* signature algorithms */) {
+	      } else if(extension_id == 13 /* signature algorithms */ &&
+	                offset+extension_offset+1 < total_len) {
 		int s_offset = offset+extension_offset, safari_signature_algorithms = 0, chrome_signature_algorithms = 0,
 		  duplicate_found = 0, last_signature = 0;
 		u_int16_t tot_signature_algorithms_len = ntohs(*((u_int16_t*)&packet->payload[s_offset]));


### PR DESCRIPTION
Detected by oss-fuzz:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43705