### PR TITLE
Remove unused code

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1096,10 +1096,6 @@ typedef struct ndpi_proto {
 /* PLEASE DO NOT REMOVE OR CHANGE THE ORDER OF WHAT IS DELIMITED BY CFFI.NDPI_MODULE_STRUCT FLAG AS IT IS USED FOR
    PYTHON BINDINGS AUTO GENERATION */
 //CFFI.NDPI_MODULE_STRUCT
-typedef enum {
-  ndpi_stun_cache,
-  ndpi_hangout_cache
-} ndpi_lru_cache_type;
 
 typedef struct ndpi_list_struct {
   char *value;
@@ -1231,8 +1227,6 @@ struct ndpi_detection_module_struct {
   ndpi_proto_defaults_t proto_defaults[NDPI_MAX_SUPPORTED_PROTOCOLS+NDPI_MAX_NUM_CUSTOM_PROTOCOLS];
 
   u_int8_t direction_detect_disable:1, /* disable internal detection of packet direction */ _pad:7;
-
-  void (*ndpi_notify_lru_add_handler_ptr)(ndpi_lru_cache_type cache_type, u_int32_t proto, u_int32_t app_proto);
 
 #ifdef CUSTOM_NDPI_PROTOCOLS
   #include "../../../nDPI-custom/custom_ndpi_typedefs.h"

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -2273,29 +2273,6 @@ ndpi_risk_enum ndpi_network_risk_ptree_match(struct ndpi_detection_module_struct
 
 /* ******************************************* */
 
-#if 0
-static u_int8_t tor_ptree_match(struct ndpi_detection_module_struct *ndpi_str, struct in_addr *pin) {
-  return((ndpi_network_ptree_match(ndpi_str, pin) == NDPI_PROTOCOL_TOR) ? 1 : 0);
-}
-#endif
-
-/* ******************************************* */
-
-u_int8_t ndpi_is_tor_flow(struct ndpi_detection_module_struct *ndpi_str, struct ndpi_flow_struct *flow) {
-  struct ndpi_packet_struct *packet = &ndpi_str->packet;
-
-  if(packet->tcp != NULL) {
-    if(packet->iph) {
-      if(flow->guessed_protocol_id_by_ip == NDPI_PROTOCOL_TOR)
-	return(1);
-    }
-  }
-
-  return(0);
-}
-
-/* ******************************************* */
-
 static ndpi_patricia_node_t* add_to_ptree(ndpi_patricia_tree_t *tree, int family, void *addr, int bits) {
   ndpi_prefix_t prefix;
   ndpi_patricia_node_t *node;
@@ -2581,15 +2558,6 @@ static const char *categories[] = {
 
 /* ******************************************************************** */
 
-#ifdef TEST_LRU_HANDLER
-void test_lru_handler(ndpi_lru_cache_type cache_type, u_int32_t proto, u_int32_t app_proto) {
-
-  printf("[test_lru_handler] %u / %u / %u\n", cache_type, proto, app_proto);
-}
-#endif
-
-/* ******************************************************************** */
-
 struct ndpi_detection_module_struct *ndpi_init_detection_module(ndpi_init_prefs prefs) {
   struct ndpi_detection_module_struct *ndpi_str = ndpi_malloc(sizeof(struct ndpi_detection_module_struct));
   int i;
@@ -2603,10 +2571,6 @@ struct ndpi_detection_module_struct *ndpi_init_detection_module(ndpi_init_prefs 
   }
 
   memset(ndpi_str, 0, sizeof(struct ndpi_detection_module_struct));
-
-#ifdef TEST_LRU_HANDLER
-  ndpi_str->ndpi_notify_lru_add_handler_ptr = test_lru_handler;
-#endif
 
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
   set_ndpi_debug_function(ndpi_str, (ndpi_debug_function_ptr) ndpi_debug_printf);

--- a/src/lib/protocols/ajp.c
+++ b/src/lib/protocols/ajp.c
@@ -58,11 +58,6 @@ static void set_ajp_detected(struct ndpi_detection_module_struct *ndpi_struct,
            struct ndpi_flow_struct *flow) {
 
   if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) {
-    ndpi_search_tcp_or_udp(ndpi_struct, flow);
-
-    /* If no custom protocol has been detected */
-    /* if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) */
-      ndpi_int_reset_protocol(flow);
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_AJP, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
   }
 }

--- a/src/lib/protocols/hangout.c
+++ b/src/lib/protocols/hangout.c
@@ -107,8 +107,6 @@ void ndpi_search_hangout(struct ndpi_detection_module_struct *ndpi_struct,
 #endif
 
 	ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key, NDPI_PROTOCOL_HANGOUT_DUO);
-	if(ndpi_struct->ndpi_notify_lru_add_handler_ptr)
-	  ndpi_struct->ndpi_notify_lru_add_handler_ptr(ndpi_hangout_cache, key, NDPI_PROTOCOL_HANGOUT_DUO); 
       }
       
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_HANGOUT_DUO,

--- a/src/lib/protocols/mongodb.c
+++ b/src/lib/protocols/mongodb.c
@@ -53,11 +53,6 @@ static void set_mongodb_detected(struct ndpi_detection_module_struct *ndpi_struc
 				 struct ndpi_flow_struct *flow) {
 
   if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) {
-    ndpi_search_tcp_or_udp(ndpi_struct, flow);
-
-    /* If no custom protocol has been detected */
-    /* if(flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) */
-    ndpi_int_reset_protocol(flow);
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_MONGODB, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
   }
 }

--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -96,12 +96,7 @@ static void ndpi_int_stun_add_connection(struct ndpi_detection_module_struct *nd
 #endif
 
 	  ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key, app_proto);
-	  if(ndpi_struct->ndpi_notify_lru_add_handler_ptr)
-	    ndpi_struct->ndpi_notify_lru_add_handler_ptr(ndpi_stun_cache, key, app_proto);
-
 	  ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key_rev, app_proto);
-	  if(ndpi_struct->ndpi_notify_lru_add_handler_ptr)
-	    ndpi_struct->ndpi_notify_lru_add_handler_ptr(ndpi_stun_cache, key_rev, app_proto);
 	}
       }
     }

