### PR TITLE
Further simplification of `ndpi_process_extra_packet()`

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1254,7 +1254,7 @@ struct ndpi_flow_struct {
   /* init parameter, internal used to set up timestamp,... */
   u_int16_t guessed_protocol_id, guessed_host_protocol_id, guessed_category, guessed_header_category;
   u_int8_t l4_proto, protocol_id_already_guessed:1, host_already_guessed:1, fail_with_unknown:1,
-    init_finished:1, client_packet_direction:1, packet_direction:1, check_extra_packets:1, is_ipv6:1;
+    init_finished:1, client_packet_direction:1, packet_direction:1, is_ipv6:1, _pad1: 1;
   u_int16_t num_dissector_calls;
   ndpi_confidence_t confidence; /* ndpi_confidence_t */
 

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -5860,10 +5860,8 @@ void ndpi_process_extra_packet(struct ndpi_detection_module_struct *ndpi_str, st
 
   /* call the extra packet function (which may add more data/info to flow) */
   if(flow->extra_packets_func) {
-    if((flow->extra_packets_func(ndpi_str, flow)) == 0) {
-      flow->check_extra_packets = 0;
+    if((flow->extra_packets_func(ndpi_str, flow)) == 0)
       flow->extra_packets_func = NULL; /* Enough packets detected */
-    }
 
     if(++flow->num_extra_packets_checked == flow->max_extra_packets_to_check)
       flow->extra_packets_func = NULL; /* Enough packets detected */
@@ -6253,7 +6251,7 @@ ndpi_protocol ndpi_detection_process_packet(struct ndpi_detection_module_struct 
   ret.master_protocol = flow->detected_protocol_stack[1],
     ret.app_protocol = flow->detected_protocol_stack[0];
 
-  if(flow->check_extra_packets) {
+  if(flow->extra_packets_func) {
     ndpi_process_extra_packet(ndpi_str, flow, packet_data, packetlen, current_time_ms, input_info);
     /* Update in case of new match */
     ret.master_protocol = flow->detected_protocol_stack[1],
@@ -8246,10 +8244,10 @@ int ndpi_get_lru_cache_stats(struct ndpi_detection_module_struct *ndpi_struct,
 */
 u_int8_t ndpi_extra_dissection_possible(struct ndpi_detection_module_struct *ndpi_str,
 					struct ndpi_flow_struct *flow) {
+#if 0
   u_int16_t proto =
     flow->detected_protocol_stack[1] ? flow->detected_protocol_stack[1] : flow->detected_protocol_stack[0];
 
-#if 0
   printf("[DEBUG] %s(%u.%u): %u\n", __FUNCTION__,
 	 flow->detected_protocol_stack[0],
 	 flow->detected_protocol_stack[1],
@@ -8258,37 +8256,7 @@ u_int8_t ndpi_extra_dissection_possible(struct ndpi_detection_module_struct *ndp
 
   if(!flow->extra_packets_func)
     return(0);
-
-  switch(proto) {
-  case NDPI_PROTOCOL_TLS:
-  case NDPI_PROTOCOL_DTLS:
-  case NDPI_PROTOCOL_MAIL_POPS:
-  case NDPI_PROTOCOL_MAIL_IMAPS:
-  case NDPI_PROTOCOL_MAIL_SMTPS:
-  case NDPI_PROTOCOL_HTTP:
-  case NDPI_PROTOCOL_HTTP_PROXY:
-  case NDPI_PROTOCOL_HTTP_CONNECT:
-  case NDPI_PROTOCOL_DNS:
-  case NDPI_PROTOCOL_MDNS:
-  case NDPI_PROTOCOL_FTP_CONTROL:
-  case NDPI_PROTOCOL_MAIL_POP:
-  case NDPI_PROTOCOL_MAIL_IMAP:
-  case NDPI_PROTOCOL_MAIL_SMTP:
-  case NDPI_PROTOCOL_SSH:
-  case NDPI_PROTOCOL_TELNET:
-  case NDPI_PROTOCOL_SKYPE_TEAMS:
-  case NDPI_PROTOCOL_QUIC:
-  case NDPI_PROTOCOL_KERBEROS:
-  case NDPI_PROTOCOL_SNMP:
-  case NDPI_PROTOCOL_BITTORRENT:
-      return(1);
-    break;
-
-  case NDPI_PROTOCOL_SOFTETHER:
-    return(1);
-  }
-
-  return(0);
+  return(1);
 }
 
 /* ******************************************************************** */

--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -113,9 +113,6 @@ static void ndpi_add_connection_as_bittorrent(struct ndpi_detection_module_struc
 					    confidence);
   
   if(flow->protos.bittorrent.hash[0] == '\0') {
-    /* This is necessary to inform the core to call this dissector again */
-    flow->check_extra_packets = 1;
-    
     /* Don't use just 1 as in TCP DNS more packets could be returned (e.g. ACK). */
     flow->max_extra_packets_to_check = 3;
     flow->extra_packets_func = search_bittorrent_again;

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -553,12 +553,12 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
       /* In this case we say that the protocol has been detected just to let apps carry on with their activities */
       ndpi_set_detected_protocol(ndpi_struct, flow, ret.app_protocol, ret.master_protocol, NDPI_CONFIDENCE_DPI);
 
-      /* This is necessary to inform the core to call this dissector again */
-      flow->check_extra_packets = 1;
-
-      /* Don't use just 1 as in TCP DNS more packets could be returned (e.g. ACK). */
-      flow->max_extra_packets_to_check = 5;
-      flow->extra_packets_func = search_dns_again;
+      /* We have never triggered extra-dissection for LLMNR. Keep the old behaviour */
+      if(ret.master_protocol != NDPI_PROTOCOL_LLMNR) {
+        /* Don't use just 1 as in TCP DNS more packets could be returned (e.g. ACK). */
+        flow->max_extra_packets_to_check = 5;
+        flow->extra_packets_func = search_dns_again;
+      }
       return; /* The response will set the verdict */
     }
 

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -369,8 +369,6 @@ static void ndpi_int_http_add_connection(struct ndpi_detection_module_struct *nd
 			       master_protocol,
 			       NDPI_CONFIDENCE_DPI);
 
-  /* This is necessary to inform the core to call this dissector again */
-  flow->check_extra_packets = 1;
   flow->max_extra_packets_to_check = 8;
   flow->extra_packets_func = ndpi_search_http_tcp_again;
   flow->http_detected = 1;

--- a/src/lib/protocols/kerberos.c
+++ b/src/lib/protocols/kerberos.c
@@ -568,7 +568,6 @@ void ndpi_search_kerberos(struct ndpi_detection_module_struct *ndpi_struct,
 #ifdef KERBEROS_DEBUG
 	      printf("[Kerberos] Setting extra func from AS-REQ\n");
 #endif
-	      flow->check_extra_packets = 1;
 	      flow->max_extra_packets_to_check = 5; /* Reply may be split into multiple segments */
 	      flow->extra_packets_func = ndpi_search_kerberos_extra;
 	    } else if(msg_type == 0x0e) /* AS-REQ */ {
@@ -624,7 +623,6 @@ void ndpi_search_kerberos(struct ndpi_detection_module_struct *ndpi_struct,
 	      printf("[Kerberos] Setting extra func from TGS-REQ\n");
 #endif
 	      if(!packet->udp) {
-	        flow->check_extra_packets = 1;
 	        flow->max_extra_packets_to_check = 5; /* Reply may be split into multiple segments */
 	        flow->extra_packets_func = ndpi_search_kerberos_extra;
 	      }

--- a/src/lib/protocols/mail_pop.c
+++ b/src/lib/protocols/mail_pop.c
@@ -244,7 +244,6 @@ static void popInitExtraPacketProcessing(struct ndpi_flow_struct *flow) {
   printf("**** %s()\n", __FUNCTION__);
 #endif
   
-  flow->check_extra_packets = 1;
   /* At most 7 packets should almost always be enough */
   flow->max_extra_packets_to_check = 7;
   flow->extra_packets_func = ndpi_extra_search_mail_pop_tcp;

--- a/src/lib/protocols/mail_smtp.c
+++ b/src/lib/protocols/mail_smtp.c
@@ -396,7 +396,7 @@ void ndpi_search_mail_smtp_tcp(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  if((!flow->check_extra_packets) || (flow->packet_counter > 12))
+  if((!flow->extra_packets_func) || (flow->packet_counter > 12))
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
@@ -461,7 +461,6 @@ static void smtpInitExtraPacketProcessing(struct ndpi_flow_struct *flow) {
   printf("**** %s(%u)\n", __FUNCTION__, ++num);
 #endif
 
-  flow->check_extra_packets = 1;
   /* At most 12 packets should almost always be enough */
   flow->max_extra_packets_to_check = 12;
   flow->extra_packets_func = ndpi_extra_search_mail_smtp_tcp;

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1696,7 +1696,6 @@ static void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
    * 7) We need to process other packets than (the first) ClientHello/CHLO?
    */
   if(eval_extra_processing(ndpi_struct, flow, version)) {
-    flow->check_extra_packets = 1;
     flow->max_extra_packets_to_check = 24; /* TODO */
     flow->extra_packets_func = ndpi_search_quic_extra;
   } else if(!crypto_data) {

--- a/src/lib/protocols/snmp_proto.c
+++ b/src/lib/protocols/snmp_proto.c
@@ -90,8 +90,6 @@ void ndpi_search_snmp(struct ndpi_detection_module_struct *ndpi_struct,
 	 (offset + 2 < packet->payload_packet_len)) {
 
         if(flow->extra_packets_func == NULL) {
-          /* This is necessary to inform the core to call this dissector again */
-          flow->check_extra_packets = 1;
           flow->max_extra_packets_to_check = 8;
           flow->extra_packets_func = ndpi_search_snmp_again;
         }

--- a/src/lib/protocols/softether.c
+++ b/src/lib/protocols/softether.c
@@ -59,7 +59,6 @@ static void ndpi_int_softether_add_connection(struct ndpi_detection_module_struc
 					      struct ndpi_flow_struct * const flow) {
   NDPI_LOG_INFO(ndpi_struct, "found softether\n");
 
-  flow->check_extra_packets = 1;
   flow->max_extra_packets_to_check = 15;
   flow->extra_packets_func = ndpi_search_softether_again;
 
@@ -330,8 +329,6 @@ static int ndpi_search_softether_again(struct ndpi_detection_module_struct *ndpi
        && (flow->protos.softether.port[0] != '\0')
        && (flow->protos.softether.hostname[0] != '\0')
        && (flow->protos.softether.fqdn[0] != '\0')) {
-      flow->check_extra_packets = 0;
-      flow->max_extra_packets_to_check = 0;
       flow->extra_packets_func = NULL;
 
       return 0;

--- a/src/lib/protocols/ssh.c
+++ b/src/lib/protocols/ssh.c
@@ -211,8 +211,6 @@ static void ndpi_int_ssh_add_connection(struct ndpi_detection_module_struct
 
   flow->guessed_host_protocol_id = flow->guessed_protocol_id = NDPI_PROTOCOL_SSH;
   
-  /* This is necessary to inform the core to call this dissector again */
-  flow->check_extra_packets = 1;
   flow->max_extra_packets_to_check = 12;
   flow->extra_packets_func = search_ssh_again;
   

--- a/src/lib/protocols/telnet.c
+++ b/src/lib/protocols/telnet.c
@@ -132,8 +132,6 @@ static void ndpi_int_telnet_add_connection(struct ndpi_detection_module_struct
 					   *ndpi_struct, struct ndpi_flow_struct *flow) {
   flow->guessed_host_protocol_id = flow->guessed_protocol_id = NDPI_PROTOCOL_TELNET;
 
-  /* This is necessary to inform the core to call this dissector again */
-  flow->check_extra_packets = 1;
   flow->max_extra_packets_to_check = 64;
   flow->extra_packets_func = search_telnet_again;
 

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1094,7 +1094,6 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 #ifdef DEBUG_TLS_BLOCKS
     printf("*** [TLS Block] No more blocks\n");
 #endif
-    flow->check_extra_packets = 0;
     flow->extra_packets_func = NULL;
     return(0); /* That's all */
   } else
@@ -1205,7 +1204,6 @@ static int ndpi_search_tls_udp(struct ndpi_detection_module_struct *ndpi_struct,
 
   if(no_dtls || change_cipher_found || flow->l4.tcp.tls.certificate_processed) {
     NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_DTLS);
-    flow->check_extra_packets = 0;
     flow->extra_packets_func = NULL;
     return(0); /* That's all */
   } else {
@@ -1218,8 +1216,6 @@ static int ndpi_search_tls_udp(struct ndpi_detection_module_struct *ndpi_struct,
 static void tlsInitExtraPacketProcessing(struct ndpi_detection_module_struct *ndpi_struct,
 					 struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
-
-  flow->check_extra_packets = 1;
 
   /* At most 12 packets should almost always be enough to find the server certificate if it's there */
   flow->max_extra_packets_to_check = 12 + (ndpi_struct->num_tls_blocks_to_follow*4);
@@ -1277,7 +1273,7 @@ static void ndpi_int_tls_add_connection(struct ndpi_detection_module_struct *ndp
 
   if((flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) ||
      (flow->detected_protocol_stack[1] != NDPI_PROTOCOL_UNKNOWN)) {
-    if(!flow->check_extra_packets)
+    if(!flow->extra_packets_func)
       tlsInitExtraPacketProcessing(ndpi_struct, flow);
     return;
   }


### PR DESCRIPTION
See 95e16872.

After c0732eda, we can safely remove the protocol list from
`ndpi_process_extra_packet()`.

The field `flow->check_extra_packets` is redundant; remove it.