### PR TITLE
Increment current/total number of active flows on successful flow insertion

### DIFF
--- a/example/ndpiSimpleIntegration.c
+++ b/example/ndpiSimpleIntegration.c
@@ -776,8 +776,6 @@ static void ndpi_process_packet(uint8_t * const args,
       return;
     }
 
-    workflow->cur_active_flows++;
-    workflow->total_active_flows++;
     memcpy(flow_to_process, &flow, sizeof(*flow_to_process));
     flow_to_process->flow_id = __sync_fetch_and_add(&flow_id, 1);
 
@@ -796,6 +794,9 @@ static void ndpi_process_packet(uint8_t * const args,
       /* Possible Leak, but should not happen as we'd abort earlier. */
       return;
     }
+
+    workflow->cur_active_flows++;
+    workflow->total_active_flows++;
   } else {
     flow_to_process = *(struct nDPI_flow_info **)tree_result;
   }


### PR DESCRIPTION
Memory allocation or ndpi_tsearch might fail, so the two values should be
incremented only when insertion actually happened.