### PR TITLE
Replaced ndpiReader's libjson-c support with libnDPI's internal serialization interface.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,11 @@ AC_DEFINE_UNQUOTED(NDPI_GIT_DATE, "${GIT_DATE}", [Last GIT change])
 
 if ! test "${with_only_libndpi+set}" = set; then :
     dnl> used by json-c for unit tests
-    PKG_CHECK_MODULES([JSONC], [json-c], [JSONC_LIBS="${pkg_cv_JSONC_LIBS}" JSONC_CFLAGS="${pkg_cv_JSONC_CFLAGS}"], [AC_MSG_WARN([JSON-C not available. Disabled unit test.])])
+    PKG_CHECK_MODULES([JSONC], [json-c], [
+        AC_DEFINE(HAVE_LIBJSON_C, 1, [libjson-c is present])
+        JSONC_LIBS="${pkg_cv_JSONC_LIBS}"
+        JSONC_CFLAGS="${pkg_cv_JSONC_CFLAGS}"
+    ], [AC_MSG_WARN([JSON-C not available. Disabled unit test.])])
     AC_CHECK_LIB([json-c], [json_object_put], [EXTRA_TARGETS="$EXTRA_TARGETS tests/unit"], [
         AC_MSG_WARN([JSON-C not available. Disabled unit test.])
         JSONC_LIBS=""

--- a/fuzz/fuzz_ndpi_reader.c
+++ b/fuzz/fuzz_ndpi_reader.c
@@ -60,7 +60,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     prefs->max_ndpi_flows = 1024 * 1024;
     prefs->quiet_mode = 0;
 
-    workflow = ndpi_workflow_init(prefs, NULL /* pcap handler will be set later */, 0);
+    workflow = ndpi_workflow_init(prefs, NULL /* pcap handler will be set later */, 0, ndpi_serialization_format_json);
     // enable all protocols
     NDPI_BITMASK_SET_ALL(all);
     ndpi_set_protocol_detection_bitmask2(workflow->ndpi_struct, &all);
@@ -79,6 +79,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   if (pkts == NULL) {
     remove(pcap_path);
     free(pcap_path);
+    ndpi_term_serializer(&workflow->ndpi_serializer);
     return 0;
   }
   if (ndpi_is_datalink_supported(pcap_datalink(pkts)) == 0)
@@ -87,6 +88,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     pcap_close(pkts);
     remove(pcap_path);
     free(pcap_path);
+    ndpi_term_serializer(&workflow->ndpi_serializer);
     return 0;
   }
 
@@ -104,7 +106,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
       ndpi_risk flow_risk;
 
       memcpy(packet_checked, pkt, header->caplen);
-      ndpi_workflow_process_packet(workflow, header, packet_checked, &flow_risk, NULL);
+      ndpi_workflow_process_packet(workflow, header, packet_checked, &flow_risk);
       free(packet_checked);
     }
 

--- a/fuzz/fuzz_process_packet.c
+++ b/fuzz/fuzz_process_packet.c
@@ -4,6 +4,8 @@
 #include <stdio.h>
 
 struct ndpi_detection_module_struct *ndpi_info_mod = NULL;
+static ndpi_serializer json_serializer = {};
+static ndpi_serializer csv_serializer = {};
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   uint8_t protocol_was_guessed;
@@ -17,12 +19,27 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     ndpi_set_log_level(ndpi_info_mod, 4);
     ndpi_set_debug_bitmask(ndpi_info_mod, debug_bitmask);
     ndpi_finalize_initialization(ndpi_info_mod);
+    ndpi_init_serializer(&json_serializer, ndpi_serialization_format_json);
+    ndpi_init_serializer(&csv_serializer, ndpi_serialization_format_csv);
   }
 
   struct ndpi_flow_struct *ndpi_flow = ndpi_flow_malloc(SIZEOF_FLOW_STRUCT);
   memset(ndpi_flow, 0, SIZEOF_FLOW_STRUCT);
