### PR TITLE
Fix `ndpi_do_guess()`

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6193,42 +6193,15 @@ static int ndpi_do_guess(struct ndpi_detection_module_struct *ndpi_str, struct n
     }
 
     if(user_defined_proto && flow->guessed_protocol_id != NDPI_PROTOCOL_UNKNOWN) {
-      if(packet->iph) {
-	if(flow->guessed_host_protocol_id != NDPI_PROTOCOL_UNKNOWN) {
-	  u_int8_t protocol_was_guessed;
+      if(flow->guessed_host_protocol_id != NDPI_PROTOCOL_UNKNOWN) {
+        u_int8_t protocol_was_guessed;
 
-	  /* ret->master_protocol = flow->guessed_protocol_id , ret->app_protocol = flow->guessed_host_protocol_id; /\* ****** *\/ */
-	  *ret = ndpi_detection_giveup(ndpi_str, flow, 0, &protocol_was_guessed);
-	}
-
-	// if(ndpi_str->ndpi_num_custom_protocols != 0)
-	ndpi_fill_protocol_category(ndpi_str, flow, ret);
-	return(-1);
+        /* ret->master_protocol = flow->guessed_protocol_id , ret->app_protocol = flow->guessed_host_protocol_id; /\* ****** *\/ */
+        *ret = ndpi_detection_giveup(ndpi_str, flow, 0, &protocol_was_guessed);
       }
-    } else {
-      /* guess host protocol */
-      if(packet->iph) {
-	flow->guessed_host_protocol_id = ndpi_guess_host_protocol_id(ndpi_str, flow);
 
-	/*
-	  We could implement a shortcut here skipping dissectors for
-	  protocols we have identified by other means such as with the IP
-
-	  However we do NOT stop here and skip invoking the dissectors
-	  because we want to dissect the flow (e.g. dissect the TLS)
-	  and extract metadata.
-	*/
-#if SKIP_INVOKING_THE_DISSECTORS
-	if(flow->guessed_host_protocol_id != NDPI_PROTOCOL_UNKNOWN) {
-	  /*
-	    We have identified a protocol using the IP address so
-	    it is not worth to dissect the traffic as we already have
-	    the solution
-	  */
-	  ret->master_protocol = flow->guessed_protocol_id, ret->app_protocol = flow->guessed_host_protocol_id;
-	}
-#endif
-      }
+      ndpi_fill_protocol_category(ndpi_str, flow, ret);
+      return(-1);
     }
   }
 

--- a/tests/result/1kxun.pcap.out
+++ b/tests/result/1kxun.pcap.out
@@ -21,7 +21,7 @@ Automa risk mask:     18/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   252/0 (search/found)
 Patricia risk:        6/0 (search/found)
-Patricia protocols:   698/72 (search/found)
+Patricia protocols:   360/36 (search/found)
 
 Unknown	24	6428	14
 DNS	2	378	1

--- a/tests/result/443-chrome.pcap.out
+++ b/tests/result/443-chrome.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 TLS	1	1506	1
 

--- a/tests/result/443-curl.pcap.out
+++ b/tests/result/443-curl.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 ntop	109	73982	1
 

--- a/tests/result/443-firefox.pcap.out
+++ b/tests/result/443-firefox.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 ntop	667	458067	1
 

--- a/tests/result/443-git.pcap.out
+++ b/tests/result/443-git.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  1/1 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 Github	70	37189	1
 

--- a/tests/result/443-opvn.pcap.out
+++ b/tests/result/443-opvn.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 OpenVPN	46	11573	1
 

--- a/tests/result/443-safari.pcap.out
+++ b/tests/result/443-safari.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  7/7 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 ntop	41	19929	1
 

--- a/tests/result/4in4tunnel.pcap.out
+++ b/tests/result/4in4tunnel.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Unknown	5	850	1
 

--- a/tests/result/4in6tunnel.pcap.out
+++ b/tests/result/4in6tunnel.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Microsoft	4	2188	1
 

--- a/tests/result/BGP_Cisco_hdlc_slarp.pcap.out
+++ b/tests/result/BGP_Cisco_hdlc_slarp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 BGP	14	969	1
 

--- a/tests/result/BGP_redist.pcap.out
+++ b/tests/result/BGP_redist.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        4/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 BGP	2	322	2
 

--- a/tests/result/EAQ.pcap.out
+++ b/tests/result/EAQ.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   62/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   120/4 (search/found)
+Patricia protocols:   60/2 (search/found)
 
 Google	23	11743	2
 EAQ	174	10092	29

--- a/tests/result/FAX-Call-t38-CA-TDM-SIP-FB-1.pcap.out
+++ b/tests/result/FAX-Call-t38-CA-TDM-SIP-FB-1.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   10/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   20/0 (search/found)
+Patricia protocols:   10/0 (search/found)
 
 RTP	6995	1395012	1
 SIP	92	52851	3

--- a/tests/result/IEC104.pcap.out
+++ b/tests/result/IEC104.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 IEC60870	15	1431	2
 

--- a/tests/result/KakaoTalk_chat.pcap.out
+++ b/tests/result/KakaoTalk_chat.pcap.out
@@ -21,7 +21,7 @@ Automa risk mask:     3/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   78/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   130/30 (search/found)
+Patricia protocols:   67/15 (search/found)
 
 DNS	2	217	1
 HTTP	1	56	1

--- a/tests/result/KakaoTalk_talk.pcap.out
+++ b/tests/result/KakaoTalk_talk.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   44/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   72/23 (search/found)
+Patricia protocols:   39/12 (search/found)
 
 HTTP	5	280	1
 QQ	15	1727	1

--- a/tests/result/NTPv2.pcap.out
+++ b/tests/result/NTPv2.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 NTP	1	410	1
 

--- a/tests/result/NTPv3.pcap.out
+++ b/tests/result/NTPv3.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 NTP	1	90	1
 

--- a/tests/result/NTPv4.pcap.out
+++ b/tests/result/NTPv4.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 NTP	1	90	1
 

--- a/tests/result/Oscar.pcap.out
+++ b/tests/result/Oscar.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 TLS	71	9386	1
 

--- a/tests/result/TivoDVR.pcap.out
+++ b/tests/result/TivoDVR.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 TiVoConnect	2	422	1
 

--- a/tests/result/WebattackRCE.pcap.out
+++ b/tests/result/WebattackRCE.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     777/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   1594/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   3188/0 (search/found)
+Patricia protocols:   1594/0 (search/found)
 
 HTTP	797	191003	797
 

--- a/tests/result/WebattackSQLinj.pcap.out
+++ b/tests/result/WebattackSQLinj.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   18/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   36/0 (search/found)
+Patricia protocols:   18/0 (search/found)
 
 HTTP	94	30008	9
 

--- a/tests/result/WebattackXSS.pcap.out
+++ b/tests/result/WebattackXSS.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   1322/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2644/0 (search/found)
+Patricia protocols:   1322/0 (search/found)
 
 HTTP	9374	4721148	661
 

--- a/tests/result/activision.pcap.out
+++ b/tests/result/activision.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   24/0 (search/found)
+Patricia protocols:   16/0 (search/found)
 
 Activision	60	3904	4
 

--- a/tests/result/afp.pcap.out
+++ b/tests/result/afp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 AFP	16	1218	1
 

--- a/tests/result/agora-sd-rtn.pcap.out
+++ b/tests/result/agora-sd-rtn.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   52/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   156/0 (search/found)
+Patricia protocols:   104/0 (search/found)
 
 SD-RTN	403	112365	26
 

--- a/tests/result/ah.pcapng.out
+++ b/tests/result/ah.pcapng.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 IPSec	6	1768	2
 

--- a/tests/result/aimini-http.pcap.out
+++ b/tests/result/aimini-http.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   16/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   32/0 (search/found)
+Patricia protocols:   16/0 (search/found)
 
 Aimini	133	86722	4
 

--- a/tests/result/ajp.pcap.out
+++ b/tests/result/ajp.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Unknown	6	2200	2
 AJP	26	4446	2

--- a/tests/result/alexa-app.pcapng.out
+++ b/tests/result/alexa-app.pcapng.out
@@ -21,7 +21,7 @@ Automa risk mask:     82/0 (search/found)
 Automa common alpns:  48/48 (search/found)
 Patricia risk mask:   356/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   476/244 (search/found)
+Patricia protocols:   238/122 (search/found)
 
 DNS	4	400	2
 DHCP	3	1056	2

--- a/tests/result/alicloud.pcap.out
+++ b/tests/result/alicloud.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   30/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   60/0 (search/found)
+Patricia protocols:   30/0 (search/found)
 
 AliCloud	225	22986	15
 

--- a/tests/result/among_us.pcap.out
+++ b/tests/result/among_us.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 AmongUs	1	57	1
 