--- a/src/lib/protocols/tcp_udp.c
+++ b/src/lib/protocols/tcp_udp.c
@@ -21,8 +21,6 @@
 
 #include "ndpi_api.h"
 
-/* ndpi_main.c */
-extern u_int8_t  ndpi_is_tor_flow(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow);
 
 u_int ndpi_search_tcp_or_udp_raw(struct ndpi_detection_module_struct *ndpi_struct,
 				 struct ndpi_flow_struct *flow,
@@ -59,11 +57,6 @@ void ndpi_search_tcp_or_udp(struct ndpi_detection_module_struct *ndpi_struct, st
 
   if(flow->host_server_name[0] != '\0')
     return;
-
-  if(ndpi_is_tor_flow(ndpi_struct, flow)) {
-    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TOR, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
-    return;
-  }
 
   if(packet->udp) sport = ntohs(packet->udp->source), dport = ntohs(packet->udp->dest);
   else if(packet->tcp) sport = ntohs(packet->tcp->source), dport = ntohs(packet->tcp->dest);

--- a/src/lib/protocols/websocket.c
+++ b/src/lib/protocols/websocket.c
@@ -50,9 +50,6 @@ static void set_websocket_detected(struct ndpi_detection_module_struct *ndpi_str
   /* If no custom protocol has been detected */
   if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN)
     {
-      ndpi_search_tcp_or_udp(ndpi_struct, flow);
-
-      ndpi_int_reset_protocol(flow);
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_WEBSOCKET, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
     }
 }


### PR DESCRIPTION
LRU callbacks have been added in 460ff3c7a, but they have never been used and they have never been extended to the other LRU caches.

`ndpi_search_tcp_or_udp()` basically returns the classification by port/ip of the flow; calling it from the dissector is useless.
The same for TOR detection: ips are checked in the generic code