### PR TITLE
configure: fix usage of libgpg-error with `--with-local-libgcrypt`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -248,15 +248,9 @@ dnl> libgcrypt (external)
 USE_HOST_LIBGCRYPT=0
 AS_IF([test "${with_local_libgcrypt+set}" = set],[
   USE_HOST_LIBGCRYPT=1
-  AC_CHECK_LIB(gcrypt, gcry_cipher_checktag)
-  if test "x$ac_cv_lib_gcrypt_gcry_cipher_checktag" = xyes; then :
-    ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lgcrypt"
-  else
-    $as_unset ac_cv_lib_gcrypt_gcry_cipher_checktag
-    AC_CHECK_LIB(gpg-error, gpg_strerror_r, [], AC_MSG_ERROR([libgpg-error required (because of --with-local-libgcrypt) but not found or too old.]))
-    AC_CHECK_LIB(gcrypt, gcry_cipher_checktag, [], AC_MSG_ERROR([libgcrypt required (because of --with-local-libgcrypt) but not found or too old.]))
-    ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lgcrypt -lgpg-error"
-  fi
+  AC_CHECK_LIB(gpg-error, gpg_strerror_r, [], AC_MSG_ERROR([libgpg-error required (because of --with-local-libgcrypt) but not found or too old.]))
+  AC_CHECK_LIB(gcrypt, gcry_cipher_checktag, [], AC_MSG_ERROR([libgcrypt required (because of --with-local-libgcrypt) but not found or too old.]))
+  ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lgcrypt -lgpg-error"
   AC_DEFINE_UNQUOTED(USE_HOST_LIBGCRYPT, 1, [Use locally installed libgcrypt instead of builtin gcrypt-light])
 ])
 

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -246,16 +246,11 @@ static uint16_t gquic_get_u16(const uint8_t *buf, uint32_t version)
 #ifdef DEBUG_CRYPT
 char *__gcry_err(gpg_error_t err, char *buf, size_t buflen)
 {
-#if defined(HAVE_LIBGPG_ERROR) || !defined(USE_HOST_LIBGCRYPT)
   gpg_strerror_r(err, buf, buflen);
   /* I am not sure if the string will be always null-terminated...
      Better safe than sorry */
   if(buflen > 0)
     buf[buflen - 1] = '\0';
-#else
-  if(buflen > 0)
-    buf[0] = '\0';
-#endif
   return buf;
 }
 #endif /* DEBUG_CRYPT */


### PR DESCRIPTION
Right now, using external libgcrypt, nDPI is not linked to libgpg-error
because configure script never checks for it.

```
ivan@ivan-Latitude-E6540:~/svnrepos/nDPI(dev)$ CC=gcc-11 CXX=g++-11 CFLAGS="-O3 -g -Werror" ./autogen.sh --enable-debug-messages --with-pcre  --with-local-libgcrypt && make -s -j
[...]
checking for numa_available in -lnuma... yes
checking for pcap_open_live in -lpcap... yes
checking for pthread_setaffinity_np in -lpthread... yes
checking for gcry_cipher_checktag in -lgcrypt... yes             <------- missing check for libgpg-error
checking for pcre_compile in -lpcre... yes
checking that generated files are newer than configure... done
[...]
ivan@ivan-Latitude-E6540:~/svnrepos/nDPI(dev)$ grep HAVE_LIBGPG_ERROR src/include/ndpi_config.h
/* #undef HAVE_LIBGPG_ERROR */

```

Make both libgcrypt and libgpg-error mandatory if
`--with-local-libgcrypt` is used.

Technically speaking, libgpg-error might be optional, because it is used
only for debug messages. However having both libraries mandatory
slightly simplified the logic.
In most environments, libgpg-error is a dependency of libgcrypt anyway,
so having both libraries should be the standard case.