--- a/tests/result/amqp.pcap.out
+++ b/tests/result/amqp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   18/0 (search/found)
+Patricia protocols:   12/0 (search/found)
 
 AMQP	160	23514	3
 

--- a/tests/result/android.pcap.out
+++ b/tests/result/android.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     5/0 (search/found)
 Automa common alpns:  4/4 (search/found)
 Patricia risk mask:   104/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   178/58 (search/found)
+Patricia protocols:   89/29 (search/found)
 
 DNS	4	390	2
 MDNS	2	174	2

--- a/tests/result/anyconnect-vpn.pcap.out
+++ b/tests/result/anyconnect-vpn.pcap.out
@@ -22,7 +22,7 @@ Automa risk mask:     10/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   116/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   266/14 (search/found)
+Patricia protocols:   133/7 (search/found)
 
 Unknown	19	1054	2
 DNS	32	3655	16

--- a/tests/result/anydesk-2.pcap.out
+++ b/tests/result/anydesk-2.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 AnyDesk	2083	346113	4
 

--- a/tests/result/anydesk.pcap.out
+++ b/tests/result/anydesk.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/4 (search/found)
+Patricia protocols:   2/2 (search/found)
 
 AnyDesk	6963	2795460	2
 

--- a/tests/result/avast.pcap.out
+++ b/tests/result/avast.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   20/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   40/30 (search/found)
+Patricia protocols:   30/20 (search/found)
 
 AVAST	142	9433	10
 

--- a/tests/result/avast_securedns.pcapng.out
+++ b/tests/result/avast_securedns.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   78/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   234/0 (search/found)
+Patricia protocols:   156/0 (search/found)
 
 AVASTSecureDNS	77	11443	39
 

--- a/tests/result/bad-dns-traffic.pcap.out
+++ b/tests/result/bad-dns-traffic.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     3/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   12/0 (search/found)
+Patricia protocols:   6/0 (search/found)
 
 DNS	382	99374	3
 

--- a/tests/result/bitcoin.pcap.out
+++ b/tests/result/bitcoin.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   12/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   24/0 (search/found)
+Patricia protocols:   12/0 (search/found)
 
 Mining	637	581074	6
 

--- a/tests/result/bittorrent.pcap.out
+++ b/tests/result/bittorrent.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   48/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   140/0 (search/found)
+Patricia protocols:   92/0 (search/found)
 
 BitTorrent	299	305728	24
 

--- a/tests/result/bittorrent_utp.pcap.out
+++ b/tests/result/bittorrent_utp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 BitTorrent	86	41489	1
 

--- a/tests/result/bjnp.pcap.out
+++ b/tests/result/bjnp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   20/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   40/0 (search/found)
+Patricia protocols:   20/0 (search/found)
 
 BJNP	10	460	10
 

--- a/tests/result/bot.pcap.out
+++ b/tests/result/bot.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/2 (search/found)
+Patricia protocols:   2/1 (search/found)
 
 Azure	402	431124	1
 

--- a/tests/result/bt_search.pcap.out
+++ b/tests/result/bt_search.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 BitTorrent	2	322	1
 

--- a/tests/result/cachefly.pcapng.out
+++ b/tests/result/cachefly.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Cachefly	6	6163	1
 

--- a/tests/result/capwap.pcap.out
+++ b/tests/result/capwap.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   24/0 (search/found)
+Patricia protocols:   12/0 (search/found)
 
 DNS	2	166	1
 DHCP	5	2090	1

--- a/tests/result/cassandra.pcap.out
+++ b/tests/result/cassandra.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Cassandra	286	126016	2
 

--- a/tests/result/check_mk_new.pcap.out
+++ b/tests/result/check_mk_new.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 CHECKMK	98	20242	1
 

--- a/tests/result/chrome.pcap.out
+++ b/tests/result/chrome.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   12/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   24/0 (search/found)
+Patricia protocols:   12/0 (search/found)
 
 TLS	5633	4985157	6
 

--- a/tests/result/citrix.pcap.out
+++ b/tests/result/citrix.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Citrix	100	11332	1
 

--- a/tests/result/cloudflare-warp.pcap.out
+++ b/tests/result/cloudflare-warp.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   16/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   20/14 (search/found)
+Patricia protocols:   11/7 (search/found)
 
 Jabber	11	890	1
 Google	8	476	3

--- a/tests/result/coap_mqtt.pcap.out
+++ b/tests/result/coap_mqtt.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   16/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   32/0 (search/found)
+Patricia protocols:   16/0 (search/found)
 
 COAP	19	1614	8
 Dropbox	800	80676	4

--- a/tests/result/collectd.pcap.out
+++ b/tests/result/collectd.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   12/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   38/0 (search/found)
+Patricia protocols:   22/0 (search/found)
 
 collectd	81	109386	8
 

--- a/tests/result/corba.pcap.out
+++ b/tests/result/corba.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   12/0 (search/found)
+Patricia protocols:   6/0 (search/found)
 
 Corba	22	3681	3
 

--- a/tests/result/cpha.pcap.out
+++ b/tests/result/cpha.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 CPHA	1	96	1
 

--- a/tests/result/dazn.pcapng.out
+++ b/tests/result/dazn.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/6 (search/found)
+Patricia protocols:   3/3 (search/found)
 
 Dazn	12	6675	3
 

--- a/tests/result/dcerpc.pcap.out
+++ b/tests/result/dcerpc.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 RPC	16	6866	4
 

--- a/tests/result/dhcp-fuzz.pcapng.out
+++ b/tests/result/dhcp-fuzz.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 DHCP	1	342	1
 

--- a/tests/result/diameter.pcap.out
+++ b/tests/result/diameter.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Diameter	6	1980	1
 

--- a/tests/result/discord.pcap.out
+++ b/tests/result/discord.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   68/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   122/95 (search/found)
+Patricia protocols:   88/61 (search/found)
 
 Discord	411	98410	34
 

--- a/tests/result/dlt_ppp.pcap.out
+++ b/tests/result/dlt_ppp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 QUIC	1	1230	1
 

--- a/tests/result/dnp3.pcap.out
+++ b/tests/result/dnp3.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   48/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   96/0 (search/found)
+Patricia protocols:   48/0 (search/found)
 
 DNP3	543	38754	8
 

--- a/tests/result/dns-invalid-chars.pcap.out
+++ b/tests/result/dns-invalid-chars.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DNS	2	196	1
 

--- a/tests/result/dns-tunnel-iodine.pcap.out
+++ b/tests/result/dns-tunnel-iodine.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DNS	434	70252	1
 

--- a/tests/result/dns_ambiguous_names.pcap.out
+++ b/tests/result/dns_ambiguous_names.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   20/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   20/20 (search/found)
+Patricia protocols:   10/10 (search/found)
 
 QQ	2	212	1
 Google	2	208	1

--- a/tests/result/dns_doh.pcap.out
+++ b/tests/result/dns_doh.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 DoH_DoT	142	20362	1
 

--- a/tests/result/dns_dot.pcap.out
+++ b/tests/result/dns_dot.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 DoH_DoT	24	5869	1
 

--- a/tests/result/dns_exfiltration.pcap.out
+++ b/tests/result/dns_exfiltration.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DNS	300	73545	1
 

--- a/tests/result/dns_fragmented.pcap.out
+++ b/tests/result/dns_fragmented.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     10/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   10/0 (search/found)
 Patricia risk:        10/0 (search/found)
-Patricia protocols:   20/6 (search/found)
+Patricia protocols:   10/3 (search/found)
 
 DNS	53	16888	18
 Google	6	4807	3

--- a/tests/result/dns_invert_query.pcapng.out
+++ b/tests/result/dns_invert_query.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DNS	2	134	1
 

--- a/tests/result/dns_long_domainname.pcap.out
+++ b/tests/result/dns_long_domainname.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 Google	2	262	1
 

--- a/tests/result/dnscrypt-v1-and-resolver-pings.pcap.out
+++ b/tests/result/dnscrypt-v1-and-resolver-pings.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   490/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   1458/18 (search/found)
+Patricia protocols:   974/12 (search/found)
 
 DNScrypt	488	309562	245
 

--- a/tests/result/dnscrypt-v2-doh.pcap.out
+++ b/tests/result/dnscrypt-v2-doh.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     6/0 (search/found)
 Automa common alpns:  6/6 (search/found)
 Patricia risk mask:   66/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   136/0 (search/found)
+Patricia protocols:   68/0 (search/found)
 
 DoH_DoT	577	216583	34
 

--- a/tests/result/dnscrypt-v2.pcap.out
+++ b/tests/result/dnscrypt-v2.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   18/0 (search/found)
+Patricia protocols:   12/0 (search/found)
 
 DNScrypt	6	4300	3
 

