### PR TITLE
Follow up on using internal crypto code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "ubuntu-18.04", "macOS-latest", "macos-11"]
         arch: ["x86_64"]
-        gcrypt: ["--disable-gcrypt", ""]
+        gcrypt: ["--with-libgcrypt", ""]
         compiler: ["default-cc"]
         pcre: [""]
         maxminddb: [""]
@@ -151,7 +151,7 @@ jobs:
           sudo apt-get install doxygen python3-sphinx python3-sphinx-rtd-theme python3-breathe python3-pip
           sudo apt-get install rrdtool librrd-dev
       - name: Install Ubuntu Prerequisites (libgcrypt)
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 'x86_64') && !startsWith(matrix.gcrypt, '--disable-gcrypt')
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 'x86_64') && startsWith(matrix.gcrypt, '--with-libgcrypt')
         run: |
           sudo apt-get install libgcrypt20-dev
       - name: Install Ubuntu Prerequisites (libpcre)
@@ -177,7 +177,7 @@ jobs:
           brew install coreutils
           brew install rrdtool
       - name: Install MacOS Prerequisites (libgcrypt)
-        if: startsWith(matrix.os, 'macOS') && startsWith(matrix.arch, 'x86_64') && !startsWith(matrix.gcrypt, '--disable-gcrypt')
+        if: startsWith(matrix.os, 'macOS') && startsWith(matrix.arch, 'x86_64') && startsWith(matrix.gcrypt, '--with-libgcrypt')
         run: |
           brew install libgcrypt
       - name: Install MacOS Prerequisites (libpcre)

