### PR TITLE
Dissectors shouldn't update `flow->guessed_host_protocol_id`

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1260,9 +1260,9 @@ struct ndpi_flow_struct {
   u_int16_t detected_protocol_stack[NDPI_PROTOCOL_SIZE];
 
   /* init parameter, internal used to set up timestamp,... */
-  u_int16_t guessed_protocol_id, guessed_host_protocol_id, guessed_category, guessed_header_category;
-  u_int8_t l4_proto, protocol_id_already_guessed:1, host_already_guessed:1, fail_with_unknown:1,
-    init_finished:1, client_packet_direction:1, packet_direction:1, is_ipv6:1, _pad1: 1;
+  u_int16_t guessed_protocol_id, guessed_protocol_id_by_ip, guessed_category, guessed_header_category;
+  u_int8_t l4_proto, protocol_id_already_guessed:1, fail_with_unknown:1,
+    init_finished:1, client_packet_direction:1, packet_direction:1, is_ipv6:1, _pad1: 2;
   u_int16_t num_dissector_calls;
   ndpi_confidence_t confidence; /* ndpi_confidence_t */
 

--- a/src/lib/protocols/ajp.c
+++ b/src/lib/protocols/ajp.c
@@ -63,7 +63,7 @@ static void set_ajp_detected(struct ndpi_detection_module_struct *ndpi_struct,
     /* If no custom protocol has been detected */
     /* if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) */
       ndpi_int_reset_protocol(flow);
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_AJP, flow->guessed_host_protocol_id, NDPI_CONFIDENCE_DPI);
+      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_AJP, flow->guessed_protocol_id_by_ip, NDPI_CONFIDENCE_DPI);
   }
 }
 

--- a/src/lib/protocols/alicloud.c
+++ b/src/lib/protocols/alicloud.c
@@ -30,7 +30,7 @@ static void ndpi_int_alicloud_add_connection(struct ndpi_detection_module_struct
 {
   NDPI_LOG_INFO(ndpi_struct, "found alicloud\n");
 
-  ndpi_set_detected_protocol(ndpi_struct, flow, flow->guessed_host_protocol_id, NDPI_PROTOCOL_ALICLOUD,
+  ndpi_set_detected_protocol(ndpi_struct, flow, flow->guessed_protocol_id_by_ip, NDPI_PROTOCOL_ALICLOUD,
                              NDPI_CONFIDENCE_DPI);
 }
 

--- a/src/lib/protocols/mongodb.c
+++ b/src/lib/protocols/mongodb.c
@@ -58,7 +58,7 @@ static void set_mongodb_detected(struct ndpi_detection_module_struct *ndpi_struc
     /* If no custom protocol has been detected */
     /* if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) */
     ndpi_int_reset_protocol(flow);
-    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MONGODB, flow->guessed_host_protocol_id, NDPI_CONFIDENCE_DPI);
+    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MONGODB, flow->guessed_protocol_id_by_ip, NDPI_CONFIDENCE_DPI);
   }
 }
 