--- a/tests/result/dnscrypt_skype_false_positive.pcapng.out
+++ b/tests/result/dnscrypt_skype_false_positive.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 DNScrypt	6	2380	1
 

--- a/tests/result/doq_adguard.pcapng.out
+++ b/tests/result/doq_adguard.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DoH_DoT	296	44445	1
 

--- a/tests/result/dos_win98_smb_netbeui.pcap.out
+++ b/tests/result/dos_win98_smb_netbeui.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 NetBIOS	46	5060	2
 SMBv1	15	3447	1

--- a/tests/result/drda_db2.pcap.out
+++ b/tests/result/drda_db2.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 DRDA	38	6691	1
 

--- a/tests/result/dropbox.pcap.out
+++ b/tests/result/dropbox.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   18/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   60/0 (search/found)
+Patricia protocols:   30/0 (search/found)
 
 Dropbox	848	90532	15
 

--- a/tests/result/dtls.pcap.out
+++ b/tests/result/dtls.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DTLS	2	394	1
 

--- a/tests/result/dtls2.pcap.out
+++ b/tests/result/dtls2.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DTLS	30	4991	1
 

--- a/tests/result/dtls_certificate.pcapng.out
+++ b/tests/result/dtls_certificate.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 WindowsUpdate	1	1486	1
 

--- a/tests/result/dtls_certificate_fragments.pcap.out
+++ b/tests/result/dtls_certificate_fragments.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 GoogleCloud	20	5978	1
 

--- a/tests/result/dtls_mid_sessions.pcapng.out
+++ b/tests/result/dtls_mid_sessions.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        8/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 DTLS	91	37868	4
 

--- a/tests/result/dtls_old_version.pcapng.out
+++ b/tests/result/dtls_old_version.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DTLS	7	994	1
 

--- a/tests/result/dtls_session_id_and_coockie_both.pcap.out
+++ b/tests/result/dtls_session_id_and_coockie_both.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DTLS	4	604	1
 

--- a/tests/result/emotet.pcap.out
+++ b/tests/result/emotet.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     2/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   12/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   26/0 (search/found)
+Patricia protocols:   14/0 (search/found)
 
 SMTP	626	438465	1
 HTTP	1601	1581542	3

--- a/tests/result/encrypted_sni.pcap.out
+++ b/tests/result/encrypted_sni.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/6 (search/found)
+Patricia protocols:   3/3 (search/found)
 
 Cloudflare	3	2310	3
 

--- a/tests/result/esp.pcapng.out
+++ b/tests/result/esp.pcapng.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 IPSec	6	1856	2
 

--- a/tests/result/ethereum.pcap.out
+++ b/tests/result/ethereum.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   152/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   248/58 (search/found)
+Patricia protocols:   124/29 (search/found)
 
 Mining	1997	215877	72
 AmazonAWS	1	78	1

--- a/tests/result/ethernetIP.pcap.out
+++ b/tests/result/ethernetIP.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        8/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 EthernetIP	100	17384	4
 

--- a/tests/result/exe_download.pcap.out
+++ b/tests/result/exe_download.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 HTTP	703	717463	1
 

--- a/tests/result/exe_download_as_png.pcap.out
+++ b/tests/result/exe_download_as_png.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 HTTP	534	529449	1
 

--- a/tests/result/facebook.pcap.out
+++ b/tests/result/facebook.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  6/6 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/4 (search/found)
+Patricia protocols:   2/2 (search/found)
 
 Facebook	60	30511	2
 

--- a/tests/result/fastcgi.pcap.out
+++ b/tests/result/fastcgi.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 FastCGI	102	72243	1
 

--- a/tests/result/firefox.pcap.out
+++ b/tests/result/firefox.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   12/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   24/0 (search/found)
+Patricia protocols:   12/0 (search/found)
 
 TLS	5441	4952732	6
 

--- a/tests/result/fix.pcap.out
+++ b/tests/result/fix.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   24/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   72/0 (search/found)
+Patricia protocols:   48/0 (search/found)
 
 FIX	1261	115514	12
 

--- a/tests/result/fix2.pcap.out
+++ b/tests/result/fix2.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   12/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 FIX	3046	246540	2
 

--- a/tests/result/forticlient.pcap.out
+++ b/tests/result/forticlient.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     5/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   10/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   20/0 (search/found)
+Patricia protocols:   10/0 (search/found)
 
 FortiClient	2000	430931	5
 

--- a/tests/result/ftp-start-tls.pcap.out
+++ b/tests/result/ftp-start-tls.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 FTPS	51	7510	1
 

--- a/tests/result/ftp.pcap.out
+++ b/tests/result/ftp.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   14/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 Unknown	1115	1122198	1
 FTP_CONTROL	68	5571	1

--- a/tests/result/fuzz-2006-06-26-2594.pcap.out
+++ b/tests/result/fuzz-2006-06-26-2594.pcap.out
@@ -21,7 +21,7 @@ Automa risk mask:     38/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   458/0 (search/found)
 Patricia risk:        26/0 (search/found)
-Patricia protocols:   1074/0 (search/found)
+Patricia protocols:   572/0 (search/found)
 
 Unknown	30	3356	30
 FTP_CONTROL	36	2569	12

--- a/tests/result/fuzz-2006-09-29-28586.pcap.out
+++ b/tests/result/fuzz-2006-09-29-28586.pcap.out
@@ -21,7 +21,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   74/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   158/6 (search/found)
+Patricia protocols:   85/4 (search/found)
 
 Unknown	3	655	3
 HTTP	116	27378	35

--- a/tests/result/fuzz-2020-02-16-11740.pcap.out
+++ b/tests/result/fuzz-2020-02-16-11740.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   148/0 (search/found)
 Patricia risk:        18/0 (search/found)
-Patricia protocols:   340/0 (search/found)
+Patricia protocols:   186/0 (search/found)
 
 Unknown	19	6603	19
 VRRP	1	725	1

--- a/tests/result/genshin-impact.pcap.out
+++ b/tests/result/genshin-impact.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   12/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   24/9 (search/found)
+Patricia protocols:   15/6 (search/found)
 
 GenshinImpact	90	18405	6
 

--- a/tests/result/git.pcap.out
+++ b/tests/result/git.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Git	90	74005	1
 

--- a/tests/result/gnutella.pcap.out
+++ b/tests/result/gnutella.pcap.out
@@ -22,7 +22,7 @@ Automa risk mask:     4/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   1768/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4380/3 (search/found)
+Patricia protocols:   2577/2 (search/found)
 
 Unknown	1423	119577	595
 MDNS	18	1632	2

--- a/tests/result/google_ssl.pcap.out
+++ b/tests/result/google_ssl.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/3 (search/found)
+Patricia protocols:   3/2 (search/found)
 
 Google	28	9108	1
 

--- a/tests/result/googledns_android10.pcap.out
+++ b/tests/result/googledns_android10.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     5/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   16/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/16 (search/found)
+Patricia protocols:   8/8 (search/found)
 
 ICMP	4	392	1
 Google	8	504	2

--- a/tests/result/gquic.pcap.out
+++ b/tests/result/gquic.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 Google	1	1392	1
 

--- a/tests/result/gre_no_options.pcapng.out
+++ b/tests/result/gre_no_options.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 GRE	2	276	1
 

--- a/tests/result/gtp_c.pcap.out
+++ b/tests/result/gtp_c.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 GTP_C	4	684	1
 

--- a/tests/result/gtp_false_positive.pcapng.out
+++ b/tests/result/gtp_false_positive.pcapng.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        6/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   10/0 (search/found)
 
 Unknown	5	428	1
 GTP	2	424	2

--- a/tests/result/gtp_prime.pcapng.out
+++ b/tests/result/gtp_prime.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 GTP_PRIME	1	300	1
 

--- a/tests/result/h323-overflow.pcap.out
+++ b/tests/result/h323-overflow.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 HTTP	1	58	1
 

--- a/tests/result/h323.pcap.out
+++ b/tests/result/h323.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        4/0 (search/found)
-Patricia protocols:   6/6 (search/found)
+Patricia protocols:   4/4 (search/found)
 
 H323	12	1825	2
 

--- a/tests/result/hangout.pcap.out
+++ b/tests/result/hangout.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   5/3 (search/found)
+Patricia protocols:   3/2 (search/found)
 
 GoogleHangoutDuo	19	2774	1
 

--- a/tests/result/hpvirtgrp.pcap.out
+++ b/tests/result/hpvirtgrp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   20/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   58/0 (search/found)
+Patricia protocols:   38/0 (search/found)
 
 HP_VIRTGRP	135	12739	9
 

--- a/tests/result/hsrp0.pcap.out
+++ b/tests/result/hsrp0.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 HSRP	4	264	4
 

--- a/tests/result/hsrp2.pcap.out
+++ b/tests/result/hsrp2.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 HSRP	2	188	2
 

