### PR TITLE
ASN1/BER: fix signed integer overflow

### DIFF
--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -165,7 +165,7 @@ extern "C" {
   char *ndpi_hostname_sni_set(struct ndpi_flow_struct *flow, const u_int8_t *value, size_t value_len);
   char *ndpi_user_agent_set(struct ndpi_flow_struct *flow, const u_int8_t *value, size_t value_len);
 
-  int ndpi_asn1_ber_decode_length(const unsigned char *payload, int payload_len, u_int16_t *value_len);
+  int64_t ndpi_asn1_ber_decode_length(const unsigned char *payload, int payload_len, u_int16_t *value_len);
 
 #ifdef __cplusplus
 }

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -2707,7 +2707,7 @@ u_int8_t ndpi_check_flow_risk_exceptions(struct ndpi_detection_module_struct *nd
 
 /* ******************************************* */
 
-int ndpi_asn1_ber_decode_length(const unsigned char *payload, int payload_len, u_int16_t *value_len)
+int64_t ndpi_asn1_ber_decode_length(const unsigned char *payload, int payload_len, u_int16_t *value_len)
 {
   unsigned int value, i;
 

--- a/src/lib/protocols/kerberos.c
+++ b/src/lib/protocols/kerberos.c
@@ -41,7 +41,7 @@ static int krb_decode_asn1_length(struct ndpi_detection_module_struct *ndpi_stru
                                   size_t * const kasn1_offset)
 {
   struct ndpi_packet_struct * const packet = &ndpi_struct->packet;
-  int length;
+  int64_t length;
   u_int16_t value_len;
 
   length = ndpi_asn1_ber_decode_length(&packet->payload[*kasn1_offset],

--- a/src/lib/protocols/ldap.c
+++ b/src/lib/protocols/ldap.c
@@ -38,7 +38,7 @@ static void ndpi_int_ldap_add_connection(struct ndpi_detection_module_struct *nd
 void ndpi_search_ldap(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
-  int length;
+  int64_t length;
   u_int16_t length_len = 0, msg_id_len;
   u_int8_t op;
 	

--- a/src/lib/protocols/snmp_proto.c
+++ b/src/lib/protocols/snmp_proto.c
@@ -69,7 +69,7 @@ void ndpi_search_snmp(struct ndpi_detection_module_struct *ndpi_struct,
 
   if(packet->payload_packet_len > 16 && packet->payload[0] == 0x30) {
     u_int16_t len_length = 0, offset;
-    int len;
+    int64_t len;
 
     len = ndpi_asn1_ber_decode_length(&packet->payload[1], packet->payload_packet_len - 1, &len_length);
 


### PR DESCRIPTION
```
protocols/snmp_proto.c:77:23: runtime error: signed integer overflow: 6 + 2147483647 cannot be represented in type 'int'
 #0 0x52f69e in ndpi_search_snmp ndpi/src/lib/protocols/snmp_proto.c:77:23
 #1 0x4c5347 in check_ndpi_detection_func ndpi/src/lib/ndpi_main.c:5211:4
 #2 0x4c5591 in ndpi_check_flow_func ndpi/src/lib/ndpi_main.c:0
 #3 0x4c8903 in ndpi_detection_process_packet ndpi/src/lib/ndpi_main.c:6145:15
 #4 0x4b3712 in LLVMFuzzerTestOneInput ndpi/fuzz/fuzz_process_packet.c:29:5
[...]
```
Found by oss-fuzzer.
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=49057