### PR TITLE
Fix json export of ipv6 addresses

### DIFF
--- a/example/reader_util.h
+++ b/example/reader_util.h
@@ -182,7 +182,7 @@ typedef struct ndpi_flow_info {
   u_int16_t vlan_id;
   ndpi_packet_tunnel tunnel_type;
   struct ndpi_flow_struct *ndpi_flow;
-  char src_name[48], dst_name[48];
+  char src_name[INET6_ADDRSTRLEN], dst_name[INET6_ADDRSTRLEN];
   u_int8_t ip_version;
   u_int32_t cwr_count, src2dst_cwr_count, dst2src_cwr_count;
   u_int32_t ece_count, src2dst_ece_count, dst2src_ece_count;

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -1516,7 +1516,7 @@ int ndpi_flow2json(struct ndpi_detection_module_struct *ndpi_struct,
 		   u_int16_t src_port, u_int16_t dst_port,
 		   ndpi_protocol l7_protocol,
 		   ndpi_serializer *serializer) {
-  char src_name[32] = {'\0'}, dst_name[32] = {'\0'};
+  char src_name[INET6_ADDRSTRLEN] = {'\0'}, dst_name[INET6_ADDRSTRLEN] = {'\0'};
 
   if(ip_version == 4) {
     inet_ntop(AF_INET, &src_v4, src_name, sizeof(src_name));


### PR DESCRIPTION
The "string" buffer was to short; better start using `INET6_ADDRSTRLEN` as reported in the man page of `inet_ntop`.

Close: #1794