--- a/tests/result/http-crash-content-disposition.pcap.out
+++ b/tests/result/http-crash-content-disposition.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 AmazonAWS	9	3328	1
 

--- a/tests/result/http-lines-split.pcap.out
+++ b/tests/result/http-lines-split.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 HTTP	14	2503	1
 

--- a/tests/result/http-manipulated.pcap.out
+++ b/tests/result/http-manipulated.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     2/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 HTTP	328	959347	2
 

--- a/tests/result/http-proxy.pcapng.out
+++ b/tests/result/http-proxy.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 HTTP_Proxy	11	1652	1
 

--- a/tests/result/http_auth.pcap.out
+++ b/tests/result/http_auth.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 HTTP	33	20574	1
 

--- a/tests/result/http_connect.pcap.out
+++ b/tests/result/http_connect.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   12/0 (search/found)
+Patricia protocols:   6/0 (search/found)
 
 DNS	2	178	1
 TLS	58	36496	1

--- a/tests/result/http_guessed_host_and_guessed.pcapng.out
+++ b/tests/result/http_guessed_host_and_guessed.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 Alibaba	1	123	1
 

--- a/tests/result/http_on_sip_port.pcap.out
+++ b/tests/result/http_on_sip_port.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 HTTP	4	1831	1
 

--- a/tests/result/i3d.pcap.out
+++ b/tests/result/i3d.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/12 (search/found)
+Patricia protocols:   12/8 (search/found)
 
 i3D	60	36502	4
 

--- a/tests/result/iax.pcap.out
+++ b/tests/result/iax.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 IAX	50	9172	1
 

--- a/tests/result/icmp-tunnel.pcap.out
+++ b/tests/result/icmp-tunnel.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 ICMP	863	190810	1
 

--- a/tests/result/iec60780-5-104.pcap.out
+++ b/tests/result/iec60780-5-104.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   12/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   24/0 (search/found)
+Patricia protocols:   12/0 (search/found)
 
 IEC60870	147	9033	6
 

--- a/tests/result/imap-starttls.pcap.out
+++ b/tests/result/imap-starttls.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 IMAPS	32	7975	1
 

--- a/tests/result/imap.pcap.out
+++ b/tests/result/imap.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 IMAP	33	3774	1
 

--- a/tests/result/imaps.pcap.out
+++ b/tests/result/imaps.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     2/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   12/0 (search/found)
+Patricia protocols:   6/0 (search/found)
 
 ntop	20	5196	1
 IMAPS	8	4378	1

--- a/tests/result/imo.pcap.out
+++ b/tests/result/imo.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   10/0 (search/found)
+Patricia protocols:   6/0 (search/found)
 
 IMO	100	35380	2
 

--- a/tests/result/instagram.pcap.out
+++ b/tests/result/instagram.pcap.out
@@ -22,7 +22,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   70/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   128/33 (search/found)
+Patricia protocols:   68/17 (search/found)
 
 Unknown	1	66	1
 HTTP	116	91784	6

--- a/tests/result/iphone.pcap.out
+++ b/tests/result/iphone.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     3/3 (search/found)
 Automa common alpns:  13/13 (search/found)
 Patricia risk mask:   76/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   164/20 (search/found)
+Patricia protocols:   82/10 (search/found)
 
 Unknown	2	120	1
 MDNS	17	7012	5

--- a/tests/result/ipp.pcap.out
+++ b/tests/result/ipp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     3/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   12/0 (search/found)
+Patricia protocols:   6/0 (search/found)
 
 IPP	277	248554	3
 

--- a/tests/result/ipsec_isakmp_esp.pcap.out
+++ b/tests/result/ipsec_isakmp_esp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   48/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   96/0 (search/found)
+Patricia protocols:   48/0 (search/found)
 
 IPSec	1080	580682	24
 

--- a/tests/result/irc.pcap.out
+++ b/tests/result/irc.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 IRC	29	8945	1
 

--- a/tests/result/ja3_lots_of_cipher_suites.pcap.out
+++ b/tests/result/ja3_lots_of_cipher_suites.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 TLS	11	5132	1
 

--- a/tests/result/ja3_lots_of_cipher_suites_2_anon.pcap.out
+++ b/tests/result/ja3_lots_of_cipher_suites_2_anon.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 TLS	27	6966	1
 

--- a/tests/result/jabber.pcap.out
+++ b/tests/result/jabber.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   24/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   58/0 (search/found)
+Patricia protocols:   34/0 (search/found)
 
 Jabber	358	61304	12
 

--- a/tests/result/kerberos-error.pcap.out
+++ b/tests/result/kerberos-error.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Kerberos	2	481	1
 

--- a/tests/result/kerberos-login.pcap.out
+++ b/tests/result/kerberos-login.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   28/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   56/0 (search/found)
+Patricia protocols:   28/0 (search/found)
 
 Kerberos	39	37272	13
 

--- a/tests/result/kerberos.pcap.out
+++ b/tests/result/kerberos.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   72/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   194/0 (search/found)
+Patricia protocols:   122/0 (search/found)
 
 Unknown	9	3031	2
 SMBv23	6	1914	3

--- a/tests/result/kerberos_fuzz.pcapng.out
+++ b/tests/result/kerberos_fuzz.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Kerberos	1	288	1
 

--- a/tests/result/kismet.pcap.out
+++ b/tests/result/kismet.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Kismet	35	4871	1
 

--- a/tests/result/kontiki.pcap.out
+++ b/tests/result/kontiki.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   14/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   36/0 (search/found)
+Patricia protocols:   20/0 (search/found)
 
 Unknown	4	1696	2
 Kontiki	3278	3852324	2

--- a/tests/result/lisp_registration.pcap.out
+++ b/tests/result/lisp_registration.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 LISP	30	5266	4
 

--- a/tests/result/log4j-webapp-exploit.pcap.out
+++ b/tests/result/log4j-webapp-exploit.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     3/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   14/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   28/0 (search/found)
+Patricia protocols:   14/0 (search/found)
 
 Unknown	356	25081	2
 HTTP	34	6741	3

--- a/tests/result/long_tls_certificate.pcap.out
+++ b/tests/result/long_tls_certificate.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Alibaba	47	14812	1
 

--- a/tests/result/malformed_dns.pcap.out
+++ b/tests/result/malformed_dns.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DNS	6	5860	1
 

--- a/tests/result/malformed_icmp.pcap.out
+++ b/tests/result/malformed_icmp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 ICMP	1	42	1
 

--- a/tests/result/malware.pcap.out
+++ b/tests/result/malware.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   10/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/4 (search/found)
+Patricia protocols:   8/2 (search/found)
 
 DNS	2	216	1
 HTTP	1	66	1

--- a/tests/result/memcached.cap.out
+++ b/tests/result/memcached.cap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Memcached	10	1711	1
 

--- a/tests/result/mgcp.pcapng.out
+++ b/tests/result/mgcp.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 MGCP	20	2437	2
 

--- a/tests/result/modbus.pcap.out
+++ b/tests/result/modbus.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Modbus	102	6681	1
 

--- a/tests/result/monero.pcap.out
+++ b/tests/result/monero.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Mining	319	166676	2
 

--- a/tests/result/mongo_false_positive.pcapng.out
+++ b/tests/result/mongo_false_positive.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 TLS	26	12163	1
 

--- a/tests/result/mongodb.pcap.out
+++ b/tests/result/mongodb.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   16/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   34/0 (search/found)
+Patricia protocols:   18/0 (search/found)
 
 Unknown	3	230	1
 MongoDB	24	2510	7

--- a/tests/result/mpeg-dash.pcap.out
+++ b/tests/result/mpeg-dash.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   10/6 (search/found)
+Patricia protocols:   5/3 (search/found)
 
 MpegDash	13	4669	4
 

--- a/tests/result/mpeg.pcap.out
+++ b/tests/result/mpeg.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 ntop	19	10643	1
 

--- a/tests/result/mpegts.pcap.out
+++ b/tests/result/mpegts.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 MPEG_TS	1	1362	1
 

--- a/tests/result/mqtt.pcap.out
+++ b/tests/result/mqtt.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   6/2 (search/found)
+Patricia protocols:   3/1 (search/found)
 
 MQTT	9	1481	2
 

--- a/tests/result/mssql_tds.pcap.out
+++ b/tests/result/mssql_tds.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   24/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   50/0 (search/found)
+Patricia protocols:   26/0 (search/found)
 
 MsSQL-TDS	38	16260	12
 

--- a/tests/result/mysql-8.pcap.out
+++ b/tests/result/mysql-8.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 MySQL	4	367	1
 

--- a/tests/result/nats.pcap.out
+++ b/tests/result/nats.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Nats	27	2460	2
 

--- a/tests/result/ndpi_match_string_subprotocol__error.pcapng.out
+++ b/tests/result/ndpi_match_string_subprotocol__error.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 SOAP	13	2935	1
 

