### PR TITLE
ndpiReader leaks memory when to free idle flows

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3314,7 +3314,7 @@ static void ndpi_process_packet(u_char *args,
 		     ndpi_workflow_node_cmp);
 
 	/* free the memory associated to idle flow in "idle_flows" - (see struct reader thread)*/
-	ndpi_free_flow_info_half(ndpi_thread_info[thread_id].idle_flows[ndpi_thread_info[thread_id].num_idle_flows]);
+	ndpi_flow_info_free_data(ndpi_thread_info[thread_id].idle_flows[ndpi_thread_info[thread_id].num_idle_flows]);
 	ndpi_free(ndpi_thread_info[thread_id].idle_flows[ndpi_thread_info[thread_id].num_idle_flows]);
       }
 


### PR DESCRIPTION
Looks like some memory happens in live-capture scenario. Some metadata is leaked during flow freeing. 