### PR TITLE
[autoconf] Fixed .git submodule detection test.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_DEFINE_UNQUOTED(NDPI_PATCH_LEVEL,   "${NDPI_PATCH}", [nDPI patch level])
 
 # .git as directory in a cloned repo
 # .git as file in submodule based integration
-if test -d ".git" || test -f ".git" ; then :
+if test -d ".git" || test -f ".git" -a -d `cat .git | cut -d' ' -f2`; then :
      GIT_TAG=`git log -1 --format=%h`
      GIT_DATE=`git log -1 --format=%cd`
      #


### PR DESCRIPTION
The .git submodule detection test does not check that the path within the parent project actually exists.  The result is that the `NDPI_API_VERSION` define can be left empty and subsequent compilation will fail with:

```
ndpi_main.c: In function 'ndpi_get_api_version':
ndpi_main.c:7641:26: error: expected expression before ')' token
   return(NDPI_API_VERSION);
                          ^
ndpi_main.c:7642:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
```

This PR adds a check to ensure the parent's path exists and is a directory.

This was discovered while building for OpenWrt.

Signed-off-by: Darryl Sokoloski <darryl@sokoloski.ca>