--- a/tests/result/nest_log_sink.pcap.out
+++ b/tests/result/nest_log_sink.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   28/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   54/38 (search/found)
+Patricia protocols:   39/25 (search/found)
 
 DNS	15	1612	1
 NestLogSink	676	112058	12

--- a/tests/result/netbios.pcap.out
+++ b/tests/result/netbios.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     2/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   16/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   60/0 (search/found)
+Patricia protocols:   30/0 (search/found)
 
 NetBIOS	258	24196	13
 SMBv1	2	486	2

--- a/tests/result/netbios_wildcard_dns_query.pcap.out
+++ b/tests/result/netbios_wildcard_dns_query.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 DNS	1	92	1
 

--- a/tests/result/netflix.pcap.out
+++ b/tests/result/netflix.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     13/0 (search/found)
 Automa common alpns:  7/7 (search/found)
 Patricia risk mask:   118/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   164/80 (search/found)
+Patricia protocols:   82/40 (search/found)
 
 DNS	4	386	2
 SSDP	16	2648	1

--- a/tests/result/netflow-fritz.pcap.out
+++ b/tests/result/netflow-fritz.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 NetFlow	1	222	1
 

--- a/tests/result/netflowv9.pcap.out
+++ b/tests/result/netflowv9.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 NetFlow	10	13888	1
 

--- a/tests/result/nfsv2.pcap.out
+++ b/tests/result/nfsv2.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   14/0 (search/found)
 Patricia risk:        14/0 (search/found)
-Patricia protocols:   28/0 (search/found)
+Patricia protocols:   14/0 (search/found)
 
 NFS	156	23144	7
 

--- a/tests/result/nfsv3.pcap.out
+++ b/tests/result/nfsv3.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   16/0 (search/found)
 Patricia risk:        16/0 (search/found)
-Patricia protocols:   32/0 (search/found)
+Patricia protocols:   16/0 (search/found)
 
 NFS	128	22816	8
 

--- a/tests/result/nintendo.pcap.out
+++ b/tests/result/nintendo.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     2/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   42/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   84/24 (search/found)
+Patricia protocols:   52/14 (search/found)
 
 ICMP	30	2100	2
 Nintendo	890	320242	12

--- a/tests/result/nntp.pcap.out
+++ b/tests/result/nntp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Usenet	32	7037	1
 

--- a/tests/result/no_sni.pcap.out
+++ b/tests/result/no_sni.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   16/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/16 (search/found)
+Patricia protocols:   8/8 (search/found)
 
 DoH_DoT	268	31882	1
 Cloudflare	917	562254	7

--- a/tests/result/ocs.pcap.out
+++ b/tests/result/ocs.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   54/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   54/54 (search/found)
+Patricia protocols:   27/27 (search/found)
 
 Google	29	3320	5
 OCS	863	57552	7

--- a/tests/result/ocsp.pcapng.out
+++ b/tests/result/ocsp.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   20/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   34/6 (search/found)
+Patricia protocols:   17/3 (search/found)
 
 HTTP	23	10871	1
 OCSP	321	62776	9

--- a/tests/result/ookla.pcap.out
+++ b/tests/result/ookla.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Ookla	5086	4689745	2
 

--- a/tests/result/openvpn.pcap.out
+++ b/tests/result/openvpn.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   18/0 (search/found)
+Patricia protocols:   12/0 (search/found)
 
 OpenVPN	298	57111	3
 

--- a/tests/result/oracle12.pcapng.out
+++ b/tests/result/oracle12.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Oracle	20	2518	1
 

--- a/tests/result/os_detected.pcapng.out
+++ b/tests/result/os_detected.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 Google	1	1294	1
 

--- a/tests/result/ospfv2_add_new_prefix.pcap.out
+++ b/tests/result/ospfv2_add_new_prefix.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 OSPF	2	200	1
 

--- a/tests/result/pgm.pcap.out
+++ b/tests/result/pgm.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 PGM	1000	196302	1
 

--- a/tests/result/pgsql.pcap.out
+++ b/tests/result/pgsql.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   12/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 PostgreSQL	39	4709	2
 

--- a/tests/result/pim.pcap.out
+++ b/tests/result/pim.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 IP_PIM	10	920	1
 

--- a/tests/result/pluralsight.pcap.out
+++ b/tests/result/pluralsight.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  8/8 (search/found)
 Patricia risk mask:   12/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/8 (search/found)
+Patricia protocols:   8/4 (search/found)
 
 Pluralsight	44	29652	6
 

--- a/tests/result/pop3.pcap.out
+++ b/tests/result/pop3.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 POP3	31	3915	1
 

--- a/tests/result/pop3_stls.pcap.out
+++ b/tests/result/pop3_stls.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 POPS	53	11189	1
 

--- a/tests/result/pops.pcapng.out
+++ b/tests/result/pops.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 POPS	5	2998	1
 

--- a/tests/result/pps.pcap.out
+++ b/tests/result/pps.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   194/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   452/4 (search/found)
+Patricia protocols:   240/2 (search/found)
 
 Unknown	990	378832	34
 HTTP	372	399367	45

--- a/tests/result/pptp.pcap.out
+++ b/tests/result/pptp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 PPTP	24	2328	1
 

--- a/tests/result/psiphon3.pcap.out
+++ b/tests/result/psiphon3.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/4 (search/found)
+Patricia protocols:   2/2 (search/found)
 
 Psiphon	62	11818	1
 

--- a/tests/result/punycode-idn.pcap.out
+++ b/tests/result/punycode-idn.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     2/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   10/2 (search/found)
+Patricia protocols:   5/1 (search/found)
 
 DNS	2	162	1
 Spotify	2	197	1

--- a/tests/result/quic-24.pcap.out
+++ b/tests/result/quic-24.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 QUIC	15	8000	1
 

--- a/tests/result/quic-28.pcap.out
+++ b/tests/result/quic-28.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 Cloudflare	253	246793	1
 

--- a/tests/result/quic-29.pcap.out
+++ b/tests/result/quic-29.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 QUIC	15	9386	1
 

--- a/tests/result/quic-34.pcap.out
+++ b/tests/result/quic-34.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 QUIC	4	4836	1
 

--- a/tests/result/quic-fuzz-overflow.pcapng.out
+++ b/tests/result/quic-fuzz-overflow.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 QUIC	1	1280	1
 

--- a/tests/result/quic-mvfst-22.pcap.out
+++ b/tests/result/quic-mvfst-22.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 Facebook	490	288303	1
 

--- a/tests/result/quic-mvfst-22_decryption_error.pcap.out
+++ b/tests/result/quic-mvfst-22_decryption_error.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 QUIC	353	400490	1
 

--- a/tests/result/quic-mvfst-27.pcapng.out
+++ b/tests/result/quic-mvfst-27.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 Facebook	20	11399	1
 

--- a/tests/result/quic-v2-01.pcapng.out
+++ b/tests/result/quic-v2-01.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 QUIC	923	1311986	1
 

--- a/tests/result/quic.pcap.out
+++ b/tests/result/quic.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   20/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   24/19 (search/found)
+Patricia protocols:   13/10 (search/found)
 
 GMail	413	254874	1
 YouTube	85	76193	5

--- a/tests/result/quic046.pcap.out
+++ b/tests/result/quic046.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 YouTube	100	91297	1
 

--- a/tests/result/quic_0RTT.pcap.out
+++ b/tests/result/quic_0RTT.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/3 (search/found)
+Patricia protocols:   3/2 (search/found)
 
 Google	15	5178	1
 QUIC	2	2588	1

--- a/tests/result/quic_crypto_aes_auth_size.pcap.out
+++ b/tests/result/quic_crypto_aes_auth_size.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        4/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Snapchat	2	2784	2
 

--- a/tests/result/quic_frags_ch_out_of_order_same_packet_craziness.pcapng.out
+++ b/tests/result/quic_frags_ch_out_of_order_same_packet_craziness.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   218/0 (search/found)
 Patricia risk:        206/0 (search/found)
-Patricia protocols:   442/32 (search/found)
+Patricia protocols:   221/16 (search/found)
 
 DataSaver	1	1392	1
 YouTube	21	29232	21

--- a/tests/result/quic_interop_V.pcapng.out
+++ b/tests/result/quic_interop_V.pcapng.out
@@ -18,7 +18,7 @@ Automa risk mask:     42/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   84/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   140/32 (search/found)
+Patricia protocols:   70/16 (search/found)
 
 ICMP	21	7436	9
 ICMPV6	10	10642	5

--- a/tests/result/quic_q39.pcap.out
+++ b/tests/result/quic_q39.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 YouTube	60	24185	1
 

