### PR TITLE
SoftEther: fix heap-buffer-overflow

### DIFF
--- a/src/lib/protocols/softether.c
+++ b/src/lib/protocols/softether.c
@@ -288,12 +288,23 @@ static int dissect_softether_ip_port(struct ndpi_flow_struct *flow,
     return 1;
   }
 
+  if (ip_port_separator < (char const *)packet->payload + NDPI_STATICSTRING_LEN("IP="))
+  {
+    return 1;
+  }
+
   ip_len = ndpi_min(sizeof(flow->protos.softether.ip) - 1,
                     ip_port_separator - (char const *)packet->payload -
                     NDPI_STATICSTRING_LEN("IP="));
   strncpy(flow->protos.softether.ip, (char const *)packet->payload + NDPI_STATICSTRING_LEN("IP="),
           ip_len);
   flow->protos.softether.ip[ip_len] = '\0';
+
+  if (ip_port_separator < (char const *)packet->payload +
+                          NDPI_STATICSTRING_LEN("IP=") + NDPI_STATICSTRING_LEN(",PORT="))
+  {
+    return 1;
+  }
 
   port_len = ndpi_min(sizeof(flow->protos.softether.port) - 1,
                       ip_port_separator - (char const *)packet->payload -


### PR DESCRIPTION
```
==160665==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x604000000038 at pc 0x55f7250d9a5c bp 0x7fff02c82b90 sp 0x7fff02c82350
READ of size 4 at 0x604000000038 thread T0
    #0 0x55f7250d9a5b in __interceptor_strncpy (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet_with_main+0x548a5b) (BuildId: 12fd06e7a171f035d3a25f016184ac357088379c)
    #1 0x55f7253e6495 in dissect_softether_ip_port /home/ivan/svnrepos/nDPI/src/lib/protocols/softether.c:303:3
    #2 0x55f7253e5703 in ndpi_search_softether /home/ivan/svnrepos/nDPI/src/lib/protocols/softether.c:330:9
    #3 0x55f7251d87c5 in check_ndpi_detection_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5397:6
    #4 0x55f7251d958b in check_ndpi_udp_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5433:10
    #5 0x55f7251d8f2c in ndpi_check_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5466:12
    #6 0x55f7251ead39 in ndpi_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:6293:15
    #7 0x55f72512b87e in LLVMFuzzerTestOneInput /home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet.c:29:5
    #8 0x55f72512b9f7 in main /home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet.c:101:17
    #9 0x7fdef837b082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16
    #10 0x55f72506a45d in _start (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet_with_main+0x4d945d) (BuildId: 12fd06e7a171f035d3a25f016184ac357088379c)
```

Found by oss-fuzz.
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=49638