### PR TITLE
fuzz: fix signed-integer-overflow

### DIFF
--- a/fuzz/fuzz_ndpi_reader.c
+++ b/fuzz/fuzz_ndpi_reader.c
@@ -27,6 +27,7 @@ struct ndpi_bin malloc_bins; /* unused */
 
 static int mem_alloc_state = 0;
 
+__attribute__((no_sanitize("integer")))
 static int fastrand ()
 {
   if(!mem_alloc_state) return 1; /* No failures */


### PR DESCRIPTION
```
fuzz_ndpi_reader.c:33:29: runtime error: signed integer overflow: 214013 * 24360337 cannot be represented in type 'int'
    #0 0x4c1cf7 in fastrand ndpi/fuzz/fuzz_ndpi_reader.c:33:29
    #1 0x4c1cf7 in malloc_wrapper ndpi/fuzz/fuzz_ndpi_reader.c:38:11
    #2 0x523057 in ndpi_malloc ndpi/src/lib/ndpi_main.c:220:25
```
Found by oss-fuzz
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54112