### PR TITLE
QUIC: handle retransmissions and overlapping fragments in reassembler (#1195)

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -716,7 +716,7 @@ struct ndpi_flow_udp_struct {
 
   /* NDPI_PROTOCOL_QUIC */
   u_int8_t *quic_reasm_buf;
-  u_int32_t quic_reasm_buf_len;
+  u_int8_t *quic_reasm_buf_bitmap;
   u_int32_t quic_reasm_buf_last_pos;
 
   /* NDPI_PROTOCOL_CSGO */

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4590,8 +4590,10 @@ void ndpi_free_flow_data(struct ndpi_flow_struct* flow) {
     }
 
     if(flow->l4_proto == IPPROTO_UDP) {
-      if(flow->l4.udp.quic_reasm_buf)
-	ndpi_free(flow->l4.udp.quic_reasm_buf);
+      if(flow->l4.udp.quic_reasm_buf){
+        ndpi_free(flow->l4.udp.quic_reasm_buf);
+        ndpi_free(flow->l4.udp.quic_reasm_buf_bitmap);
+      }
     }
   }
 }

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4592,7 +4592,8 @@ void ndpi_free_flow_data(struct ndpi_flow_struct* flow) {
     if(flow->l4_proto == IPPROTO_UDP) {
       if(flow->l4.udp.quic_reasm_buf){
         ndpi_free(flow->l4.udp.quic_reasm_buf);
-        ndpi_free(flow->l4.udp.quic_reasm_buf_bitmap);
+        if(flow->l4.udp.quic_reasm_buf_bitmap)
+          ndpi_free(flow->l4.udp.quic_reasm_buf_bitmap);
       }
     }
   }

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1026,7 +1026,7 @@ static void update_reasm_buf_bitmap(u_int8_t *buffer_bitmap,
 static int is_reasm_buf_complete(const u_int8_t *buffer_bitmap,
                                  const u_int32_t buffer_len)
 {
-  for (u_int32_t i = 0; i < buffer_len / 8; i++)
+  for(u_int32_t i = 0; i < buffer_len / 8; i++)
     if (buffer_bitmap[i] != 0xff)
       return 0;
   return 1;

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1041,7 +1041,7 @@ static int __reassemble(struct ndpi_flow_struct *flow, const u_int8_t *frag,
   const uint64_t last_pos = frag_offset + frag_len;
 
   if(!flow->l4.udp.quic_reasm_buf) {
-    flow->l4.udp.quic_reasm_buf = (uint8_t *)ndpi_calloc(max_quic_reasm_buffer_len, sizeof(uint8_t));
+    flow->l4.udp.quic_reasm_buf = (uint8_t *)ndpi_malloc(max_quic_reasm_buffer_len);
     flow->l4.udp.quic_reasm_buf_bitmap = (uint8_t *)ndpi_calloc(quic_reasm_buffer_bitmap_len, sizeof(uint8_t));
     if(!flow->l4.udp.quic_reasm_buf || !flow->l4.udp.quic_reasm_buf_bitmap)
       return -1; /* Memory error */

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1041,7 +1041,7 @@ static int __reassemble(struct ndpi_flow_struct *flow, const u_int8_t *frag,
   const uint64_t last_pos = frag_offset + frag_len;
 
   if(!flow->l4.udp.quic_reasm_buf) {
-    flow->l4.udp.quic_reasm_buf = (uint8_t *)ndpi_malloc(max_quic_reasm_buffer_len);
+    flow->l4.udp.quic_reasm_buf = (uint8_t *)ndpi_calloc(max_quic_reasm_buffer_len, sizeof(uint8_t));
     flow->l4.udp.quic_reasm_buf_bitmap = (uint8_t *)ndpi_calloc(quic_reasm_buffer_bitmap_len, sizeof(uint8_t));
     if(!flow->l4.udp.quic_reasm_buf || !flow->l4.udp.quic_reasm_buf_bitmap)
       return -1; /* Memory error */

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1073,8 +1073,8 @@ static int is_ch_complete(const u_int8_t *buf, uint64_t buf_len)
 static int is_ch_reassembler_pending(struct ndpi_flow_struct *flow)
 {
   return flow->l4.udp.quic_reasm_buf != NULL &&
-         !(is_ch_complete(flow->l4.udp.quic_reasm_buf, flow->l4.udp.quic_reasm_buf_last_pos)
-            && is_reasm_buf_complete(flow->l4.udp.quic_reasm_buf_bitmap, flow->l4.udp.quic_reasm_buf_last_pos));
+         !(is_reasm_buf_complete(flow->l4.udp.quic_reasm_buf_bitmap, flow->l4.udp.quic_reasm_buf_last_pos)
+            && is_ch_complete(flow->l4.udp.quic_reasm_buf, flow->l4.udp.quic_reasm_buf_last_pos));
 }
 static const uint8_t *get_reassembled_crypto_data(struct ndpi_detection_module_struct *ndpi_struct,
 						  struct ndpi_flow_struct *flow,
@@ -1098,8 +1098,8 @@ static const uint8_t *get_reassembled_crypto_data(struct ndpi_detection_module_s
   rc = __reassemble(flow, frag, frag_len, frag_offset,
                     &crypto_data, crypto_data_len);
   if(rc == 0) {
-    if(is_ch_complete(crypto_data, *crypto_data_len) &&
-      is_reasm_buf_complete(flow->l4.udp.quic_reasm_buf_bitmap, *crypto_data_len)) {
+    if(is_reasm_buf_complete(flow->l4.udp.quic_reasm_buf_bitmap, *crypto_data_len) &&
+      is_ch_complete(crypto_data, *crypto_data_len)) {
       NDPI_LOG_DBG2(ndpi_struct, "Reassembler completed!\n");
       return crypto_data;
     }

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1026,9 +1026,16 @@ static void update_reasm_buf_bitmap(u_int8_t *buffer_bitmap,
 static int is_reasm_buf_complete(const u_int8_t *buffer_bitmap,
                                  const u_int32_t buffer_len)
 {
-  for(u_int32_t i = 0; i < buffer_len / 8; i++)
+  const u_int32_t complete_bytes = buffer_len / 8;
+  const u_int32_t remaining_bits = buffer_len % 8;
+
+  for(u_int32_t i = 0; i < complete_bytes; i++)
     if (buffer_bitmap[i] != 0xff)
       return 0;
+
+  if (remaining_bits && buffer_bitmap[complete_bytes] != (1U << (remaining_bits)) - 1) 
+    return 0;
+    
   return 1;
 }
 

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1019,7 +1019,7 @@ static void update_reasm_buf_bitmap(u_int8_t *buffer_bitmap,
     for (u_int32_t i = start_byte + 1; i <= end_byte - 1; i++)
       buffer_bitmap[i] = 0xff; // completely received byte
     buffer_bitmap[start_byte] |= ~((1U << start_bit) - 1U); // fill from bit 'start_bit' until bit 7, both inclusive
-    buffer_bitmap[end_byte] |= (1U << end_bit + 1U) - 1U; // fill from bit 0 until bit 'end_bit', both inclusive
+    buffer_bitmap[end_byte] |= (1U << (end_bit + 1U)) - 1U; // fill from bit 0 until bit 'end_bit', both inclusive
   }
 }
 

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1042,11 +1042,10 @@ static int __reassemble(struct ndpi_flow_struct *flow, const u_int8_t *frag,
 
   if(!flow->l4.udp.quic_reasm_buf) {
     flow->l4.udp.quic_reasm_buf = (uint8_t *)ndpi_malloc(max_quic_reasm_buffer_len);
-    flow->l4.udp.quic_reasm_buf_bitmap = (uint8_t *)ndpi_malloc(quic_reasm_buffer_bitmap_len);
+    flow->l4.udp.quic_reasm_buf_bitmap = (uint8_t *)ndpi_calloc(quic_reasm_buffer_bitmap_len, sizeof(uint8_t));
     if(!flow->l4.udp.quic_reasm_buf || !flow->l4.udp.quic_reasm_buf_bitmap)
       return -1; /* Memory error */
     flow->l4.udp.quic_reasm_buf_last_pos = 0;
-    memset(flow->l4.udp.quic_reasm_buf_bitmap, 0, quic_reasm_buffer_bitmap_len);
   }
   if(last_pos > max_quic_reasm_buffer_len)
     return -3; /* Buffer too small */


### PR DESCRIPTION
Trying to handle the two remaining cases in QUIC reassembler: retransmissions and overlapping fragments.