### PR TITLE
Add some statistics to ndpiReader

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3201,7 +3201,7 @@ static void printFlowsStats() {
 	//freeing the hash table
 	HASH_ITER(hh, hostsHashT, host_iter, tmp7){
 	   HASH_DEL(hostsHashT, host_iter);
-	   free(host_iter);
+	   ndpi_free(host_iter);
 	}
 	    
   }

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3190,7 +3190,7 @@ static void printFlowsStats() {
    	int diff;
 	HASH_ITER(hh, hostsHashT, host_iter, tmp6){
 		
-		printf("%s", host_iter->domain_name);
+		printf("\t%s", host_iter->domain_name);
 		//to print the occurency in aligned column	    	
 		diff = len_max-strlen(host_iter->domain_name);
 	    	for (j = 0; j <= diff+5;j++)

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3098,7 +3098,6 @@ static void printFlowsStats() {
 		unsigned int len_table_max = 1000;
 	      	//number of element to delete when the table is full
 		int toDelete = 10;
-		unsigned int size_table;
 		struct hash_stats *hostsHashT = NULL;
 		struct hash_stats *host_iter = NULL;
 		struct hash_stats *tmp4 = NULL;

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3111,8 +3111,7 @@ static void printFlowsStats() {
 		if(all_flows[i].flow->host_server_name[0] != '\0'){
 		
 			int len = strlen(all_flows[i].flow->host_server_name);
-			if(len > len_max)
-				len_max = len;
+			len_max = ndpi_max(len,len_max);
 				
 			struct hash_stats *hostFound;
 			HASH_FIND_STR(hostsHashT, all_flows[i].flow->host_server_name, hostFound);
@@ -3146,8 +3145,7 @@ static void printFlowsStats() {
 		if(all_flows[i].flow->ssh_tls.server_info[0] != '\0'){
 		
 			int len = strlen(all_flows[i].flow->host_server_name);
-			if(len > len_max)
-				len_max = len;
+			len_max = ndpi_max(len,len_max);
 				
 			struct hash_stats *hostFound;
 		  	HASH_FIND_STR(hostsHashT, all_flows[i].flow->ssh_tls.server_info, hostFound);

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3187,7 +3187,6 @@ static void printFlowsStats() {
 	
       	//print the element of the hash table
    	int j;
-   	int diff;
 	HASH_ITER(hh, hostsHashT, host_iter, tmp6){
 		
 		printf("\t%s", host_iter->domain_name);

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3120,8 +3120,6 @@ static void printFlowsStats() {
 				struct hash_stats *newHost = (struct hash_stats*)ndpi_malloc(sizeof(hash_stats));
 			      	newHost->domain_name = all_flows[i].flow->host_server_name;
 				newHost->occurency = 1;
-				    
-				size_t size_table;
 				if (HASH_COUNT(hostsHashT) == len_table_max) {
 				  int i=0;
 				  while (i<=toDelete){
@@ -3155,7 +3153,7 @@ static void printFlowsStats() {
 	      	    		newHost->domain_name = all_flows[i].flow->ssh_tls.server_info;
 		    		newHost->occurency = 1;
 	    
-	    			if ((size_table = HASH_COUNT(hostsHashT)) == len_table_max) {
+	    			if ((HASH_COUNT(hostsHashT)) == len_table_max) {
 				  int i=0;
 				  while (i<toDelete){
 		

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3191,7 +3191,7 @@ static void printFlowsStats() {
 		
 		printf("\t%s", host_iter->domain_name);
 		//to print the occurency in aligned column	    	
-		diff = len_max-strlen(host_iter->domain_name);
+		int diff = len_max-strlen(host_iter->domain_name);
 	    	for (j = 0; j <= diff+5;j++)
 	    		printf (" ");
 	    	printf("%d\n",host_iter->occurency);

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3154,7 +3154,7 @@ static void printFlowsStats() {
 		  	HASH_FIND_STR(hostsHashT, all_flows[i].flow->ssh_tls.server_info, hostFound);
 
 		  	if(hostFound == NULL){
-		    		struct hash_stats *newHost = (struct hash_stats*)malloc(sizeof(hash_stats));
+		    		struct hash_stats *newHost = (struct hash_stats*)ndpi_malloc(sizeof(hash_stats));
 	      	    		newHost->domain_name = all_flows[i].flow->ssh_tls.server_info;
 		    		newHost->occurency = 1;
 	    

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3164,7 +3164,7 @@ static void printFlowsStats() {
 		
 				    HASH_ITER(hh, hostsHashT, host_iter, tmp5){
 			 	     HASH_DEL(hostsHashT,host_iter);
-			  	    free(host_iter);
+			  	    ndpi_free(host_iter);
 			   	   i++;		
 			 	   }
 				  }	

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3119,7 +3119,7 @@ static void printFlowsStats() {
 			HASH_FIND_STR(hostsHashT, all_flows[i].flow->host_server_name, hostFound);
 
 			if(hostFound == NULL){
-				struct hash_stats *newHost = (struct hash_stats*)malloc(sizeof(hash_stats));
+				struct hash_stats *newHost = (struct hash_stats*)ndpi_malloc(sizeof(hash_stats));
 			      	newHost->domain_name = all_flows[i].flow->host_server_name;
 				newHost->occurency = 1;
 				    

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3158,7 +3158,7 @@ static void printFlowsStats() {
 	      	    		newHost->domain_name = all_flows[i].flow->ssh_tls.server_info;
 		    		newHost->occurency = 1;
 	    
-	    			if ((size_table = HASH_COUNT(hostsHashT)==len_table_max)){
+	    			if ((size_table = HASH_COUNT(hostsHashT)) == len_table_max) {
 				  int i=0;
 				  while (i<toDelete){
 		

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3197,6 +3197,7 @@ static void printFlowsStats() {
 	    		printf (" ");
 	    	printf("%d\n",host_iter->occurency);
 	}
+	printf("%s", "\n\n");
 
 	//freeing the hash table
 	HASH_ITER(hh, hostsHashT, host_iter, tmp7){

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3123,7 +3123,7 @@ static void printFlowsStats() {
 				newHost->occurency = 1;
 				    
 				size_t size_table;
-				if ((size_table = HASH_COUNT(hostsHashT)) == len_table_max) {
+				if (HASH_COUNT(hostsHashT) == len_table_max) {
 				  int i=0;
 				  while (i<=toDelete){
 					

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3100,10 +3100,7 @@ static void printFlowsStats() {
 		int toDelete = 10;
 		struct hash_stats *hostsHashT = NULL;
 		struct hash_stats *host_iter = NULL;
-		struct hash_stats *tmp4 = NULL;
-		struct hash_stats *tmp5 = NULL;
-		struct hash_stats *tmp6 = NULL;
-		struct hash_stats *tmp7 = NULL;
+		struct hash_stats *tmp = NULL;
 		int len_max = 0;    
 		      
 	      	for (i = 0; i<num_flows; i++){
@@ -3124,7 +3121,7 @@ static void printFlowsStats() {
 				  int i=0;
 				  while (i<=toDelete){
 					
-				    HASH_ITER(hh, hostsHashT, host_iter, tmp4){
+				    HASH_ITER(hh, hostsHashT, host_iter, tmp){
 				      HASH_DEL(hostsHashT,host_iter);
 				      free(host_iter);
 				      i++;		
@@ -3157,7 +3154,7 @@ static void printFlowsStats() {
 				  int i=0;
 				  while (i<toDelete){
 		
-				    HASH_ITER(hh, hostsHashT, host_iter, tmp5){
+				    HASH_ITER(hh, hostsHashT, host_iter, tmp){
 			 	     HASH_DEL(hostsHashT,host_iter);
 			  	    ndpi_free(host_iter);
 			   	   i++;		
@@ -3182,7 +3179,7 @@ static void printFlowsStats() {
 	
       	//print the element of the hash table
    	int j;
-	HASH_ITER(hh, hostsHashT, host_iter, tmp6){
+	HASH_ITER(hh, hostsHashT, host_iter, tmp){
 		
 		printf("\t%s", host_iter->domain_name);
 		//to print the occurency in aligned column	    	
@@ -3194,7 +3191,7 @@ static void printFlowsStats() {
 	printf("%s", "\n\n");
 
 	//freeing the hash table
-	HASH_ITER(hh, hostsHashT, host_iter, tmp7){
+	HASH_ITER(hh, hostsHashT, host_iter, tmp){
 	   HASH_DEL(hostsHashT, host_iter);
 	   ndpi_free(host_iter);
 	}

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -3123,7 +3123,8 @@ static void printFlowsStats() {
 			      	newHost->domain_name = all_flows[i].flow->host_server_name;
 				newHost->occurency = 1;
 				    
-				if ((size_table = HASH_COUNT(hostsHashT)==len_table_max)){
+				size_t size_table;
+				if ((size_table = HASH_COUNT(hostsHashT)) == len_table_max) {
 				  int i=0;
 				  while (i<=toDelete){
 					

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -2729,8 +2729,18 @@ static void printRiskStats() {
 
 /* *********************************************** */
 
-/*function to use in HASH_SORT function in verbose == 4 */
-static int hash_stats_sort(void *_a, void *_b){
+/*function to use in HASH_SORT function in verbose == 4 to order in creasing order to delete host with the leatest occurency*/
+static int hash_stats_sort_to_order(void *_a, void *_b){
+	struct hash_stats *a = (struct hash_stats*)_a;
+	struct hash_stats *b = (struct hash_stats*)_b;
+	
+	return (a->occurency - b->occurency);
+}
+
+/* *********************************************** */
+
+/*function to use in HASH_SORT function in verbose == 4 to print in decreasing order*/
+static int hash_stats_sort_to_print(void *_a, void *_b){
 	struct hash_stats *a = (struct hash_stats*)_a;
 	struct hash_stats *b = (struct hash_stats*)_b;
 	
@@ -3171,13 +3181,14 @@ static void printFlowsStats() {
 			
 		}	
 		
-		//sort the table by the occurency
-		HASH_SORT(hostsHashT, hash_stats_sort);
+		//sort the table by the least occurency
+		HASH_SORT(hostsHashT, hash_stats_sort_to_order);
 	}
 
-      
-	
-      	//print the element of the hash table
+	//sort the table in decreasing order to print
+      	HASH_SORT(hostsHashT, hash_stats_sort_to_print);
+      	
+	//print the element of the hash table
    	int j;
 	HASH_ITER(hh, hostsHashT, host_iter, tmp){
 		


### PR DESCRIPTION
The purpose of this version of ndpiReader is too adding some other statistics printed by ndpiReader. In this simple version the domain names(in the flows) that are collected are:
flow-> ssh_tls.server_info
flow-> host_server_name
and are placed in a UT_hash_table, ordering them by number of occurrences.