### PR TITLE
Remove any references to LGTM

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@ EXTRA_DIST = README.md README.fuzzer.md CHANGELOG.md CONTRIBUTING.md \
 	python/DEV_GUIDE.md python/dev_requirements.txt python/ndpi_example.py python/ndpi/__init__.py \
 		python/ndpi/ndpi_build.py python/ndpi/ndpi.py python/README.md \
 		python/requirements.txt python/setup.py python/tests.py \
-	sonar-project.properties .github .ci-ignore lgtm.yml
+	sonar-project.properties .github .ci-ignore
 
 
 .PHONY: doc doc-view

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 # nDPI
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/ntop/nDPI/build.yml?branch=dev&logo=github)](https://github.com/ntop/nDPI/actions?query=workflow%3ABuild)
-[![Code Quality: Cpp](https://img.shields.io/lgtm/grade/cpp/g/ntop/nDPI.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ntop/nDPI/context:cpp)
-[![Total Alerts](https://img.shields.io/lgtm/alerts/g/ntop/nDPI.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ntop/nDPI/alerts)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/ndpi.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:ndpi)
 
 ## What is nDPI ?

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,2 +1,0 @@
-queries:
-  - exclude: cpp/cleartext-storage-file


### PR DESCRIPTION
LGTM.com service has been discontinued.
See: https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/