--- a/tests/result/quic_q43.pcap.out
+++ b/tests/result/quic_q43.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/2 (search/found)
+Patricia protocols:   2/1 (search/found)
 
 DoH_DoT	2	1464	1
 

--- a/tests/result/quic_q46.pcap.out
+++ b/tests/result/quic_q46.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Google	20	21241	1
 

--- a/tests/result/quic_q46_b.pcap.out
+++ b/tests/result/quic_q46_b.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 YouTubeUpload	20	7020	1
 

--- a/tests/result/quic_q50.pcap.out
+++ b/tests/result/quic_q50.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 GoogleServices	20	20434	1
 

--- a/tests/result/quic_t50.pcap.out
+++ b/tests/result/quic_t50.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 GoogleServices	12	8420	1
 

--- a/tests/result/quic_t51.pcap.out
+++ b/tests/result/quic_t51.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Google	642	573718	1
 

--- a/tests/result/quickplay.pcap.out
+++ b/tests/result/quickplay.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     5/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   42/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   70/14 (search/found)
+Patricia protocols:   35/7 (search/found)
 
 HTTP	133	96179	11
 QQ	12	4781	5

--- a/tests/result/raknet.pcap.out
+++ b/tests/result/raknet.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   24/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   66/0 (search/found)
+Patricia protocols:   42/0 (search/found)
 
 RakNet	66	9600	12
 

--- a/tests/result/rdp.pcap.out
+++ b/tests/result/rdp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 RDP	2010	622743	1
 

--- a/tests/result/reasm_crash_anon.pcapng.out
+++ b/tests/result/reasm_crash_anon.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Unknown	200	20067	1
 

--- a/tests/result/reasm_segv_anon.pcapng.out
+++ b/tests/result/reasm_segv_anon.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 HTTP	82	77940	1
 

--- a/tests/result/riotgames.pcap.out
+++ b/tests/result/riotgames.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   18/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   32/25 (search/found)
+Patricia protocols:   23/16 (search/found)
 
 Discord	4	220	2
 RiotGames	40	3733	7

--- a/tests/result/rsh-syslog-false-positive.pcap.out
+++ b/tests/result/rsh-syslog-false-positive.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Syslog	6	3335	1
 

--- a/tests/result/rsh.pcap.out
+++ b/tests/result/rsh.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 RSH	24	1721	2
 

--- a/tests/result/rsync.pcap.out
+++ b/tests/result/rsync.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 RSYNC	30	2493	1
 

--- a/tests/result/rtmp.pcap.out
+++ b/tests/result/rtmp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 RTMP	26	8368	1
 

--- a/tests/result/rtsp.pcap.out
+++ b/tests/result/rtsp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   58/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   116/0 (search/found)
+Patricia protocols:   58/0 (search/found)
 
 RTSP	568	100872	7
 

--- a/tests/result/rtsp_setup_http.pcapng.out
+++ b/tests/result/rtsp_setup_http.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 RTSP	1	233	1
 

--- a/tests/result/rx.pcap.out
+++ b/tests/result/rx.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   10/0 (search/found)
 Patricia risk:        10/0 (search/found)
-Patricia protocols:   30/0 (search/found)
+Patricia protocols:   20/0 (search/found)
 
 RX	132	26475	5
 

--- a/tests/result/s7comm.pcap.out
+++ b/tests/result/s7comm.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 s7comm	55	5260	1
 

--- a/tests/result/safari.pcap.out
+++ b/tests/result/safari.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     5/0 (search/found)
 Automa common alpns:  14/14 (search/found)
 Patricia risk mask:   14/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   28/0 (search/found)
+Patricia protocols:   14/0 (search/found)
 
 TLS	6019	5570309	7
 

--- a/tests/result/salesforce.pcap.out
+++ b/tests/result/salesforce.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  7/7 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Salesforce	15	5205	1
 

--- a/tests/result/sccp_hw_conf_register.pcapng.out
+++ b/tests/result/sccp_hw_conf_register.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 CiscoSkinny	17	1522	1
 

--- a/tests/result/sctp.cap.out
+++ b/tests/result/sctp.cap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 SCTP	4	340	2
 

--- a/tests/result/selfsigned.pcap.out
+++ b/tests/result/selfsigned.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 ntop	20	3766	1
 

--- a/tests/result/sflow.pcap.out
+++ b/tests/result/sflow.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 sFlow	9	1702	1
 

--- a/tests/result/signal.pcap.out
+++ b/tests/result/signal.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     2/0 (search/found)
 Automa common alpns:  16/16 (search/found)
 Patricia risk mask:   36/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   54/22 (search/found)
+Patricia protocols:   27/11 (search/found)
 
 DNS	2	186	1
 DHCP	4	1368	1

--- a/tests/result/simple-dnscrypt.pcap.out
+++ b/tests/result/simple-dnscrypt.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     4/0 (search/found)
 Automa common alpns:  8/8 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 DNScrypt	111	44676	4
 

--- a/tests/result/sip.pcap.out
+++ b/tests/result/sip.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 RTP	9	1926	1
 SIP	102	47087	2

--- a/tests/result/sip_hello.pcapng.out
+++ b/tests/result/sip_hello.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 SIP	30	5592	1
 

--- a/tests/result/sites.pcapng.out
+++ b/tests/result/sites.pcapng.out
@@ -20,7 +20,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  24/24 (search/found)
 Patricia risk mask:   106/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   146/66 (search/found)
+Patricia protocols:   73/33 (search/found)
 
 HTTP	2	148	1
 Xbox	4	2245	1

--- a/tests/result/skinny.pcap.out
+++ b/tests/result/skinny.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   18/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   36/0 (search/found)
+Patricia protocols:   18/0 (search/found)
 
 ICMP	2	140	1
 RTP	2871	614394	5

--- a/tests/result/skype-conference-call.pcap.out
+++ b/tests/result/skype-conference-call.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 Skype_TeamsCall	200	39687	1
 

--- a/tests/result/skype.pcap.out
+++ b/tests/result/skype.pcap.out
@@ -22,7 +22,7 @@ Automa risk mask:     3/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   580/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   1608/10 (search/found)
+Patricia protocols:   1000/5 (search/found)
 
 Unknown	1575	272476	61
 DNS	2	267	1

--- a/tests/result/skype_no_unknown.pcap.out
+++ b/tests/result/skype_no_unknown.pcap.out
@@ -21,7 +21,7 @@ Automa risk mask:     4/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   536/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   1482/6 (search/found)
+Patricia protocols:   918/3 (search/found)
 
 Unknown	850	152468	45
 DNS	2	267	1

--- a/tests/result/skype_udp.pcap.out
+++ b/tests/result/skype_udp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Skype_Teams	5	339	1
 

--- a/tests/result/smb_deletefile.pcap.out
+++ b/tests/result/smb_deletefile.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 SMBv23	101	30748	1
 

--- a/tests/result/smb_frags.pcap.out
+++ b/tests/result/smb_frags.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 SMBv1	8	2763	1
 

--- a/tests/result/smbv1.pcap.out
+++ b/tests/result/smbv1.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 SMBv1	7	1197	1
 

--- a/tests/result/smpp_in_general.pcap.out
+++ b/tests/result/smpp_in_general.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 SMPP	17	1144	1
 

--- a/tests/result/smtp-starttls.pcap.out
+++ b/tests/result/smtp-starttls.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     2/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 SMTPS	33	6429	1
 Google	36	8403	1

--- a/tests/result/smtp.pcap.out
+++ b/tests/result/smtp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 SMTP	95	23157	1
 

--- a/tests/result/smtps.pcapng.out
+++ b/tests/result/smtps.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 SMTPS	4	936	1
 

--- a/tests/result/snapchat.pcap.out
+++ b/tests/result/snapchat.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/6 (search/found)
+Patricia protocols:   3/3 (search/found)
 
 Google	22	2879	1
 Snapchat	34	7320	2

--- a/tests/result/snapchat_call.pcapng.out
+++ b/tests/result/snapchat_call.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 SnapchatCall	50	12772	1
 

--- a/tests/result/snmp.pcap.out
+++ b/tests/result/snmp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   26/0 (search/found)
 Patricia risk:        30/0 (search/found)
-Patricia protocols:   68/8 (search/found)
+Patricia protocols:   34/4 (search/found)
 
 SNMP	72	14435	17
 

--- a/tests/result/soap.pcap.out
+++ b/tests/result/soap.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   10/0 (search/found)
 
 HTTP	14	5498	1
 SOAP	6	5450	2

--- a/tests/result/socks-http-example.pcap.out
+++ b/tests/result/socks-http-example.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   14/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 SOCKS	46	8383	3
 

--- a/tests/result/softether.pcap.out
+++ b/tests/result/softether.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   18/0 (search/found)
+Patricia protocols:   10/0 (search/found)
 
 Softether	177	21287	4
 

