### PR TITLE
First step in simplify `ndpi_process_extra_packet()`

### DIFF
--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -370,6 +370,9 @@ static int search_dns_again(struct ndpi_detection_module_struct *ndpi_struct, st
   /* possibly dissect the DNS reply */
   ndpi_search_dns(ndpi_struct, flow);
 
+  if(flow->protos.dns.num_answers != 0)
+    return(0);
+
   /* Possibly more processing */
   return(1);
 }

--- a/src/lib/protocols/mail_pop.c
+++ b/src/lib/protocols/mail_pop.c
@@ -46,6 +46,7 @@
 static void ndpi_int_mail_pop_add_connection(struct ndpi_detection_module_struct
 					     *ndpi_struct, struct ndpi_flow_struct *flow) {
 
+  NDPI_LOG_INFO(ndpi_struct, "mail_pop identified\n");
   flow->guessed_protocol_id = NDPI_PROTOCOL_UNKNOWN; /* Avoid POP3S to be used s sub-protocol */
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MAIL_POP, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
 }
@@ -185,12 +186,12 @@ void ndpi_search_mail_pop_tcp(struct ndpi_detection_module_struct
 
     if((bit_count + flow->l4.tcp.mail_pop_stage) >= 3) {
       if(flow->l4.tcp.mail_pop_stage > 0) {
-	NDPI_LOG_INFO(ndpi_struct, "mail_pop identified\n");
 	
 	if((flow->l4.tcp.ftp_imap_pop_smtp.password[0] != '\0')
 	   || (flow->l4.tcp.mail_pop_stage > 3)) {
 	  ndpi_int_mail_pop_add_connection(ndpi_struct, flow);
-	  popInitExtraPacketProcessing(flow);
+	  if(flow->l4.tcp.ftp_imap_pop_smtp.password[0] == '\0')
+	    popInitExtraPacketProcessing(flow);
 	}
       }
       

--- a/src/lib/protocols/mail_smtp.c
+++ b/src/lib/protocols/mail_smtp.c
@@ -440,7 +440,9 @@ int ndpi_extra_search_mail_smtp_tcp(struct ndpi_detection_module_struct *ndpi_st
     }
   } else {
     ndpi_search_mail_smtp_tcp(ndpi_struct, flow);
-    rc = (flow->l4.tcp.ftp_imap_pop_smtp.password[0] == '\0') ? 1 : 0;
+    rc = ((flow->l4.tcp.ftp_imap_pop_smtp.password[0] == '\0') &&
+          (flow->l4.tcp.ftp_imap_pop_smtp.auth_tls == 1 ||
+           flow->l4.tcp.ftp_imap_pop_smtp.auth_done == 0)) ? 1 : 0;
   }
 
 #ifdef SMTP_DEBUG

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -936,7 +936,7 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
     u_int8_t content_type;
 
     if(message->buffer_used < 5)
-      return(1); /* Keep working */
+      break;
 
     len = (message->buffer[3] << 8) + message->buffer[4] + 5;
 
@@ -1074,6 +1074,8 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
   if(something_went_wrong
      || ((ndpi_struct->num_tls_blocks_to_follow > 0)
 	 && (flow->l4.tcp.tls.num_tls_blocks == ndpi_struct->num_tls_blocks_to_follow))
+     || ((ndpi_struct->num_tls_blocks_to_follow == 0)
+	 && (flow->l4.tcp.tls.certificate_processed == 1))
      ) {
 #ifdef DEBUG_TLS_BLOCKS
     printf("*** [TLS Block] No more blocks\n");
@@ -1187,7 +1189,7 @@ static int ndpi_search_tls_udp(struct ndpi_detection_module_struct *ndpi_struct,
   packet->payload = p;
   packet->payload_packet_len = p_len; /* Restore */
 
-  if(no_dtls || change_cipher_found) {
+  if(no_dtls || change_cipher_found || flow->l4.tcp.tls.certificate_processed) {
     NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_DTLS);
     flow->check_extra_packets = 0;
     flow->extra_packets_func = NULL;


### PR DESCRIPTION
Move the prottocol specific logic into the proper dissector code, where
it belongs.

Next step: remove that list of protocols. Long goal: remove this
function altogether...