### PR TITLE
Fix warnings on OpenWrt CCs, caused by the memcpy builtin.

### DIFF
--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -469,7 +469,7 @@ static int tls13_hkdf_expand_label_context(struct ndpi_detection_module_struct *
 
   memcpy(&info_data[info_len], &context_length, 1);
   info_len += 1;
-  if(context_length) {
+  if(context_length && context_hash != NULL) {
     memcpy(&info_data[info_len], context_hash, context_length);
     info_len += context_length;
   }


### PR DESCRIPTION
This is a false positive IMHO, because looking at the calls to `tls13_hkdf_expand_label_context`, I could not find any that leads to `context_length != 0`, but `context_hash == NULL`.

The warning could be related to `-D_FORTIFY_SOURCE=1`, unsure.