### PR TITLE
Fix undefined-behavior when setting empty user-agent

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -9105,6 +9105,9 @@ char *ndpi_user_agent_set(struct ndpi_flow_struct *flow,
     /* Already set: ignore double set */
     return NULL;
   }
+  if(value_len == 0) {
+    return NULL;
+  }
 
   flow->http.user_agent = ndpi_malloc(value_len + 1);
   if(flow->http.user_agent != NULL) {


### PR DESCRIPTION
```
ndpi_main.c:9111:35: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ndpi_main.c:9111:35 in
```