### PR TITLE
TLS: avoid useless extra dissection

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -709,6 +709,7 @@ struct ndpi_flow_tcp_struct {
 
     /* NDPI_PROTOCOL_TLS */
     u_int8_t certificate_processed:1, fingerprint_set:1, _pad:6;
+    u_int8_t app_data_seen[2];
     u_int8_t num_tls_blocks;
     int16_t tls_application_blocks_len[NDPI_MAX_NUM_TLS_APPL_BLOCKS]; /* + = src->dst, - = dst->src */
   } tls;

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1052,6 +1052,12 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	    ndpi_int_tls_add_connection(ndpi_struct, flow);
 	  }
 
+	/* If we have seen Application Data blocks in both directions, it means
+	   we are after the handshake. Stop extra processing */
+	flow->l4.tcp.tls.app_data_seen[packet->packet_direction] = 1;
+	if(flow->l4.tcp.tls.app_data_seen[!packet->packet_direction] == 1)
+	  flow->l4.tcp.tls.certificate_processed = 1;
+
 	if(flow->l4.tcp.tls.certificate_processed) {
 	  if(flow->l4.tcp.tls.num_tls_blocks < ndpi_struct->num_tls_blocks_to_follow)
 	    flow->l4.tcp.tls.tls_application_blocks_len[flow->l4.tcp.tls.num_tls_blocks++] =

--- a/tests/result/1kxun.pcap.out
+++ b/tests/result/1kxun.pcap.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	26
+Guessed flow protos:	24
 
-DPI Packets (TCP):	427	(4.36 pkts/flow)
+DPI Packets (TCP):	415	(4.23 pkts/flow)
 DPI Packets (UDP):	120	(1.21 pkts/flow)
 Confidence Unknown          : 14 (flows)
 Confidence Match by port    : 5 (flows)

--- a/tests/result/anyconnect-vpn.pcap.out
+++ b/tests/result/anyconnect-vpn.pcap.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	12
+Guessed flow protos:	10
 
-DPI Packets (TCP):	163	(7.41 pkts/flow)
+DPI Packets (TCP):	131	(5.95 pkts/flow)
 DPI Packets (UDP):	82	(2.22 pkts/flow)
 DPI Packets (other):	10	(1.00 pkts/flow)
 Confidence Unknown          : 2 (flows)

--- a/tests/result/anydesk.pcap.out
+++ b/tests/result/anydesk.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	0
 
-DPI Packets (TCP):	21	(10.50 pkts/flow)
+DPI Packets (TCP):	13	(6.50 pkts/flow)
 Confidence DPI              : 2 (flows)
 Num dissector calls: 6 (3.00 diss/flow)
 LRU cache ookla:      0/0/0 (insert/search/found)

--- a/tests/result/http_ipv6.pcap.out
+++ b/tests/result/http_ipv6.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	7
 
-DPI Packets (TCP):	85	(6.54 pkts/flow)
+DPI Packets (TCP):	77	(5.92 pkts/flow)
 DPI Packets (UDP):	4	(2.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
 Confidence Match by port    : 6 (flows)

--- a/tests/result/instagram.pcap.out
+++ b/tests/result/instagram.pcap.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	15
+Guessed flow protos:	12
 
-DPI Packets (TCP):	295	(9.83 pkts/flow)
+DPI Packets (TCP):	265	(8.83 pkts/flow)
 DPI Packets (UDP):	10	(1.43 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)

--- a/tests/result/nintendo.pcap.out
+++ b/tests/result/nintendo.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	6
 
-DPI Packets (TCP):	29	(7.25 pkts/flow)
+DPI Packets (TCP):	18	(4.50 pkts/flow)
 DPI Packets (UDP):	35	(2.33 pkts/flow)
 DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Match by IP      : 6 (flows)

--- a/tests/result/pinterest.pcap.out
+++ b/tests/result/pinterest.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	16
 
-DPI Packets (TCP):	224	(6.05 pkts/flow)
+DPI Packets (TCP):	216	(5.84 pkts/flow)
 Confidence Match by port    : 16 (flows)
 Confidence DPI              : 21 (flows)
 Num dissector calls: 21 (0.57 diss/flow)

--- a/tests/result/signal.pcap.out
+++ b/tests/result/signal.pcap.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	1
+Guessed flow protos:	0
 
-DPI Packets (TCP):	97	(6.47 pkts/flow)
+DPI Packets (TCP):	92	(6.13 pkts/flow)
 DPI Packets (UDP):	5	(1.67 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence DPI              : 19 (flows)

--- a/tests/result/skype.pcap.out
+++ b/tests/result/skype.pcap.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	97
+Guessed flow protos:	95
 
-DPI Packets (TCP):	1578	(16.27 pkts/flow)
+DPI Packets (TCP):	1554	(16.02 pkts/flow)
 DPI Packets (UDP):	337	(1.76 pkts/flow)
 DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 61 (flows)

--- a/tests/result/skype_no_unknown.pcap.out
+++ b/tests/result/skype_no_unknown.pcap.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	72
+Guessed flow protos:	69
 
-DPI Packets (TCP):	1120	(14.74 pkts/flow)
+DPI Packets (TCP):	1080	(14.21 pkts/flow)
 DPI Packets (UDP):	288	(1.55 pkts/flow)
 DPI Packets (other):	5	(1.00 pkts/flow)
 Confidence Unknown          : 45 (flows)

--- a/tests/result/starcraft_battle.pcap.out
+++ b/tests/result/starcraft_battle.pcap.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	16
+Guessed flow protos:	15
 
-DPI Packets (TCP):	166	(4.37 pkts/flow)
+DPI Packets (TCP):	165	(4.34 pkts/flow)
 DPI Packets (UDP):	36	(2.77 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by port    : 8 (flows)

--- a/tests/result/teams.pcap.out
+++ b/tests/result/teams.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	4
 
-DPI Packets (TCP):	347	(8.26 pkts/flow)
+DPI Packets (TCP):	337	(8.02 pkts/flow)
 DPI Packets (UDP):	87	(2.17 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)

--- a/tests/result/tls-appdata.pcap.out
+++ b/tests/result/tls-appdata.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	1
 
-DPI Packets (TCP):	20	(10.00 pkts/flow)
+DPI Packets (TCP):	17	(8.50 pkts/flow)
 Confidence DPI              : 2 (flows)
 Num dissector calls: 124 (62.00 diss/flow)
 LRU cache ookla:      0/0/0 (insert/search/found)

--- a/tests/result/tls_certificate_too_long.pcap.out
+++ b/tests/result/tls_certificate_too_long.pcap.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	5
+Guessed flow protos:	4
 
-DPI Packets (TCP):	120	(7.50 pkts/flow)
+DPI Packets (TCP):	105	(6.56 pkts/flow)
 DPI Packets (UDP):	33	(1.94 pkts/flow)
 DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Unknown          : 1 (flows)

--- a/tests/result/tumblr.pcap.out
+++ b/tests/result/tumblr.pcap.out
@@ -1,6 +1,6 @@
-Guessed flow protos:	32
+Guessed flow protos:	28
 
-DPI Packets (TCP):	237	(5.04 pkts/flow)
+DPI Packets (TCP):	198	(4.21 pkts/flow)
 Confidence Match by port    : 28 (flows)
 Confidence DPI              : 19 (flows)
 Num dissector calls: 19 (0.40 diss/flow)

--- a/tests/result/wechat.pcap.out
+++ b/tests/result/wechat.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	43
 
-DPI Packets (TCP):	458	(7.76 pkts/flow)
+DPI Packets (TCP):	448	(7.59 pkts/flow)
 DPI Packets (UDP):	70	(1.89 pkts/flow)
 DPI Packets (other):	7	(1.00 pkts/flow)
 Confidence Match by port    : 17 (flows)

--- a/tests/result/whatsapp_login_call.pcap.out
+++ b/tests/result/whatsapp_login_call.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	20
 
-DPI Packets (TCP):	105	(3.89 pkts/flow)
+DPI Packets (TCP):	95	(3.52 pkts/flow)
 DPI Packets (UDP):	35	(1.21 pkts/flow)
 DPI Packets (other):	1	(1.00 pkts/flow)
 Confidence Match by port    : 4 (flows)

--- a/tests/result/whatsapp_login_chat.pcap.out
+++ b/tests/result/whatsapp_login_chat.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	2
 
-DPI Packets (TCP):	25	(8.33 pkts/flow)
+DPI Packets (TCP):	17	(5.67 pkts/flow)
 DPI Packets (UDP):	7	(1.17 pkts/flow)
 Confidence DPI              : 9 (flows)
 Num dissector calls: 300 (33.33 diss/flow)

--- a/tests/result/zoom.pcap.out
+++ b/tests/result/zoom.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	5
 
-DPI Packets (TCP):	119	(8.50 pkts/flow)
+DPI Packets (TCP):	110	(7.86 pkts/flow)
 DPI Packets (UDP):	25	(1.47 pkts/flow)
 DPI Packets (other):	2	(1.00 pkts/flow)
 Confidence Match by IP      : 2 (flows)


### PR DESCRIPTION
If we have seen Application Data blocks in both directions, it means we
are after the handshake. At that point, extra dissection is useless.

Useful feature with TLS mid-sessions, i.e. sessions without initial
packets.