### PR TITLE
TINC: avoid processing SYN packets

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -556,11 +556,6 @@ struct ndpi_flow_input_info {
 /* ******************* ********************* ****************** */
 /* ************************************************************ */
 
-PACK_ON struct tinc_cache_entry {
-  u_int32_t src_address;
-  u_int32_t dst_address;
-  u_int16_t dst_port;
-} PACK_OFF;
 //CFFI.NDPI_PACKED_STRUCTURES
 #endif // NDPI_CFFI_PREPROCESSING_EXCLUDE_PACKED
 
@@ -1458,7 +1453,6 @@ struct ndpi_flow_struct {
 
   /* NDPI_PROTOCOL_TINC */
   u_int8_t tinc_state;
-  struct tinc_cache_entry tinc_cache_entry;
 
   /* 
      Leave this field below at the end

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -5280,10 +5280,10 @@ static u_int32_t check_ndpi_detection_func(struct ndpi_detection_module_struct *
 					   struct ndpi_flow_struct * const flow,
 					   NDPI_SELECTION_BITMASK_PROTOCOL_SIZE const ndpi_selection_packet,
 					   struct ndpi_call_function_struct const * const callback_buffer,
-					   uint32_t callback_buffer_size)
+					   uint32_t callback_buffer_size,
+					   int is_tcp_without_payload)
 {
   void *func = NULL;
-  u_int8_t is_tcp_without_payload = (callback_buffer == ndpi_str->callback_buffer_tcp_no_payload);
   u_int32_t num_calls = 0;
   u_int16_t proto_index = ndpi_str->proto_defaults[flow->guessed_protocol_id].protoIdx;
   u_int16_t proto_id = ndpi_str->proto_defaults[flow->guessed_protocol_id].protoId;
@@ -5349,7 +5349,7 @@ u_int32_t check_ndpi_other_flow_func(struct ndpi_detection_module_struct *ndpi_s
 {
   return check_ndpi_detection_func(ndpi_str, flow, *ndpi_selection_packet,
 				   ndpi_str->callback_buffer_non_tcp_udp,
-				   ndpi_str->callback_buffer_size_non_tcp_udp);
+				   ndpi_str->callback_buffer_size_non_tcp_udp, 0);
 }
 
 /* ************************************************ */
@@ -5360,7 +5360,7 @@ static u_int32_t check_ndpi_udp_flow_func(struct ndpi_detection_module_struct *n
 {
   return check_ndpi_detection_func(ndpi_str, flow, *ndpi_selection_packet,
 				   ndpi_str->callback_buffer_udp,
-				   ndpi_str->callback_buffer_size_udp);
+				   ndpi_str->callback_buffer_size_udp, 0);
 }
 
 /* ************************************************ */
@@ -5372,12 +5372,12 @@ static u_int32_t check_ndpi_tcp_flow_func(struct ndpi_detection_module_struct *n
   if (ndpi_str->packet.payload_packet_len != 0) {
     return check_ndpi_detection_func(ndpi_str, flow, *ndpi_selection_packet,
 				     ndpi_str->callback_buffer_tcp_payload,
-				     ndpi_str->callback_buffer_size_tcp_payload);
+				     ndpi_str->callback_buffer_size_tcp_payload, 0);
   } else {
     /* no payload */
     return check_ndpi_detection_func(ndpi_str, flow, *ndpi_selection_packet,
 				     ndpi_str->callback_buffer_tcp_no_payload,
-				     ndpi_str->callback_buffer_size_tcp_no_payload);
+				     ndpi_str->callback_buffer_size_tcp_no_payload, 1);
   }
 }
 

--- a/tests/result/1kxun.pcap.out
+++ b/tests/result/1kxun.pcap.out
@@ -6,7 +6,7 @@ Confidence Unknown          : 14 (flows)
 Confidence Match by port    : 5 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 177 (flows)
-Num dissector calls: 4718 (23.95 diss/flow)
+Num dissector calls: 4630 (23.50 diss/flow)
 
 Unknown	24	6428	14
 DNS	2	378	1

--- a/tests/result/443-curl.pcap.out
+++ b/tests/result/443-curl.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 ntop	109	73982	1
 

--- a/tests/result/443-firefox.pcap.out
+++ b/tests/result/443-firefox.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 ntop	667	458067	1
 

--- a/tests/result/443-git.pcap.out
+++ b/tests/result/443-git.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Github	70	37189	1
 

--- a/tests/result/443-opvn.pcap.out
+++ b/tests/result/443-opvn.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 126 (126.00 diss/flow)
+Num dissector calls: 123 (123.00 diss/flow)
 
 OpenVPN	46	11573	1
 

--- a/tests/result/443-safari.pcap.out
+++ b/tests/result/443-safari.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 ntop	41	19929	1
 

