### PR TITLE
DNS-over-QUIC: update default port

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -1154,7 +1154,7 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
   ndpi_set_proto_defaults(ndpi_str, 0 /* encrypted */, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_DOH_DOT,
 			  "DoH_DoT", NDPI_PROTOCOL_CATEGORY_NETWORK /* dummy */,
 			  ndpi_build_default_ports(ports_a, 853, 0, 0, 0, 0) /* TCP */,
-			  ndpi_build_default_ports(ports_b, 784, 0, 0, 0, 0) /* UDP */);
+			  ndpi_build_default_ports(ports_b, 784, 853, 0, 0, 0) /* UDP */);
   ndpi_set_proto_defaults(ndpi_str, 0 /* encrypted */, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_REDDIT,
 			  "Reddit", NDPI_PROTOCOL_CATEGORY_SOCIAL_NETWORK,
 			  ndpi_build_default_ports(ports_a, 0, 0, 0, 0, 0) /* TCP */,


### PR DESCRIPTION
Final RFC (https://www.rfc-editor.org/rfc/rfc9250.txt) changed the
default port to 853 (from the 784 used on the early drafts).
Since there is at least one deployed implementation still stuck at
draft-02, keep also the old value, for the time being.