### PR TITLE
fuzz: add a new fuzzer testing memory allocation failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,11 @@
 /fuzz/Makefile
 /fuzz/fuzz_ndpi_reader
 /fuzz/fuzz_process_packet
+/fuzz/fuzz_ndpi_reader_alloc_fail
 /fuzz/fuzz_quic_get_crypto_data
+/fuzz/fuzz_ndpi_reader_alloc_fail_seed_corpus.zip
+/fuzz/fuzz_ndpi_reader_seed_corpus.zip
+/fuzz/fuzz_quic_get_crypto_data_seed_corpus.zip
 /influxdb/Makefile
 /install-sh
 /libndpi.pc

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,4 +1,4 @@
-bin_PROGRAMS = fuzz_process_packet fuzz_ndpi_reader fuzz_quic_get_crypto_data
+bin_PROGRAMS = fuzz_process_packet fuzz_ndpi_reader fuzz_ndpi_reader_alloc_fail fuzz_quic_get_crypto_data
 
 fuzz_process_packet_SOURCES = fuzz_process_packet.c
 fuzz_process_packet_CFLAGS = @NDPI_CFLAGS@ $(CXXFLAGS)
@@ -26,6 +26,19 @@ fuzz_ndpi_reader_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
     $(LIBTOOLFLAGS) --mode=link $(CXX) @NDPI_CFLAGS@ $(AM_CXXFLAGS) $(CXXFLAGS) \
     $(fuzz_ndpi_reader_LDFLAGS) @NDPI_LDFLAGS@ $(LDFLAGS) -o $@
 
+fuzz_ndpi_reader_alloc_fail_SOURCES = fuzz_ndpi_reader.c ../example/reader_util.c
+fuzz_ndpi_reader_alloc_fail_CFLAGS = -I../example/ @NDPI_CFLAGS@ $(CXXFLAGS) -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -DENABLE_MEM_ALLOC_FAILURES
+fuzz_ndpi_reader_alloc_fail_LDADD = ../src/lib/libndpi.a
+fuzz_ndpi_reader_alloc_fail_LDFLAGS = $(PCAP_LIB) $(ADDITIONAL_LIBS) $(LIBS)
+if HAS_FUZZLDFLAGS
+fuzz_ndpi_reader_alloc_fail_CFLAGS += $(LIB_FUZZING_ENGINE)
+fuzz_ndpi_reader_alloc_fail_LDFLAGS += $(LIB_FUZZING_ENGINE)
+endif
+# force usage of CXX for linker
+fuzz_ndpi_reader_alloc_fail_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+    $(LIBTOOLFLAGS) --mode=link $(CXX) @NDPI_CFLAGS@ $(AM_CXXFLAGS) $(CXXFLAGS) \
+    $(fuzz_ndpi_reader_alloc_fail_LDFLAGS) @NDPI_LDFLAGS@ $(LDFLAGS) -o $@
+
 fuzz_quic_get_crypto_data_SOURCES = fuzz_quic_get_crypto_data.c
 fuzz_quic_get_crypto_data_CFLAGS = @NDPI_CFLAGS@ $(CXXFLAGS)
 fuzz_quic_get_crypto_data_LDADD = ../src/lib/libndpi.a