--- a/tests/result/someip-tp.pcap.out
+++ b/tests/result/someip-tp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 SOMEIP	9	12850	1
 

--- a/tests/result/someip-udp-method-call.pcapng.out
+++ b/tests/result/someip-udp-method-call.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 SOMEIP	3	504	2
 

--- a/tests/result/someip_sd_sample.pcap.out
+++ b/tests/result/someip_sd_sample.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 SOMEIP	6	660	2
 

--- a/tests/result/sql_injection.pcap.out
+++ b/tests/result/sql_injection.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 HTTP	5	2748	1
 

--- a/tests/result/ssdp-m-search-ua.pcap.out
+++ b/tests/result/ssdp-m-search-ua.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 SSDP	4	864	1
 

--- a/tests/result/ssdp-m-search.pcap.out
+++ b/tests/result/ssdp-m-search.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 SSDP	19	1197	1
 

--- a/tests/result/ssh.pcap.out
+++ b/tests/result/ssh.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 SSH	258	35546	1
 

--- a/tests/result/ssl-cert-name-mismatch.pcap.out
+++ b/tests/result/ssl-cert-name-mismatch.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  1/1 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   2/2 (search/found)
+Patricia protocols:   1/1 (search/found)
 
 GoogleCloud	21	5412	1
 

--- a/tests/result/starcraft_battle.pcap.out
+++ b/tests/result/starcraft_battle.pcap.out
@@ -21,7 +21,7 @@ Automa risk mask:     4/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   100/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   195/15 (search/found)
+Patricia protocols:   98/8 (search/found)
 
 DNS	26	2848	7
 HTTP	450	294880	19

--- a/tests/result/steam.pcap.out
+++ b/tests/result/steam.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   110/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   196/24 (search/found)
+Patricia protocols:   98/12 (search/found)
 
 Steam	104	9020	55
 

--- a/tests/result/steam_datagram_relay_ping.pcapng.out
+++ b/tests/result/steam_datagram_relay_ping.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Steam	2	2684	1
 

--- a/tests/result/stun.pcap.out
+++ b/tests/result/stun.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   14/6 (search/found)
+Patricia protocols:   10/4 (search/found)
 
 STUN	62	7620	2
 GoogleHangoutDuo	33	6292	1

--- a/tests/result/stun_signal.pcapng.out
+++ b/tests/result/stun_signal.pcapng.out
@@ -19,7 +19,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   46/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   54/48 (search/found)
+Patricia protocols:   29/25 (search/found)
 
 ICMP	53	5186	2
 GoogleHangoutDuo	40	2720	4

--- a/tests/result/synscan.pcap.out
+++ b/tests/result/synscan.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   3988/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   7960/0 (search/found)
+Patricia protocols:   3988/0 (search/found)
 
 Unknown	1870	108468	1866
 FTP_CONTROL	2	116	2

--- a/tests/result/syslog.pcap.out
+++ b/tests/result/syslog.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   56/0 (search/found)
 Patricia risk:        6/0 (search/found)
-Patricia protocols:   112/0 (search/found)
+Patricia protocols:   56/0 (search/found)
 
 Unknown	1	78	1
 Syslog	93	20321	21

--- a/tests/result/targusdataspeed_false_positives.pcap.out
+++ b/tests/result/targusdataspeed_false_positives.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   12/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 BitTorrent	4	939	2
 

--- a/tests/result/teams.pcap.out
+++ b/tests/result/teams.pcap.out
@@ -22,7 +22,7 @@ Automa risk mask:     21/0 (search/found)
 Automa common alpns:  12/12 (search/found)
 Patricia risk mask:   156/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   246/95 (search/found)
+Patricia protocols:   125/48 (search/found)
 
 Unknown	4	456	1
 DNS	10	1357	5

--- a/tests/result/teamspeak3.pcap.out
+++ b/tests/result/teamspeak3.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 TeamSpeak	13	1911	1
 

--- a/tests/result/teamviewer.pcap.out
+++ b/tests/result/teamviewer.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   10/0 (search/found)
+Patricia protocols:   6/0 (search/found)
 
 TeamViewer	1298	704218	2
 

--- a/tests/result/telegram.pcap.out
+++ b/tests/result/telegram.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     4/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   58/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   156/28 (search/found)
+Patricia protocols:   80/14 (search/found)
 
 Unknown	304	72496	2
 DNS	8	716	4

--- a/tests/result/telnet.pcap.out
+++ b/tests/result/telnet.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Telnet	87	7418	1
 

--- a/tests/result/teredo.pcap.out
+++ b/tests/result/teredo.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   10/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   20/0 (search/found)
+Patricia protocols:   10/0 (search/found)
 
 Teredo	24	2574	5
 

--- a/tests/result/tftp.pcap.out
+++ b/tests/result/tftp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   14/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   30/0 (search/found)
+Patricia protocols:   16/0 (search/found)
 
 TFTP	107	31296	7
 

--- a/tests/result/threema.pcap.out
+++ b/tests/result/threema.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   12/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   24/18 (search/found)
+Patricia protocols:   18/12 (search/found)
 
 Threema	83	11578	6
 

--- a/tests/result/tinc.pcap.out
+++ b/tests/result/tinc.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        8/0 (search/found)
-Patricia protocols:   20/0 (search/found)
+Patricia protocols:   12/0 (search/found)
 
 TINC	317	352291	4
 

--- a/tests/result/tk.pcap.out
+++ b/tests/result/tk.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     3/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   12/0 (search/found)
+Patricia protocols:   6/0 (search/found)
 
 DNS	6	566	3
 

--- a/tests/result/tls-appdata.pcap.out
+++ b/tests/result/tls-appdata.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/5 (search/found)
+Patricia protocols:   4/3 (search/found)
 
 Facebook	6	789	1
 Twitch	114	119156	1

--- a/tests/result/tls-esni-fuzzed.pcap.out
+++ b/tests/result/tls-esni-fuzzed.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/6 (search/found)
+Patricia protocols:   3/3 (search/found)
 
 Cloudflare	3	2310	3
 

--- a/tests/result/tls-rdn-extract.pcap.out
+++ b/tests/result/tls-rdn-extract.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Microsoft	6	7205	1
 

--- a/tests/result/tls_2_reasms.pcapng.out
+++ b/tests/result/tls_2_reasms.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Instagram	14	6907	1
 

--- a/tests/result/tls_2_reasms_b.pcapng.out
+++ b/tests/result/tls_2_reasms_b.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Facebook	15	13455	1
 

--- a/tests/result/tls_alert.pcap.out
+++ b/tests/result/tls_alert.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 TLS	7	533	1
 Google	11	952	1

--- a/tests/result/tls_certificate_too_long.pcap.out
+++ b/tests/result/tls_certificate_too_long.pcap.out
@@ -21,7 +21,7 @@ Automa risk mask:     11/0 (search/found)
 Automa common alpns:  16/16 (search/found)
 Patricia risk mask:   62/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   88/56 (search/found)
+Patricia protocols:   47/29 (search/found)
 
 Unknown	13	5582	1
 MDNS	5	983	3

--- a/tests/result/tls_cipher_lens.pcap.out
+++ b/tests/result/tls_cipher_lens.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   10/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   10/10 (search/found)
+Patricia protocols:   5/5 (search/found)
 
 Google	5	1165	5
 

--- a/tests/result/tls_esni_sni_both.pcap.out
+++ b/tests/result/tls_esni_sni_both.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     2/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/4 (search/found)
+Patricia protocols:   2/2 (search/found)
 
 Cloudflare	38	15899	2
 

--- a/tests/result/tls_false_positives.pcapng.out
+++ b/tests/result/tls_false_positives.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Unknown	30	37313	1
 

--- a/tests/result/tls_invalid_reads.pcap.out
+++ b/tests/result/tls_invalid_reads.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   8/4 (search/found)
+Patricia protocols:   4/2 (search/found)
 
 TLS	7	1827	1
 Crashlytics	3	560	1

--- a/tests/result/tls_long_cert.pcap.out
+++ b/tests/result/tls_long_cert.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 TLS	182	117601	1
 

--- a/tests/result/tls_missing_ch_frag.pcap.out
+++ b/tests/result/tls_missing_ch_frag.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 TLS	14	10082	1
 

--- a/tests/result/tls_multiple_synack_different_seq.pcapng.out
+++ b/tests/result/tls_multiple_synack_different_seq.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 AmazonAWS	10	6532	1
 

--- a/tests/result/tls_port_80.pcapng.out
+++ b/tests/result/tls_port_80.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        8/0 (search/found)
-Patricia protocols:   16/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 TLS	13	2439	1
 

--- a/tests/result/tls_torrent.pcapng.out
+++ b/tests/result/tls_torrent.pcapng.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 BitTorrent	7	6308	1
 