--- a/configure.ac
+++ b/configure.ac
@@ -240,25 +240,9 @@ AC_CHECK_LIB(pthread, pthread_setaffinity_np, AC_DEFINE_UNQUOTED(HAVE_PTHREAD_SE
 
 AS_IF([test "${with_libgcrypt+set}" = set],[
 dnl> GCRYPT
-GCRYPT_ENABLED=1
-AC_ARG_ENABLE([gcrypt],
-  [AS_HELP_STRING([--disable-gcrypt], [Avoid compiling with libgcrypt/libgpg-error, even if they are present. QUIC sub-classification may be missing])],
-  [GCRYPT_ENABLED=0],
-  [AC_CHECK_LIB(gcrypt, gcry_cipher_checktag)])
-AS_IF([test ${GCRYPT_ENABLED} -eq 1], [
-  if test "x$ac_cv_lib_gcrypt_gcry_cipher_checktag" = xyes; then :
-    ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lgcrypt"
-  else
-    $as_unset ac_cv_lib_gcrypt_gcry_cipher_checktag
-    AC_CHECK_LIB(gpg-error, gpg_strerror_r)
-    AC_CHECK_LIB(gcrypt, gcry_cipher_checktag)
-    if test "x$ac_cv_lib_gcrypt_gcry_cipher_checktag" = xyes -a "x$ac_cv_lib_gpg_error_gpg_strerror_r" = xyes; then :
-      ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lgcrypt -lgpg-error"
-    else
-      GCRYPT_ENABLED=0
-    fi
-  fi
-])
+  AC_CHECK_LIB(gpg-error, gpg_strerror_r, [], [AC_MSG_ERROR([libgpg-error required (because of --with-libgcrypt) but not found or too old.])])
+  AC_CHECK_LIB(gcrypt, gcry_cipher_checktag, [], [AC_MSG_ERROR([libgcrypt required (because of --with-libgcrypt) but not found or too old.])])
+  ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lgcrypt -lgpg-error"
 ])
 
 dnl> PCRE
@@ -314,6 +298,5 @@ AC_SUBST(BUILD_MINGW_X64)
 AC_SUBST(BUILD_FUZZTARGETS)
 AC_SUBST(JSONC_CFLAGS)
 AC_SUBST(JSONC_LIBS)
-AC_SUBST(GCRYPT_ENABLED)
 AC_SUBST(PCRE_ENABLED)
 AC_OUTPUT

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -36,7 +36,6 @@
 #include <gcrypt.h>
 #else
 #include <gcrypt_light.h>
-#define HAVE_LIBGCRYPT 1
 #endif
 
 #include <time.h>
@@ -2420,7 +2419,6 @@ struct ndpi_detection_module_struct *ndpi_init_detection_module(ndpi_init_prefs 
   if(prefs & ndpi_enable_ja3_plus)
     ndpi_str->enable_ja3_plus = 1;
 
-#ifdef HAVE_LIBGCRYPT
   if(!(prefs & ndpi_dont_init_libgcrypt)) {
     if(!gcry_control (GCRYCTL_INITIALIZATION_FINISHED_P)) {
       const char *gcrypt_ver = gcry_check_version(NULL);
@@ -2436,7 +2434,6 @@ struct ndpi_detection_module_struct *ndpi_init_detection_module(ndpi_init_prefs 
   } else {
     NDPI_LOG_DBG(ndpi_str, "Libgcrypt initialization skipped\n");
   }
-#endif
 
   if((ndpi_str->protocols_ptree = ndpi_patricia_new(32 /* IPv4 */)) != NULL) {
     ndpi_init_ptree_ipv4(ndpi_str, ndpi_str->protocols_ptree, host_protocol_list);
@@ -7554,10 +7551,7 @@ u_int16_t ndpi_get_api_version() {
 }
 
 const char *ndpi_get_gcrypt_version(void) {
-#ifdef HAVE_LIBGCRYPT
   return gcry_check_version(NULL);
-#endif
-  return NULL;
 }
 
 ndpi_proto_defaults_t *ndpi_get_proto_defaults(struct ndpi_detection_module_struct *ndpi_str) {

--- a/tests/do.sh.in
+++ b/tests/do.sh.in
@@ -13,10 +13,8 @@ if [ "$NDPI_TESTS_VALGRIND" = "1" ]; then
    VALGRIND="valgrind -q --leak-check=full"
 fi
 
-GCRYPT_ENABLED=1
 PCRE_ENABLED=@PCRE_ENABLED@
 PCRE_PCAPS="WebattackRCE.pcap"
-GCRYPT_PCAPS="gquic.pcap quic-23.pcap quic-24.pcap quic-27.pcap quic-28.pcap quic-29.pcap quic-mvfst-22.pcap quic-mvfst-27.pcapng quic-mvfst-exp.pcap quic_q50.pcap quic_t50.pcap quic_t51.pcap quic_0RTT.pcap quic_interop_V.pcapng quic-33.pcapng doq.pcapng doq_adguard.pcapng dlt_ppp.pcap os_detected.pcapng quic_frags_ch_out_of_order_same_packet_craziness.pcapng quic_frags_ch_in_multiple_packets.pcapng quic-v2-00.pcapng"
 READER="$VALGRIND ../example/ndpiReader -p ../example/protos.txt -c ../example/categories.txt -r ../example/risky_domains.txt -j ../example/ja3_fingerprints.csv -S ../example/sha1_fingerprints.csv"
 
 RC=0
@@ -53,14 +51,6 @@ check_results() {
 		[ $SKIP_PCAP = 1 ] && continue
 	    fi
 	    SKIP_PCAP=0
-	    if [ $GCRYPT_ENABLED -eq 0 ]; then
-	      for g in $GCRYPT_PCAPS; do
-	        if [ $f = $g ]; then
-	          SKIP_PCAP=1
-	          break
-	        fi
-	      done
-	    fi
 	    if [ $PCRE_ENABLED -eq 0 ]; then
 	      for p in $PCRE_PCAPS; do
 	        if [ $f = $p ]; then


### PR DESCRIPTION
Two possible configurations:
* using internal crypto library (default)
* using external libgrypt (via `--with-libgcrypt`). In that case, if
libgrypt/libgpg-error are not available (or if it is too old) an error
is returned.

Update CI configuration to tests both.

Bottom line: QUIC flows are always decoded.

The define `HAVE_LIBGCRYPT` should be set only when the external
libgcrypt is used.