--- a/tests/result/4in6tunnel.pcap.out
+++ b/tests/result/4in6tunnel.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 3 (3.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Microsoft	4	2188	1
 

--- a/tests/result/BGP_Cisco_hdlc_slarp.pcap.out
+++ b/tests/result/BGP_Cisco_hdlc_slarp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 BGP	14	969	1
 

--- a/tests/result/EAQ.pcap.out
+++ b/tests/result/EAQ.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	12	(6.00 pkts/flow)
 DPI Packets (UDP):	116	(4.00 pkts/flow)
 Confidence DPI              : 31 (flows)
-Num dissector calls: 4022 (129.74 diss/flow)
+Num dissector calls: 4016 (129.55 diss/flow)
 
 Google	23	11743	2
 EAQ	174	10092	29

--- a/tests/result/IEC104.pcap.out
+++ b/tests/result/IEC104.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(2.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 4 (2.00 diss/flow)
+Num dissector calls: 2 (1.00 diss/flow)
 
 IEC60870	15	1431	2
 

--- a/tests/result/KakaoTalk_chat.pcap.out
+++ b/tests/result/KakaoTalk_chat.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by port    : 4 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 33 (flows)
-Num dissector calls: 671 (17.66 diss/flow)
+Num dissector calls: 617 (16.24 diss/flow)
 
 DNS	2	217	1
 HTTP	1	56	1

--- a/tests/result/KakaoTalk_talk.pcap.out
+++ b/tests/result/KakaoTalk_talk.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	6	(1.20 pkts/flow)
 Confidence Match by port    : 4 (flows)
 Confidence Match by IP      : 5 (flows)
 Confidence DPI              : 11 (flows)
-Num dissector calls: 877 (43.85 diss/flow)
+Num dissector calls: 853 (42.65 diss/flow)
 
 HTTP	5	280	1
 QQ	15	1727	1

--- a/tests/result/Oscar.pcap.out
+++ b/tests/result/Oscar.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 339 (339.00 diss/flow)
+Num dissector calls: 336 (336.00 diss/flow)
 
 TLS	71	9386	1
 

--- a/tests/result/WebattackSQLinj.pcap.out
+++ b/tests/result/WebattackSQLinj.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	54	(6.00 pkts/flow)
 Confidence DPI              : 9 (flows)
-Num dissector calls: 162 (18.00 diss/flow)
+Num dissector calls: 135 (15.00 diss/flow)
 
 HTTP	94	30008	9
 

--- a/tests/result/WebattackXSS.pcap.out
+++ b/tests/result/WebattackXSS.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	639
 DPI Packets (TCP):	3972	(6.01 pkts/flow)
 Confidence Match by port    : 639 (flows)
 Confidence DPI              : 22 (flows)
-Num dissector calls: 4236 (6.41 diss/flow)
+Num dissector calls: 330 (0.50 diss/flow)
 
 HTTP	9374	4721148	661
 

--- a/tests/result/aimini-http.pcap.out
+++ b/tests/result/aimini-http.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	36	(9.00 pkts/flow)
 Confidence DPI              : 4 (flows)
-Num dissector calls: 92 (23.00 diss/flow)
+Num dissector calls: 76 (19.00 diss/flow)
 
 Aimini	133	86722	4
 

--- a/tests/result/ajp.pcap.out
+++ b/tests/result/ajp.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	8	(4.00 pkts/flow)
 DPI Packets (other):	6	(3.00 pkts/flow)
 Confidence Unknown          : 2 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 8 (2.00 diss/flow)
+Num dissector calls: 2 (0.50 diss/flow)
 
 Unknown	6	2200	2
 AJP	26	4446	2

--- a/tests/result/alexa-app.pcapng.out
+++ b/tests/result/alexa-app.pcapng.out
@@ -6,7 +6,7 @@ DPI Packets (other):	6	(1.00 pkts/flow)
 Confidence Match by port    : 5 (flows)
 Confidence Match by IP      : 9 (flows)
 Confidence DPI              : 146 (flows)
-Num dissector calls: 924 (5.78 diss/flow)
+Num dissector calls: 536 (3.35 diss/flow)
 
 DNS	4	400	2
 DHCP	3	1056	2

--- a/tests/result/alicloud.pcap.out
+++ b/tests/result/alicloud.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	60	(4.00 pkts/flow)
 Confidence DPI              : 15 (flows)
-Num dissector calls: 1860 (124.00 diss/flow)
+Num dissector calls: 1815 (121.00 diss/flow)
 
 AliCloud	225	22986	15
 

--- a/tests/result/android.pcap.out
+++ b/tests/result/android.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	52	(1.68 pkts/flow)
 DPI Packets (other):	4	(1.00 pkts/flow)
 Confidence Match by IP      : 3 (flows)
 Confidence DPI              : 60 (flows)
-Num dissector calls: 348 (5.52 diss/flow)
+Num dissector calls: 280 (4.44 diss/flow)
 
 DNS	4	390	2
 MDNS	2	174	2

--- a/tests/result/anyconnect-vpn.pcap.out
+++ b/tests/result/anyconnect-vpn.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 2 (flows)
 Confidence Match by port    : 5 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 61 (flows)
-Num dissector calls: 971 (14.07 diss/flow)
+Num dissector calls: 917 (13.29 diss/flow)
 
 Unknown	19	1054	2
 DNS	32	3655	16

--- a/tests/result/anydesk-2.pcap.out
+++ b/tests/result/anydesk-2.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	13	(6.50 pkts/flow)
 DPI Packets (UDP):	4	(2.00 pkts/flow)
 Confidence DPI              : 4 (flows)
-Num dissector calls: 14 (3.50 diss/flow)
+Num dissector calls: 8 (2.00 diss/flow)
 
 AnyDesk	2083	346113	4
 

--- a/tests/result/anydesk.pcap.out
+++ b/tests/result/anydesk.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	21	(10.50 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 9 (4.50 diss/flow)
+Num dissector calls: 6 (3.00 diss/flow)
 
 AnyDesk	6963	2795460	2
 

--- a/tests/result/avast.pcap.out
+++ b/tests/result/avast.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	40	(4.00 pkts/flow)
 Confidence DPI              : 10 (flows)
-Num dissector calls: 1250 (125.00 diss/flow)
+Num dissector calls: 1220 (122.00 diss/flow)
 
 AVAST	142	9433	10
 

--- a/tests/result/bot.pcap.out
+++ b/tests/result/bot.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 18 (18.00 diss/flow)
+Num dissector calls: 15 (15.00 diss/flow)
 
 Azure	402	431124	1
 

--- a/tests/result/cachefly.pcapng.out
+++ b/tests/result/cachefly.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 2 (2.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Cachefly	6	6163	1
 

--- a/tests/result/cassandra.pcap.out
+++ b/tests/result/cassandra.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(4.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 8 (4.00 diss/flow)
+Num dissector calls: 2 (1.00 diss/flow)
 
 Cassandra	286	126016	2
 

--- a/tests/result/check_mk_new.pcap.out
+++ b/tests/result/check_mk_new.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 CHECKMK	98	20242	1
 

--- a/tests/result/chrome.pcap.out
+++ b/tests/result/chrome.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	36	(6.00 pkts/flow)
 Confidence DPI              : 6 (flows)
-Num dissector calls: 24 (4.00 diss/flow)
+Num dissector calls: 6 (1.00 diss/flow)
 
 TLS	5633	4985157	6
 

--- a/tests/result/citrix.pcap.out
+++ b/tests/result/citrix.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Citrix	100	11332	1
 

--- a/tests/result/cloudflare-warp.pcap.out
+++ b/tests/result/cloudflare-warp.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	4
 DPI Packets (TCP):	41	(5.12 pkts/flow)
 Confidence Match by IP      : 3 (flows)
 Confidence DPI              : 5 (flows)
-Num dissector calls: 201 (25.12 diss/flow)
+Num dissector calls: 178 (22.25 diss/flow)
 
 Jabber	11	890	1
 Google	8	476	3

--- a/tests/result/coap_mqtt.pcap.out
+++ b/tests/result/coap_mqtt.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	7	(1.75 pkts/flow)
 DPI Packets (UDP):	12	(1.00 pkts/flow)
 Confidence DPI              : 16 (flows)
-Num dissector calls: 351 (21.94 diss/flow)
+Num dissector calls: 348 (21.75 diss/flow)
 
 COAP	19	1614	8
 Dropbox	800	80676	4

--- a/tests/result/corba.pcap.out
+++ b/tests/result/corba.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	12	(4.00 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 234 (78.00 diss/flow)
+Num dissector calls: 225 (75.00 diss/flow)
 
 Corba	22	3681	3
 

--- a/tests/result/dazn.pcapng.out
+++ b/tests/result/dazn.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	12	(4.00 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 9 (3.00 diss/flow)
+Num dissector calls: 3 (1.00 diss/flow)
 
 Dazn	12	6675	3
 

--- a/tests/result/discord.pcap.out
+++ b/tests/result/discord.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	5	(5.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 3 (3.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Discord	7	3708	1
 

--- a/tests/result/dnp3.pcap.out
+++ b/tests/result/dnp3.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	80	(10.00 pkts/flow)
 Confidence DPI              : 8 (flows)
-Num dissector calls: 64 (8.00 diss/flow)
+Num dissector calls: 8 (1.00 diss/flow)
 
 DNP3	543	38754	8
 

--- a/tests/result/dns_doh.pcap.out
+++ b/tests/result/dns_doh.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 DoH_DoT	142	20362	1
 

--- a/tests/result/dns_dot.pcap.out
+++ b/tests/result/dns_dot.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 6 (6.00 diss/flow)
+Num dissector calls: 3 (3.00 diss/flow)
 
 DoH_DoT	24	5869	1
 

--- a/tests/result/dns_fragmented.pcap.out
+++ b/tests/result/dns_fragmented.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	12	(6.00 pkts/flow)
 DPI Packets (UDP):	39	(2.05 pkts/flow)
 Confidence DPI              : 21 (flows)
-Num dissector calls: 24 (1.14 diss/flow)
+Num dissector calls: 21 (1.00 diss/flow)
 
 DNS	53	16888	18
 Google	6	4807	3

--- a/tests/result/drda_db2.pcap.out
+++ b/tests/result/drda_db2.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 91 (91.00 diss/flow)
+Num dissector calls: 88 (88.00 diss/flow)
 
 DRDA	38	6691	1
 

--- a/tests/result/emotet.pcap.out
+++ b/tests/result/emotet.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	48	(8.00 pkts/flow)
 Confidence DPI              : 6 (flows)
-Num dissector calls: 216 (36.00 diss/flow)
+Num dissector calls: 198 (33.00 diss/flow)
 
 SMTP	626	438465	1
 HTTP	1601	1581542	3

--- a/tests/result/ethereum.pcap.out
+++ b/tests/result/ethereum.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	18	(1.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence Match by IP      : 2 (flows)
 Confidence DPI              : 71 (flows)
-Num dissector calls: 755 (10.20 diss/flow)
+Num dissector calls: 593 (8.01 diss/flow)
 
 Mining	1997	215877	72
 AmazonAWS	1	78	1

--- a/tests/result/exe_download.pcap.out
+++ b/tests/result/exe_download.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 18 (18.00 diss/flow)
+Num dissector calls: 15 (15.00 diss/flow)
 
 HTTP	703	717463	1
 

--- a/tests/result/exe_download_as_png.pcap.out
+++ b/tests/result/exe_download_as_png.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 18 (18.00 diss/flow)
+Num dissector calls: 15 (15.00 diss/flow)
 
 HTTP	534	529449	1
 

--- a/tests/result/facebook.pcap.out
+++ b/tests/result/facebook.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	16	(8.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 8 (4.00 diss/flow)
+Num dissector calls: 2 (1.00 diss/flow)
 
 Facebook	60	30511	2
 

--- a/tests/result/firefox.pcap.out
+++ b/tests/result/firefox.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	36	(6.00 pkts/flow)
 Confidence DPI              : 6 (flows)
-Num dissector calls: 24 (4.00 diss/flow)
+Num dissector calls: 6 (1.00 diss/flow)
 
 TLS	5441	4952732	6
 

--- a/tests/result/fix2.pcap.out
+++ b/tests/result/fix2.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(4.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 188 (94.00 diss/flow)
+Num dissector calls: 182 (91.00 diss/flow)
 
 FIX	3046	246540	2
 

--- a/tests/result/forticlient.pcap.out
+++ b/tests/result/forticlient.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	35	(7.00 pkts/flow)
 Confidence DPI (cache)      : 4 (flows)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 30 (6.00 diss/flow)
+Num dissector calls: 15 (3.00 diss/flow)
 
 FortiClient	2000	430931	5
 

--- a/tests/result/ftp-start-tls.pcap.out
+++ b/tests/result/ftp-start-tls.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(10.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 155 (155.00 diss/flow)
+Num dissector calls: 151 (151.00 diss/flow)
 
 FTP_CONTROL	51	7510	1
 

--- a/tests/result/ftp.pcap.out
+++ b/tests/result/ftp.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	49	(16.33 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 645 (215.00 diss/flow)
+Num dissector calls: 636 (212.00 diss/flow)
 
 Unknown	1115	1122198	1
 FTP_CONTROL	68	5571	1

--- a/tests/result/fuzz-2006-06-26-2594.pcap.out
+++ b/tests/result/fuzz-2006-06-26-2594.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 30 (flows)
 Confidence Match by port    : 28 (flows)
 Confidence DPI              : 193 (flows)
-Num dissector calls: 5226 (20.82 diss/flow)
+Num dissector calls: 5218 (20.79 diss/flow)
 
 Unknown	30	3356	30
 FTP_CONTROL	36	2569	12

--- a/tests/result/fuzz-2006-09-29-28586.pcap.out
+++ b/tests/result/fuzz-2006-09-29-28586.pcap.out
@@ -6,7 +6,7 @@ Confidence Unknown          : 3 (flows)
 Confidence Match by port    : 24 (flows)
 Confidence Match by IP      : 2 (flows)
 Confidence DPI              : 11 (flows)
-Num dissector calls: 1048 (26.20 diss/flow)
+Num dissector calls: 997 (24.92 diss/flow)
 
 Unknown	3	655	3
 HTTP	116	27378	35

--- a/tests/result/genshin-impact.pcap.out
+++ b/tests/result/genshin-impact.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	12	(4.00 pkts/flow)
 DPI Packets (UDP):	3	(1.00 pkts/flow)
 Confidence DPI              : 6 (flows)
-Num dissector calls: 526 (87.67 diss/flow)
+Num dissector calls: 517 (86.17 diss/flow)
 
 GenshinImpact	90	18405	6
 

--- a/tests/result/git.pcap.out
+++ b/tests/result/git.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Git	90	74005	1
 

--- a/tests/result/gnutella.pcap.out
+++ b/tests/result/gnutella.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 595 (flows)
 Confidence Match by port    : 1 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 163 (flows)
-Num dissector calls: 63001 (82.90 diss/flow)
+Num dissector calls: 62705 (82.51 diss/flow)
 
 Unknown	1423	119577	595
 MDNS	18	1632	2

--- a/tests/result/google_ssl.pcap.out
+++ b/tests/result/google_ssl.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	28	(28.00 pkts/flow)
 Confidence Match by IP      : 1 (flows)
-Num dissector calls: 215 (215.00 diss/flow)
+Num dissector calls: 212 (212.00 diss/flow)
 
 Google	28	9108	1
 

--- a/tests/result/googledns_android10.pcap.out
+++ b/tests/result/googledns_android10.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	42	(6.00 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by IP      : 2 (flows)
 Confidence DPI              : 6 (flows)
-Num dissector calls: 39 (4.88 diss/flow)
+Num dissector calls: 16 (2.00 diss/flow)
 
 ICMP	4	392	1
 Google	8	504	2

--- a/tests/result/hpvirtgrp.pcap.out
+++ b/tests/result/hpvirtgrp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	37	(4.11 pkts/flow)
 Confidence DPI              : 9 (flows)
-Num dissector calls: 1026 (114.00 diss/flow)
+Num dissector calls: 999 (111.00 diss/flow)
 
 HP_VIRTGRP	135	12739	9
 

--- a/tests/result/http-crash-content-disposition.pcap.out
+++ b/tests/result/http-crash-content-disposition.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(8.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 18 (18.00 diss/flow)
+Num dissector calls: 15 (15.00 diss/flow)
 
 AmazonAWS	9	3328	1
 

--- a/tests/result/http-lines-split.pcap.out
+++ b/tests/result/http-lines-split.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(8.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 18 (18.00 diss/flow)
+Num dissector calls: 15 (15.00 diss/flow)
 
 HTTP	14	2503	1
 

--- a/tests/result/http-manipulated.pcap.out
+++ b/tests/result/http-manipulated.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	12	(6.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 36 (18.00 diss/flow)
+Num dissector calls: 30 (15.00 diss/flow)
 
 HTTP	328	959347	2
 

--- a/tests/result/http-proxy.pcapng.out
+++ b/tests/result/http-proxy.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 HTTP_Proxy	11	1652	1
 

--- a/tests/result/http_auth.pcap.out
+++ b/tests/result/http_auth.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 18 (18.00 diss/flow)
+Num dissector calls: 15 (15.00 diss/flow)
 
 HTTP	33	20574	1
 

--- a/tests/result/http_connect.pcap.out
+++ b/tests/result/http_connect.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	12	(6.00 pkts/flow)
 DPI Packets (UDP):	2	(2.00 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 9 (3.00 diss/flow)
+Num dissector calls: 3 (1.00 diss/flow)
 
 DNS	2	178	1
 TLS	58	36496	1

--- a/tests/result/iec60780-5-104.pcap.out
+++ b/tests/result/iec60780-5-104.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	24	(4.00 pkts/flow)
 Confidence DPI              : 6 (flows)
-Num dissector calls: 24 (4.00 diss/flow)
+Num dissector calls: 6 (1.00 diss/flow)
 
 IEC60870	147	9033	6
 

--- a/tests/result/imap-starttls.pcap.out
+++ b/tests/result/imap-starttls.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(10.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 181 (181.00 diss/flow)
+Num dissector calls: 178 (178.00 diss/flow)
 
 IMAPS	32	7975	1
 

--- a/tests/result/imap.pcap.out
+++ b/tests/result/imap.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	11	(11.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 204 (204.00 diss/flow)
+Num dissector calls: 201 (201.00 diss/flow)
 
 IMAP	33	3774	1
 

--- a/tests/result/imaps.pcap.out
+++ b/tests/result/imaps.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 6 (6.00 diss/flow)
+Num dissector calls: 3 (3.00 diss/flow)
 
 ntop	20	5196	1
 

--- a/tests/result/instagram.pcap.out
+++ b/tests/result/instagram.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 1 (flows)
 Confidence Match by port    : 6 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 30 (flows)
-Num dissector calls: 1863 (49.03 diss/flow)
+Num dissector calls: 1820 (47.89 diss/flow)
 
 Unknown	1	66	1
 HTTP	116	91784	6

--- a/tests/result/iphone.pcap.out
+++ b/tests/result/iphone.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	55	(1.77 pkts/flow)
 DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence DPI              : 50 (flows)
-Num dissector calls: 397 (7.78 diss/flow)
+Num dissector calls: 352 (6.90 diss/flow)
 
 Unknown	2	120	1
 MDNS	17	7012	5

--- a/tests/result/ipp.pcap.out
+++ b/tests/result/ipp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	21	(7.00 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 66 (22.00 diss/flow)
+Num dissector calls: 57 (19.00 diss/flow)
 
 IPP	277	248554	3
 

--- a/tests/result/irc.pcap.out
+++ b/tests/result/irc.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 159 (159.00 diss/flow)
+Num dissector calls: 156 (156.00 diss/flow)
 
 IRC	29	8945	1
 

--- a/tests/result/ja3_lots_of_cipher_suites.pcap.out
+++ b/tests/result/ja3_lots_of_cipher_suites.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 TLS	11	5132	1
 

--- a/tests/result/ja3_lots_of_cipher_suites_2_anon.pcap.out
+++ b/tests/result/ja3_lots_of_cipher_suites_2_anon.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 TLS	27	6966	1
 

--- a/tests/result/jabber.pcap.out
+++ b/tests/result/jabber.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	74	(6.17 pkts/flow)
 Confidence DPI              : 12 (flows)
-Num dissector calls: 1424 (118.67 diss/flow)
+Num dissector calls: 1397 (116.42 diss/flow)
 
 Jabber	358	61304	12
 

--- a/tests/result/kerberos-login.pcap.out
+++ b/tests/result/kerberos-login.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	11	(11.00 pkts/flow)
 DPI Packets (UDP):	12	(1.00 pkts/flow)
 Confidence DPI              : 13 (flows)
-Num dissector calls: 17 (1.31 diss/flow)
+Num dissector calls: 13 (1.00 diss/flow)
 
 Kerberos	39	37272	13
 

--- a/tests/result/lisp_registration.pcap.out
+++ b/tests/result/lisp_registration.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	8	(4.00 pkts/flow)
 DPI Packets (UDP):	2	(1.00 pkts/flow)
 Confidence DPI              : 4 (flows)
-Num dissector calls: 206 (51.50 diss/flow)
+Num dissector calls: 200 (50.00 diss/flow)
 
 LISP	30	5266	4
 

--- a/tests/result/log4j-webapp-exploit.pcap.out
+++ b/tests/result/log4j-webapp-exploit.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	2
 DPI Packets (TCP):	63	(9.00 pkts/flow)
 Confidence Unknown          : 2 (flows)
 Confidence DPI              : 5 (flows)
-Num dissector calls: 467 (66.71 diss/flow)
+Num dissector calls: 447 (63.86 diss/flow)
 
 Unknown	356	25081	2
 HTTP	34	6741	3

--- a/tests/result/long_tls_certificate.pcap.out
+++ b/tests/result/long_tls_certificate.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	12	(12.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Alibaba	47	14812	1
 

--- a/tests/result/malware.pcap.out
+++ b/tests/result/malware.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	2	(2.00 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 4 (flows)
-Num dissector calls: 22 (4.40 diss/flow)
+Num dissector calls: 18 (3.60 diss/flow)
 
 DNS	2	216	1
 HTTP	1	66	1

--- a/tests/result/memcached.cap.out
+++ b/tests/result/memcached.cap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 126 (126.00 diss/flow)
+Num dissector calls: 123 (123.00 diss/flow)
 
 Memcached	10	1711	1
 

--- a/tests/result/monero.pcap.out
+++ b/tests/result/monero.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(4.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 68 (34.00 diss/flow)
+Num dissector calls: 62 (31.00 diss/flow)
 
 Mining	319	166676	2
 

--- a/tests/result/mongo_false_positive.pcapng.out
+++ b/tests/result/mongo_false_positive.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	26	(26.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 409 (409.00 diss/flow)
+Num dissector calls: 407 (407.00 diss/flow)
 
 TLS	26	12163	1
 

--- a/tests/result/mongodb.pcap.out
+++ b/tests/result/mongodb.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	27	(3.38 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence Match by port    : 2 (flows)
 Confidence DPI              : 5 (flows)
-Num dissector calls: 136 (17.00 diss/flow)
+Num dissector calls: 114 (14.25 diss/flow)
 
 Unknown	3	230	1
 MongoDB	24	2510	7

--- a/tests/result/mpeg-dash.pcap.out
+++ b/tests/result/mpeg-dash.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(2.50 pkts/flow)
 Confidence DPI              : 4 (flows)
-Num dissector calls: 69 (17.25 diss/flow)
+Num dissector calls: 64 (16.00 diss/flow)
 
 AmazonAWS	9	2693	3
 MpegDash	4	1976	1

--- a/tests/result/mpeg.pcap.out
+++ b/tests/result/mpeg.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 18 (18.00 diss/flow)
+Num dissector calls: 15 (15.00 diss/flow)
 
 ntop	19	10643	1
 

--- a/tests/result/mqtt.pcap.out
+++ b/tests/result/mqtt.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	3	(1.50 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 3 (1.50 diss/flow)
+Num dissector calls: 2 (1.00 diss/flow)
 
 MQTT	9	1481	2
 

--- a/tests/result/mysql-8.pcap.out
+++ b/tests/result/mysql-8.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 MySQL	4	367	1
 

--- a/tests/result/nats.pcap.out
+++ b/tests/result/nats.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(5.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 30 (15.00 diss/flow)
+Num dissector calls: 22 (11.00 diss/flow)
 
 Nats	27	2460	2
 

--- a/tests/result/ndpi_match_string_subprotocol__error.pcapng.out
+++ b/tests/result/ndpi_match_string_subprotocol__error.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	3	(3.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 19 (19.00 diss/flow)
+Num dissector calls: 18 (18.00 diss/flow)
 
 SOAP	13	2935	1
 

--- a/tests/result/nest_log_sink.pcap.out
+++ b/tests/result/nest_log_sink.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	130	(10.00 pkts/flow)
 DPI Packets (UDP):	2	(2.00 pkts/flow)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 13 (flows)
-Num dissector calls: 1905 (136.07 diss/flow)
+Num dissector calls: 1837 (131.21 diss/flow)
 
 DNS	15	1612	1
 NestLogSink	676	112058	12

--- a/tests/result/netflix.pcap.out
+++ b/tests/result/netflix.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	27	(2.08 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 60 (flows)
-Num dissector calls: 596 (9.77 diss/flow)
+Num dissector calls: 456 (7.48 diss/flow)
 
 DNS	4	386	2
 SSDP	16	2648	1

--- a/tests/result/nintendo.pcap.out
+++ b/tests/result/nintendo.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	35	(2.33 pkts/flow)
 DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Match by IP      : 6 (flows)
 Confidence DPI              : 15 (flows)
-Num dissector calls: 1265 (60.24 diss/flow)
+Num dissector calls: 1257 (59.86 diss/flow)
 
 ICMP	30	2100	2
 Nintendo	890	320242	12

--- a/tests/result/nntp.pcap.out
+++ b/tests/result/nntp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 132 (132.00 diss/flow)
+Num dissector calls: 129 (129.00 diss/flow)
 
 Usenet	32	7037	1
 

--- a/tests/result/no_sni.pcap.out
+++ b/tests/result/no_sni.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	51	(6.38 pkts/flow)
 Confidence DPI              : 8 (flows)
-Num dissector calls: 29 (3.62 diss/flow)
+Num dissector calls: 8 (1.00 diss/flow)
 
 DoH_DoT	268	31882	1
 Cloudflare	917	562254	7

--- a/tests/result/ocs.pcap.out
+++ b/tests/result/ocs.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	92	(7.67 pkts/flow)
 DPI Packets (UDP):	8	(1.00 pkts/flow)
 Confidence Match by IP      : 2 (flows)
 Confidence DPI              : 18 (flows)
-Num dissector calls: 110 (5.50 diss/flow)
+Num dissector calls: 88 (4.40 diss/flow)
 
 Google	29	3320	5
 OCS	863	57552	7

--- a/tests/result/ocsp.pcapng.out
+++ b/tests/result/ocsp.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	60	(6.00 pkts/flow)
 Confidence DPI              : 10 (flows)
-Num dissector calls: 180 (18.00 diss/flow)
+Num dissector calls: 150 (15.00 diss/flow)
 
 HTTP	23	10871	1
 OCSP	321	62776	9

--- a/tests/result/ookla.pcap.out
+++ b/tests/result/ookla.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	16	(8.00 pkts/flow)
 Confidence DPI (cache)      : 1 (flows)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 118 (59.00 diss/flow)
+Num dissector calls: 112 (56.00 diss/flow)
 
 Ookla	5086	4689745	2
 

--- a/tests/result/openvpn.pcap.out
+++ b/tests/result/openvpn.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 DPI Packets (UDP):	5	(2.50 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 383 (127.67 diss/flow)
+Num dissector calls: 380 (126.67 diss/flow)
 
 OpenVPN	298	57111	3
 

--- a/tests/result/oracle12.pcapng.out
+++ b/tests/result/oracle12.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	20	(20.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 291 (291.00 diss/flow)
+Num dissector calls: 288 (288.00 diss/flow)
 
 Oracle	20	2518	1
 

--- a/tests/result/pgsql.pcap.out
+++ b/tests/result/pgsql.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	12	(6.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 252 (126.00 diss/flow)
+Num dissector calls: 246 (123.00 diss/flow)
 
 PostgreSQL	39	4709	2
 

--- a/tests/result/pluralsight.pcap.out
+++ b/tests/result/pluralsight.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	33	(5.50 pkts/flow)
 Confidence DPI              : 6 (flows)
-Num dissector calls: 18 (3.00 diss/flow)
+Num dissector calls: 6 (1.00 diss/flow)
 
 Pluralsight	44	29652	6
 

--- a/tests/result/pop3.pcap.out
+++ b/tests/result/pop3.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(10.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 180 (180.00 diss/flow)
+Num dissector calls: 177 (177.00 diss/flow)
 
 POP3	31	3915	1
 

--- a/tests/result/pops.pcapng.out
+++ b/tests/result/pops.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	3	(3.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 5 (5.00 diss/flow)
+Num dissector calls: 3 (3.00 diss/flow)
 
 POPS	5	2998	1
 

--- a/tests/result/pps.pcap.out
+++ b/tests/result/pps.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	201	(4.57 pkts/flow)
 Confidence Unknown          : 34 (flows)
 Confidence Match by port    : 2 (flows)
 Confidence DPI              : 71 (flows)
-Num dissector calls: 6257 (58.48 diss/flow)
+Num dissector calls: 6254 (58.45 diss/flow)
 
 Unknown	990	378832	34
 HTTP	372	399367	45

--- a/tests/result/pptp.pcap.out
+++ b/tests/result/pptp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 53 (53.00 diss/flow)
+Num dissector calls: 50 (50.00 diss/flow)
 
 PPTP	24	2328	1
 

--- a/tests/result/psiphon3.pcap.out
+++ b/tests/result/psiphon3.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	12	(12.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 5 (5.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Psiphon	62	11818	1
 

--- a/tests/result/punycode-idn.pcap.out
+++ b/tests/result/punycode-idn.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	8	(8.00 pkts/flow)
 DPI Packets (UDP):	4	(2.00 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 20 (6.67 diss/flow)
+Num dissector calls: 17 (5.67 diss/flow)
 
 DNS	2	162	1
 Spotify	2	197	1

--- a/tests/result/rdp.pcap.out
+++ b/tests/result/rdp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 RDP	2010	622743	1
 

--- a/tests/result/reasm_segv_anon.pcapng.out
+++ b/tests/result/reasm_segv_anon.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
-Num dissector calls: 260 (260.00 diss/flow)
+Num dissector calls: 257 (257.00 diss/flow)
 
 HTTP	82	77940	1
 

--- a/tests/result/rsh.pcap.out
+++ b/tests/result/rsh.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	12	(6.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 304 (152.00 diss/flow)
+Num dissector calls: 298 (149.00 diss/flow)
 
 RSH	24	1721	2
 

--- a/tests/result/rsync.pcap.out
+++ b/tests/result/rsync.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	9	(9.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 173 (173.00 diss/flow)
+Num dissector calls: 170 (170.00 diss/flow)
 
 RSYNC	30	2493	1
 

--- a/tests/result/rtmp.pcap.out
+++ b/tests/result/rtmp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(8.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 155 (155.00 diss/flow)
+Num dissector calls: 152 (152.00 diss/flow)
 
 RTMP	26	8368	1
 

--- a/tests/result/rtsp.pcap.out
+++ b/tests/result/rtsp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	87	(12.43 pkts/flow)
 Confidence DPI              : 7 (flows)
-Num dissector calls: 82 (11.71 diss/flow)
+Num dissector calls: 28 (4.00 diss/flow)
 
 RTSP	568	100872	7
 

--- a/tests/result/safari.pcap.out
+++ b/tests/result/safari.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	46	(6.57 pkts/flow)
 Confidence DPI              : 7 (flows)
-Num dissector calls: 28 (4.00 diss/flow)
+Num dissector calls: 7 (1.00 diss/flow)
 
 TLS	6019	5570309	7
 

--- a/tests/result/salesforce.pcap.out
+++ b/tests/result/salesforce.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(8.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Salesforce	15	5205	1
 

--- a/tests/result/sccp_hw_conf_register.pcapng.out
+++ b/tests/result/sccp_hw_conf_register.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 CiscoSkinny	17	1522	1
 

--- a/tests/result/selfsigned.pcap.out
+++ b/tests/result/selfsigned.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 7 (7.00 diss/flow)
+Num dissector calls: 3 (3.00 diss/flow)
 
 ntop	20	3766	1
 

--- a/tests/result/signal.pcap.out
+++ b/tests/result/signal.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	97	(6.47 pkts/flow)
 DPI Packets (UDP):	5	(1.67 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence DPI              : 19 (flows)
-Num dissector calls: 55 (2.89 diss/flow)
+Num dissector calls: 19 (1.00 diss/flow)
 
 DNS	2	186	1
 DHCP	4	1368	1

--- a/tests/result/simple-dnscrypt.pcap.out
+++ b/tests/result/simple-dnscrypt.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	47	(11.75 pkts/flow)
 Confidence DPI (cache)      : 3 (flows)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 16 (4.00 diss/flow)
+Num dissector calls: 4 (1.00 diss/flow)
 
 DNScrypt	111	44676	4
 

--- a/tests/result/sites.pcapng.out
+++ b/tests/result/sites.pcapng.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	3	(1.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence Match by IP      : 3 (flows)
 Confidence DPI              : 43 (flows)
-Num dissector calls: 154 (3.28 diss/flow)
+Num dissector calls: 57 (1.21 diss/flow)
 
 HTTP	2	148	1
 Xbox	4	2245	1

--- a/tests/result/skype.pcap.out
+++ b/tests/result/skype.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 61 (flows)
 Confidence Match by port    : 27 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 204 (flows)
-Num dissector calls: 28965 (98.86 diss/flow)
+Num dissector calls: 28684 (97.90 diss/flow)
 
 Unknown	1575	272476	61
 DNS	2	267	1

--- a/tests/result/skype_no_unknown.pcap.out
+++ b/tests/result/skype_no_unknown.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 45 (flows)
 Confidence Match by port    : 22 (flows)
 Confidence DPI              : 200 (flows)
-Num dissector calls: 24039 (90.03 diss/flow)
+Num dissector calls: 23828 (89.24 diss/flow)
 
 Unknown	850	152468	45
 DNS	2	267	1

--- a/tests/result/smb_frags.pcap.out
+++ b/tests/result/smb_frags.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	5	(5.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 154 (154.00 diss/flow)
+Num dissector calls: 152 (152.00 diss/flow)
 
 SMBv1	8	2763	1
 

--- a/tests/result/smpp_in_general.pcap.out
+++ b/tests/result/smpp_in_general.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 92 (92.00 diss/flow)
+Num dissector calls: 89 (89.00 diss/flow)
 
 SMPP	17	1144	1
 

--- a/tests/result/smtp-starttls.pcap.out
+++ b/tests/result/smtp-starttls.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	11	(11.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Google	36	8403	1
 

--- a/tests/result/smtp.pcap.out
+++ b/tests/result/smtp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	11	(11.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 198 (198.00 diss/flow)
+Num dissector calls: 195 (195.00 diss/flow)
 
 SMTP	95	23157	1
 

--- a/tests/result/smtps.pcapng.out
+++ b/tests/result/smtps.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	3	(3.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 5 (5.00 diss/flow)
+Num dissector calls: 3 (3.00 diss/flow)
 
 SMTPS	4	936	1
 

--- a/tests/result/snapchat.pcap.out
+++ b/tests/result/snapchat.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	18	(6.00 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 12 (4.00 diss/flow)
+Num dissector calls: 3 (1.00 diss/flow)
 
 Google	22	2879	1
 Snapchat	34	7320	2

--- a/tests/result/soap.pcap.out
+++ b/tests/result/soap.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	20	(6.67 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 378 (126.00 diss/flow)
+Num dissector calls: 375 (125.00 diss/flow)
 
 HTTP	14	5498	1
 Microsoft	1	1506	1

--- a/tests/result/socks-http-example.pcap.out
+++ b/tests/result/socks-http-example.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	29	(9.67 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 482 (160.67 diss/flow)
+Num dissector calls: 473 (157.67 diss/flow)
 
 SOCKS	46	8383	3
 

--- a/tests/result/softether-http.pcap.out
+++ b/tests/result/softether-http.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 18 (18.00 diss/flow)
+Num dissector calls: 15 (15.00 diss/flow)
 
 Softether	4	1392	1
 

--- a/tests/result/ssh.pcap.out
+++ b/tests/result/ssh.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(10.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 SSH	258	35546	1
 

--- a/tests/result/ssl-cert-name-mismatch.pcap.out
+++ b/tests/result/ssl-cert-name-mismatch.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(10.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 GoogleCloud	21	5412	1
 

--- a/tests/result/starcraft_battle.pcap.out
+++ b/tests/result/starcraft_battle.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by port    : 8 (flows)
 Confidence Match by IP      : 5 (flows)
 Confidence DPI              : 39 (flows)
-Num dissector calls: 1545 (29.71 diss/flow)
+Num dissector calls: 1464 (28.15 diss/flow)
 
 DNS	26	2848	7
 HTTP	450	294880	19

--- a/tests/result/synscan.pcap.out
+++ b/tests/result/synscan.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1992
 DPI Packets (TCP):	2011	(1.01 pkts/flow)
 Confidence Unknown          : 1868 (flows)
 Confidence Match by port    : 126 (flows)
-Num dissector calls: 2003 (1.00 diss/flow)
+Num dissector calls: 0 (0.00 diss/flow)
 
 Unknown	1872	108584	1868
 FTP_CONTROL	2	116	2

--- a/tests/result/syslog.pcap.out
+++ b/tests/result/syslog.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	10	(5.00 pkts/flow)
 DPI Packets (UDP):	20	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence DPI              : 21 (flows)
-Num dissector calls: 64 (2.91 diss/flow)
+Num dissector calls: 62 (2.82 diss/flow)
 
 Unknown	1	78	1
 Syslog	93	20321	21

--- a/tests/result/teams.pcap.out
+++ b/tests/result/teams.pcap.out
@@ -7,7 +7,7 @@ Confidence Unknown          : 1 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI (partial)    : 1 (flows)
 Confidence DPI              : 80 (flows)
-Num dissector calls: 712 (8.58 diss/flow)
+Num dissector calls: 595 (7.17 diss/flow)
 
 Unknown	4	456	1
 DNS	10	1357	5

--- a/tests/result/teamviewer.pcap.out
+++ b/tests/result/teamviewer.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 DPI Packets (UDP):	4	(4.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 145 (72.50 diss/flow)
+Num dissector calls: 142 (71.00 diss/flow)
 
 TeamViewer	1298	704218	2
 

--- a/tests/result/telnet.pcap.out
+++ b/tests/result/telnet.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	33	(33.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 154 (154.00 diss/flow)
+Num dissector calls: 151 (151.00 diss/flow)
 
 Telnet	87	7418	1
 

--- a/tests/result/threema.pcap.out
+++ b/tests/result/threema.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	2
 DPI Packets (TCP):	66	(11.00 pkts/flow)
 Confidence Match by IP      : 2 (flows)
 Confidence DPI              : 4 (flows)
-Num dissector calls: 1262 (210.33 diss/flow)
+Num dissector calls: 1244 (207.33 diss/flow)
 
 Threema	83	11578	6
 

--- a/tests/result/tinc.pcap.out
+++ b/tests/result/tinc.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	19	(9.50 pkts/flow)
 DPI Packets (UDP):	2	(1.00 pkts/flow)
 Confidence DPI (cache)      : 2 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 535 (133.75 diss/flow)
+Num dissector calls: 524 (131.00 diss/flow)
 
 TINC	317	352291	4
 

--- a/tests/result/tls_2_reasms.pcapng.out
+++ b/tests/result/tls_2_reasms.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 2 (2.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Instagram	14	6907	1
 

--- a/tests/result/tls_2_reasms_b.pcapng.out
+++ b/tests/result/tls_2_reasms_b.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	5	(5.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 3 (3.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Facebook	15	13455	1
 

--- a/tests/result/tls_alert.pcap.out
+++ b/tests/result/tls_alert.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	12	(6.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 5 (2.50 diss/flow)
+Num dissector calls: 2 (1.00 diss/flow)
 
 TLS	7	533	1
 Google	11	952	1

--- a/tests/result/tls_certificate_too_long.pcap.out
+++ b/tests/result/tls_certificate_too_long.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 33 (flows)
-Num dissector calls: 626 (17.89 diss/flow)
+Num dissector calls: 593 (16.94 diss/flow)
 
 Unknown	13	5582	1
 MDNS	5	983	3

--- a/tests/result/tls_esni_sni_both.pcap.out
+++ b/tests/result/tls_esni_sni_both.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	12	(6.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 8 (4.00 diss/flow)
+Num dissector calls: 2 (1.00 diss/flow)
 
 Cloudflare	38	15899	2
 

--- a/tests/result/tls_false_positives.pcapng.out
+++ b/tests/result/tls_false_positives.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	30	(30.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
-Num dissector calls: 408 (408.00 diss/flow)
+Num dissector calls: 407 (407.00 diss/flow)
 
 Unknown	30	37313	1
 

--- a/tests/result/tls_invalid_reads.pcap.out
+++ b/tests/result/tls_invalid_reads.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	2
 DPI Packets (TCP):	10	(3.33 pkts/flow)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 128 (42.67 diss/flow)
+Num dissector calls: 124 (41.33 diss/flow)
 
 TLS	7	1827	1
 Crashlytics	3	560	1

--- a/tests/result/tls_long_cert.pcap.out
+++ b/tests/result/tls_long_cert.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	9	(9.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 TLS	182	117601	1
 

--- a/tests/result/tls_missing_ch_frag.pcap.out
+++ b/tests/result/tls_missing_ch_frag.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	3	(3.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 124 (124.00 diss/flow)
+Num dissector calls: 123 (123.00 diss/flow)
 
 TLS	14	10082	1
 

--- a/tests/result/tls_port_80.pcapng.out
+++ b/tests/result/tls_port_80.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	13	(13.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 6 (6.00 diss/flow)
+Num dissector calls: 3 (3.00 diss/flow)
 
 TLS	13	2439	1
 

--- a/tests/result/tls_torrent.pcapng.out
+++ b/tests/result/tls_torrent.pcapng.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	7	(7.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 3 (3.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 BitTorrent	7	6308	1
 

--- a/tests/result/tls_verylong_certificate.pcap.out
+++ b/tests/result/tls_verylong_certificate.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	11	(11.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 TLS	48	22229	1
 

--- a/tests/result/tor.pcap.out
+++ b/tests/result/tor.pcap.out
@@ -4,7 +4,7 @@ DPI Packets (TCP):	43	(5.38 pkts/flow)
 DPI Packets (UDP):	3	(1.00 pkts/flow)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 10 (flows)
-Num dissector calls: 73 (6.64 diss/flow)
+Num dissector calls: 51 (4.64 diss/flow)
 
 SMBv1	1	252	1
 TLS	2028	1601908	4

--- a/tests/result/trickbot.pcap.out
+++ b/tests/result/trickbot.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	8	(8.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 18 (18.00 diss/flow)
+Num dissector calls: 15 (15.00 diss/flow)
 
 HTTP	74	62002	1
 

--- a/tests/result/tunnelbear.pcap.out
+++ b/tests/result/tunnelbear.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	3
 DPI Packets (TCP):	125	(5.95 pkts/flow)
 Confidence Match by IP      : 1 (flows)
 Confidence DPI              : 20 (flows)
-Num dissector calls: 85 (4.05 diss/flow)
+Num dissector calls: 22 (1.05 diss/flow)
 
 TLS	34	13737	2
 Google	5	306	1

--- a/tests/result/ultrasurf.pcap.out
+++ b/tests/result/ultrasurf.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	13	(4.33 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 131 (43.67 diss/flow)
+Num dissector calls: 125 (41.67 diss/flow)
 
 TLS	5171	5127023	2
 UltraSurf	2971	2991918	1

--- a/tests/result/viber.pcap.out
+++ b/tests/result/viber.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	27	(1.93 pkts/flow)
 DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Match by IP      : 4 (flows)
 Confidence DPI              : 25 (flows)
-Num dissector calls: 557 (19.21 diss/flow)
+Num dissector calls: 518 (17.86 diss/flow)
 
 DNS	8	1267	4
 MDNS	4	412	1

--- a/tests/result/vnc.pcap.out
+++ b/tests/result/vnc.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(5.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 264 (132.00 diss/flow)
+Num dissector calls: 258 (129.00 diss/flow)
 
 VNC	4551	329158	2
 

--- a/tests/result/wa_voice.pcap.out
+++ b/tests/result/wa_voice.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	33	(1.57 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence DPI              : 27 (flows)
-Num dissector calls: 457 (16.32 diss/flow)
+Num dissector calls: 446 (15.93 diss/flow)
 
 Unknown	2	120	1
 MDNS	10	1188	2

--- a/tests/result/waze.pcap.out
+++ b/tests/result/waze.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	1	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence Match by port    : 9 (flows)
 Confidence DPI              : 23 (flows)
-Num dissector calls: 482 (14.61 diss/flow)
+Num dissector calls: 380 (11.52 diss/flow)
 
 Unknown	10	786	1
 HTTP	65	64777	8

--- a/tests/result/webex.pcap.out
+++ b/tests/result/webex.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	17	(8.50 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence Match by IP      : 3 (flows)
 Confidence DPI              : 53 (flows)
-Num dissector calls: 478 (8.39 diss/flow)
+Num dissector calls: 316 (5.54 diss/flow)
 
 HTTP	22	3182	2
 TLS	106	11841	8

--- a/tests/result/wechat.pcap.out
+++ b/tests/result/wechat.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	7	(1.00 pkts/flow)
 Confidence Match by port    : 17 (flows)
 Confidence Match by IP      : 8 (flows)
 Confidence DPI              : 78 (flows)
-Num dissector calls: 590 (5.73 diss/flow)
+Num dissector calls: 315 (3.06 diss/flow)
 
 DNS	13	1075	8
 HTTP	70	4620	8

--- a/tests/result/weibo.pcap.out
+++ b/tests/result/weibo.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	44	(3.14 pkts/flow)
 Confidence Match by port    : 13 (flows)
 Confidence Match by IP      : 8 (flows)
 Confidence DPI              : 23 (flows)
-Num dissector calls: 646 (14.68 diss/flow)
+Num dissector calls: 580 (13.18 diss/flow)
 
 DNS	6	630	3
 HTTP	19	2275	5

--- a/tests/result/whatsapp.pcap.out
+++ b/tests/result/whatsapp.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	344	(4.00 pkts/flow)
 Confidence DPI              : 86 (flows)
-Num dissector calls: 12642 (147.00 diss/flow)
+Num dissector calls: 12470 (145.00 diss/flow)
 
 WhatsApp	679	96293	86
 

--- a/tests/result/whatsapp_login_call.pcap.out
+++ b/tests/result/whatsapp_login_call.pcap.out
@@ -6,7 +6,7 @@ DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by port    : 4 (flows)
 Confidence Match by IP      : 16 (flows)
 Confidence DPI              : 37 (flows)
-Num dissector calls: 408 (7.16 diss/flow)
+Num dissector calls: 331 (5.81 diss/flow)
 
 HTTP	11	726	3
 MDNS	8	952	4

--- a/tests/result/whatsapp_login_chat.pcap.out
+++ b/tests/result/whatsapp_login_chat.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	2
 DPI Packets (TCP):	25	(8.33 pkts/flow)
 DPI Packets (UDP):	7	(1.17 pkts/flow)
 Confidence DPI              : 9 (flows)
-Num dissector calls: 304 (33.78 diss/flow)
+Num dissector calls: 300 (33.33 diss/flow)
 
 MDNS	2	202	2
 DHCP	6	2052	1

--- a/tests/result/whatsapp_voice_and_message.pcap.out
+++ b/tests/result/whatsapp_voice_and_message.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	20	(4.00 pkts/flow)
 DPI Packets (UDP):	8	(1.00 pkts/flow)
 Confidence DPI              : 13 (flows)
-Num dissector calls: 503 (38.69 diss/flow)
+Num dissector calls: 488 (37.54 diss/flow)
 
 WhatsAppCall	44	5916	8
 WhatsApp	217	22139	5

--- a/tests/result/whatsappfiles.pcap.out
+++ b/tests/result/whatsappfiles.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	14	(7.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 8 (4.00 diss/flow)
+Num dissector calls: 2 (1.00 diss/flow)
 
 WhatsAppFiles	620	452233	2
 

--- a/tests/result/whois.pcapng.out
+++ b/tests/result/whois.pcapng.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	16	(5.33 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 190 (63.33 diss/flow)
+Num dissector calls: 183 (61.00 diss/flow)
 
 TLS	7	2046	1
 Whois-DAS	16	4294	2

--- a/tests/result/windowsupdate_over_http.pcap.out
+++ b/tests/result/windowsupdate_over_http.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	6	(6.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 18 (18.00 diss/flow)
+Num dissector calls: 15 (15.00 diss/flow)
 
 WindowsUpdate	20	15975	1
 

--- a/tests/result/wow.pcap.out
+++ b/tests/result/wow.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	36	(7.20 pkts/flow)
 Confidence DPI              : 5 (flows)
-Num dissector calls: 150 (30.00 diss/flow)
+Num dissector calls: 130 (26.00 diss/flow)
 
 WorldOfWarcraft	95	10688	5
 

--- a/tests/result/xiaomi.pcap.out
+++ b/tests/result/xiaomi.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	1
 
 DPI Packets (TCP):	19	(2.71 pkts/flow)
 Confidence DPI              : 7 (flows)
-Num dissector calls: 723 (103.29 diss/flow)
+Num dissector calls: 711 (101.57 diss/flow)
 
 Xiaomi	52	11467	7
 

--- a/tests/result/xss.pcap.out
+++ b/tests/result/xss.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	9	(4.50 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 21 (10.50 diss/flow)
+Num dissector calls: 15 (7.50 diss/flow)
 
 HTTP	11	3209	2
 

--- a/tests/result/youtubeupload.pcap.out
+++ b/tests/result/youtubeupload.pcap.out
@@ -3,7 +3,7 @@ Guessed flow protos:	0
 DPI Packets (TCP):	8	(8.00 pkts/flow)
 DPI Packets (UDP):	2	(1.00 pkts/flow)
 Confidence DPI              : 3 (flows)
-Num dissector calls: 6 (2.00 diss/flow)
+Num dissector calls: 3 (1.00 diss/flow)
 
 YouTubeUpload	137	127038	3
 

--- a/tests/result/z3950.pcapng.out
+++ b/tests/result/z3950.pcapng.out
@@ -3,7 +3,7 @@ Guessed flow protos:	1
 DPI Packets (TCP):	26	(13.00 pkts/flow)
 Confidence Match by port    : 1 (flows)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 471 (235.50 diss/flow)
+Num dissector calls: 465 (232.50 diss/flow)
 
 Z3950	31	6308	2
 

--- a/tests/result/zabbix.pcap.out
+++ b/tests/result/zabbix.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 4 (4.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 
 Zabbix	10	715	1
 

--- a/tests/result/zattoo.pcap.out
+++ b/tests/result/zattoo.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	10	(5.00 pkts/flow)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 21 (10.50 diss/flow)
+Num dissector calls: 15 (7.50 diss/flow)
 
 Zattoo	32	13467	2
 

--- a/tests/result/zcash.pcap.out
+++ b/tests/result/zcash.pcap.out
@@ -2,7 +2,7 @@ Guessed flow protos:	0
 
 DPI Packets (TCP):	4	(4.00 pkts/flow)
 Confidence DPI              : 1 (flows)
-Num dissector calls: 34 (34.00 diss/flow)
+Num dissector calls: 31 (31.00 diss/flow)
 
 Mining	145	20644	1
 

--- a/tests/result/zoom.pcap.out
+++ b/tests/result/zoom.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	25	(1.47 pkts/flow)
 DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Match by IP      : 2 (flows)
 Confidence DPI              : 31 (flows)
-Num dissector calls: 834 (25.27 diss/flow)
+Num dissector calls: 805 (24.39 diss/flow)
 
 DNS	2	205	1
 MDNS	1	87	1

--- a/tests/result/zoom2.pcap.out
+++ b/tests/result/zoom2.pcap.out
@@ -5,7 +5,7 @@ DPI Packets (UDP):	75	(25.00 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by IP      : 3 (flows)
 Confidence DPI              : 2 (flows)
-Num dissector calls: 860 (172.00 diss/flow)
+Num dissector calls: 857 (171.40 diss/flow)
 
 ICMP	27	1890	1
 Zoom	11950	9004950	4


### PR DESCRIPTION
Since e6b332aa, we have proper support for detecting client/server
direction. So Tinc dissector is now able to properly initialize the
cache entry only when needed and not anymore at the SYN time; initializing
that entry for **every** SYN packets was a complete waste of resources.

Since 4896dabb, the various `struct ndpi_call_function_struct`
structures are not more separate objects and therefore comparing them
using only their pointers is bogus: this bug was triggered by this
change because `ndpi_str->callback_buffer_size_tcp_no_payload` is now 0.