### PR TITLE
Fix possible null deref in ndpi_utils:2347, ahocorasick.c:632

### DIFF
--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -2289,7 +2289,7 @@ void ndpi_set_risk(struct ndpi_detection_module_struct *ndpi_str,
 		   struct ndpi_flow_struct *flow, ndpi_risk_enum r,
 		   char *risk_message) {
   /* Check if the risk is not yet set */
-  if(!ndpi_isset_risk(ndpi_str, flow, r)) {
+  if(flow && !ndpi_isset_risk(ndpi_str, flow, r)) {
     ndpi_risk v = 1ull << r;
     
     // NDPI_SET_BIT(flow->risk, (u_int32_t)r);

--- a/src/lib/third_party/src/ahocorasick.c
+++ b/src/lib/third_party/src/ahocorasick.c
@@ -629,6 +629,9 @@ static void dump_node_header(AC_NODE_t * n, struct aho_dump_info *ai) {
 static AC_ERROR_t dump_node_common(AC_AUTOMATA_t * thiz,
         AC_NODE_t * n, int idx, void *data) {
     struct aho_dump_info *ai = (struct aho_dump_info *)data;
+
+    if(!ai) return ACERR_ERROR;
+
     char *rstr = ai->bufstr;
 
     if(idx) return ACERR_SUCCESS;


### PR DESCRIPTION
Hi!
Pointer 'flow' that can have only NULL value (ndpi_get_http_method function), is passed as 2nd parameter in call to function ndpi_set_risk where it is dereferenced at ndpi_utils.c:2347.