### PR TITLE
Fix string copy truncation warning.

### DIFF
--- a/src/lib/protocols/ubntac2.c
+++ b/src/lib/protocols/ubntac2.c
@@ -65,8 +65,8 @@ void ndpi_search_ubntac2(struct ndpi_detection_module_struct *ndpi_struct, struc
 	  
 	  version[j] = '\0';
 
-	  len = ndpi_min(sizeof(flow->protos.ubntac2.version)-1, j);
-	  strncpy(flow->protos.ubntac2.version, (const char *)version, len);
+	  len = ndpi_min(sizeof(flow->protos.ubntac2.version) - 1, j);
+	  memcpy(flow->protos.ubntac2.version, (const char *)version, len);
 	  flow->protos.ubntac2.version[len] = '\0';
 	}
 	


### PR DESCRIPTION
protocols/ubntac2.c: In function ‘ndpi_search_ubntac2’:
protocols/ubntac2.c:69:4: warning: ‘strncpy’ output may be truncated copying between 0 and 31 bytes from a string of length 255 [-Wstringop-truncation]
   69 |    strncpy(flow->protos.ubntac2.version, (const char *)version, len);
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>