### PR TITLE
Fix memory access in ndpi_strnstr()

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -7110,9 +7110,9 @@ char *ndpi_strnstr(const char *s, const char *find, size_t slen) {
 const char * ndpi_strncasestr(const char *str1, const char *str2, size_t len) {
   size_t str1_len = strnlen(str1, len);
   size_t str2_len = strlen(str2);
-  size_t i;
+  int i; /* signed! */
 
-  for(i = 0; i < (str1_len - str2_len + 1); i++){
+  for(i = 0; i < (int)(str1_len - str2_len + 1); i++){
     if(str1[0] == '\0')
       return NULL;
     else if(strncasecmp(str1, str2, str2_len) == 0)


### PR DESCRIPTION
Found by oss-fuzz:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44482

It should be the same error reported (and only partially fixed) in
79968f32