### PR TITLE
HTTP, Bittorrent, Kerberos: fix stopping of extra dissection

### DIFF
--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -54,7 +54,7 @@ static int search_bittorrent_again(struct ndpi_detection_module_struct *ndpi_str
   ndpi_search_bittorrent_hash(ndpi_struct, flow, -1);
   
   /* Possibly more processing */
-  return(1);
+  return flow->extra_packets_func != NULL;
 }
 
 /* *********************************************** */

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -720,7 +720,6 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
 
     /* Copy result for nDPI apps */
     ndpi_hostname_sni_set(flow, packet->host_line.ptr, packet->host_line.len);
-    flow->extra_packets_func = NULL; /* We're good now */
 
     if(strlen(flow->host_server_name) > 0) {
       ndpi_check_dga_name(ndpi_struct, flow, flow->host_server_name, 1);

--- a/src/lib/protocols/kerberos.c
+++ b/src/lib/protocols/kerberos.c
@@ -693,7 +693,7 @@ static int ndpi_search_kerberos_extra(struct ndpi_detection_module_struct *ndpi_
   ndpi_search_kerberos(ndpi_struct, flow);
 
   /* Possibly more processing */
-  return 1;
+  return flow->extra_packets_func != NULL;
 }
 
 void init_kerberos_dissector(struct ndpi_detection_module_struct *ndpi_struct,

--- a/tests/result/1kxun.pcap.out
+++ b/tests/result/1kxun.pcap.out
@@ -1,6 +1,6 @@
 Guessed flow protos:	25
 
-DPI Packets (TCP):	415	(4.23 pkts/flow)
+DPI Packets (TCP):	416	(4.24 pkts/flow)
 DPI Packets (UDP):	120	(1.21 pkts/flow)
 Confidence Unknown          : 14 (flows)
 Confidence Match by port    : 5 (flows)


### PR DESCRIPTION
The return value of the extra-dissection callback indicates if the extra
dissection needs to be called again.

In the HTTP cose, this setting to NULL of the callabck is wrong since we
stop extra dissection only if we have a hostname *and* a return code.