--- a/src/lib/protocols/ssh.c
+++ b/src/lib/protocols/ssh.c
@@ -209,8 +209,6 @@ static void ndpi_int_ssh_add_connection(struct ndpi_detection_module_struct
   if(flow->extra_packets_func != NULL)
     return;
 
-  flow->guessed_host_protocol_id = flow->guessed_protocol_id = NDPI_PROTOCOL_SSH;
-  
   flow->max_extra_packets_to_check = 12;
   flow->extra_packets_func = search_ssh_again;
   
@@ -445,7 +443,7 @@ static void ndpi_search_ssh_tcp(struct ndpi_detection_module_struct *ndpi_struct
 #endif
       
       NDPI_LOG_DBG2(ndpi_struct, "ssh stage 1 passed\n");
-      flow->guessed_host_protocol_id = flow->guessed_protocol_id = NDPI_PROTOCOL_SSH;
+      flow->guessed_protocol_id = NDPI_PROTOCOL_SSH;
       
 #ifdef SSH_DEBUG
       printf("[SSH] [completed stage: %u]\n", flow->l4.tcp.ssh_stage);

--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -424,7 +424,7 @@ void ndpi_search_stun(struct ndpi_detection_module_struct *ndpi_struct, struct n
 
   NDPI_LOG_DBG(ndpi_struct, "search stun\n");
 
-  app_proto = flow->guessed_host_protocol_id;
+  app_proto = flow->guessed_protocol_id_by_ip;
 
   if(packet->tcp) {
     /* STUN may be encapsulated in TCP packets */

--- a/src/lib/protocols/tcp_udp.c
+++ b/src/lib/protocols/tcp_udp.c
@@ -40,7 +40,7 @@ u_int ndpi_search_tcp_or_udp_raw(struct ndpi_detection_module_struct *ndpi_struc
   }
 
   if(flow)
-    return(flow->guessed_host_protocol_id);
+    return(flow->guessed_protocol_id_by_ip);
   else {
     host.s_addr = htonl(saddr);
     if((rc = ndpi_network_ptree_match(ndpi_struct, &host)) != NDPI_PROTOCOL_UNKNOWN)

--- a/src/lib/protocols/telnet.c
+++ b/src/lib/protocols/telnet.c
@@ -130,8 +130,6 @@ static int search_telnet_again(struct ndpi_detection_module_struct *ndpi_struct,
 
 static void ndpi_int_telnet_add_connection(struct ndpi_detection_module_struct
 					   *ndpi_struct, struct ndpi_flow_struct *flow) {
-  flow->guessed_host_protocol_id = flow->guessed_protocol_id = NDPI_PROTOCOL_TELNET;
-
   flow->max_extra_packets_to_check = 64;
   flow->extra_packets_func = search_telnet_again;
 

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -2491,7 +2491,7 @@ static void ndpi_search_tls_wrapper(struct ndpi_detection_module_struct *ndpi_st
 #ifdef DEBUG_TLS
   printf("==>> %s() %u [len: %u][version: %u]\n",
 	 __FUNCTION__,
-	 flow->guessed_host_protocol_id,
+	 flow->guessed_protocol_id_by_ip,
 	 packet->payload_packet_len,
 	 flow->protos.tls_quic.ssl_version);
 #endif

--- a/src/lib/protocols/websocket.c
+++ b/src/lib/protocols/websocket.c
@@ -53,7 +53,7 @@ static void set_websocket_detected(struct ndpi_detection_module_struct *ndpi_str
       ndpi_search_tcp_or_udp(ndpi_struct, flow);
 
       ndpi_int_reset_protocol(flow);
-      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_WEBSOCKET, flow->guessed_host_protocol_id, NDPI_CONFIDENCE_DPI);
+      ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_WEBSOCKET, flow->guessed_protocol_id_by_ip, NDPI_CONFIDENCE_DPI);
     }
 }
 

--- a/src/lib/protocols/wireguard.c
+++ b/src/lib/protocols/wireguard.c
@@ -140,8 +140,7 @@ void ndpi_search_wireguard(struct ndpi_detection_module_struct
     u_int32_t receiver_index = get_u_int32_t(payload, 4);
 
     /* We speculate this is wireguard, so let's remember it */
-    if(flow->guessed_host_protocol_id == NDPI_PROTOCOL_UNKNOWN)
-      flow->guessed_host_protocol_id = NDPI_PROTOCOL_WIREGUARD;
+    flow->guessed_protocol_id = NDPI_PROTOCOL_WIREGUARD;
     
     if (flow->l4.udp.wireguard_stage == 0) {
       flow->l4.udp.wireguard_stage = 3 + packet->packet_direction;


### PR DESCRIPTION
The field `flow->guessed_host_protocol_id` is set at the beginning of the flow analysis and it represents the "classification by ip" of the flow itself.

This field should never be changed. Dissectors which want to provide an "hint" about the classification, should update `flow->guessed_protocol_id` instead. Such "hint" is useless if the dissector set the "extra-dissection" data-path.

Rename such field to `guessed_protocol_id_by_ip` to better describe its role.

Preliminary work necessary for #1687