### PR TITLE
TLS: fix parsing of certificate elements

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -273,6 +273,8 @@ static int extractRDNSequence(struct ndpi_packet_struct *packet,
 		      "%s%s=%s", (*rdnSeqBuf_offset > 0) ? ", " : "",
 		      label, buffer);
 
+    if(rc > 0 && ((u_int)rc > rdnSeqBuf_len-(*rdnSeqBuf_offset)))
+      return -1; /* Truncated; not enough buffer */
     if(rc > 0)
       (*rdnSeqBuf_offset) += rc;
   }
@@ -329,7 +331,7 @@ static void processCertificateElements(struct ndpi_detection_module_struct *ndpi
 #endif
 
   /* Check after handshake protocol header (5 bytes) and message header (4 bytes) */
-  for(i = p_offset; i < certificate_len; i++) {
+  for(i = p_offset; i < certificate_len - 2; i++) {
     /*
       See https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.sec.doc/q009860_.htm
       for X.509 certificate labels


### PR DESCRIPTION
Found by oss-fuzz:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44280
```
==263603==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x592478 in ndpi_is_printable_string ndpi/src/lib/ndpi_utils.c:2200:9
    #1 0x5b047c in processCertificateElements ndpi/src/lib/protocols/tls.c:400:7
    #2 0x5ac880 in processCertificate ndpi/src/lib/protocols/tls.c:790:7
    #3 0x5c3a32 in processTLSBlock ndpi/src/lib/protocols/tls.c:844:13
    #4 0x5c2c61 in ndpi_search_tls_tcp ndpi/src/lib/protocols/tls.c:973:2
    #5 0x5c117d in ndpi_search_tls_wrapper ndpi/src/lib/protocols/tls.c:2367:5
    #6 0x552a50 in check_ndpi_detection_func ndpi/src/lib/ndpi_main.c:4792:6
```