### PR TITLE
reader_util: stop processing a flow

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1562,6 +1562,7 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
 							    iph ? (uint8_t *)iph : (uint8_t *)iph6,
 							    ipsize, time_ms);
 
+    enough_packets |= ndpi_flow->fail_with_unknown;
     if(enough_packets || (flow->detected_protocol.app_protocol != NDPI_PROTOCOL_UNKNOWN)) {
       if((!enough_packets)
 	 && ndpi_extra_dissection_possible(workflow->ndpi_struct, ndpi_flow))

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6086,6 +6086,7 @@ ndpi_protocol ndpi_detection_process_packet(struct ndpi_detection_module_struct 
 
   if(ndpi_str->max_packets_to_process > 0 && flow->num_processed_pkts >= ndpi_str->max_packets_to_process) {
     flow->extra_packets_func = NULL; /* To allow ndpi_extra_dissection_possible() to fail */
+    flow->fail_with_unknown = 1;
     return(ret); /* Avoid spending too much time with this flow */
   }
 

--- a/tests/result/Oscar.pcap.out
+++ b/tests/result/Oscar.pcap.out
@@ -1,9 +1,9 @@
 Guessed flow protos:	1
 
-DPI Packets (TCP):	71	(71.00 pkts/flow)
+DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Num dissector calls: 365 (365.00 diss/flow)
 
 TLS	71	9386	1
 
-	1	TCP 10.30.29.3:63357 <-> 178.237.24.249:443 [proto: 91/TLS][Encrypted][Confidence: Match by port][cat: Web/5][38 pkts/3580 bytes <-> 33 pkts/5806 bytes][Goodput ratio: 42/68][72.45 sec][bytes ratio: -0.237 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 2392/2607 58175/58215 10382/11142][Pkt Len c2s/s2c min/avg/max/stddev: 54/60 94/176 369/1414 75/257][PLAIN TEXT (Adium/1.5.10)][Plen Bins: 7,58,5,5,0,0,5,2,2,7,0,0,0,0,2,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0]
+	1	TCP 10.30.29.3:63357 <-> 178.237.24.249:443 [proto: 91/TLS][Encrypted][Confidence: Match by port][cat: Web/5][38 pkts/3580 bytes <-> 33 pkts/5806 bytes][Goodput ratio: 42/68][72.45 sec][bytes ratio: -0.237 (Download)][IAT c2s/s2c min/avg/max/stddev: 0/0 2392/2607 58175/58215 10382/11142][Pkt Len c2s/s2c min/avg/max/stddev: 54/60 94/176 369/1414 75/257][Plen Bins: 7,58,5,5,0,0,5,2,2,7,0,0,0,0,2,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0]

--- a/tests/result/anyconnect-vpn.pcap.out
+++ b/tests/result/anyconnect-vpn.pcap.out
@@ -1,7 +1,7 @@
 Guessed flow protos:	12
 
 DPI Packets (TCP):	161	(7.32 pkts/flow)
-DPI Packets (UDP):	103	(2.78 pkts/flow)
+DPI Packets (UDP):	83	(2.24 pkts/flow)
 DPI Packets (other):	10	(1.00 pkts/flow)
 Confidence Unknown          : 2 (flows)
 Confidence Match by port    : 5 (flows)

--- a/tests/result/ftp.pcap.out
+++ b/tests/result/ftp.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	1
 
-DPI Packets (TCP):	97	(32.33 pkts/flow)
+DPI Packets (TCP):	49	(16.33 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence DPI              : 2 (flows)
 Num dissector calls: 691 (230.33 diss/flow)

--- a/tests/result/instagram.pcap.out
+++ b/tests/result/instagram.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	15
 
-DPI Packets (TCP):	360	(12.00 pkts/flow)
+DPI Packets (TCP):	295	(9.83 pkts/flow)
 DPI Packets (UDP):	10	(1.43 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)

--- a/tests/result/log4j-webapp-exploit.pcap.out
+++ b/tests/result/log4j-webapp-exploit.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	2
 
-DPI Packets (TCP):	111	(15.86 pkts/flow)
+DPI Packets (TCP):	63	(9.00 pkts/flow)
 Confidence Unknown          : 2 (flows)
 Confidence DPI              : 5 (flows)
 Num dissector calls: 549 (78.43 diss/flow)

--- a/tests/result/nest_log_sink.pcap.out
+++ b/tests/result/nest_log_sink.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	1
 
-DPI Packets (TCP):	176	(13.54 pkts/flow)
+DPI Packets (TCP):	128	(9.85 pkts/flow)
 DPI Packets (UDP):	2	(2.00 pkts/flow)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 13 (flows)

--- a/tests/result/reasm_crash_anon.pcapng.out
+++ b/tests/result/reasm_crash_anon.pcapng.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	1
 
-DPI Packets (TCP):	81	(81.00 pkts/flow)
+DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Num dissector calls: 337 (337.00 diss/flow)
 

--- a/tests/result/reasm_segv_anon.pcapng.out
+++ b/tests/result/reasm_segv_anon.pcapng.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	1
 
-DPI Packets (TCP):	81	(81.00 pkts/flow)
+DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Num dissector calls: 336 (336.00 diss/flow)
 

--- a/tests/result/skype.pcap.out
+++ b/tests/result/skype.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	97
 
-DPI Packets (TCP):	1691	(17.43 pkts/flow)
+DPI Packets (TCP):	1578	(16.27 pkts/flow)
 DPI Packets (UDP):	337	(1.76 pkts/flow)
 DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 61 (flows)

--- a/tests/result/skype_no_unknown.pcap.out
+++ b/tests/result/skype_no_unknown.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	72
 
-DPI Packets (TCP):	1159	(15.25 pkts/flow)
+DPI Packets (TCP):	1111	(14.62 pkts/flow)
 DPI Packets (UDP):	288	(1.55 pkts/flow)
 DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 45 (flows)

--- a/tests/result/viber.pcap.out
+++ b/tests/result/viber.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	5
 
-DPI Packets (TCP):	131	(10.08 pkts/flow)
+DPI Packets (TCP):	106	(8.15 pkts/flow)
 DPI Packets (UDP):	27	(1.93 pkts/flow)
 DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Match by IP      : 4 (flows)

--- a/tests/result/wa_video.pcap.out
+++ b/tests/result/wa_video.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	1
 
-DPI Packets (TCP):	81	(81.00 pkts/flow)
+DPI Packets (TCP):	33	(33.00 pkts/flow)
 DPI Packets (UDP):	13	(1.00 pkts/flow)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 13 (flows)


### PR DESCRIPTION
We should stop processing a flow if all protocols have been excluded or
if we have already processed too many packets.