--- a/tests/result/tls_verylong_certificate.pcap.out
+++ b/tests/result/tls_verylong_certificate.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  1/1 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 TLS	48	22229	1
 

--- a/tests/result/toca-boca.pcap.out
+++ b/tests/result/toca-boca.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   42/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   92/0 (search/found)
+Patricia protocols:   50/0 (search/found)
 
 TocaBoca	77	15576	21
 

--- a/tests/result/tor.pcap.out
+++ b/tests/result/tor.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     6/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   18/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   38/2 (search/found)
+Patricia protocols:   19/1 (search/found)
 
 SMBv1	1	252	1
 TLS	2028	1601908	4

--- a/tests/result/trickbot.pcap.out
+++ b/tests/result/trickbot.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 HTTP	74	62002	1
 

--- a/tests/result/tunnelbear.pcap.out
+++ b/tests/result/tunnelbear.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     3/0 (search/found)
 Automa common alpns:  28/28 (search/found)
 Patricia risk mask:   42/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   46/38 (search/found)
+Patricia protocols:   23/19 (search/found)
 
 TLS	34	13737	2
 Google	5	306	1

--- a/tests/result/ubntac2.pcap.out
+++ b/tests/result/ubntac2.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   32/0 (search/found)
+Patricia protocols:   16/0 (search/found)
 
 UBNTAC2	8	1736	8
 

--- a/tests/result/ultrasurf.pcap.out
+++ b/tests/result/ultrasurf.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   14/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 TLS	5171	5127023	2
 UltraSurf	2971	2991918	1

--- a/tests/result/upnp.pcap.out
+++ b/tests/result/upnp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   0/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 WSD	14	9912	2
 

--- a/tests/result/viber.pcap.out
+++ b/tests/result/viber.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  7/7 (search/found)
 Patricia risk mask:   54/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   80/35 (search/found)
+Patricia protocols:   41/18 (search/found)
 
 DNS	8	1267	4
 MDNS	4	412	1

--- a/tests/result/vnc.pcap.out
+++ b/tests/result/vnc.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 VNC	4551	329158	2
 

--- a/tests/result/vxlan.pcap.out
+++ b/tests/result/vxlan.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   18/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   36/0 (search/found)
+Patricia protocols:   18/0 (search/found)
 
 VXLAN	127	85322	9
 

--- a/tests/result/wa_video.pcap.out
+++ b/tests/result/wa_video.pcap.out
@@ -19,7 +19,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   16/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   46/13 (search/found)
+Patricia protocols:   24/7 (search/found)
 
 SSDP	8	1377	3
 DHCP	2	684	1

--- a/tests/result/wa_voice.pcap.out
+++ b/tests/result/wa_voice.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   36/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   90/21 (search/found)
+Patricia protocols:   46/11 (search/found)
 
 Unknown	2	120	1
 MDNS	10	1188	2

--- a/tests/result/waze.pcap.out
+++ b/tests/result/waze.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   66/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   96/40 (search/found)
+Patricia protocols:   50/20 (search/found)
 
 Unknown	10	786	1
 HTTP	65	64777	8

--- a/tests/result/webex.pcap.out
+++ b/tests/result/webex.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     5/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   132/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   156/108 (search/found)
+Patricia protocols:   78/54 (search/found)
 
 HTTP	22	3182	2
 TLS	106	11841	8

--- a/tests/result/websocket.pcap.out
+++ b/tests/result/websocket.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 WebSocket	5	441	1
 

--- a/tests/result/wechat.pcap.out
+++ b/tests/result/wechat.pcap.out
@@ -21,7 +21,7 @@ Automa risk mask:     29/0 (search/found)
 Automa common alpns:  4/4 (search/found)
 Patricia risk mask:   168/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   340/42 (search/found)
+Patricia protocols:   171/21 (search/found)
 
 DNS	13	1075	8
 HTTP	70	4620	8

--- a/tests/result/weibo.pcap.out
+++ b/tests/result/weibo.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     2/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   88/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   163/18 (search/found)
+Patricia protocols:   83/10 (search/found)
 
 DNS	6	630	3
 HTTP	19	2275	5

--- a/tests/result/whatsapp.pcap.out
+++ b/tests/result/whatsapp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   172/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   172/172 (search/found)
+Patricia protocols:   86/86 (search/found)
 
 WhatsApp	679	96293	86
 

--- a/tests/result/whatsapp_login_call.pcap.out
+++ b/tests/result/whatsapp_login_call.pcap.out
@@ -21,7 +21,7 @@ Automa risk mask:     3/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   100/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   148/74 (search/found)
+Patricia protocols:   75/37 (search/found)
 
 HTTP	11	726	3
 MDNS	8	952	4

--- a/tests/result/whatsapp_login_chat.pcap.out
+++ b/tests/result/whatsapp_login_chat.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        2/0 (search/found)
-Patricia protocols:   34/5 (search/found)
+Patricia protocols:   19/3 (search/found)
 
 MDNS	2	202	2
 DHCP	6	2052	1

--- a/tests/result/whatsapp_voice_and_message.pcap.out
+++ b/tests/result/whatsapp_voice_and_message.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   26/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   46/16 (search/found)
+Patricia protocols:   28/8 (search/found)
 
 WhatsAppCall	44	5916	8
 WhatsApp	217	22139	5

--- a/tests/result/whatsappfiles.pcap.out
+++ b/tests/result/whatsappfiles.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  14/14 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/4 (search/found)
+Patricia protocols:   2/2 (search/found)
 
 WhatsAppFiles	620	452233	2
 

--- a/tests/result/whois.pcapng.out
+++ b/tests/result/whois.pcapng.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   8/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   18/0 (search/found)
+Patricia protocols:   10/0 (search/found)
 
 TLS	7	2046	1
 Whois-DAS	16	4294	2

--- a/tests/result/windowsupdate_over_http.pcap.out
+++ b/tests/result/windowsupdate_over_http.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 WindowsUpdate	20	15975	1
 

--- a/tests/result/wireguard.pcap.out
+++ b/tests/result/wireguard.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 WireGuard	2399	734182	1
 

--- a/tests/result/wow.pcap.out
+++ b/tests/result/wow.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   20/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   36/4 (search/found)
+Patricia protocols:   18/2 (search/found)
 
 WorldOfWarcraft	95	10688	5
 

--- a/tests/result/xdmcp.pcap.out
+++ b/tests/result/xdmcp.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 XDMCP	6	598	1
 

--- a/tests/result/xiaomi.pcap.out
+++ b/tests/result/xiaomi.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   14/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   36/6 (search/found)
+Patricia protocols:   24/4 (search/found)
 
 Xiaomi	52	11467	7
 

--- a/tests/result/xss.pcap.out
+++ b/tests/result/xss.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 HTTP	11	3209	2
 

--- a/tests/result/youtube_quic.pcap.out
+++ b/tests/result/youtube_quic.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/6 (search/found)
+Patricia protocols:   3/3 (search/found)
 
 YouTube	258	178495	1
 Google	31	13144	2

--- a/tests/result/youtubeupload.pcap.out
+++ b/tests/result/youtubeupload.pcap.out
@@ -18,7 +18,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  2/2 (search/found)
 Patricia risk mask:   6/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   6/6 (search/found)
+Patricia protocols:   3/3 (search/found)
 
 YouTubeUpload	137	127038	3
 

--- a/tests/result/z3950.pcapng.out
+++ b/tests/result/z3950.pcapng.out
@@ -18,7 +18,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   12/0 (search/found)
+Patricia protocols:   8/0 (search/found)
 
 Z3950	31	6308	2
 

--- a/tests/result/zabbix.pcap.out
+++ b/tests/result/zabbix.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Zabbix	10	715	1
 

--- a/tests/result/zattoo.pcap.out
+++ b/tests/result/zattoo.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   4/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   8/0 (search/found)
+Patricia protocols:   4/0 (search/found)
 
 Zattoo	32	13467	2
 

--- a/tests/result/zcash.pcap.out
+++ b/tests/result/zcash.pcap.out
@@ -17,7 +17,7 @@ Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   4/0 (search/found)
+Patricia protocols:   2/0 (search/found)
 
 Mining	145	20644	1
 

--- a/tests/result/zoom.pcap.out
+++ b/tests/result/zoom.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     7/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   56/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   114/33 (search/found)
+Patricia protocols:   63/18 (search/found)
 
 DNS	2	205	1
 MDNS	1	87	1

--- a/tests/result/zoom2.pcap.out
+++ b/tests/result/zoom2.pcap.out
@@ -20,7 +20,7 @@ Automa risk mask:     1/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   10/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   16/13 (search/found)
+Patricia protocols:   11/8 (search/found)
 
 ICMP	27	1890	1
 Zoom	11950	9004950	4


### PR DESCRIPTION
Avoid a double call of `ndpi_guess_host_protocol_id()`.
Some code paths work for ipv4/6 both