### PR TITLE
TINC: fix invalid memory read

### DIFF
--- a/src/lib/protocols/tinc.c
+++ b/src/lib/protocols/tinc.c
@@ -90,11 +90,11 @@ static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, st
 	u_int16_t i = 3;
 	u_int8_t numbers_left = 4;
 	while(numbers_left) {
-	  while(packet_payload[i] >= '0' && packet_payload[i] <= '9') {
+	  while(i < payload_len && packet_payload[i] >= '0' && packet_payload[i] <= '9') {
 	    i++;
 	  }
 
-	  if(packet_payload[i++] == ' ') {
+	  if(i < payload_len && packet_payload[i++] == ' ') {
 	    numbers_left--;
 	  }
 	  else break;
@@ -102,12 +102,13 @@ static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, st
           
 	if(numbers_left) break;
           
-	while((packet_payload[i] >= '0' && packet_payload[i] <= '9') ||
-	      (packet_payload[i] >= 'A' && packet_payload[i] <= 'Z')) {
+	while(i < payload_len &&
+	      ((packet_payload[i] >= '0' && packet_payload[i] <= '9') ||
+	       (packet_payload[i] >= 'A' && packet_payload[i] <= 'Z'))) {
 	  i++;
 	}
           
-	if(packet_payload[i] == '\n') {
+	if(i < payload_len && packet_payload[i] == '\n') {
 	  if(++flow->tinc_state > 3) {
 	    if(ndpi_struct->tinc_cache == NULL)
 	      ndpi_struct->tinc_cache = cache_new(TINC_CACHE_MAX_SIZE);              


### PR DESCRIPTION
```
=================================================================
==19324==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60600061be96 at pc 0x55b4a4cb4460 bp 0x7ffc7b461a70 sp 0x7ffc7b461a68
READ of size 1 at 0x60600061be96 thread T0
    #0 0x55b4a4cb445f in ndpi_check_tinc /home/ivan/svnrepos/nDPI/src/lib/protocols/tinc.c:105:9
    #1 0x55b4a4cb1888 in ndpi_search_tinc /home/ivan/svnrepos/nDPI/src/lib/protocols/tinc.c:135:5
    #2 0x55b4a4b4a6e1 in check_ndpi_detection_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5013:6
    #3 0x55b4a4b4c2d4 in check_ndpi_tcp_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5084:12
    #4 0x55b4a4b4bf77 in ndpi_check_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5103:12
    #5 0x55b4a4b5dcca in ndpi_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5924:15
    #6 0x55b4a4a87734 in packet_processing /home/ivan/svnrepos/nDPI/example/reader_util.c:1519:31
    #7 0x55b4a4a80761 in ndpi_workflow_process_packet /home/ivan/svnrepos/nDPI/example/reader_util.c:2093:10
    #8 0x55b4a4a39c8d in LLVMFuzzerTestOneInput /home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader.c:107:7
    #9 0x55b4a4a3a46b in main /home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader.c:179:17
    #10 0x7f69c63760b2 in __libc_start_main /build/glibc-sMfBJT/glibc-2.31/csu/../csu/libc-start.c:308:16
    #11 0x55b4a497954d in _start (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_with_main+0x61654d) (BuildId: 705ebc5c412d267294a65cb01f03a1f012aeaf20)

0x60600061be96 is located 0 bytes to the right of 54-byte region [0x60600061be60,0x60600061be96)
allocated by thread T0 here:
[...]
```
Found by oss-fuzz:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46499