### PR TITLE
Skype: improvements

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -725,7 +725,6 @@ struct ndpi_flow_udp_struct {
   u_int32_t xbox_stage:1;
 
   /* NDPI_PROTOCOL_SKYPE */
-  u_int8_t skype_packet_id;
   u_int8_t skype_crc[4];
 
   /* NDPI_PROTOCOL_TEAMVIEWER */

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -686,9 +686,6 @@ struct ndpi_flow_tcp_struct {
   /* NDPI_PROTOCOL_SOAP */
   u_int32_t soap_stage:1;
 
-  /* NDPI_PROTOCOL_SKYPE */
-  u_int8_t skype_packet_id;
-
   /* NDPI_PROTOCOL_LOTUS_NOTES */
   u_int8_t lotus_notes_packet_id;
 

--- a/src/lib/protocols/skype.c
+++ b/src/lib/protocols/skype.c
@@ -148,39 +148,6 @@ static void ndpi_check_skype(struct ndpi_detection_module_struct *ndpi_struct, s
     
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
     return;
-    // TCP check
-  } else if((packet->tcp != NULL)
-	    /* As the TCP skype heuristic is weak, we need to make sure no other protocols overlap */
-	    && (flow->guessed_host_protocol_id == NDPI_PROTOCOL_UNKNOWN)
-	    && (flow->guessed_protocol_id == NDPI_PROTOCOL_UNKNOWN)) {
-    flow->l4.tcp.skype_packet_id++;
-
-    if(flow->l4.tcp.skype_packet_id < 3) {
-      ; /* Too early */
-    } else if((flow->l4.tcp.skype_packet_id == 3)
-	      /* We have seen the 3-way handshake */
-	      && flow->l4.tcp.seen_syn
-	      && flow->l4.tcp.seen_syn_ack
-	      && flow->l4.tcp.seen_ack) {
-      /* Disabled this logic as it's too weak and leads to false positives */
-#if 0
-      if((payload_len == 8) || (payload_len == 3) || (payload_len == 17)) {
-	// printf("[SKYPE] payload_len=%u\n", payload_len);
-	/* printf("[SKYPE] %u/%u\n", ntohs(packet->tcp->source), ntohs(packet->tcp->dest)); */
-	
-	NDPI_LOG_INFO(ndpi_struct, "found skype\n");
-	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SKYPE_TEAMS_CALL, NDPI_PROTOCOL_SKYPE_TEAMS, NDPI_CONFIDENCE_DPI);
-      } else {
-	// printf("NO [SKYPE] payload_len=%u\n", payload_len);
-      }
-
-      /* printf("[SKYPE] [id: %u][len: %d]\n", flow->l4.tcp.skype_packet_id, payload_len);  */
-#endif
-    } else {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-    }
-
-    return;
   }
 }
 
