### PR TITLE
HTTP: remove some wrong code

### DIFF
--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -751,28 +751,6 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
       ndpi_check_dga_name(ndpi_struct, flow, flow->host_server_name, 1, 0);
     }
 
-    /**
-       check result of host subprotocol detection
-
-       if "detected" in flow == 0 then "detected" = "guess"
-       else "guess" = "detected"
-    **/
-    if(flow->detected_protocol_stack[1] == NDPI_PROTOCOL_UNKNOWN) {
-      /* Avoid putting as subprotocol a "core" protocol such as SSL or DNS */
-      if(ndpi_struct->proto_defaults[flow->guessed_protocol_id].subprotocol_count == 0) {
-	if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN &&
-	   flow->guessed_host_protocol_id != NDPI_PROTOCOL_UNKNOWN) {
-	  ndpi_set_detected_protocol(ndpi_struct, flow, flow->guessed_host_protocol_id, flow->guessed_protocol_id, NDPI_CONFIDENCE_DPI);
-        }
-      }
-    }
-    else {
-      if(flow->detected_protocol_stack[1] != flow->guessed_protocol_id)
-	flow->guessed_protocol_id = flow->detected_protocol_stack[1];
-      if(flow->detected_protocol_stack[0] != flow->guessed_host_protocol_id)
-	flow->guessed_host_protocol_id = flow->detected_protocol_stack[0];
-    }
-
     if((flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN)
        && (flow->http_detected)
        && (packet->http_origin.len > 0)) {

--- a/tests/result/http_guessed_host_and_guessed.pcapng.out
+++ b/tests/result/http_guessed_host_and_guessed.pcapng.out
@@ -1,8 +1,8 @@
 Guessed flow protos:	1
 
 DPI Packets (TCP):	1	(1.00 pkts/flow)
-Confidence DPI              : 1 (flows)
-Num dissector calls: 2 (2.00 diss/flow)
+Confidence Match by IP      : 1 (flows)
+Num dissector calls: 126 (126.00 diss/flow)
 LRU cache ookla:      0/0/0 (insert/search/found)
 LRU cache bittorrent: 0/0/0 (insert/search/found)
 LRU cache zoom:       0/0/0 (insert/search/found)
@@ -10,15 +10,15 @@ LRU cache stun:       0/0/0 (insert/search/found)
 LRU cache tls_cert:   0/0/0 (insert/search/found)
 LRU cache mining:     0/0/0 (insert/search/found)
 LRU cache msteams:    0/0/0 (insert/search/found)
-Automa host:          1/0 (search/found)
-Automa domain:        1/0 (search/found)
+Automa host:          2/0 (search/found)
+Automa domain:        2/0 (search/found)
 Automa tls cert:      0/0 (search/found)
 Automa risk mask:     0/0 (search/found)
 Automa common alpns:  0/0 (search/found)
 Patricia risk mask:   2/0 (search/found)
 Patricia risk:        0/0 (search/found)
-Patricia protocols:   1/1 (search/found)
+Patricia protocols:   3/2 (search/found)
 
 Alibaba	1	123	1
 
-	1	TCP 170.33.13.5:110 -> 192.168.0.1:179 [proto: 2.274/POP3.Alibaba][ClearText][Confidence: DPI][cat: Email/3][1 pkts/123 bytes -> 0 pkts/0 bytes][Goodput ratio: 40/0][< 1 sec][Hostname/SNI: pornhub.com][Risk: ** Unidirectional Traffic **][Risk Score: 10][Risk Info: No client to server traffic][PLAIN TEXT (6 HTTP/1.1)][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	1	TCP 170.33.13.5:110 -> 192.168.0.1:179 [proto: 2.274/POP3.Alibaba][ClearText][Confidence: Match by IP][cat: Email/3][1 pkts/123 bytes -> 0 pkts/0 bytes][Goodput ratio: 40/0][< 1 sec][Hostname/SNI: pornhub.com][Risk: ** Unidirectional Traffic **][Risk Score: 10][Risk Info: No client to server traffic][PLAIN TEXT (6 HTTP/1.1)][Plen Bins: 0,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]


### PR DESCRIPTION
This code seems wrong or in the wrong place, at least:
* "classification by port" and "classification by ip" protocols (i.e "guessed" protocols) should be used to set the protocol stack only after trying all the dissectors, and only by the generic code
* there are no reason (for a dissector) to update the "guessed" information using the protocol stack values: it is usually the other way around (see previous point)