### PR TITLE
Add support for flow client/server information

### DIFF
--- a/example/ndpiSimpleIntegration.c
+++ b/example/ndpiSimpleIntegration.c
@@ -884,7 +884,7 @@ static void ndpi_process_packet(uint8_t * const args,
   flow_to_process->detected_l7_protocol =
     ndpi_detection_process_packet(workflow->ndpi_struct, flow_to_process->ndpi_flow,
 				  ip != NULL ? (uint8_t *)ip : (uint8_t *)ip6,
-				  ip_size, time_ms);
+				  ip_size, time_ms, NULL);
 
   if (ndpi_is_protocol_detected(workflow->ndpi_struct,
 				flow_to_process->detected_l7_protocol) != 0 &&

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1543,6 +1543,8 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
   }
 
   if(!flow->detection_completed) {
+    struct ndpi_flow_input_info input_info;
+
     u_int enough_packets =
       (((proto == IPPROTO_UDP) && ((flow->src2dst_packets + flow->dst2src_packets) > max_num_udp_dissected_pkts))
        || ((proto == IPPROTO_TCP) && ((flow->src2dst_packets + flow->dst2src_packets) > max_num_tcp_dissected_pkts))) ? 1 : 0;
@@ -1558,9 +1560,13 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
     else
       workflow->stats.dpi_packet_count[2]++;
 
+    memset(&input_info, '\0', sizeof(input_info)); /* To be sure to set to "unknown" any fields */
+    /* Set here any information (easily) available; in this trivial example we don't have any */
+    input_info.in_pkt_dir = NDPI_IN_PKT_DIR_UNKNOWN;
+    input_info.seen_flow_beginning = NDPI_FLOW_BEGINNING_UNKNOWN;
     flow->detected_protocol = ndpi_detection_process_packet(workflow->ndpi_struct, ndpi_flow,
 							    iph ? (uint8_t *)iph : (uint8_t *)iph6,
-							    ipsize, time_ms);
+							    ipsize, time_ms, &input_info);
 
     enough_packets |= ndpi_flow->fail_with_unknown;
     if(enough_packets || (flow->detected_protocol.app_protocol != NDPI_PROTOCOL_UNKNOWN)) {

--- a/fuzz/fuzz_process_packet.c
+++ b/fuzz/fuzz_process_packet.c
@@ -26,7 +26,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   struct ndpi_flow_struct *ndpi_flow = ndpi_flow_malloc(SIZEOF_FLOW_STRUCT);
   memset(ndpi_flow, 0, SIZEOF_FLOW_STRUCT);
   ndpi_protocol detected_protocol =
-    ndpi_detection_process_packet(ndpi_info_mod, ndpi_flow, Data, Size, 0);
+    ndpi_detection_process_packet(ndpi_info_mod, ndpi_flow, Data, Size, 0, NULL);
   ndpi_protocol guessed_protocol =
     ndpi_detection_giveup(ndpi_info_mod, ndpi_flow, 1, &protocol_was_guessed);
 

--- a/python/ndpi/ndpi.py
+++ b/python/ndpi/ndpi.py
@@ -45,12 +45,13 @@ class NDPI(object):
     def revision(self):
         return ffi.string(lib.ndpi_revision()).decode('utf-8', errors='ignore')
 
-    def process_packet(self, flow, packet, packet_time_ms):
+    def process_packet(self, flow, packet, packet_time_ms, input_info):
         p = lib.ndpi_detection_process_packet(self._detection_module,
                                               flow.C,
                                               packet,
                                               len(packet),
-                                              int(packet_time_ms))
+                                              int(packet_time_ms),
+                                              input_info)
         return ndpi_protocol(C=p,
                              master_protocol=p.master_protocol,
                              app_protocol=p.app_protocol,

--- a/python/ndpi/ndpi_build.py
+++ b/python/ndpi/ndpi_build.py
@@ -56,7 +56,8 @@ ndpi_protocol ndpi_detection_process_packet(struct ndpi_detection_module_struct 
                                             struct ndpi_flow_struct *flow,
                                             const unsigned char *packet,
                                             const unsigned short packetlen,
-                                            const u_int64_t packet_time_ms);
+                                            const u_int64_t packet_time_ms,
+                                            const struct ndpi_flow_input_info *input_info);
 ndpi_protocol ndpi_detection_giveup(struct ndpi_detection_module_struct *ndpi_struct,
                                     struct ndpi_flow_struct *flow,
                                     u_int8_t enable_guess,

--- a/python/ndpi_example.py
+++ b/python/ndpi_example.py
@@ -14,7 +14,7 @@ If not, see <http://www.gnu.org/licenses/>.
 """
 
 from collections import namedtuple
-from ndpi import NDPI, NDPIFlow
+from ndpi import NDPI, NDPIFlow, ffi
 import argparse
 import socket
 import dpkt
@@ -131,7 +131,7 @@ if __name__ == "__main__":
                 key = ppkt_to_flow_key(ppkt)
                 try:  # Try a Flow update
                     flow = flow_cache[key]
-                    flow.detected_protocol = nDPI.process_packet(flow.ndpi_flow, ppkt.ip_bytes, time_ms)
+                    flow.detected_protocol = nDPI.process_packet(flow.ndpi_flow, ppkt.ip_bytes, time_ms, ffi.NULL)
                     flow.pkts += 1
                     flow.bytes += len(packet)
                 except KeyError:  # New Flow
@@ -139,7 +139,7 @@ if __name__ == "__main__":
                     flow.index = flow_count
                     flow_count += 1
                     flow.ndpi_flow = NDPIFlow()  # We create an nDPIFlow object per Flow
-                    flow.detected_protocol = nDPI.process_packet(flow.ndpi_flow, ppkt.ip_bytes, time_ms)
+                    flow.detected_protocol = nDPI.process_packet(flow.ndpi_flow, ppkt.ip_bytes, time_ms, ffi.NULL)
                     flow.pkts += 1
                     flow.bytes += len(packet)
                     flow_cache[key] = flow

--- a/python/tests.py
+++ b/python/tests.py
@@ -13,7 +13,7 @@ If not, see <http://www.gnu.org/licenses/>.
 ------------------------------------------------------------------------------------------------------------------------
 """
 
-from ndpi import NDPI, NDPIFlow
+from ndpi import NDPI, NDPIFlow, ffi
 import time
 
 
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     try:
         nDPI = NDPI()
         ndpi_flow = NDPIFlow()
-        nDPI.process_packet(ndpi_flow, b'', time.time())
+        nDPI.process_packet(ndpi_flow, b'', time.time(), ffi.NULL)
         nDPI.giveup(ndpi_flow)
         print("nDPI Python bindings: OK")
     except Exception:

--- a/src/include/ndpi_api.h.in
+++ b/src/include/ndpi_api.h.in
@@ -302,6 +302,7 @@ extern "C" {
    * @par    packet         = unsigned char pointer to the Layer 3 (IP header)
    * @par    packetlen      = the length of the packet
    * @par    packet_time_ms = the current timestamp for the packet (expressed in msec)
+   * @par    input_info     = (optional) flow information provided by the (external) flow manager
    * @return void
    *
    */
@@ -309,7 +310,8 @@ extern "C" {
 				 struct ndpi_flow_struct *flow,
 				 const unsigned char *packet,
 				 const unsigned short packetlen,
-				 const u_int64_t packet_time_ms);
+				 const u_int64_t packet_time_ms,
+				 const struct ndpi_flow_input_info *input_info);
 
   /**
    * Processes one packet and returns the ID of the detected protocol.
@@ -320,6 +322,7 @@ extern "C" {
    * @par    packet         = unsigned char pointer to the Layer 3 (IP header)
    * @par    packetlen      = the length of the packet
    * @par    packet_time_ms = the current timestamp for the packet (expressed in msec)
+   * @par    input_info     = (optional) flow information provided by the (external) flow manager
    * @return the detected ID of the protocol
    *
    */
@@ -327,7 +330,8 @@ extern "C" {
 					      struct ndpi_flow_struct *flow,
 					      const unsigned char *packet,
 					      const unsigned short packetlen,
-					      const u_int64_t packet_time_ms);
+					      const u_int64_t packet_time_ms,
+					      const struct ndpi_flow_input_info *input_info);
   /**
    * Get the main protocol of the passed flows for the detected module
    *

--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -167,6 +167,10 @@ extern "C" {
 
   int64_t ndpi_asn1_ber_decode_length(const unsigned char *payload, int payload_len, u_int16_t *value_len);
 
+  int ndpi_current_pkt_from_client_to_server(const struct ndpi_packet_struct *packet, const struct ndpi_flow_struct *flow);
+  int ndpi_current_pkt_from_server_to_client(const struct ndpi_packet_struct *packet, const struct ndpi_flow_struct *flow);
+  int ndpi_seen_flow_beginning(const struct ndpi_flow_struct *flow);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -2271,8 +2271,8 @@ static void ndpi_handle_risk_exceptions(struct ndpi_detection_module_struct *ndp
   /* TODO: add IPv6 support */
   if(!flow->ip_risk_mask_evaluated) {
     if(flow->is_ipv6 == 0) {
-      ndpi_check_ipv4_exception(ndpi_str, flow, flow->saddr /* Source */);
-      ndpi_check_ipv4_exception(ndpi_str, flow, flow->daddr /* Destination */);
+      ndpi_check_ipv4_exception(ndpi_str, flow, flow->c_address.v4 /* Client */);
+      ndpi_check_ipv4_exception(ndpi_str, flow, flow->s_address.v4 /* Server */);
     }
 
     flow->ip_risk_mask_evaluated = 1;

--- a/src/lib/protocols/ftp_data.c
+++ b/src/lib/protocols/ftp_data.c
@@ -232,7 +232,7 @@ static void ndpi_check_ftp_data(struct ndpi_detection_module_struct *ndpi_struct
     Make sure we see the beginning of the connection as otherwise we might have
     false positive results
   */
-  if(flow->l4.tcp.seen_syn) {
+  if(ndpi_seen_flow_beginning(flow)) {
     if((packet->payload_packet_len > 0)
        && (ndpi_match_file_header(ndpi_struct, flow)
 	   || ndpi_match_ftp_data_directory(ndpi_struct, flow) 

--- a/src/lib/protocols/icecast.c
+++ b/src/lib/protocols/icecast.c
@@ -60,14 +60,12 @@ void ndpi_search_icecast_tcp(struct ndpi_detection_module_struct *ndpi_struct, s
     }
   }
 
-  if(flow == NULL) return;
-    
-  if((packet->packet_direction == flow->setup_packet_direction)
+  if(ndpi_current_pkt_from_client_to_server(packet, flow)
       && (flow->packet_counter < 10)) {
     return;
   }
 
-  if(packet->packet_direction != flow->setup_packet_direction) {
+  if(ndpi_current_pkt_from_server_to_client(packet, flow)) {
     /* server answer, now test Server for Icecast */
 
     ndpi_parse_packet_line_info(ndpi_struct, flow);

--- a/src/lib/protocols/lotus_notes.c
+++ b/src/lib/protocols/lotus_notes.c
@@ -37,11 +37,8 @@ static void ndpi_check_lotus_notes(struct ndpi_detection_module_struct *ndpi_str
 
   flow->l4.tcp.lotus_notes_packet_id++;
   
-  if((flow->l4.tcp.lotus_notes_packet_id == 1)
-     /* We have seen the 3-way handshake */
-     && flow->l4.tcp.seen_syn
-     && flow->l4.tcp.seen_syn_ack
-     && flow->l4.tcp.seen_ack) {
+  if((flow->l4.tcp.lotus_notes_packet_id == 1) &&
+     ndpi_seen_flow_beginning(flow)) {
     if(payload_len > 16) {
       char lotus_notes_header[] = { 0x00, 0x00, 0x02, 0x00, 0x00, 0x40, 0x02, 0x0F };
       

--- a/tests/result/1kxun.pcap.out
+++ b/tests/result/1kxun.pcap.out
@@ -6,7 +6,7 @@ Confidence Unknown          : 14 (flows)
 Confidence Match by port    : 5 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 177 (flows)
-Num dissector calls: 5061 (25.69 diss/flow)
+Num dissector calls: 5058 (25.68 diss/flow)
 
 Unknown	24	6428	14
 DNS	2	378	1

--- a/tests/result/KakaoTalk_chat.pcap.out
+++ b/tests/result/KakaoTalk_chat.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by port    : 4 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 33 (flows)
-Num dissector calls: 878 (23.11 diss/flow)
+Num dissector calls: 879 (23.13 diss/flow)
 
 DNS	2	217	1
 HTTP	1	56	1

--- a/tests/result/KakaoTalk_talk.pcap.out
+++ b/tests/result/KakaoTalk_talk.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	6	(1.20 pkts/flow)
 Confidence Match by port    : 4 (flows)
 Confidence Match by IP      : 5 (flows)
 Confidence DPI              : 11 (flows)
-Num dissector calls: 993 (49.65 diss/flow)
+Num dissector calls: 999 (49.95 diss/flow)
 
 HTTP	5	280	1
 QQ	15	1727	1

--- a/tests/result/Oscar.pcap.out
+++ b/tests/result/Oscar.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 351 (351.00 diss/flow)
+Num dissector calls: 352 (352.00 diss/flow)
 
 TLS	71	9386	1
 

--- a/tests/result/amqp.pcap.out
+++ b/tests/result/amqp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	9	(3.00 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 398 (132.67 diss/flow)
+Num dissector calls: 401 (133.67 diss/flow)
 
 AMQP	160	23514	3
 

--- a/tests/result/anyconnect-vpn.pcap.out
+++ b/tests/result/anyconnect-vpn.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 2 (flows)
 Confidence Match by port    : 5 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 61 (flows)
-Num dissector calls: 1165 (16.88 diss/flow)
+Num dissector calls: 1170 (16.96 diss/flow)
 
 Unknown	19	1054	2
 DNS	32	3655	16

--- a/tests/result/cloudflare-warp.pcap.out
+++ b/tests/result/cloudflare-warp.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	4
 DPI Packets (TCP):	41	(5.12 pkts/flow)
 Confidence Match by IP      : 3 (flows)
 Confidence DPI              : 5 (flows)
-Num dissector calls: 285 (35.62 diss/flow)
+Num dissector calls: 286 (35.75 diss/flow)
 
 Jabber	11	890	1
 Google	8	476	3

--- a/tests/result/dnp3.pcap.out
+++ b/tests/result/dnp3.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	80	(10.00 pkts/flow)
 Confidence DPI              : 8 (flows)
-Num dissector calls: 351 (43.88 diss/flow)
+Num dissector calls: 248 (31.00 diss/flow)
 
 DNP3	543	38754	8
 

--- a/tests/result/emotet.pcap.out
+++ b/tests/result/emotet.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	48	(8.00 pkts/flow)
 Confidence DPI              : 6 (flows)
-Num dissector calls: 281 (46.83 diss/flow)
+Num dissector calls: 280 (46.67 diss/flow)
 
 SMTP	626	438465	1
 HTTP	1601	1581542	3

--- a/tests/result/ftp_failed.pcap.out
+++ b/tests/result/ftp_failed.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(8.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 161 (161.00 diss/flow)
+Num dissector calls: 160 (160.00 diss/flow)
 
 FTP_CONTROL	18	1700	1
 

--- a/tests/result/fuzz-2006-06-26-2594.pcap.out
+++ b/tests/result/fuzz-2006-06-26-2594.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 30 (flows)
 Confidence Match by port    : 28 (flows)
 Confidence DPI              : 193 (flows)
-Num dissector calls: 5303 (21.13 diss/flow)
+Num dissector calls: 5266 (20.98 diss/flow)
 
 Unknown	30	3356	30
 FTP_CONTROL	36	2569	12

--- a/tests/result/fuzz-2006-09-29-28586.pcap.out
+++ b/tests/result/fuzz-2006-09-29-28586.pcap.out
@@ -6,7 +6,7 @@ Confidence Unknown          : 3 (flows)
 Confidence Match by port    : 23 (flows)
 Confidence Match by IP      : 2 (flows)
 Confidence DPI              : 12 (flows)
-Num dissector calls: 1227 (30.67 diss/flow)
+Num dissector calls: 1232 (30.80 diss/flow)
 
 Unknown	3	655	3
 HTTP	116	27378	35

--- a/tests/result/google_ssl.pcap.out
+++ b/tests/result/google_ssl.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	28	(28.00 pkts/flow)
 Confidence Match by IP      : 1 (flows)
-Num dissector calls: 252 (252.00 diss/flow)
+Num dissector calls: 253 (253.00 diss/flow)
 
 Google	28	9108	1
 

--- a/tests/result/imap-starttls.pcap.out
+++ b/tests/result/imap-starttls.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(10.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 193 (193.00 diss/flow)
+Num dissector calls: 192 (192.00 diss/flow)
 
 IMAPS	32	7975	1
 

--- a/tests/result/instagram.pcap.out
+++ b/tests/result/instagram.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 1 (flows)
 Confidence Match by port    : 6 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 30 (flows)
-Num dissector calls: 2069 (54.45 diss/flow)
+Num dissector calls: 2042 (53.74 diss/flow)
 
 Unknown	1	66	1
 HTTP	116	91784	6

--- a/tests/result/irc.pcap.out
+++ b/tests/result/irc.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 168 (168.00 diss/flow)
+Num dissector calls: 169 (169.00 diss/flow)
 
 IRC	29	8945	1
 

--- a/tests/result/mongo_false_positive.pcapng.out
+++ b/tests/result/mongo_false_positive.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	26	(26.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 413 (413.00 diss/flow)
+Num dissector calls: 414 (414.00 diss/flow)
 
 TLS	26	12163	1
 

--- a/tests/result/oracle12.pcapng.out
+++ b/tests/result/oracle12.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	20	(20.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 304 (304.00 diss/flow)
+Num dissector calls: 305 (305.00 diss/flow)
 
 Oracle	20	2518	1
 

--- a/tests/result/skype.pcap.out
+++ b/tests/result/skype.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 61 (flows)
 Confidence Match by port    : 27 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 204 (flows)
-Num dissector calls: 31948 (109.04 diss/flow)
+Num dissector calls: 31972 (109.12 diss/flow)
 
 Unknown	1575	272476	61
 DNS	2	267	1

--- a/tests/result/skype_no_unknown.pcap.out
+++ b/tests/result/skype_no_unknown.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 45 (flows)
 Confidence Match by port    : 22 (flows)
 Confidence DPI              : 200 (flows)
-Num dissector calls: 26144 (97.92 diss/flow)
+Num dissector calls: 26166 (98.00 diss/flow)
 
 Unknown	850	152468	45
 DNS	2	267	1

--- a/tests/result/socks-http-example.pcap.out
+++ b/tests/result/socks-http-example.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	29	(9.67 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 514 (171.33 diss/flow)
+Num dissector calls: 515 (171.67 diss/flow)
 
 SOCKS	46	8383	3
 

--- a/tests/result/tinc.pcap.out
+++ b/tests/result/tinc.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	19	(9.50 pkts/flow)
 DPI Packets (UDP):	2	(1.00 pkts/flow)
 Confidence DPI (cache)      : 2 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 555 (138.75 diss/flow)
+Num dissector calls: 556 (139.00 diss/flow)
 
 TINC	317	352291	4
 

--- a/tests/result/tls_false_positives.pcapng.out
+++ b/tests/result/tls_false_positives.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	30	(30.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
-Num dissector calls: 409 (409.00 diss/flow)
+Num dissector calls: 410 (410.00 diss/flow)
 
 Unknown	30	37313	1
 

--- a/tests/result/waze.pcap.out
+++ b/tests/result/waze.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	1	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence Match by port    : 9 (flows)
 Confidence DPI              : 23 (flows)
-Num dissector calls: 885 (26.82 diss/flow)
+Num dissector calls: 890 (26.97 diss/flow)
 
 Unknown	10	786	1
 HTTP	65	64777	8

--- a/tests/result/z3950.pcapng.out
+++ b/tests/result/z3950.pcapng.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	26	(13.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 493 (246.50 diss/flow)
+Num dissector calls: 494 (247.00 diss/flow)
 
 Z3950	31	6308	2
 


### PR DESCRIPTION
In a lot of places in ndPI we use *packet* source/dest info
(address/port/direction) when we are interested in *flow* client/server
info, instead.

Add basic logic to autodetect this kind of information.

nDPI doesn't perform any "flow management" itself but this task is
delegated to the external application. It is then likely that the
application might provide more reliable hints about flow
client/server direction and about the TCP handshake presence: in that case,
these information might be (optionally) passed to the library, disabling
the internal "autodetect" logic.

These new fields have been used in some LRU caches and in the "guessing"
algorithm.
It is quite likely that some other code needs to be updated.