@@ -199,7 +166,7 @@ void init_skype_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_in
   ndpi_set_bitmask_protocol_detection("Skype_Teams", ndpi_struct, detection_bitmask, *id,
 				      NDPI_PROTOCOL_SKYPE_TEAMS,
 				      ndpi_search_skype,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/tests/result/1kxun.pcap.out
+++ b/tests/result/1kxun.pcap.out
@@ -6,7 +6,7 @@ Confidence Unknown          : 14 (flows)
 Confidence Match by port    : 5 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 177 (flows)
-Num dissector calls: 5084 (25.81 diss/flow)
+Num dissector calls: 5065 (25.71 diss/flow)
 
 Unknown	24	6428	14
 DNS	2	378	1

--- a/tests/result/443-chrome.pcap.out
+++ b/tests/result/443-chrome.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	1	(1.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 121 (121.00 diss/flow)
+Num dissector calls: 120 (120.00 diss/flow)
 
 TLS	1	1506	1
 

--- a/tests/result/443-opvn.pcap.out
+++ b/tests/result/443-opvn.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 135 (135.00 diss/flow)
+Num dissector calls: 134 (134.00 diss/flow)
 
 OpenVPN	46	11573	1
 

--- a/tests/result/KakaoTalk_chat.pcap.out
+++ b/tests/result/KakaoTalk_chat.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by port    : 4 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 33 (flows)
-Num dissector calls: 894 (23.53 diss/flow)
+Num dissector calls: 870 (22.89 diss/flow)
 
 DNS	2	217	1
 HTTP	1	56	1

--- a/tests/result/KakaoTalk_talk.pcap.out
+++ b/tests/result/KakaoTalk_talk.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	6	(1.20 pkts/flow)
 Confidence Match by port    : 4 (flows)
 Confidence Match by IP      : 5 (flows)
 Confidence DPI              : 11 (flows)
-Num dissector calls: 999 (49.95 diss/flow)
+Num dissector calls: 983 (49.15 diss/flow)
 
 HTTP	5	280	1
 QQ	15	1727	1

--- a/tests/result/Oscar.pcap.out
+++ b/tests/result/Oscar.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 365 (365.00 diss/flow)
+Num dissector calls: 347 (347.00 diss/flow)
 
 TLS	71	9386	1
 

--- a/tests/result/alexa-app.pcapng.out
+++ b/tests/result/alexa-app.pcapng.out
@@ -6,7 +6,7 @@ DPI Packets (other):	6	(1.00 pkts/flow)
 Confidence Match by port    : 5 (flows)
 Confidence Match by IP      : 9 (flows)
 Confidence DPI              : 146 (flows)
-Num dissector calls: 2329 (14.56 diss/flow)
+Num dissector calls: 2328 (14.55 diss/flow)
 
 DNS	4	400	2
 DHCP	3	1056	2

--- a/tests/result/amqp.pcap.out
+++ b/tests/result/amqp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	9	(3.00 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 400 (133.33 diss/flow)
+Num dissector calls: 395 (131.67 diss/flow)
 
 AMQP	160	23514	3
 

--- a/tests/result/anyconnect-vpn.pcap.out
+++ b/tests/result/anyconnect-vpn.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 2 (flows)
 Confidence Match by port    : 5 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 61 (flows)
-Num dissector calls: 1176 (17.04 diss/flow)
+Num dissector calls: 1170 (16.96 diss/flow)
 
 Unknown	19	1054	2
 DNS	32	3655	16

--- a/tests/result/bittorrent.pcap.out
+++ b/tests/result/bittorrent.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	24	(1.00 pkts/flow)
 Confidence DPI              : 24 (flows)
-Num dissector calls: 2114 (88.08 diss/flow)
+Num dissector calls: 2092 (87.17 diss/flow)
 
 BitTorrent	299	305728	24
 

--- a/tests/result/cloudflare-warp.pcap.out
+++ b/tests/result/cloudflare-warp.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	4
 DPI Packets (TCP):	41	(5.12 pkts/flow)
 Confidence Match by IP      : 3 (flows)
 Confidence DPI              : 5 (flows)
-Num dissector calls: 285 (35.62 diss/flow)
+Num dissector calls: 282 (35.25 diss/flow)
 
 Jabber	11	890	1
 Google	8	476	3

--- a/tests/result/dnp3.pcap.out
+++ b/tests/result/dnp3.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	80	(10.00 pkts/flow)
 Confidence DPI              : 8 (flows)
-Num dissector calls: 352 (44.00 diss/flow)
+Num dissector calls: 351 (43.88 diss/flow)
 
 DNP3	543	38754	8
 

--- a/tests/result/dnscrypt_skype_false_positive.pcapng.out
+++ b/tests/result/dnscrypt_skype_false_positive.pcapng.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	0
 
-DPI Packets (UDP):	4	(4.00 pkts/flow)
+DPI Packets (UDP):	2	(2.00 pkts/flow)
 Confidence DPI              : 1 (flows)
 Num dissector calls: 118 (118.00 diss/flow)
 

--- a/tests/result/emotet.pcap.out
+++ b/tests/result/emotet.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	48	(8.00 pkts/flow)
 Confidence DPI              : 6 (flows)
-Num dissector calls: 281 (46.83 diss/flow)
+Num dissector calls: 279 (46.50 diss/flow)
 
 SMTP	626	438465	1
 HTTP	1601	1581542	3

--- a/tests/result/ftp-start-tls.pcap.out
+++ b/tests/result/ftp-start-tls.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(10.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 177 (177.00 diss/flow)
+Num dissector calls: 174 (174.00 diss/flow)
 
 FTP_CONTROL	51	7510	1
 

--- a/tests/result/ftp.pcap.out
+++ b/tests/result/ftp.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	49	(16.33 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 691 (230.33 diss/flow)
+Num dissector calls: 683 (227.67 diss/flow)
 
 Unknown	1115	1122198	1
 FTP_CONTROL	68	5571	1

--- a/tests/result/ftp_failed.pcap.out
+++ b/tests/result/ftp_failed.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(8.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 161 (161.00 diss/flow)
+Num dissector calls: 159 (159.00 diss/flow)
 
 FTP_CONTROL	18	1700	1
 

--- a/tests/result/fuzz-2006-06-26-2594.pcap.out
+++ b/tests/result/fuzz-2006-06-26-2594.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 30 (flows)
 Confidence Match by port    : 28 (flows)
 Confidence DPI              : 193 (flows)
-Num dissector calls: 5311 (21.16 diss/flow)
+Num dissector calls: 5287 (21.06 diss/flow)
 
 Unknown	30	3356	30
 FTP_CONTROL	36	2569	12

--- a/tests/result/fuzz-2006-09-29-28586.pcap.out
+++ b/tests/result/fuzz-2006-09-29-28586.pcap.out
@@ -6,7 +6,7 @@ Confidence Unknown          : 3 (flows)
 Confidence Match by port    : 23 (flows)
 Confidence Match by IP      : 2 (flows)
 Confidence DPI              : 12 (flows)
-Num dissector calls: 1229 (30.73 diss/flow)
+Num dissector calls: 1218 (30.45 diss/flow)
 
 Unknown	3	655	3
 HTTP	116	27378	35

--- a/tests/result/fuzz-2021-10-13.pcap.out
+++ b/tests/result/fuzz-2021-10-13.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	1	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
-Num dissector calls: 119 (119.00 diss/flow)
+Num dissector calls: 118 (118.00 diss/flow)
 
 Unknown	1	197	1
 

--- a/tests/result/genshin-impact.pcap.out
+++ b/tests/result/genshin-impact.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	12	(4.00 pkts/flow)
 DPI Packets (UDP):	3	(1.00 pkts/flow)
 Confidence DPI              : 6 (flows)
-Num dissector calls: 556 (92.67 diss/flow)
+Num dissector calls: 553 (92.17 diss/flow)
 
 GenshinImpact	90	18405	6
 

--- a/tests/result/google_ssl.pcap.out
+++ b/tests/result/google_ssl.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	28	(28.00 pkts/flow)
 Confidence Match by IP      : 1 (flows)
-Num dissector calls: 261 (261.00 diss/flow)
+Num dissector calls: 249 (249.00 diss/flow)
 
 Google	28	9108	1
 

--- a/tests/result/h323-overflow.pcap.out
+++ b/tests/result/h323-overflow.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	1	(1.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 121 (121.00 diss/flow)
+Num dissector calls: 120 (120.00 diss/flow)
 
 HTTP	1	58	1
 

--- a/tests/result/h323.pcap.out
+++ b/tests/result/h323.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	2	(2.00 pkts/flow)
 DPI Packets (UDP):	1	(1.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 123 (61.50 diss/flow)
+Num dissector calls: 122 (61.00 diss/flow)
 
 H323	12	1825	2
 

--- a/tests/result/hpvirtgrp.pcap.out
+++ b/tests/result/hpvirtgrp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	37	(4.11 pkts/flow)
 Confidence DPI              : 9 (flows)
-Num dissector calls: 1116 (124.00 diss/flow)
+Num dissector calls: 1107 (123.00 diss/flow)
 
 HP_VIRTGRP	135	12739	9
 

--- a/tests/result/imap-starttls.pcap.out
+++ b/tests/result/imap-starttls.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(10.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 193 (193.00 diss/flow)
+Num dissector calls: 190 (190.00 diss/flow)
 
 IMAPS	32	7975	1
 

--- a/tests/result/imap.pcap.out
+++ b/tests/result/imap.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	11	(11.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 215 (215.00 diss/flow)
+Num dissector calls: 211 (211.00 diss/flow)
 
 IMAP	33	3774	1
 

--- a/tests/result/instagram.pcap.out
+++ b/tests/result/instagram.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 1 (flows)
 Confidence Match by port    : 6 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 30 (flows)
-Num dissector calls: 2126 (55.95 diss/flow)
+Num dissector calls: 2053 (54.03 diss/flow)
 
 Unknown	1	66	1
 HTTP	116	91784	6

--- a/tests/result/irc.pcap.out
+++ b/tests/result/irc.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 168 (168.00 diss/flow)
+Num dissector calls: 166 (166.00 diss/flow)
 
 IRC	29	8945	1
 

--- a/tests/result/jabber.pcap.out
+++ b/tests/result/jabber.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	74	(6.17 pkts/flow)
 Confidence DPI              : 12 (flows)
-Num dissector calls: 1525 (127.08 diss/flow)
+Num dissector calls: 1505 (125.42 diss/flow)
 
 Jabber	358	61304	12
 

--- a/tests/result/kerberos.pcap.out
+++ b/tests/result/kerberos.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	77	(2.14 pkts/flow)
 Confidence Unknown          : 2 (flows)
 Confidence Match by port    : 23 (flows)
 Confidence DPI              : 11 (flows)
-Num dissector calls: 3865 (107.36 diss/flow)
+Num dissector calls: 3813 (105.92 diss/flow)
 
 Unknown	9	3031	2
 SMBv23	6	1914	3

--- a/tests/result/lisp_registration.pcap.out
+++ b/tests/result/lisp_registration.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	8	(4.00 pkts/flow)
 DPI Packets (UDP):	2	(1.00 pkts/flow)
 Confidence DPI              : 4 (flows)
-Num dissector calls: 226 (56.50 diss/flow)
+Num dissector calls: 224 (56.00 diss/flow)
 
 LISP	30	5266	4
 

--- a/tests/result/log4j-webapp-exploit.pcap.out
+++ b/tests/result/log4j-webapp-exploit.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	2
 DPI Packets (TCP):	63	(9.00 pkts/flow)
 Confidence Unknown          : 2 (flows)
 Confidence DPI              : 5 (flows)
-Num dissector calls: 549 (78.43 diss/flow)
+Num dissector calls: 545 (77.86 diss/flow)
 
 Unknown	356	25081	2
 HTTP	34	6741	3

--- a/tests/result/memcached.cap.out
+++ b/tests/result/memcached.cap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 135 (135.00 diss/flow)
+Num dissector calls: 134 (134.00 diss/flow)
 
 Memcached	10	1711	1
 

--- a/tests/result/mongo_false_positive.pcapng.out
+++ b/tests/result/mongo_false_positive.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	26	(26.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 431 (431.00 diss/flow)
+Num dissector calls: 409 (409.00 diss/flow)
 
 TLS	26	12163	1
 

--- a/tests/result/mongodb.pcap.out
+++ b/tests/result/mongodb.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	27	(3.38 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence Match by port    : 2 (flows)
 Confidence DPI              : 5 (flows)
-Num dissector calls: 217 (27.12 diss/flow)
+Num dissector calls: 216 (27.00 diss/flow)
 
 Unknown	3	230	1
 MongoDB	24	2510	7

--- a/tests/result/mssql_tds.pcap.out
+++ b/tests/result/mssql_tds.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	18	(1.50 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 11 (flows)
-Num dissector calls: 287 (23.92 diss/flow)
+Num dissector calls: 280 (23.33 diss/flow)
 
 MsSQL-TDS	38	16260	12
 

--- a/tests/result/nest_log_sink.pcap.out
+++ b/tests/result/nest_log_sink.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	128	(9.85 pkts/flow)
 DPI Packets (UDP):	2	(2.00 pkts/flow)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 13 (flows)
-Num dissector calls: 2104 (150.29 diss/flow)
+Num dissector calls: 2080 (148.57 diss/flow)
 
 DNS	15	1612	1
 NestLogSink	676	112058	12

--- a/tests/result/netbios.pcap.out
+++ b/tests/result/netbios.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	2	(2.00 pkts/flow)
 DPI Packets (UDP):	14	(1.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 14 (flows)
-Num dissector calls: 136 (9.07 diss/flow)
+Num dissector calls: 135 (9.00 diss/flow)
 
 NetBIOS	258	24196	13
 SMBv1	2	486	2

--- a/tests/result/nntp.pcap.out
+++ b/tests/result/nntp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 141 (141.00 diss/flow)
+Num dissector calls: 140 (140.00 diss/flow)
 
 Usenet	32	7037	1
 

--- a/tests/result/ookla.pcap.out
+++ b/tests/result/ookla.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	16	(8.00 pkts/flow)
 Confidence DPI (cache)      : 1 (flows)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 139 (69.50 diss/flow)
+Num dissector calls: 138 (69.00 diss/flow)
 
 Ookla	5086	4689745	2
 

--- a/tests/result/openvpn.pcap.out
+++ b/tests/result/openvpn.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 DPI Packets (UDP):	5	(2.50 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 395 (131.67 diss/flow)
+Num dissector calls: 394 (131.33 diss/flow)
 
 OpenVPN	298	57111	3
 

--- a/tests/result/oracle12.pcapng.out
+++ b/tests/result/oracle12.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	20	(20.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 311 (311.00 diss/flow)
+Num dissector calls: 300 (300.00 diss/flow)
 
 Oracle	20	2518	1
 

--- a/tests/result/pgsql.pcap.out
+++ b/tests/result/pgsql.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	12	(6.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 270 (135.00 diss/flow)
+Num dissector calls: 268 (134.00 diss/flow)
 
 PostgreSQL	39	4709	2
 

--- a/tests/result/pop3.pcap.out
+++ b/tests/result/pop3.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(10.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 191 (191.00 diss/flow)
+Num dissector calls: 188 (188.00 diss/flow)
 
 POP3	31	3915	1
 

--- a/tests/result/reasm_crash_anon.pcapng.out
+++ b/tests/result/reasm_crash_anon.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
-Num dissector calls: 337 (337.00 diss/flow)
+Num dissector calls: 334 (334.00 diss/flow)
 
 Unknown	200	20067	1
 

--- a/tests/result/reasm_segv_anon.pcapng.out
+++ b/tests/result/reasm_segv_anon.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 336 (336.00 diss/flow)
+Num dissector calls: 315 (315.00 diss/flow)
 
 HTTP	82	77940	1
 

--- a/tests/result/rsh.pcap.out
+++ b/tests/result/rsh.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	12	(6.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 324 (162.00 diss/flow)
+Num dissector calls: 320 (160.00 diss/flow)
 
 RSH	24	1721	2
 

--- a/tests/result/rsync.pcap.out
+++ b/tests/result/rsync.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	9	(9.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 183 (183.00 diss/flow)
+Num dissector calls: 180 (180.00 diss/flow)
 
 RSYNC	30	2493	1
 

--- a/tests/result/rtmp.pcap.out
+++ b/tests/result/rtmp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(8.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 165 (165.00 diss/flow)
+Num dissector calls: 163 (163.00 diss/flow)
 
 RTMP	26	8368	1
 

--- a/tests/result/skype.pcap.out
+++ b/tests/result/skype.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 61 (flows)
 Confidence Match by port    : 27 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 204 (flows)
-Num dissector calls: 32126 (109.65 diss/flow)
+Num dissector calls: 31676 (108.11 diss/flow)
 
 Unknown	1575	272476	61
 DNS	2	267	1

--- a/tests/result/skype_no_unknown.pcap.out
+++ b/tests/result/skype_no_unknown.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 45 (flows)
 Confidence Match by port    : 22 (flows)
 Confidence DPI              : 200 (flows)
-Num dissector calls: 26274 (98.40 diss/flow)
+Num dissector calls: 25957 (97.22 diss/flow)
 
 Unknown	850	152468	45
 DNS	2	267	1

--- a/tests/result/skype_udp.pcap.out
+++ b/tests/result/skype_udp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (UDP):	2	(2.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 99 (99.00 diss/flow)
+Num dissector calls: 117 (117.00 diss/flow)
 
 Skype_Teams	5	339	1
 

--- a/tests/result/smb_frags.pcap.out
+++ b/tests/result/smb_frags.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	5	(5.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 159 (159.00 diss/flow)
+Num dissector calls: 157 (157.00 diss/flow)
 
 SMBv1	8	2763	1
 

--- a/tests/result/smbv1.pcap.out
+++ b/tests/result/smbv1.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	3	(3.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 153 (153.00 diss/flow)
+Num dissector calls: 151 (151.00 diss/flow)
 
 SMBv1	7	1197	1
 

--- a/tests/result/smtp.pcap.out
+++ b/tests/result/smtp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	11	(11.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 208 (208.00 diss/flow)
+Num dissector calls: 204 (204.00 diss/flow)
 
 SMTP	95	23157	1
 

--- a/tests/result/soap.pcap.out
+++ b/tests/result/soap.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	11	(3.67 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 366 (122.00 diss/flow)
+Num dissector calls: 360 (120.00 diss/flow)
 
 Microsoft	1	1506	1
 SOAP	19	9442	2

--- a/tests/result/socks-http-example.pcap.out
+++ b/tests/result/socks-http-example.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	29	(9.67 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 520 (173.33 diss/flow)
+Num dissector calls: 511 (170.33 diss/flow)
 
 SOCKS	46	8383	3
 

--- a/tests/result/starcraft_battle.pcap.out
+++ b/tests/result/starcraft_battle.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by port    : 8 (flows)
 Confidence Match by IP      : 5 (flows)
 Confidence DPI              : 39 (flows)
-Num dissector calls: 1873 (36.02 diss/flow)
+Num dissector calls: 1866 (35.88 diss/flow)
 
 DNS	26	2848	7
 HTTP	450	294880	19

--- a/tests/result/teams.pcap.out
+++ b/tests/result/teams.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 1 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI (partial)    : 1 (flows)
 Confidence DPI              : 80 (flows)
-Num dissector calls: 1166 (14.05 diss/flow)
+Num dissector calls: 1164 (14.02 diss/flow)
 
 Unknown	4	456	1
 DNS	10	1357	5

--- a/tests/result/telnet.pcap.out
+++ b/tests/result/telnet.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 163 (163.00 diss/flow)
+Num dissector calls: 161 (161.00 diss/flow)
 
 Telnet	87	7418	1
 

--- a/tests/result/threema.pcap.out
+++ b/tests/result/threema.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	2
 DPI Packets (TCP):	66	(11.00 pkts/flow)
 Confidence Match by IP      : 2 (flows)
 Confidence DPI              : 4 (flows)
-Num dissector calls: 1334 (222.33 diss/flow)
+Num dissector calls: 1306 (217.67 diss/flow)
 
 Threema	83	11578	6
 

--- a/tests/result/tinc.pcap.out
+++ b/tests/result/tinc.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	19	(9.50 pkts/flow)
 DPI Packets (UDP):	2	(1.00 pkts/flow)
 Confidence DPI (cache)      : 2 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 557 (139.25 diss/flow)
+Num dissector calls: 551 (137.75 diss/flow)
 
 TINC	317	352291	4
 

--- a/tests/result/tls-appdata.pcap.out
+++ b/tests/result/tls-appdata.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	20	(10.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 123 (61.50 diss/flow)
+Num dissector calls: 122 (61.00 diss/flow)
 
 Facebook	6	789	1
 Twitch	114	119156	1

--- a/tests/result/tls_certificate_too_long.pcap.out
+++ b/tests/result/tls_certificate_too_long.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 33 (flows)
-Num dissector calls: 751 (21.46 diss/flow)
+Num dissector calls: 746 (21.31 diss/flow)
 
 Unknown	13	5582	1
 MDNS	5	983	3

--- a/tests/result/tls_false_positives.pcapng.out
+++ b/tests/result/tls_false_positives.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	30	(30.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
-Num dissector calls: 408 (408.00 diss/flow)
+Num dissector calls: 405 (405.00 diss/flow)
 
 Unknown	30	37313	1
 

--- a/tests/result/tls_invalid_reads.pcap.out
+++ b/tests/result/tls_invalid_reads.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	2
 DPI Packets (TCP):	10	(3.33 pkts/flow)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 143 (47.67 diss/flow)
+Num dissector calls: 142 (47.33 diss/flow)
 
 TLS	7	1827	1
 Crashlytics	3	560	1

--- a/tests/result/ultrasurf.pcap.out
+++ b/tests/result/ultrasurf.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	13	(4.33 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 154 (51.33 diss/flow)
+Num dissector calls: 153 (51.00 diss/flow)
 
 TLS	5171	5127023	2
 UltraSurf	2971	2991918	1

--- a/tests/result/viber.pcap.out
+++ b/tests/result/viber.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	27	(1.93 pkts/flow)
 DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Match by IP      : 4 (flows)
 Confidence DPI              : 25 (flows)
-Num dissector calls: 719 (24.79 diss/flow)
+Num dissector calls: 701 (24.17 diss/flow)
 
 DNS	8	1267	4
 MDNS	4	412	1

--- a/tests/result/vnc.pcap.out
+++ b/tests/result/vnc.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(5.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 280 (140.00 diss/flow)
+Num dissector calls: 278 (139.00 diss/flow)
 
 VNC	4551	329158	2
 

--- a/tests/result/wa_video.pcap.out
+++ b/tests/result/wa_video.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	33	(33.00 pkts/flow)
 DPI Packets (UDP):	13	(1.00 pkts/flow)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 13 (flows)
-Num dissector calls: 546 (39.00 diss/flow)
+Num dissector calls: 526 (37.57 diss/flow)
 
 SSDP	8	1377	3
 DHCP	2	684	1

--- a/tests/result/wa_voice.pcap.out
+++ b/tests/result/wa_voice.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	33	(1.57 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence DPI              : 27 (flows)
-Num dissector calls: 497 (17.75 diss/flow)
+Num dissector calls: 496 (17.71 diss/flow)
 
 Unknown	2	120	1
 MDNS	10	1188	2

--- a/tests/result/waze.pcap.out
+++ b/tests/result/waze.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	1	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence Match by port    : 9 (flows)
 Confidence DPI              : 23 (flows)
-Num dissector calls: 887 (26.88 diss/flow)
+Num dissector calls: 883 (26.76 diss/flow)
 
 Unknown	10	786	1
 HTTP	65	64777	8

--- a/tests/result/websocket.pcap.out
+++ b/tests/result/websocket.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	1	(1.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 108 (108.00 diss/flow)
+Num dissector calls: 107 (107.00 diss/flow)
 
 WebSocket	5	441	1
 

--- a/tests/result/wechat.pcap.out
+++ b/tests/result/wechat.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	7	(1.00 pkts/flow)
 Confidence Match by port    : 17 (flows)
 Confidence Match by IP      : 8 (flows)
 Confidence DPI              : 78 (flows)
-Num dissector calls: 1531 (14.86 diss/flow)
+Num dissector calls: 1530 (14.85 diss/flow)
 
 DNS	13	1075	8
 HTTP	70	4620	8

--- a/tests/result/whatsapp.pcap.out
+++ b/tests/result/whatsapp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	344	(4.00 pkts/flow)
 Confidence DPI              : 86 (flows)
-Num dissector calls: 13158 (153.00 diss/flow)
+Num dissector calls: 12986 (151.00 diss/flow)
 
 WhatsApp	679	96293	86
 

--- a/tests/result/whatsapp_login_call.pcap.out
+++ b/tests/result/whatsapp_login_call.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by port    : 4 (flows)
 Confidence Match by IP      : 16 (flows)
 Confidence DPI              : 37 (flows)
-Num dissector calls: 690 (12.11 diss/flow)
+Num dissector calls: 689 (12.09 diss/flow)
 
 HTTP	11	726	3
 MDNS	8	952	4

--- a/tests/result/whatsapp_login_chat.pcap.out
+++ b/tests/result/whatsapp_login_chat.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	2
 DPI Packets (TCP):	25	(8.33 pkts/flow)
 DPI Packets (UDP):	7	(1.17 pkts/flow)
 Confidence DPI              : 9 (flows)
-Num dissector calls: 316 (35.11 diss/flow)
+Num dissector calls: 314 (34.89 diss/flow)
 
 MDNS	2	202	2
 DHCP	6	2052	1

--- a/tests/result/whatsapp_voice_and_message.pcap.out
+++ b/tests/result/whatsapp_voice_and_message.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	20	(4.00 pkts/flow)
 DPI Packets (UDP):	8	(1.00 pkts/flow)
 Confidence DPI              : 13 (flows)
-Num dissector calls: 553 (42.54 diss/flow)
+Num dissector calls: 548 (42.15 diss/flow)
 
 WhatsAppCall	44	5916	8
 WhatsApp	217	22139	5

--- a/tests/result/whois.pcapng.out
+++ b/tests/result/whois.pcapng.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	16	(5.33 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 215 (71.67 diss/flow)
+Num dissector calls: 212 (70.67 diss/flow)
 
 TLS	7	2046	1
 Whois-DAS	16	4294	2

--- a/tests/result/xiaomi.pcap.out
+++ b/tests/result/xiaomi.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	19	(2.71 pkts/flow)
 Confidence DPI              : 7 (flows)
-Num dissector calls: 767 (109.57 diss/flow)
+Num dissector calls: 761 (108.71 diss/flow)
 
 Xiaomi	52	11467	7
 

--- a/tests/result/z3950.pcapng.out
+++ b/tests/result/z3950.pcapng.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	26	(13.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 497 (248.50 diss/flow)
+Num dissector calls: 485 (242.50 diss/flow)
 
 Z3950	31	6308	2
 

--- a/tests/result/zoom.pcap.out
+++ b/tests/result/zoom.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	25	(1.47 pkts/flow)
 DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Match by IP      : 2 (flows)
 Confidence DPI              : 31 (flows)
-Num dissector calls: 942 (28.55 diss/flow)
+Num dissector calls: 937 (28.39 diss/flow)
 
 DNS	2	205	1
 MDNS	1	87	1


### PR DESCRIPTION
Skype detection over TCP has been completely disable since https://github.com/ntop/nDPI/commit/659f75138c2a95e5823608a545b9a3d3ced223bc (3
years ago!).
Since that logic was too weak anyway, remove it.

Commit https://github.com/ntop/nDPI/commit/ba6a48c9fec64b0e3617f7f7f1f6afeedd8b6437 is completely bogus: we can't set extra dissection
without having set a proper classification.

The idea behind that commit seems to be that we need to look for 2
(consecutives?) packets with the same crc/pattern: try to implement this
logic in a saner way.