### PR TITLE
TLS/DTLS: we process certificate for UDP flows, too

### DIFF
--- a/example/ndpiSimpleIntegration.c
+++ b/example/ndpiSimpleIntegration.c
@@ -956,7 +956,7 @@ static void ndpi_process_packet(uint8_t * const args,
 	      flow_to_process->tls_client_hello_seen = 1;
             }
 	  if (flow_to_process->tls_server_hello_seen == 0 &&
-	      flow_to_process->ndpi_flow->l4.tcp.tls.certificate_processed != 0)
+	      flow_to_process->ndpi_flow->tls_quic.certificate_processed != 0)
             {
 	      uint8_t unknown_tls_version = 0;
 	      char buf_ver[16];

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1239,7 +1239,7 @@ void process_ndpi_collected_info(struct ndpi_workflow * workflow, struct ndpi_fl
     flow->ssh_tls.server_unsafe_cipher = flow->ndpi_flow->protos.tls_quic.server_unsafe_cipher;
     flow->ssh_tls.server_cipher = flow->ndpi_flow->protos.tls_quic.server_cipher;
 
-    if(flow->ndpi_flow->l4.tcp.tls.fingerprint_set) {
+    if(flow->ndpi_flow->protos.tls_quic.fingerprint_set) {
       memcpy(flow->ssh_tls.sha1_cert_fingerprint,
 	     flow->ndpi_flow->protos.tls_quic.sha1_certificate_fingerprint, 20);
       flow->ssh_tls.sha1_cert_fingerprint_set = 1;

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -708,7 +708,6 @@ struct ndpi_flow_tcp_struct {
     message_t message[2]; /* Directions */
 
     /* NDPI_PROTOCOL_TLS */
-    u_int8_t certificate_processed:1, fingerprint_set:1, _pad:6;
     u_int8_t app_data_seen[2];
     u_int8_t num_tls_blocks;
     int16_t tls_application_blocks_len[NDPI_MAX_NUM_TLS_APPL_BLOCKS]; /* + = src->dst, - = dst->src */
@@ -1373,6 +1372,10 @@ struct ndpi_flow_struct {
     u_int16_t num_processed_pkts;
   } stun;
 
+  struct {
+    u_int8_t certificate_processed:1, _pad:7;
+  } tls_quic; /* Used also by DTLS and POPS/IMAPS/SMTPS/FTPS */
+
   union {
     /* the only fields useful for nDPI and ntopng */
     struct {
@@ -1403,7 +1406,7 @@ struct ndpi_flow_struct {
       char ja3_client[33], ja3_server[33];
       u_int16_t server_cipher;
       u_int8_t sha1_certificate_fingerprint[20];
-      u_int8_t hello_processed:1, subprotocol_detected:1, _pad:6;
+      u_int8_t hello_processed:1, subprotocol_detected:1, fingerprint_set:1, _pad:5;
 
 #ifdef TLS_HANDLE_SIGNATURE_ALGORITMS
       /* Under #ifdef to save memory for those who do not need them */


### PR DESCRIPTION
Note that current code access `certificate_processed` state even before setting the protocol classification, so this piece of information can't be saved in `flow->protos` union.