### PR TITLE
SoftEtehr: fix a heap-buffer overflow

### DIFF
--- a/src/lib/protocols/softether.c
+++ b/src/lib/protocols/softether.c
@@ -97,7 +97,7 @@ static size_t dissect_softether_type(enum softether_value_type t,
 
       v->value.ptr.raw = payload + 4;
       u_int32_t siz = ntohl(get_u_int32_t(payload, 0));
-      if(siz == 0 || payload_len < siz + 3)
+      if(siz == 0 || (u_int64_t)payload_len < (u_int64_t)siz + 3)
 	return 0;
 
       if(t == VALUE_DATA)


### PR DESCRIPTION
```
==26717==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60c0000000bf at pc 0x55e503f8959b bp 0x7fff7f6876b0 sp 0x7fff7f686e58
READ of size 1 at 0x60c0000000bf thread T0
    #0 0x55e503f8959a in strncmp (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet_with_main+0x4f459a) (BuildId: 44038d7ca9391c877fae9b2735828da9905a6daa)
    #1 0x55e5042ee98f in dissect_softether_host_fqdn /home/ivan/svnrepos/nDPI/src/lib/protocols/softether.c:236:8
    #2 0x55e5042ec41b in ndpi_search_softether /home/ivan/svnrepos/nDPI/src/lib/protocols/softether.c:318:8
    #3 0x55e5040e0345 in check_ndpi_detection_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5414:6
    #4 0x55e5040e110b in check_ndpi_udp_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5450:10
    #5 0x55e5040e0aac in ndpi_check_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5483:12
    #6 0x55e5040f2838 in ndpi_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:6308:15
    #7 0x55e50403287e in LLVMFuzzerTestOneInput /home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet.c:29:5
    #8 0x55e5040329f7 in main /home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet.c:101:17
    #9 0x7fd09fdbb082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16
    #10 0x55e503f7145d in _start (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet_with_main+0x4dc45d) (BuildId: 44038d7ca9391c877fae9b2735828da9905a6daa)
```

Found by oss-fuzzer
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=49901