-  ndpi_detection_process_packet(ndpi_info_mod, ndpi_flow, Data, Size, 0);
-  ndpi_detection_giveup(ndpi_info_mod, ndpi_flow, 1, &protocol_was_guessed);
+  ndpi_protocol detected_protocol =
+    ndpi_detection_process_packet(ndpi_info_mod, ndpi_flow, Data, Size, 0);
+  ndpi_protocol guessed_protocol =
+    ndpi_detection_giveup(ndpi_info_mod, ndpi_flow, 1, &protocol_was_guessed);
+
+  ndpi_reset_serializer(&json_serializer);
+  ndpi_reset_serializer(&csv_serializer);
+  if (protocol_was_guessed == 0)
+  {
+    ndpi_dpi2json(ndpi_info_mod, ndpi_flow, detected_protocol, &json_serializer);
+    ndpi_dpi2json(ndpi_info_mod, ndpi_flow, detected_protocol, &csv_serializer);
+  } else {
+    ndpi_dpi2json(ndpi_info_mod, ndpi_flow, guessed_protocol, &json_serializer);
+    ndpi_dpi2json(ndpi_info_mod, ndpi_flow, guessed_protocol, &csv_serializer);
+  }
   ndpi_free_flow(ndpi_flow);
 
   return 0;

--- a/tests/unit/unit.c
+++ b/tests/unit/unit.c
@@ -55,9 +55,7 @@
 #include "ndpi_api.h"
 #include "ndpi_define.h"
 
-#ifdef HAVE_LIBJSON_C
 #include "json.h" /* JSON-C */
-#endif
 
 static struct ndpi_detection_module_struct *ndpi_info_mod = NULL;
 static int verbose = 0;
@@ -65,7 +63,6 @@ static int verbose = 0;
 /* *********************************************** */
 
 int serializerUnitTest() {
-#ifdef HAVE_LIBJSON_C
   ndpi_serializer serializer, deserializer;
   int i, loop_id;
   ndpi_serialization_format fmt = {0};
@@ -229,7 +226,6 @@ int serializerUnitTest() {
   }
 
   printf("%30s                      OK\n", __FUNCTION__);
-#endif
   return 0;
 }
 
@@ -237,7 +233,6 @@ int serializerUnitTest() {
 
 int serializeProtoUnitTest(void)
 {
-#ifdef HAVE_LIBJSON_C
   ndpi_serializer serializer;
   int loop_id;
   ndpi_serialization_format fmt = {0};
@@ -277,7 +272,7 @@ int serializeProtoUnitTest(void)
     {
       buffer_len = 0;
       buffer = ndpi_serializer_get_buffer(&serializer, &buffer_len);
-      char const * const expected_json_str = "{\"ndpi\": {\"flow_risk\": {\"6\": {\"risk\":\"Self-signed Certificate\",\"severity\":\"High\",\"risk_score\": {\"total\":500,\"client\":450,\"server\":50}},\"7\": {\"risk\":\"Obsolete TLS Version (1.1 or older)\",\"severity\":\"High\",\"risk_score\": {\"total\":510,\"client\":455,\"server\":55}},\"8\": {\"risk\":\"Weak TLS Cipher\",\"severity\":\"High\",\"risk_score\": {\"total\":250,\"client\":225,\"server\":25}},\"17\": {\"risk\":\"Malformed Packet\",\"severity\":\"Low\",\"risk_score\": {\"total\":260,\"client\":130,\"server\":130}}},\"confidence\": {\"4\":\"DPI\"},\"proto\":\"TLS.Facebook\",\"breed\":\"Fun\",\"category\":\"SocialNetwork\"}}";
+      char const * const expected_json_str = "{\"ndpi\": {\"flow_risk\": {\"6\": {\"risk\":\"Self-signed Cert\",\"severity\":\"High\",\"risk_score\": {\"total\":500,\"client\":450,\"server\":50}},\"7\": {\"risk\":\"Obsolete TLS (v1.1 or older)\",\"severity\":\"High\",\"risk_score\": {\"total\":510,\"client\":455,\"server\":55}},\"8\": {\"risk\":\"Weak TLS Cipher\",\"severity\":\"High\",\"risk_score\": {\"total\":250,\"client\":225,\"server\":25}},\"17\": {\"risk\":\"Malformed Packet\",\"severity\":\"Low\",\"risk_score\": {\"total\":260,\"client\":130,\"server\":130}}},\"confidence\": {\"4\":\"DPI\"},\"proto\":\"TLS.Facebook\",\"breed\":\"Fun\",\"category\":\"SocialNetwork\"}}";
 
       if (strncmp(buffer, expected_json_str, buffer_len) != 0)
       {
@@ -316,7 +311,6 @@ int serializeProtoUnitTest(void)
   }
 
   printf("%30s                      OK\n", __FUNCTION__);
-#endif
 
   return 0;
 }


### PR DESCRIPTION
 * Fixes #1528
 * Serialization Interface should also fuzzed
 * libjson-c may only be used in the unit test to verify the internal serialization interface
 * Serialization Interface supports tlv(broken), csv and json
 * Unit test does work again and requires libjson-c

Signed-off-by: lns <matzeton@googlemail.com>