@@ -46,15 +59,20 @@ testpcaps := $(wildcard ../tests/pcap/*.pcap*)
 fuzz_ndpi_reader_seed_corpus.zip: $(testpcaps)
 	zip -r fuzz_ndpi_reader_seed_corpus.zip $(testpcaps)
 
+fuzz_ndpi_reader_alloc_fail_seed_corpus.zip: $(testpcaps)
+	zip -r fuzz_ndpi_reader_alloc_fail_seed_corpus.zip $(testpcaps)
+
 files_corpus_fuzz_quic_get_crypto_data :=  $(wildcard corpus/fuzz_quic_get_crypto_data/*)
 
 fuzz_quic_get_crypto_data_seed_corpus.zip: $(files_corpus_fuzz_quic_get_crypto_data)
 	zip -r fuzz_quic_get_crypto_data_seed_corpus.zip $(files_corpus_fuzz_quic_get_crypto_data)
 
-corpus: fuzz_quic_get_crypto_data_seed_corpus.zip
+corpus: fuzz_ndpi_reader_seed_corpus.zip fuzz_ndpi_reader_alloc_fail_seed_corpus.zip fuzz_quic_get_crypto_data_seed_corpus.zip
 
 distdir:
 	find . -type d | xargs -I'{}' mkdir -p '$(distdir)/{}'
 	find . -type f -name '*.c' \
 		-o -name '*.am' \
 		-o -name '*.bin' | xargs -I'{}' cp '{}' '$(distdir)/{}'
+
+all: corpus

--- a/fuzz/fuzz_ndpi_reader.c
+++ b/fuzz/fuzz_ndpi_reader.c
@@ -23,6 +23,26 @@ int malloc_size_stats = 0;
 int max_malloc_bins = 0;
 struct ndpi_bin malloc_bins; /* unused */
 
+#ifdef ENABLE_MEM_ALLOC_FAILURES
+
+static int mem_alloc_state = 0;
+
+static int fastrand ()
+{
+  if(!mem_alloc_state) return 1; /* No failures */
+  mem_alloc_state = (214013 * mem_alloc_state + 2531011);
+  return (mem_alloc_state >> 16) & 0x7FFF;
+}
+
+static void *malloc_wrapper(size_t size) {
+  return (fastrand () % 16) ? malloc (size) : NULL;
+}
+static void free_wrapper(void *freeable) {
+  free(freeable);
+}
+
+#endif
+
 FILE *bufferToFile(const uint8_t *Data, size_t Size) {
   FILE *fd;
   fd = tmpfile();
@@ -71,7 +91,16 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     memset(workflow->stats.protocol_flows, 0,
 	   sizeof(workflow->stats.protocol_flows));
     ndpi_finalize_initialization(workflow->ndpi_struct);
+#ifdef ENABLE_MEM_ALLOC_FAILURES
+    set_ndpi_malloc(malloc_wrapper);
+    set_ndpi_free(free_wrapper);
+    /* Don't fail memory allocations until init phase is done */
+#endif
   }
+
+#ifdef ENABLE_MEM_ALLOC_FAILURES
+  mem_alloc_state = Size;
+#endif
 
   fd = bufferToFile(Data, Size);
   if (fd == NULL)
@@ -92,6 +121,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   workflow->pcap_handle = pkts;
   /* Init flow tree */
   workflow->ndpi_flows_root = ndpi_calloc(workflow->prefs.num_roots, sizeof(void *));
+  if(!workflow->ndpi_flows_root) {
+    pcap_close(pkts);
+    return 0;
+  }
 
   header = NULL;
   r = pcap_next_ex(pkts, &header, &pkt);

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -5100,11 +5100,10 @@ void ndpi_free_flow_data(struct ndpi_flow_struct* flow) {
     }
 
     if(flow->l4_proto == IPPROTO_UDP) {
-      if(flow->l4.udp.quic_reasm_buf){
+      if(flow->l4.udp.quic_reasm_buf)
         ndpi_free(flow->l4.udp.quic_reasm_buf);
-        if(flow->l4.udp.quic_reasm_buf_bitmap)
-          ndpi_free(flow->l4.udp.quic_reasm_buf_bitmap);
-      }
+      if(flow->l4.udp.quic_reasm_buf_bitmap)
+        ndpi_free(flow->l4.udp.quic_reasm_buf_bitmap);
     }
   }
 

--- a/src/lib/ndpi_serializer.c
+++ b/src/lib/ndpi_serializer.c
@@ -224,8 +224,10 @@ int ndpi_init_serializer_ll(ndpi_serializer *_serializer,
     /* nothing to do */
 
   } else if (fmt == ndpi_serialization_format_csv) {
-    if (ndpi_init_serializer_buffer(&serializer->header, NDPI_SERIALIZER_DEFAULT_HEADER_SIZE) != 0)
+    if (ndpi_init_serializer_buffer(&serializer->header, NDPI_SERIALIZER_DEFAULT_HEADER_SIZE) != 0) {
+      ndpi_term_serializer(_serializer);
       return(-1);
+    }
 
   } else /* ndpi_serialization_format_tlv */ {
     serializer->buffer.data[0]   = 1; /* version */

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -131,8 +131,9 @@ void * ndpi_tsearch(const void *vkey, void **vrootp,
     *rootp = q;			/* link new node to old */
     q->key = key;		/* initialize new node */
     q->left = q->right = (ndpi_node *)0;
+    return ((void *)q->key);
   }
-  return ((void *)q->key);
+  return ((void *)0);
 }
 
 /* ****************************************** */

--- a/src/lib/third_party/src/libcache.c
+++ b/src/lib/third_party/src/libcache.c
@@ -161,6 +161,11 @@ cache_result cache_add(cache_t cache, void *item, uint32_t item_size) {
 
 
   entry->item = ndpi_malloc(item_size);
+  if(!entry->item) {
+    ndpi_free(entry);
+    ndpi_free(map_entry);
+    return CACHE_MALLOC_ERROR;
+  }
   memcpy(entry->item, item, item_size);
   entry->item_size = item_size;
 


### PR DESCRIPTION
Try to fuzz error paths triggered by allocation errors.
Fix some errors already found by this new fuzzer.
Basic idea taken from: https://github.com/harfbuzz/harfbuzz/pull/2566/files

`FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION` is a standard define used to
(not)compile specific code in fuzzing builds.
See: https://llvm.org/docs/LibFuzzer.html
