### PR TITLE
Fix broken ndpi_timeval_to_microseconds (>UINT_MAX).

### DIFF
--- a/src/include/ndpi_classify.h
+++ b/src/include/ndpi_classify.h
@@ -85,8 +85,8 @@ unsigned int ndpi_timer_eq(const pkt_timeval *a, const pkt_timeval *b);
 unsigned int ndpi_timer_lt(const pkt_timeval *a, const pkt_timeval *b);
 void ndpi_timer_sub(const pkt_timeval *a, const pkt_timeval *b, pkt_timeval *result);
 void ndpi_timer_clear(pkt_timeval *a);
-unsigned int ndpi_timeval_to_milliseconds(pkt_timeval ts);
-unsigned int ndpi_timeval_to_microseconds(pkt_timeval ts);
+u_int64_t ndpi_timeval_to_milliseconds(pkt_timeval ts);
+u_int64_t ndpi_timeval_to_microseconds(pkt_timeval ts);
 void ndpi_log_timestamp(char *log_ts, uint32_t log_ts_len);
 
 #endif /* NDPI_CLASSIFY_H */

--- a/src/lib/ndpi_classify.c
+++ b/src/lib/ndpi_classify.c
@@ -657,24 +657,24 @@ ndpi_timer_clear(pkt_timeval *a)
 /**
  * \brief Calculate the milliseconds representation of a timeval.
  * \param ts Timeval
- * \return unsigned int - Milliseconds
+ * \return unsigned int (64bit) - Milliseconds
  */
-unsigned int
+u_int64_t
 ndpi_timeval_to_milliseconds(pkt_timeval ts)
 {
-  unsigned int result = ts.tv_usec / 1000 + ts.tv_sec * 1000;
+  u_int64_t result = ts.tv_usec / 1000 + ts.tv_sec * 1000;
   return result;
 }
 
 /**
  * \brief Calculate the microseconds representation of a timeval.
  * \param ts Timeval
- * \return unsigned int - Milliseconds
+ * \return unsigned int (64bit) - Microseconds
  */
-unsigned int
+u_int64_t
 ndpi_timeval_to_microseconds(pkt_timeval ts)
 {
-  unsigned int result = ts.tv_usec + ts.tv_sec * 1000 * 1000;
+  u_int64_t result = ts.tv_usec + ts.tv_sec * 1000 * 1000;
   return result;
 }
 


### PR DESCRIPTION
Just recognized in my app, that `ndpi_timeval_to_microseconds` gives me wrong timestamps..