### PR TITLE
HTTP: fix heap-buffer-overflow error

### DIFF
--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -979,7 +979,7 @@ static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_str
       if(is_a_suspicious_header(suspicious_http_header_keys_A, packet->line[i])) {
 	char str[64];
 
-	snprintf(str, sizeof(str), "Found %s", packet->line[i].ptr);
+	snprintf(str, sizeof(str), "Found %.*s", packet->line[i].len, packet->line[i].ptr);
 	ndpi_set_risk(ndpi_struct, flow, NDPI_HTTP_SUSPICIOUS_HEADER, str);
 	return;
       }
@@ -988,7 +988,7 @@ static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_str
       if(is_a_suspicious_header(suspicious_http_header_keys_C, packet->line[i])) {
 	char str[64];
 
-	snprintf(str, sizeof(str), "Found %s", packet->line[i].ptr);
+	snprintf(str, sizeof(str), "Found %.*s", packet->line[i].len, packet->line[i].ptr);
 	ndpi_set_risk(ndpi_struct, flow, NDPI_HTTP_SUSPICIOUS_HEADER, str);
 	return;
       }
@@ -997,7 +997,7 @@ static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_str
       if(is_a_suspicious_header(suspicious_http_header_keys_M, packet->line[i])) {
 	char str[64];
 
-	snprintf(str, sizeof(str), "Found %s", packet->line[i].ptr);
+	snprintf(str, sizeof(str), "Found %.*s", packet->line[i].len, packet->line[i].ptr);
 	ndpi_set_risk(ndpi_struct, flow, NDPI_HTTP_SUSPICIOUS_HEADER, str);
 	return;
       }
@@ -1006,7 +1006,7 @@ static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_str
       if(is_a_suspicious_header(suspicious_http_header_keys_O, packet->line[i])) {
 	char str[64];
 
-	snprintf(str, sizeof(str), "Found %s", packet->line[i].ptr);
+	snprintf(str, sizeof(str), "Found %.*s", packet->line[i].len, packet->line[i].ptr);
 	ndpi_set_risk(ndpi_struct, flow, NDPI_HTTP_SUSPICIOUS_HEADER, str);
 	return;
       }
@@ -1015,7 +1015,7 @@ static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_str
       if(is_a_suspicious_header(suspicious_http_header_keys_R, packet->line[i])) {
 	char str[64];
 
-	snprintf(str, sizeof(str), "Found %s", packet->line[i].ptr);
+	snprintf(str, sizeof(str), "Found %.*s", packet->line[i].len, packet->line[i].ptr);
 	ndpi_set_risk(ndpi_struct, flow, NDPI_HTTP_SUSPICIOUS_HEADER, str);
 	return;
       }
@@ -1024,7 +1024,7 @@ static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_str
       if(is_a_suspicious_header(suspicious_http_header_keys_S, packet->line[i])) {
 	char str[64];
 
-	snprintf(str, sizeof(str), "Found %s", packet->line[i].ptr);
+	snprintf(str, sizeof(str), "Found %.*s", packet->line[i].len, packet->line[i].ptr);
 	ndpi_set_risk(ndpi_struct, flow, NDPI_HTTP_SUSPICIOUS_HEADER, str);
 	return;
       }
@@ -1033,7 +1033,7 @@ static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_str
       if(is_a_suspicious_header(suspicious_http_header_keys_T, packet->line[i])) {
 	char str[64];
 
-	snprintf(str, sizeof(str), "Found %s", packet->line[i].ptr);
+	snprintf(str, sizeof(str), "Found %.*s", packet->line[i].len, packet->line[i].ptr);
 	ndpi_set_risk(ndpi_struct, flow, NDPI_HTTP_SUSPICIOUS_HEADER, str);
 	return;
       }
@@ -1042,7 +1042,7 @@ static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_str
       if(is_a_suspicious_header(suspicious_http_header_keys_U, packet->line[i])) {
 	char str[64];
 
-	snprintf(str, sizeof(str), "Found %s", packet->line[i].ptr);
+	snprintf(str, sizeof(str), "Found %.*s", packet->line[i].len, packet->line[i].ptr);
 	ndpi_set_risk(ndpi_struct, flow, NDPI_HTTP_SUSPICIOUS_HEADER, str);
 	return;
       }
@@ -1051,7 +1051,7 @@ static void ndpi_check_http_header(struct ndpi_detection_module_struct *ndpi_str
       if(is_a_suspicious_header(suspicious_http_header_keys_X, packet->line[i])) {
 	char str[64];
 
-	snprintf(str, sizeof(str), "Found %s", packet->line[i].ptr);
+	snprintf(str, sizeof(str), "Found %.*s", packet->line[i].len, packet->line[i].ptr);
 	ndpi_set_risk(ndpi_struct, flow, NDPI_HTTP_SUSPICIOUS_HEADER, str);
 	return;
       }


### PR DESCRIPTION
```
==222479==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60b000014739 at pc 0x55af06f2364f bp 0x7ffd7b6f4bf0 sp 0x7ffd7b6f4378
READ of size 12 at 0x60b000014739 thread T0
    #0 0x55af06f2364e in printf_common(void*, char const*, __va_list_tag*) asan_interceptors.cpp.o
    #1 0x55af06f24f70 in __interceptor_snprintf (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_with_main+0x613f70) (BuildId: f6545ec2bd7663bc3f16aeeb87bddc64d173a2a8)
    #2 0x55af0720927f in ndpi_check_http_header /home/ivan/svnrepos/nDPI/src/lib/protocols/http.c:982:2
    #3 0x55af071f4797 in ndpi_check_http_tcp /home/ivan/svnrepos/nDPI/src/lib/protocols/http.c:1219:5
    #4 0x55af071f05c5 in ndpi_search_http_tcp /home/ivan/svnrepos/nDPI/src/lib/protocols/http.c:1402:3
    #5 0x55af07080d1e in check_ndpi_detection_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5150:6
    #6 0x55af07081734 in check_ndpi_tcp_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5198:12
    #7 0x55af070813d7 in ndpi_check_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5217:12
    #8 0x55af070939f7 in ndpi_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:6076:15
    #9 0x55af06fc7e1f in packet_processing /home/ivan/svnrepos/nDPI/example/reader_util.c:1541
    #10 0x55af06fc7e1f in ndpi_workflow_process_packet /home/ivan/svnrepos/nDPI/example/reader_util.c:2110
    #11 0x55af06fc2859 in LLVMFuzzerTestOneInput /home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader.c:109:7
    #12 0x55af06fc2feb in main /home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader.c:181:17
    #13 0x7efe5eaac082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16
    #14 0x55af06f0055d in _start (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_with_main+0x5ef55d) (BuildId: f6545ec2bd7663bc3f16aeeb87bddc64d173a2a8)

0x60b000014739 is located 0 bytes to the right of 105-byte region [0x60b0000146d0,0x60b000014739)
allocated by thread T0 here:
    #0 0x55af06f84bae in malloc (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_with_main+0x673bae) (BuildId: f6545ec2bd7663bc3f16aeeb87bddc64d173a2a8)
    #1 0x55af06fc2673 in LLVMFuzzerTestOneInput /home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader.c:103:31
    #2 0x55af06fc2feb in main /home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader.c:181:17
    #3 0x7efe5eaac082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16

```
Fiund by oss-fuzzer.
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47724