### PR TITLE
fuzz: some enhancements

### DIFF
--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = fuzz_process_packet fuzz_ndpi_reader fuzz_ndpi_reader_alloc_fail fuzz_quic_get_crypto_data
 
-fuzz_process_packet_SOURCES = fuzz_process_packet.c
+fuzz_process_packet_SOURCES = fuzz_process_packet.c fuzz_common_code.c
 fuzz_process_packet_CFLAGS = @NDPI_CFLAGS@ $(CXXFLAGS)
 fuzz_process_packet_LDADD = ../src/lib/libndpi.a
 fuzz_process_packet_LDFLAGS = $(ADDITIONAL_LIBS) $(LIBS)
@@ -39,7 +39,7 @@ fuzz_ndpi_reader_alloc_fail_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAG
     $(LIBTOOLFLAGS) --mode=link $(CXX) @NDPI_CFLAGS@ $(AM_CXXFLAGS) $(CXXFLAGS) \
     $(fuzz_ndpi_reader_alloc_fail_LDFLAGS) @NDPI_LDFLAGS@ $(LDFLAGS) -o $@
 
-fuzz_quic_get_crypto_data_SOURCES = fuzz_quic_get_crypto_data.c
+fuzz_quic_get_crypto_data_SOURCES = fuzz_quic_get_crypto_data.c fuzz_common_code.c
 fuzz_quic_get_crypto_data_CFLAGS = @NDPI_CFLAGS@ $(CXXFLAGS)
 fuzz_quic_get_crypto_data_LDADD = ../src/lib/libndpi.a
 fuzz_quic_get_crypto_data_LDFLAGS = $(ADDITIONAL_LIBS) $(LIBS)
