### PR TITLE
RTP: remove a superfluous check

### DIFF
--- a/src/lib/protocols/rtp.c
+++ b/src/lib/protocols/rtp.c
@@ -128,7 +128,7 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
 
 /* *************************************************************** */
 
-void ndpi_search_rtp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
+static void ndpi_search_rtp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int16_t source = ntohs(packet->udp->source);
@@ -138,8 +138,7 @@ void ndpi_search_rtp(struct ndpi_detection_module_struct *ndpi_struct, struct nd
   
   /* printf("*** %s(pkt=%d)\n", __FUNCTION__, flow->packet_counter); */
 
-  if((packet->udp != NULL)
-     && (source != 30303) && (dest != 30303 /* Avoid to mix it with Ethereum that looks alike */)
+  if((source != 30303) && (dest != 30303 /* Avoid to mix it with Ethereum that looks alike */)
      && (dest > 1023)
      )
     ndpi_rtp_search(ndpi_struct, flow, packet->payload, packet->payload_packet_len);


### PR DESCRIPTION
Static analyzer complains about dereferencing `packet->udp` before checking.
Since this function is called only with UDP flows, remove the check.

Close: #1792