### PR TITLE
Raknet: fix heap-buffer-overflow

### DIFF
--- a/src/lib/protocols/raknet.c
+++ b/src/lib/protocols/raknet.c
@@ -124,7 +124,9 @@ void ndpi_search_raknet(struct ndpi_detection_module_struct *ndpi_struct,
 
     case 0x07: /* Open Connection Request 2 */
       ip_addr_offset = raknet_dissect_ip(packet, 17);
-      if (packet->payload_packet_len != 34 || ip_addr_offset == 0)
+      if (ip_addr_offset == 0 ||
+          !((ip_addr_offset == 16 && packet->payload_packet_len == 46) ||
+            (ip_addr_offset == 4 && packet->payload_packet_len == 34)))
       {
         NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
         return;
@@ -142,7 +144,9 @@ void ndpi_search_raknet(struct ndpi_detection_module_struct *ndpi_struct,
 
     case 0x08: /* Open Connection Reply 2 */
       ip_addr_offset = raknet_dissect_ip(packet, 25);
-      if (packet->payload_packet_len != 35 || ip_addr_offset == 0)
+      if (ip_addr_offset == 0 ||
+          !((ip_addr_offset == 16 && packet->payload_packet_len == 47) ||
+            (ip_addr_offset == 4 && packet->payload_packet_len == 35)))
       {
         NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
         return;


### PR DESCRIPTION
```
==120637==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x606000000488 at pc 0x55a0598d97ec bp 0x7ffcfe13f2e0 sp 0x7ffcfe13f2d8
READ of size 2 at 0x606000000488 thread T0
    #0 0x55a0598d97eb in ndpi_search_raknet /home/ivan/svnrepos/nDPI/src/lib/protocols/raknet.c:152:38
    #1 0x55a05966c48e in check_ndpi_detection_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5060:6
    #2 0x55a05966e428 in check_ndpi_udp_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5119:10
    #3 0x55a05966dddc in ndpi_check_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5152:12
    #4 0x55a05967fa7a in ndpi_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5971:15
    #5 0x55a05962b860 in LLVMFuzzerTestOneInput /home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet.c:24:3
    #6 0x55a05962bd9b in main /home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet.c:84:17
    #7 0x7f4aad7d80b2 in __libc_start_main /build/glibc-sMfBJT/glibc-2.31/csu/../csu/libc-start.c:308:16
    #8 0x55a05956b46d in _start (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet_with_main+0x5d746d) (BuildId: 9429d3d08edc3836e5536f93c07f140716d8b82e)

0x606000000488 is located 9 bytes to the right of 63-byte region [0x606000000440,0x60600000047f)
allocated by thread T0 here:
    #0 0x55a0595ee80e in malloc (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet_with_main+0x65a80e) (BuildId: 9429d3d08edc3836e5536f93c07f140716d8b82e)
    #1 0x55a05962bd06 in main /home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet.c:70:17
    #2 0x7f4aad7d80b2 in __libc_start_main /build/glibc-sMfBJT/glibc-2.31/csu/../csu/libc-start.c:308:16
```

Found by oss-fuzz
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47000