@@ -57,15 +57,15 @@ fuzz_quic_get_crypto_data_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS)
 testpcaps := $(wildcard ../tests/pcap/*.pcap*)
 
 fuzz_ndpi_reader_seed_corpus.zip: $(testpcaps)
-	zip -r fuzz_ndpi_reader_seed_corpus.zip $(testpcaps)
+	zip -j fuzz_ndpi_reader_seed_corpus.zip $(testpcaps)
 
 fuzz_ndpi_reader_alloc_fail_seed_corpus.zip: $(testpcaps)
-	zip -r fuzz_ndpi_reader_alloc_fail_seed_corpus.zip $(testpcaps)
+	zip -j fuzz_ndpi_reader_alloc_fail_seed_corpus.zip $(testpcaps)
 
 files_corpus_fuzz_quic_get_crypto_data :=  $(wildcard corpus/fuzz_quic_get_crypto_data/*)
 
 fuzz_quic_get_crypto_data_seed_corpus.zip: $(files_corpus_fuzz_quic_get_crypto_data)
-	zip -r fuzz_quic_get_crypto_data_seed_corpus.zip $(files_corpus_fuzz_quic_get_crypto_data)
+	zip -j fuzz_quic_get_crypto_data_seed_corpus.zip $(files_corpus_fuzz_quic_get_crypto_data)
 
 corpus: fuzz_ndpi_reader_seed_corpus.zip fuzz_ndpi_reader_alloc_fail_seed_corpus.zip fuzz_quic_get_crypto_data_seed_corpus.zip
 
@@ -73,6 +73,7 @@ distdir:
 	find . -type d | xargs -I'{}' mkdir -p '$(distdir)/{}'
 	find . -type f -name '*.c' \
 		-o -name '*.am' \
+		-o -name '*.h' \
 		-o -name '*.bin' | xargs -I'{}' cp '{}' '$(distdir)/{}'
 
 all: corpus

--- a/fuzz/fuzz_common_code.c
+++ b/fuzz/fuzz_common_code.c
@@ -1,0 +1,31 @@
+
+#include "fuzz_common_code.h"
+
+void fuzz_init_detection_module(struct ndpi_detection_module_struct **ndpi_info_mod,
+				int enable_log)
+{
+  ndpi_init_prefs prefs = ndpi_enable_ja3_plus;
+  NDPI_PROTOCOL_BITMASK all, debug_bitmask;
+
+  if(*ndpi_info_mod == NULL) {
+    *ndpi_info_mod = ndpi_init_detection_module(prefs);
+    NDPI_BITMASK_SET_ALL(all);
+    ndpi_set_protocol_detection_bitmask2(*ndpi_info_mod, &all);
+
+    if(enable_log) {
+      NDPI_BITMASK_SET_ALL(debug_bitmask);
+      ndpi_set_log_level(*ndpi_info_mod, 4);
+      ndpi_set_debug_bitmask(*ndpi_info_mod, debug_bitmask);
+    }
+
+    ndpi_load_protocols_file(*ndpi_info_mod, "protos.txt");
+    ndpi_load_categories_file(*ndpi_info_mod, "categories.txt", NULL);
+    ndpi_load_risk_domain_file(*ndpi_info_mod, "risky_domains.txt");
+    ndpi_load_malicious_ja3_file(*ndpi_info_mod, "ja3_fingerprints.csv");
+    ndpi_load_malicious_sha1_file(*ndpi_info_mod, "sha1_fingerprints.csv");
+
+    ndpi_finalize_initialization(*ndpi_info_mod);
+  }
+}
+
+

--- a/fuzz/fuzz_common_code.h
+++ b/fuzz/fuzz_common_code.h
@@ -1,0 +1,9 @@
+#ifndef __FUZZ_COMMON_CODE_H__
+#define __FUZZ_COMMON_CODE_H__
+
+#include "ndpi_api.h"
+
+void fuzz_init_detection_module(struct ndpi_detection_module_struct **ndpi_info_mod,
+				int enable_log);
+
+#endif

--- a/fuzz/fuzz_ndpi_reader.c
+++ b/fuzz/fuzz_ndpi_reader.c
@@ -85,6 +85,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     // enable all protocols
     NDPI_BITMASK_SET_ALL(all);
     ndpi_set_protocol_detection_bitmask2(workflow->ndpi_struct, &all);
+
+    ndpi_load_protocols_file(workflow->ndpi_struct, "protos.txt");
+    ndpi_load_categories_file(workflow->ndpi_struct, "categories.txt", NULL);
+    ndpi_load_risk_domain_file(workflow->ndpi_struct, "risky_domains.txt");
+    ndpi_load_malicious_ja3_file(workflow->ndpi_struct, "ja3_fingerprints.csv");
+    ndpi_load_malicious_sha1_file(workflow->ndpi_struct, "sha1_fingerprints.csv");
+
     memset(workflow->stats.protocol_counter, 0,
 	   sizeof(workflow->stats.protocol_counter));
     memset(workflow->stats.protocol_counter_bytes, 0,

--- a/fuzz/fuzz_process_packet.c
+++ b/fuzz/fuzz_process_packet.c
@@ -1,4 +1,5 @@
 #include "ndpi_api.h"
+#include "fuzz_common_code.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -11,14 +12,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   uint8_t protocol_was_guessed;
 
   if (ndpi_info_mod == NULL) {
-    ndpi_info_mod = ndpi_init_detection_module(ndpi_enable_ja3_plus);
-    NDPI_PROTOCOL_BITMASK all, debug_bitmask;
-    NDPI_BITMASK_SET_ALL(all);
-    NDPI_BITMASK_SET_ALL(debug_bitmask);
-    ndpi_set_protocol_detection_bitmask2(ndpi_info_mod, &all);
-    ndpi_set_log_level(ndpi_info_mod, 4);
-    ndpi_set_debug_bitmask(ndpi_info_mod, debug_bitmask);
-    ndpi_finalize_initialization(ndpi_info_mod);
+    fuzz_init_detection_module(&ndpi_info_mod, 0);
+
     ndpi_init_serializer(&json_serializer, ndpi_serialization_format_json);
     ndpi_init_serializer(&csv_serializer, ndpi_serialization_format_csv);
   }

--- a/fuzz/fuzz_quic_get_crypto_data.c
+++ b/fuzz/fuzz_quic_get_crypto_data.c
@@ -1,4 +1,5 @@
 #include "ndpi_api.h"
+#include "fuzz_common_code.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -27,17 +28,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   u_int32_t first_int, version = 0;
 
   if(ndpi_info_mod == NULL) {
-    ndpi_info_mod = ndpi_init_detection_module(ndpi_enable_ja3_plus);
-    NDPI_PROTOCOL_BITMASK all;
-    NDPI_BITMASK_SET_ALL(all);
-    ndpi_set_protocol_detection_bitmask2(ndpi_info_mod, &all);
-#if 0
-    NDPI_PROTOCOL_BITMASK debug_bitmask;
-    NDPI_BITMASK_SET_ALL(debug_bitmask);
-    ndpi_set_log_level(ndpi_info_mod, 4);
-    ndpi_set_debug_bitmask(ndpi_info_mod, debug_bitmask);
-#endif
-    ndpi_finalize_initialization(ndpi_info_mod);
+    fuzz_init_detection_module(&ndpi_info_mod, 0);
 
     flow = ndpi_calloc(1, SIZEOF_FLOW_STRUCT);
   }

--- a/src/lib/protocols/ajp.c
+++ b/src/lib/protocols/ajp.c
@@ -116,10 +116,6 @@ void ndpi_search_ajp(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
-    return;
-  }
-
   NDPI_LOG_DBG(ndpi_struct, "search AJP\n");
   ndpi_check_ajp(ndpi_struct, flow);
 

--- a/src/lib/protocols/amqp.c
+++ b/src/lib/protocols/amqp.c
@@ -68,8 +68,6 @@ void ndpi_search_amqp(struct ndpi_detection_module_struct *ndpi_struct, struct n
 				}
 			}
 		}
-	} else {
-		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 	}
 }
 

--- a/src/lib/protocols/coap.c
+++ b/src/lib/protocols/coap.c
@@ -109,10 +109,6 @@ void ndpi_search_coap (struct ndpi_detection_module_struct *ndpi_struct,
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   struct ndpi_coap_hdr * h = (struct ndpi_coap_hdr*) packet->payload;
 
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
-    return;
-  }
-
   // search for udp packet
   if(packet->udp != NULL) {
     u_int16_t s_port = ntohs(packet->udp->source);

--- a/src/lib/protocols/corba.c
+++ b/src/lib/protocols/corba.c
@@ -42,8 +42,6 @@ void ndpi_search_corba(struct ndpi_detection_module_struct *ndpi_struct, struct 
       NDPI_LOG_INFO(ndpi_struct, "found corba\n");
       ndpi_int_corba_add_connection(ndpi_struct, flow);
     }
-  } else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/dhcp.c
+++ b/src/lib/protocols/dhcp.c
@@ -186,8 +186,7 @@ void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struct,
         }
       }
     }
-  } else
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  }
 }
 
 

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -238,12 +238,8 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
   if((dns_header->flags & FLAGS_MASK) == 0x0000)
     *is_query = 1;
   /* 0x8000 RESPONSE */
-  else if((dns_header->flags & FLAGS_MASK) == 0x8000)
+  else
     *is_query = 0;
-  else {
-    ndpi_set_risk(ndpi_struct, flow, NDPI_MALFORMED_PACKET, "Invalid DNS Flags");
-    return(1 /* invalid */);
-  }
 
   if(*is_query) {
     /* DNS Request */
@@ -448,9 +444,6 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
     s_port = ntohs(packet->tcp->source);
     d_port = ntohs(packet->tcp->dest);
     payload_offset = 2;
-  } else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-    return;
   }
 
   if(((s_port == DNS_PORT) || (d_port == DNS_PORT)

--- a/src/lib/protocols/eaq.c
+++ b/src/lib/protocols/eaq.c
@@ -41,15 +41,7 @@ static void ndpi_int_eaq_add_connection(struct ndpi_detection_module_struct *ndp
 
 
 void ndpi_search_eaq(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
-  if (!flow) {
-    return;
-  }
-
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
-  if (!packet) {
-    return;
-  }
-
   u_int16_t sport = ntohs(packet->udp->source), dport = ntohs(packet->udp->dest);
   
   NDPI_LOG_DBG(ndpi_struct, "search eaq\n");

--- a/src/lib/protocols/lotus_notes.c
+++ b/src/lib/protocols/lotus_notes.c
@@ -30,10 +30,7 @@ static void ndpi_check_lotus_notes(struct ndpi_detection_module_struct *ndpi_str
 				   struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
-  // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
-
-  if(packet->tcp == NULL)  return;
 
   flow->l4.tcp.lotus_notes_packet_id++;
   
@@ -58,9 +55,7 @@ void ndpi_search_lotus_notes(struct ndpi_detection_module_struct *ndpi_struct, s
 {
   NDPI_LOG_DBG(ndpi_struct, "search lotus_notes\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_LOTUS_NOTES)
-    ndpi_check_lotus_notes(ndpi_struct, flow);
+  ndpi_check_lotus_notes(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/memcached.c
+++ b/src/lib/protocols/memcached.c
@@ -106,7 +106,7 @@ void ndpi_search_memcached(
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   const u_int8_t *offset = packet->payload;
   u_int16_t length = packet->payload_packet_len;
-  u_int8_t *matches;
+  u_int8_t *matches = NULL;
 
   NDPI_LOG_DBG(ndpi_struct, "search memcached\n");
 
@@ -133,10 +133,6 @@ void ndpi_search_memcached(
     offset += MEMCACHED_UDP_HDR_LEN;
     length -= MEMCACHED_UDP_HDR_LEN;
     matches = &flow->l4.udp.memcached_matches;
-  }
-  else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-    return;
   }
 
   /* grep MCD memcached.c |\

--- a/src/lib/protocols/mongodb.c
+++ b/src/lib/protocols/mongodb.c
@@ -128,10 +128,6 @@ void ndpi_search_mongodb(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
-    return;
-  }
-
   NDPI_LOG_DBG(ndpi_struct, "search MongoDB\n");
   ndpi_check_mongodb(ndpi_struct, flow);
 

--- a/src/lib/protocols/oracle.c
+++ b/src/lib/protocols/oracle.c
@@ -56,8 +56,6 @@ void ndpi_search_oracle(struct ndpi_detection_module_struct *ndpi_struct, struct
       NDPI_LOG_INFO(ndpi_struct, "found oracle\n");
       ndpi_int_oracle_add_connection(ndpi_struct, flow);
     }
-  } else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/redis_net.c
+++ b/src/lib/protocols/redis_net.c
@@ -32,10 +32,7 @@ static void ndpi_int_redis_add_connection(struct ndpi_detection_module_struct *n
 
 static void ndpi_check_redis(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
-  u_int32_t payload_len = packet->payload_packet_len;
   
-  if(payload_len == 0) return; /* Shouldn't happen */
-
   /* Break after 20 packets. */
   if(flow->packet_counter > 20) {
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);

--- a/src/lib/protocols/rtcp.c
+++ b/src/lib/protocols/rtcp.c
@@ -45,9 +45,10 @@ void ndpi_search_rtcp(struct ndpi_detection_module_struct *ndpi_struct,
       len = packet->payload[2+offset] * 256 + packet->payload[2+offset+1];
       rtcp_section_len = (len + 1) * 4;
       
-      if(((offset+rtcp_section_len) > packet->payload_packet_len) || (rtcp_section_len == 0) || (len == 0))
-	goto exclude_rtcp;
-      else
+      if(((offset+rtcp_section_len) > packet->payload_packet_len) || (rtcp_section_len == 0) || (len == 0)) {
+        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	return;
+      } else
 	offset += rtcp_section_len;
     }
     
@@ -63,10 +64,6 @@ void ndpi_search_rtcp(struct ndpi_detection_module_struct *ndpi_struct,
 
     if(flow->packet_counter > 3)
       NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-  } else {
-  exclude_rtcp:
-    
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 

--- a/src/lib/protocols/rtp.c
+++ b/src/lib/protocols/rtp.c
@@ -114,6 +114,7 @@ static u_int8_t isZoom(u_int16_t sport, u_int16_t dport,
 		       u_int16_t *payload_offset) {
   u_int16_t header_offset = sizeof(struct zoom_sfu_encapsulation) + sizeof(struct zoom_media_encapsulation);
 
+  *payload_offset = 0;
   if(payloadLen < header_offset)
     return(0);
 

--- a/src/lib/protocols/sip.c
+++ b/src/lib/protocols/sip.c
@@ -185,12 +185,6 @@ void ndpi_search_sip_handshake(struct ndpi_detection_module_struct
     return;
   }
 
-  /* for STUN flows we need some more packets */
-  if(packet->udp != NULL && flow->detected_protocol_stack[0] == NDPI_PROTOCOL_STUN && flow->packet_counter < 40) {
-    NDPI_LOG_DBG2(ndpi_struct, "need next STUN packet\n");
-    return;
-  }
-
   if(payload_len == 4 && get_u_int32_t(packet_payload, 0) == 0) {
     NDPI_LOG_DBG2(ndpi_struct, "maybe sip. need next packet\n");
     return;
@@ -203,10 +197,7 @@ void ndpi_search_sip(struct ndpi_detection_module_struct *ndpi_struct, struct nd
 {
   NDPI_LOG_DBG(ndpi_struct, "search sip\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SIP) {
-    ndpi_search_sip_handshake(ndpi_struct, flow);
-  }
+  ndpi_search_sip_handshake(ndpi_struct, flow);
 }
 
 void init_sip_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id, NDPI_PROTOCOL_BITMASK *detection_bitmask)

--- a/src/lib/protocols/someip.c
+++ b/src/lib/protocols/someip.c
@@ -108,21 +108,12 @@ void ndpi_search_someip (struct ndpi_detection_module_struct *ndpi_struct,
 
   NDPI_LOG_DBG(ndpi_struct, "search SOME/IP\n");
 
-  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN) {
-    return;
-  }
- 
   //we extract the Message ID and Request ID and check for special cases later
   u_int32_t message_id = ntohl(someip_data_cover_32(&packet->payload[0]));
   u_int32_t request_id = ntohl(someip_data_cover_32(&packet->payload[8]));
 
   NDPI_LOG_DBG2(ndpi_struct, "====>>>> SOME/IP Message ID: %08x [len: %u]\n",
 	   message_id, packet->payload_packet_len);
-  if (packet->payload_packet_len < 16) {
-    NDPI_LOG_DBG(ndpi_struct, "Excluding SOME/IP .. mandatory header not found\n");
-    NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_SOMEIP);
-    return;
-  }
 
   //####Maximum packet size in SOMEIP depends on the carrier protocol, and I'm not certain how well enforced it is, so let's leave that for round 2####
 

--- a/src/lib/protocols/teamviewer.c
+++ b/src/lib/protocols/teamviewer.c
@@ -63,8 +63,6 @@ void ndpi_search_teamview(struct ndpi_detection_module_struct *ndpi_struct, stru
     }
   }
 
-  if(packet->payload_packet_len == 0) return;
-
   if (packet->udp != NULL) {
     if (packet->payload_packet_len > 13) {
       if (packet->payload[0] == 0x00 && packet->payload[11] == 0x17 && packet->payload[12] == 0x24) { /* byte 0 is a counter/seq number, and at the start is 0 */

--- a/src/lib/protocols/vhua.c
+++ b/src/lib/protocols/vhua.c
@@ -39,10 +39,7 @@ static void ndpi_int_vhua_add_connection(struct ndpi_detection_module_struct *nd
 
 static void ndpi_check_vhua(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
-  u_int32_t payload_len = packet->payload_packet_len;
   u_char p0[] =  { 0x05, 0x14, 0x3a, 0x05, 0x08, 0xf8, 0xa1, 0xb1, 0x03 };
-
-  if(payload_len == 0) return; /* Shouldn't happen */
 
   /* Break after 3 packets. */
   if((flow->packet_counter > 3)

--- a/src/lib/protocols/websocket.c
+++ b/src/lib/protocols/websocket.c
@@ -102,11 +102,6 @@ void ndpi_search_websocket(struct ndpi_detection_module_struct *ndpi_struct, str
       return;
     }
 
-  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_UNKNOWN)
-    {
-      return;
-    }
-
   NDPI_LOG_DBG(ndpi_struct, "search WEBSOCKET\n");
   ndpi_check_websocket(ndpi_struct, flow);
 

--- a/src/lib/protocols/zeromq.c
+++ b/src/lib/protocols/zeromq.c
@@ -37,8 +37,6 @@ static void ndpi_check_zmq(struct ndpi_detection_module_struct *ndpi_struct, str
   u_char p1[] =  { 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x7f };
   u_char p2[] =  { 0x28, 0x66, 0x6c, 0x6f, 0x77, 0x00 };
 
-  if(payload_len == 0) return; /* Shouldn't happen */
-
   /* Break after 17 packets. */
   if(flow->packet_counter > 17) {
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);

--- a/tests/do.sh.in
+++ b/tests/do.sh.in
@@ -51,7 +51,13 @@ fi
 
 fuzzy_testing() {
     if [ -f ../fuzz/fuzz_ndpi_reader ]; then
+	cp ../example/protos.txt .
+	cp ../example/categories.txt .
+	cp ../example/risky_domains.txt .
+	cp ../example/ja3_fingerprints.csv .
+	cp ../example/sha1_fingerprints.csv .
 	../fuzz/fuzz_ndpi_reader -max_total_time="${MAX_TOTAL_TIME:-592}" -print_pcs=1 -workers="${FUZZY_WORKERS:-0}" -jobs="${FUZZY_JOBS:-0}" pcap/
+	rm -f protos.txt categories.txt risky_domains.txt ja3_fingerprints.csv sha1_fingerprints.csv
     fi
 }
 


### PR DESCRIPTION
Load some custom configuration (like in the unit tests) and factorize some (fuzzing) common code.

There is no way to pass file paths to the fuzzers as parameters. The safe solution seems to be to load them from the process working dir. Anyway, missing file is not a blocking error.

Remove some dead code (found looking at the coverage report)