### PR TITLE
Fixed heap overflow in nDPI realloc wrapper if new size < old size.

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -205,7 +205,7 @@ void *ndpi_realloc(void *ptr, size_t old_size, size_t new_size) {
     return(ret);
   else {
     if(ptr != NULL) {
-      memcpy(ret, ptr, old_size);
+      memcpy(ret, ptr, (old_size < new_size ? old_size : new_size));
       ndpi_free(ptr);
     }
     return(ret);


### PR DESCRIPTION
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>