### PR TITLE
Detect SMTPs w/ STARTTLS as TLS and dissect client/server hello. Fixe…

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -8034,7 +8034,9 @@ u_int8_t ndpi_extra_dissection_possible(struct ndpi_detection_module_struct *ndp
   switch(proto) {
   case NDPI_PROTOCOL_TLS:
   case NDPI_PROTOCOL_DTLS:
-    if(flow->l4.tcp.tls.certificate_processed) return(0);
+    if(flow->l4.tcp.tls.certificate_processed ||
+       (flow->l4.tcp.ftp_imap_pop_smtp.auth_tls == 1 &&
+        flow->l4.tcp.ftp_imap_pop_smtp.auth_done == 1)) return(0);
 
     if(flow->l4.tcp.tls.num_tls_blocks <= ndpi_str->num_tls_blocks_to_follow) {
       // printf("*** %u/%u\n", flow->l4.tcp.tls.num_tls_blocks, ndpi_str->num_tls_blocks_to_follow);
@@ -8058,8 +8060,8 @@ u_int8_t ndpi_extra_dissection_possible(struct ndpi_detection_module_struct *ndp
   case NDPI_PROTOCOL_MAIL_IMAP:
   case NDPI_PROTOCOL_MAIL_SMTP:
     if(flow->l4.tcp.ftp_imap_pop_smtp.password[0] == '\0' &&
-       flow->l4.tcp.ftp_imap_pop_smtp.auth_tls == 0 &&
-       flow->l4.tcp.ftp_imap_pop_smtp.auth_done == 0)
+       (flow->l4.tcp.ftp_imap_pop_smtp.auth_tls == 1 ||
+        flow->l4.tcp.ftp_imap_pop_smtp.auth_done == 0))
       return(1);
     break;
 

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -28,6 +28,8 @@
 #include "ndpi_encryption.h"
 
 extern char *strptime(const char *s, const char *format, struct tm *tm);
+extern int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
+                           struct ndpi_flow_struct *flow);
 extern int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 				    struct ndpi_flow_struct *flow, uint32_t quic_version);
 extern int http_process_user_agent(struct ndpi_detection_module_struct *ndpi_struct,
@@ -839,8 +841,8 @@ int processCertificate(struct ndpi_detection_module_struct *ndpi_struct,
 
 /* **************************************** */
 
-static int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
-			   struct ndpi_flow_struct *flow) {
+int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
+                    struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   int ret;
 

--- a/tests/result/ftp-start-tls.pcap.out
+++ b/tests/result/ftp-start-tls.pcap.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	0
+Guessed flow protos:	1
 
-DPI Packets (TCP):	10	(10.00 pkts/flow)
+DPI Packets (TCP):	51	(51.00 pkts/flow)
 Confidence DPI              : 1 (flows)
 
 FTP_CONTROL	51	7510	1

--- a/tests/result/smtp-starttls.pcap.out
+++ b/tests/result/smtp-starttls.pcap.out
@@ -1,8 +1,13 @@
 Guessed flow protos:	0
 
-DPI Packets (TCP):	9	(9.00 pkts/flow)
+DPI Packets (TCP):	11	(11.00 pkts/flow)
 Confidence DPI              : 1 (flows)
 
 Google	36	8403	1
 
-	1	TCP 10.0.0.1:57406 <-> 173.194.68.26:25 [proto: 3.126/SMTP.Google][ClearText][Confidence: DPI][cat: Email/3][17 pkts/2514 bytes <-> 19 pkts/5889 bytes][Goodput ratio: 55/79][0.48 sec][Hostname/SNI: mx.google.com][bytes ratio: -0.402 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 30/24 156/103 42/26][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 148/310 752/1484 168/444][PLAIN TEXT (x.google.com ESMTP s4)][Plen Bins: 23,18,13,9,4,4,4,0,0,4,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,9,0,0,0]
+JA3 Host Stats: 
+		 IP Address                  	 # JA3C     
+	1	 10.0.0.1                 	 1      
+
+
+	1	TCP 10.0.0.1:57406 <-> 173.194.68.26:25 [proto: 91.126/TLS.Google][Encrypted][Confidence: DPI][cat: Email/3][17 pkts/2514 bytes <-> 19 pkts/5889 bytes][Goodput ratio: 55/79][0.48 sec][Hostname/SNI: mx.google.com][bytes ratio: -0.402 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 30/24 156/103 42/26][Pkt Len c2s/s2c min/avg/max/stddev: 66/66 148/310 752/1484 168/444][Risk: ** Obsolete TLS (v1.1 or older) **][Risk Score: 100][Risk Info: No client to server traffic / TLSv1][TLSv1][JA3C: fab507fe132c544e8a0eb7c394affeae][Plen Bins: 23,18,13,9,4,4,4,0,0,4,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,9,0,0,0]


### PR DESCRIPTION
…s #1630.

 * more packets need to be processed -> bad
 * FTP has to get updated as well as it has similiar STARTTLS semantics -> follow-up

// not a perfect solution, but sufficient to fix #1630 

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>