### PR TITLE
reader_util: fix parsing of IPv6 extension headers

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -984,6 +984,8 @@ static struct ndpi_flow_info *get_ndpi_flow_info6(struct ndpi_workflow * workflo
   u_int8_t l4proto = iph6->ip6_hdr.ip6_un1_nxt;
   u_int16_t ip_len = ntohs(iph6->ip6_hdr.ip6_un1_plen);
   const u_int8_t *l4ptr = (((const u_int8_t *) iph6) + sizeof(struct ndpi_ipv6hdr));
+  if(ipsize < sizeof(struct ndpi_ipv6hdr) + ip_len)
+    return(NULL);
   if(ndpi_handle_ipv6_extension_headers(ipsize - sizeof(struct ndpi_ipv6hdr), &l4ptr, &ip_len, &l4proto) != 0) {
     return(NULL);
   }


### PR DESCRIPTION
Found by oss-fuzz
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44942