### PR TITLE
Fix some warnings

### DIFF
--- a/src/lib/protocols/smpp.c
+++ b/src/lib/protocols/smpp.c
@@ -67,7 +67,9 @@ void ndpi_search_smpp_tcp(struct ndpi_detection_module_struct* ndpi_struct,
       // check if multiple PDUs included
       u_int32_t total_pdu_l = pdu_l;
       u_int32_t tmp_pdu_l = 0;
+#ifdef NDPI_ENABLE_DEBUG_MESSAGES
       u_int16_t pdu_c = 1;
+#endif
       // loop PDUs (check if lengths are valid)
       while(total_pdu_l < ((uint32_t)packet->payload_packet_len-4)) {
 	// get next PDU length
@@ -76,8 +78,10 @@ void ndpi_search_smpp_tcp(struct ndpi_detection_module_struct* ndpi_struct,
 	if(tmp_pdu_l == 0 ||  ndpi_check_overflow(tmp_pdu_l, total_pdu_l) ) return;
 	// inc total PDU length
 	total_pdu_l += ntohl(get_u_int32_t(packet->payload, total_pdu_l));
+#ifdef NDPI_ENABLE_DEBUG_MESSAGES
 	// inc total PDU count
 	++pdu_c;
+#endif
       }
         
       NDPI_LOG_DBG2(ndpi_struct, 

--- a/src/lib/third_party/include/ahocorasick.h
+++ b/src/lib/third_party/include/ahocorasick.h
@@ -174,8 +174,8 @@ struct edge;
 typedef struct ac_node
 {
   int id;                              /* Node ID : set after finalize(), only for ac_automata_dump */
-  AC_ALPHABET_t  one_alpha,
-		 one:1,                /* one_char: yes/no */
+  AC_ALPHABET_t  one_alpha;
+  unsigned char  one:1,                /* one_char: yes/no */
 		 range:1,              /* range symbols start from one_alpha */
 		 root:1,               /* is root node */
 	  	 final:1,	       /* 0: no ; 1: yes, it is a final node */


### PR DESCRIPTION
Ubuntu-20.04, clang-16 (nightly build)

```
Making all in src/lib
protocols/smpp.c:70:17: warning: variable 'pdu_c' set but not used [-Wunused-but-set-variable]
      u_int16_t pdu_c = 1;
                ^
1 warning generated.
third_party/src/ahocorasick.c:173:20: warning: implicit truncation from 'int' to a one-bit wide bit-field changes value from 1 to -1 [-Wsingle-bit-bitfield-constant-conversion]
  thiz->root->root = 1;
                   ^ ~
third_party/src/ahocorasick.c:336:15: warning: implicit truncation from 'int' to a one-bit wide bit-field changes value from 1 to -1 [-Wsingle-bit-bitfield-constant-conversion]
        n->ff = 1;
              ^ ~
third_party/src/ahocorasick.c:716:21: warning: implicit truncation from 'int' to a one-bit wide bit-field changes value from 1 to -1 [-Wsingle-bit-bitfield-constant-conversion]
        node->final = 1;
[...]
```