### PR TITLE
LRU caches: add a generic (optional and configurable) expiration logic

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -2477,9 +2477,10 @@ static void setupDetection(u_int16_t thread_id, pcap_t * pcap_handle) {
   if(_maliciousSHA1Path)
     ndpi_load_malicious_sha1_file(ndpi_thread_info[thread_id].workflow->ndpi_struct, _maliciousSHA1Path);
 
-  /* Enable/disable/configure LRU caches here */
+  /* Enable/disable/configure LRU caches size here */
   ndpi_set_lru_cache_size(ndpi_thread_info[thread_id].workflow->ndpi_struct,
 			  NDPI_LRUCACHE_BITTORRENT, 32768);
+  /* Enable/disable LRU caches TTL here */
 
   ndpi_finalize_initialization(ndpi_thread_info[thread_id].workflow->ndpi_struct);
 

--- a/fuzz/fuzz_config.cpp
+++ b/fuzz/fuzz_config.cpp
@@ -23,7 +23,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if(fuzzed_data.remaining_bytes() < 4 + /* ndpi_init_detection_module() */
 				     NDPI_MAX_SUPPORTED_PROTOCOLS + NDPI_MAX_NUM_CUSTOM_PROTOCOLS +
 				     5 + /* files */
-				     (NDPI_LRUCACHE_MAX * 3) + /* LRU caches */
+				     (NDPI_LRUCACHE_MAX * 5) + /* LRU caches */
 				     2 + 1 + 4 + /* ndpi_set_detection_preferences() */
 				     7 + /* Opportunistic tls */
 				     29 /* Min real data: ip length + udp length + 1 byte */)
@@ -60,8 +60,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   for(i = 0; i < NDPI_LRUCACHE_MAX; i++) {
     ndpi_set_lru_cache_size(ndpi_info_mod, static_cast<lru_cache_type>(i),
-			    fuzzed_data.ConsumeIntegralInRange(0, (1 << 24) - 1));
+			    fuzzed_data.ConsumeIntegralInRange(0, (1 << 16) - 1));
     ndpi_get_lru_cache_size(ndpi_info_mod, static_cast<lru_cache_type>(i), &num);
+
+    ndpi_set_lru_cache_ttl(ndpi_info_mod, static_cast<lru_cache_type>(i),
+			   fuzzed_data.ConsumeIntegralInRange(0, (1 << 24) - 1));
+    ndpi_get_lru_cache_ttl(ndpi_info_mod, static_cast<lru_cache_type>(i), &num);
   }
 
   if(fuzzed_data.ConsumeBool())

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -993,11 +993,11 @@ extern "C" {
   void ndpi_set_debug_bitmask(struct ndpi_detection_module_struct *ndpi_mod, NDPI_PROTOCOL_BITMASK debug_bitmask);
 
   /* LRU cache */
-  struct ndpi_lru_cache* ndpi_lru_cache_init(u_int32_t num_entries);
+  struct ndpi_lru_cache* ndpi_lru_cache_init(u_int32_t num_entries, u_int32_t ttl);
   void ndpi_lru_free_cache(struct ndpi_lru_cache *c);
   u_int8_t ndpi_lru_find_cache(struct ndpi_lru_cache *c, u_int32_t key,
-			       u_int16_t *value, u_int8_t clean_key_when_found);
-  void ndpi_lru_add_to_cache(struct ndpi_lru_cache *c, u_int32_t key, u_int16_t value);
+			       u_int16_t *value, u_int8_t clean_key_when_found, u_int32_t now_sec);
+  void ndpi_lru_add_to_cache(struct ndpi_lru_cache *c, u_int32_t key, u_int16_t value, u_int32_t now_sec);
   void ndpi_lru_get_stats(struct ndpi_lru_cache *c, struct ndpi_lru_cache_stats *stats);
 
   int ndpi_get_lru_cache_stats(struct ndpi_detection_module_struct *ndpi_struct,
@@ -1010,6 +1010,13 @@ extern "C" {
   int ndpi_set_lru_cache_size(struct ndpi_detection_module_struct *ndpi_struct,
 			      lru_cache_type cache_type,
 			      u_int32_t num_entries);
+
+  int ndpi_set_lru_cache_ttl(struct ndpi_detection_module_struct *ndpi_struct,
+			     lru_cache_type cache_type,
+			     u_int32_t ttl);
+  int ndpi_get_lru_cache_ttl(struct ndpi_detection_module_struct *ndpi_struct,
+			     lru_cache_type cache_type,
+			     u_int32_t *ttl);
 
   int ndpi_set_opportunistic_tls(struct ndpi_detection_module_struct *ndpi_struct,
 				 u_int16_t proto, int value);

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -992,6 +992,9 @@ extern "C" {
   void ndpi_set_log_level(struct ndpi_detection_module_struct *ndpi_mod, u_int l);
   void ndpi_set_debug_bitmask(struct ndpi_detection_module_struct *ndpi_mod, NDPI_PROTOCOL_BITMASK debug_bitmask);
 
+  /* Simple helper to get current time, in sec */
+  u_int32_t ndpi_get_current_time(struct ndpi_flow_struct *flow);
+
   /* LRU cache */
   struct ndpi_lru_cache* ndpi_lru_cache_init(u_int32_t num_entries, u_int32_t ttl);
   void ndpi_lru_free_cache(struct ndpi_lru_cache *c);

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -641,6 +641,7 @@ typedef enum {
 struct ndpi_lru_cache_entry {
   u_int32_t key; /* Store the whole key to avoid ambiguities */
   u_int32_t is_full:1, value:16, pad:15;
+  u_int32_t timestamp; /* sec */
 };
 
 struct ndpi_lru_cache_stats {
@@ -651,6 +652,7 @@ struct ndpi_lru_cache_stats {
 
 struct ndpi_lru_cache {
   u_int32_t num_entries;
+  u_int32_t ttl;
   struct ndpi_lru_cache_stats stats;
   struct ndpi_lru_cache_entry *entries;
 };
@@ -1187,32 +1189,40 @@ struct ndpi_detection_module_struct {
   /* NDPI_PROTOCOL_OOKLA */
   struct ndpi_lru_cache *ookla_cache;
   u_int32_t ookla_cache_num_entries;
+  u_int32_t ookla_cache_ttl;
 
   /* NDPI_PROTOCOL_BITTORRENT */
   struct ndpi_lru_cache *bittorrent_cache;
   u_int32_t bittorrent_cache_num_entries;
+  u_int32_t bittorrent_cache_ttl;
 
   /* NDPI_PROTOCOL_ZOOM */
   struct ndpi_lru_cache *zoom_cache;
   u_int32_t zoom_cache_num_entries;
+  u_int32_t zoom_cache_ttl;
 
   /* NDPI_PROTOCOL_STUN and subprotocols */
   struct ndpi_lru_cache *stun_cache;
   u_int32_t stun_cache_num_entries;
+  u_int32_t stun_cache_ttl;
   struct ndpi_lru_cache *stun_zoom_cache;
   u_int32_t stun_zoom_cache_num_entries;
+  u_int32_t stun_zoom_cache_ttl;
 
   /* NDPI_PROTOCOL_TLS and subprotocols */
   struct ndpi_lru_cache *tls_cert_cache;
   u_int32_t tls_cert_cache_num_entries;
+  int32_t tls_cert_cache_ttl;
   
   /* NDPI_PROTOCOL_MINING and subprotocols */
   struct ndpi_lru_cache *mining_cache;
   u_int32_t mining_cache_num_entries;
+  u_int32_t mining_cache_ttl;
 
   /* NDPI_PROTOCOL_MSTEAMS */
   struct ndpi_lru_cache *msteams_cache;
   u_int32_t msteams_cache_num_entries;
+  u_int32_t msteams_cache_ttl;
 
   /* *** If you add a new LRU cache, please update lru_cache_type above! *** */
 

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -2864,6 +2864,15 @@ struct ndpi_detection_module_struct *ndpi_init_detection_module(ndpi_init_prefs 
   ndpi_str->msteams_cache_num_entries = 1024;
   ndpi_str->stun_zoom_cache_num_entries = 1024;
 
+  ndpi_str->ookla_cache_ttl = 0;
+  ndpi_str->bittorrent_cache_ttl = 0;
+  ndpi_str->zoom_cache_ttl = 0;
+  ndpi_str->stun_cache_ttl = 0;
+  ndpi_str->tls_cert_cache_ttl = 0;
+  ndpi_str->mining_cache_ttl = 0;
+  ndpi_str->msteams_cache_ttl = 60; /* sec */
+  ndpi_str->stun_zoom_cache_ttl = 60; /* sec */
+
   ndpi_str->opportunistic_tls_smtp_enabled = 1;
   ndpi_str->opportunistic_tls_imap_enabled = 1;
   ndpi_str->opportunistic_tls_pop_enabled = 1;
@@ -2932,56 +2941,64 @@ void ndpi_finalize_initialization(struct ndpi_detection_module_struct *ndpi_str)
   ndpi_add_domain_risk_exceptions(ndpi_str);
 
   if(ndpi_str->ookla_cache_num_entries > 0) {
-    ndpi_str->ookla_cache = ndpi_lru_cache_init(ndpi_str->ookla_cache_num_entries);
+    ndpi_str->ookla_cache = ndpi_lru_cache_init(ndpi_str->ookla_cache_num_entries,
+                                                ndpi_str->ookla_cache_ttl);
     if(!ndpi_str->ookla_cache) {
       NDPI_LOG_ERR(ndpi_str, "Error allocating lru cache (num_entries %u)\n",
                    ndpi_str->ookla_cache_num_entries);
     }
   }
   if(ndpi_str->bittorrent_cache_num_entries > 0) {
-    ndpi_str->bittorrent_cache = ndpi_lru_cache_init(ndpi_str->bittorrent_cache_num_entries);
+    ndpi_str->bittorrent_cache = ndpi_lru_cache_init(ndpi_str->bittorrent_cache_num_entries,
+                                                     ndpi_str->bittorrent_cache_ttl);
     if(!ndpi_str->bittorrent_cache) {
       NDPI_LOG_ERR(ndpi_str, "Error allocating lru cache (num_entries %u)\n",
                    ndpi_str->bittorrent_cache_num_entries);
     }
   }
   if(ndpi_str->zoom_cache_num_entries > 0) {
-    ndpi_str->zoom_cache = ndpi_lru_cache_init(ndpi_str->zoom_cache_num_entries);
+    ndpi_str->zoom_cache = ndpi_lru_cache_init(ndpi_str->zoom_cache_num_entries,
+                                               ndpi_str->zoom_cache_ttl);
     if(!ndpi_str->zoom_cache) {
       NDPI_LOG_ERR(ndpi_str, "Error allocating lru cache (num_entries %u)\n",
                    ndpi_str->zoom_cache_num_entries);
     }
   }
   if(ndpi_str->stun_cache_num_entries > 0) {
-    ndpi_str->stun_cache = ndpi_lru_cache_init(ndpi_str->stun_cache_num_entries);
+    ndpi_str->stun_cache = ndpi_lru_cache_init(ndpi_str->stun_cache_num_entries,
+                                               ndpi_str->stun_cache_ttl);
     if(!ndpi_str->stun_cache) {
       NDPI_LOG_ERR(ndpi_str, "Error allocating lru cache (num_entries %u)\n",
                    ndpi_str->stun_cache_num_entries);
     }
   }
   if(ndpi_str->tls_cert_cache_num_entries > 0) {
-    ndpi_str->tls_cert_cache = ndpi_lru_cache_init(ndpi_str->tls_cert_cache_num_entries);
+    ndpi_str->tls_cert_cache = ndpi_lru_cache_init(ndpi_str->tls_cert_cache_num_entries,
+                                                   ndpi_str->tls_cert_cache_ttl);
     if(!ndpi_str->tls_cert_cache) {
       NDPI_LOG_ERR(ndpi_str, "Error allocating lru cache (num_entries %u)\n",
                    ndpi_str->tls_cert_cache_num_entries);
     }
   }
   if(ndpi_str->mining_cache_num_entries > 0) {
-    ndpi_str->mining_cache = ndpi_lru_cache_init(ndpi_str->mining_cache_num_entries);
+    ndpi_str->mining_cache = ndpi_lru_cache_init(ndpi_str->mining_cache_num_entries,
+                                                 ndpi_str->mining_cache_ttl);
     if(!ndpi_str->mining_cache) {
       NDPI_LOG_ERR(ndpi_str, "Error allocating lru cache (num_entries %u)\n",
                    ndpi_str->mining_cache_num_entries);
     }
   }
   if(ndpi_str->msteams_cache_num_entries > 0) {
-    ndpi_str->msteams_cache = ndpi_lru_cache_init(ndpi_str->msteams_cache_num_entries);
+    ndpi_str->msteams_cache = ndpi_lru_cache_init(ndpi_str->msteams_cache_num_entries,
+                                                  ndpi_str->msteams_cache_ttl);
     if(!ndpi_str->msteams_cache) {
       NDPI_LOG_ERR(ndpi_str, "Error allocating lru cache (num_entries %u)\n",
                    ndpi_str->msteams_cache_num_entries);
     }
   }
   if(ndpi_str->stun_zoom_cache_num_entries > 0) {
-    ndpi_str->stun_zoom_cache = ndpi_lru_cache_init(ndpi_str->stun_zoom_cache_num_entries);
+    ndpi_str->stun_zoom_cache = ndpi_lru_cache_init(ndpi_str->stun_zoom_cache_num_entries,
+                                                    ndpi_str->stun_zoom_cache_ttl);
     if(!ndpi_str->stun_zoom_cache) {
       NDPI_LOG_ERR(ndpi_str, "Error allocating lru cache (num_entries %u)\n",
                    ndpi_str->stun_zoom_cache_num_entries);
@@ -5806,7 +5823,8 @@ static void ndpi_reconcile_protocols(struct ndpi_detection_module_struct *ndpi_s
       if(ndpi_str->msteams_cache)
 	ndpi_lru_add_to_cache(ndpi_str->msteams_cache,
 			      make_msteams_key(flow),
-			      (flow->last_packet_time_ms / 1000) & 0xFFFF /* 16 bit */);
+			      0 /* dummy */,
+			      flow->last_packet_time_ms / 1000);
     }
     break;
 
@@ -5827,21 +5845,18 @@ static void ndpi_reconcile_protocols(struct ndpi_detection_module_struct *ndpi_s
   case NDPI_PROTOCOL_SKYPE_TEAMS_CALL:
     if(flow->l4_proto == IPPROTO_UDP
        && ndpi_str->msteams_cache) {
-      u_int16_t when;
+      u_int16_t dummy;
 
       if(ndpi_lru_find_cache(ndpi_str->msteams_cache, make_msteams_key(flow),
-			     &when, 0 /* Don't remove it as it can be used for other connections */)) {
-	u_int16_t tdiff = ((flow->last_packet_time_ms /1000) & 0xFFFF) - when;
-
-	if(tdiff < 60 /* sec */) {
-	  // printf("====>> NDPI_PROTOCOL_SKYPE(_CALL) -> NDPI_PROTOCOL_MSTEAMS [%u]\n", tdiff);
+			     &dummy, 0 /* Don't remove it as it can be used for other connections */,
+			     flow->last_packet_time_ms / 1000)) {
 	  ret->app_protocol = NDPI_PROTOCOL_MSTEAMS;
 
 	  /* Refresh cache */
 	  ndpi_lru_add_to_cache(ndpi_str->msteams_cache,
 				make_msteams_key(flow),
-				(flow->last_packet_time_ms / 1000) & 0xFFFF /* 16 bit */);
-	}
+				0 /* dummy */,
+				flow->last_packet_time_ms / 1000);
       }
     }
     break;
@@ -5906,9 +5921,9 @@ int ndpi_search_into_bittorrent_cache(struct ndpi_detection_module_struct *ndpi_
     key1 = ndpi_ip_port_hash_funct(saddr, sport), key2 = ndpi_ip_port_hash_funct(daddr, dport);
 
     found =
-      ndpi_lru_find_cache(ndpi_struct->bittorrent_cache, saddr+daddr, &cached_proto, 0 /* Don't remove it as it can be used for other connections */)
-      || ndpi_lru_find_cache(ndpi_struct->bittorrent_cache, key1, &cached_proto, 0     /* Don't remove it as it can be used for other connections */)
-      || ndpi_lru_find_cache(ndpi_struct->bittorrent_cache, key2, &cached_proto, 0     /* Don't remove it as it can be used for other connections */);
+      ndpi_lru_find_cache(ndpi_struct->bittorrent_cache, saddr+daddr, &cached_proto, 0 /* Don't remove it as it can be used for other connections */, flow->last_packet_time_ms / 1000)
+      || ndpi_lru_find_cache(ndpi_struct->bittorrent_cache, key1, &cached_proto, 0     /* Don't remove it as it can be used for other connections */, flow->last_packet_time_ms / 1000)
+      || ndpi_lru_find_cache(ndpi_struct->bittorrent_cache, key2, &cached_proto, 0     /* Don't remove it as it can be used for other connections */, flow->last_packet_time_ms / 1000);
 
 #ifdef BITTORRENT_CACHE_DEBUG
     if(ndpi_struct->packet.udp)
@@ -5959,7 +5974,8 @@ static u_int8_t ndpi_search_into_zoom_cache(struct ndpi_detection_module_struct 
 
     key = make_zoom_key(flow, server);
     u_int8_t found = ndpi_lru_find_cache(ndpi_struct->zoom_cache, key, &cached_proto,
-					 0 /* Don't remove it as it can be used for other connections */);
+					 0 /* Don't remove it as it can be used for other connections */,
+					 flow->last_packet_time_ms / 1000);
 
 #ifdef ZOOM_CACHE_DEBUG
     printf("[Zoom] *** [TCP] SEARCHING key %u [found: %u]\n", key, found);
@@ -5976,7 +5992,7 @@ static u_int8_t ndpi_search_into_zoom_cache(struct ndpi_detection_module_struct 
 static void ndpi_add_connection_as_zoom(struct ndpi_detection_module_struct *ndpi_struct,
 					struct ndpi_flow_struct *flow) {
   if(ndpi_struct->zoom_cache)
-    ndpi_lru_add_to_cache(ndpi_struct->zoom_cache, make_zoom_key(flow, 1), NDPI_PROTOCOL_ZOOM);
+    ndpi_lru_add_to_cache(ndpi_struct->zoom_cache, make_zoom_key(flow, 1), NDPI_PROTOCOL_ZOOM, flow->last_packet_time_ms / 1000);
 }
 
 /* ********************************************************************************* */
@@ -6007,7 +6023,8 @@ ndpi_protocol ndpi_detection_giveup(struct ndpi_detection_module_struct *ndpi_st
     u_int16_t cached_proto;
 
     if(ndpi_lru_find_cache(ndpi_str->mining_cache, make_mining_key(flow),
-			   &cached_proto, 0 /* Don't remove it as it can be used for other connections */)) {
+			   &cached_proto, 0 /* Don't remove it as it can be used for other connections */,
+			   flow->last_packet_time_ms / 1000)) {
       ndpi_set_detected_protocol(ndpi_str, flow, cached_proto, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI_PARTIAL_CACHE);
       ret.master_protocol = flow->detected_protocol_stack[1], ret.app_protocol = flow->detected_protocol_stack[0];
       ndpi_fill_protocol_category(ndpi_str, flow, &ret);
@@ -8410,12 +8427,13 @@ void ndpi_set_log_level(struct ndpi_detection_module_struct *ndpi_str, u_int l){
 /* ******************************************************************** */
 
 /* LRU cache */
-struct ndpi_lru_cache *ndpi_lru_cache_init(u_int32_t num_entries) {
+struct ndpi_lru_cache *ndpi_lru_cache_init(u_int32_t num_entries, u_int32_t ttl) {
   struct ndpi_lru_cache *c = (struct ndpi_lru_cache *) ndpi_calloc(1, sizeof(struct ndpi_lru_cache));
 
   if(!c)
     return(NULL);
 
+  c->ttl = ttl;
   c->entries = (struct ndpi_lru_cache_entry *) ndpi_calloc(num_entries, sizeof(struct ndpi_lru_cache_entry));
 
   if(!c->entries) {
@@ -8433,11 +8451,13 @@ void ndpi_lru_free_cache(struct ndpi_lru_cache *c) {
 }
 
 u_int8_t ndpi_lru_find_cache(struct ndpi_lru_cache *c, u_int32_t key,
-			     u_int16_t *value, u_int8_t clean_key_when_found) {
+			     u_int16_t *value, u_int8_t clean_key_when_found, u_int32_t now_sec) {
   u_int32_t slot = key % c->num_entries;
 
   c->stats.n_search++;
-  if(c->entries[slot].is_full && c->entries[slot].key == key) {
+  if(c->entries[slot].is_full && c->entries[slot].key == key &&
+     now_sec >= c->entries[slot].timestamp &&
+     (c->ttl == 0 || now_sec - c->entries[slot].timestamp <= c->ttl)) {
     *value = c->entries[slot].value;
     if(clean_key_when_found)
       c->entries[slot].is_full = 0;
@@ -8447,11 +8467,11 @@ u_int8_t ndpi_lru_find_cache(struct ndpi_lru_cache *c, u_int32_t key,
     return(0);
 }
 
-void ndpi_lru_add_to_cache(struct ndpi_lru_cache *c, u_int32_t key, u_int16_t value) {
+void ndpi_lru_add_to_cache(struct ndpi_lru_cache *c, u_int32_t key, u_int16_t value, u_int32_t now_sec) {
   u_int32_t slot = key % c->num_entries;
 
   c->stats.n_insert++;
-  c->entries[slot].is_full = 1, c->entries[slot].key = key, c->entries[slot].value = value;
+  c->entries[slot].is_full = 1, c->entries[slot].key = key, c->entries[slot].value = value, c->entries[slot].timestamp = now_sec;
 }
 
 void ndpi_lru_get_stats(struct ndpi_lru_cache *c, struct ndpi_lru_cache_stats *stats) {
@@ -8571,6 +8591,80 @@ int ndpi_get_lru_cache_size(struct ndpi_detection_module_struct *ndpi_struct,
     return 0;
   case NDPI_LRUCACHE_STUN_ZOOM:
     *num_entries = ndpi_struct->stun_zoom_cache_num_entries;
+    return 0;
+  default:
+    return -1;
+  }
+}
+
+int ndpi_set_lru_cache_ttl(struct ndpi_detection_module_struct *ndpi_struct,
+			   lru_cache_type cache_type,
+			   u_int32_t ttl)
+{
+  if(!ndpi_struct)
+    return -1;
+
+  switch(cache_type) {
+  case NDPI_LRUCACHE_OOKLA:
+    ndpi_struct->ookla_cache_ttl = ttl;
+    return 0;
+  case NDPI_LRUCACHE_BITTORRENT:
+    ndpi_struct->bittorrent_cache_ttl = ttl;
+    return 0;
+  case NDPI_LRUCACHE_ZOOM:
+    ndpi_struct->zoom_cache_ttl = ttl;
+    return 0;
+  case NDPI_LRUCACHE_STUN:
+    ndpi_struct->stun_cache_ttl = ttl;
+    return 0;
+  case NDPI_LRUCACHE_TLS_CERT:
+    ndpi_struct->tls_cert_cache_ttl = ttl;
+    return 0;
+  case NDPI_LRUCACHE_MINING:
+    ndpi_struct->mining_cache_ttl = ttl;
+    return 0;
+  case NDPI_LRUCACHE_MSTEAMS:
+    ndpi_struct->msteams_cache_ttl = ttl;
+    return 0;
+  case NDPI_LRUCACHE_STUN_ZOOM:
+    ndpi_struct->stun_zoom_cache_ttl = ttl;
+    return 0;
+  default:
+    return -1;
+  }
+}
+
+int ndpi_get_lru_cache_ttl(struct ndpi_detection_module_struct *ndpi_struct,
+			   lru_cache_type cache_type,
+			   u_int32_t *ttl)
+{
+  if(!ndpi_struct || !ttl)
+    return -1;
+
+  switch(cache_type) {
+  case NDPI_LRUCACHE_OOKLA:
+    *ttl = ndpi_struct->ookla_cache_ttl;
+    return 0;
+  case NDPI_LRUCACHE_BITTORRENT:
+    *ttl = ndpi_struct->bittorrent_cache_ttl;
+    return 0;
+  case NDPI_LRUCACHE_ZOOM:
+    *ttl = ndpi_struct->zoom_cache_ttl;
+    return 0;
+  case NDPI_LRUCACHE_STUN:
+    *ttl = ndpi_struct->stun_cache_ttl;
+    return 0;
+  case NDPI_LRUCACHE_TLS_CERT:
+    *ttl = ndpi_struct->tls_cert_cache_ttl;
+    return 0;
+  case NDPI_LRUCACHE_MINING:
+    *ttl = ndpi_struct->mining_cache_ttl;
+    return 0;
+  case NDPI_LRUCACHE_MSTEAMS:
+    *ttl = ndpi_struct->msteams_cache_ttl;
+    return 0;
+  case NDPI_LRUCACHE_STUN_ZOOM:
+    *ttl = ndpi_struct->stun_zoom_cache_ttl;
     return 0;
   default:
     return -1;

--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -123,19 +123,20 @@ static void ndpi_add_connection_as_bittorrent(struct ndpi_detection_module_struc
 
     key1 = ndpi_ip_port_hash_funct(flow->c_address.v4, flow->c_port), key2 = ndpi_ip_port_hash_funct(flow->s_address.v4, flow->s_port);
     
-    ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key1, NDPI_PROTOCOL_BITTORRENT);
-    ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key2, NDPI_PROTOCOL_BITTORRENT);
+    ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key1, NDPI_PROTOCOL_BITTORRENT, flow->last_packet_time_ms / 1000);
+    ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key2, NDPI_PROTOCOL_BITTORRENT, flow->last_packet_time_ms / 1000);
 
     /* Now add hosts as twins */
     ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache,
 			  flow->c_address.v4 + flow->s_address.v4,
-			  NDPI_PROTOCOL_BITTORRENT);
+			  NDPI_PROTOCOL_BITTORRENT,
+			  flow->last_packet_time_ms / 1000);
     
     /* Also add +2 ports of the sender in order to catch additional sockets open by the same client */
     for(i=0; i<2; i++) {
       key1 = ndpi_ip_port_hash_funct(flow->c_address.v4, htons(ntohs(flow->c_port)+1+i));
 
-      ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key1, NDPI_PROTOCOL_BITTORRENT);
+      ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key1, NDPI_PROTOCOL_BITTORRENT, flow->last_packet_time_ms / 1000);
     }
     
 #ifdef BITTORRENT_CACHE_DEBUG

--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -123,20 +123,20 @@ static void ndpi_add_connection_as_bittorrent(struct ndpi_detection_module_struc
 
     key1 = ndpi_ip_port_hash_funct(flow->c_address.v4, flow->c_port), key2 = ndpi_ip_port_hash_funct(flow->s_address.v4, flow->s_port);
     
-    ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key1, NDPI_PROTOCOL_BITTORRENT, flow->last_packet_time_ms / 1000);
-    ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key2, NDPI_PROTOCOL_BITTORRENT, flow->last_packet_time_ms / 1000);
+    ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key1, NDPI_PROTOCOL_BITTORRENT, ndpi_get_current_time(flow));
+    ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key2, NDPI_PROTOCOL_BITTORRENT, ndpi_get_current_time(flow));
 
     /* Now add hosts as twins */
     ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache,
 			  flow->c_address.v4 + flow->s_address.v4,
 			  NDPI_PROTOCOL_BITTORRENT,
-			  flow->last_packet_time_ms / 1000);
+			  ndpi_get_current_time(flow));
     
     /* Also add +2 ports of the sender in order to catch additional sockets open by the same client */
     for(i=0; i<2; i++) {
       key1 = ndpi_ip_port_hash_funct(flow->c_address.v4, htons(ntohs(flow->c_port)+1+i));
 
-      ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key1, NDPI_PROTOCOL_BITTORRENT, flow->last_packet_time_ms / 1000);
+      ndpi_lru_add_to_cache(ndpi_struct->bittorrent_cache, key1, NDPI_PROTOCOL_BITTORRENT, ndpi_get_current_time(flow));
     }
     
 #ifdef BITTORRENT_CACHE_DEBUG

--- a/src/lib/protocols/hangout.c
+++ b/src/lib/protocols/hangout.c
@@ -80,7 +80,7 @@ void ndpi_search_hangout(struct ndpi_detection_module_struct *ndpi_struct,
 	printf("[LRU] ADDING %u / %u.%u\n", key, NDPI_PROTOCOL_STUN, NDPI_PROTOCOL_HANGOUT_DUO);
 #endif
 
-	ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key, NDPI_PROTOCOL_HANGOUT_DUO);
+	ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key, NDPI_PROTOCOL_HANGOUT_DUO, flow->last_packet_time_ms / 1000);
       }
       
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_HANGOUT_DUO,

--- a/src/lib/protocols/hangout.c
+++ b/src/lib/protocols/hangout.c
@@ -80,7 +80,7 @@ void ndpi_search_hangout(struct ndpi_detection_module_struct *ndpi_struct,
 	printf("[LRU] ADDING %u / %u.%u\n", key, NDPI_PROTOCOL_STUN, NDPI_PROTOCOL_HANGOUT_DUO);
 #endif
 
-	ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key, NDPI_PROTOCOL_HANGOUT_DUO, flow->last_packet_time_ms / 1000);
+	ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key, NDPI_PROTOCOL_HANGOUT_DUO, ndpi_get_current_time(flow));
       }
       
       ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_HANGOUT_DUO,

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -1255,9 +1255,9 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	if(ndpi_struct->ookla_cache != NULL) {
 	  if(packet->iph != NULL) {
 	    if(packet->tcp->source == htons(8080))
-	      ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, packet->iph->saddr, 1 /* dummy */, flow->last_packet_time_ms / 1000);
+	      ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, packet->iph->saddr, 1 /* dummy */, ndpi_get_current_time(flow));
 	    else
-	      ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, packet->iph->daddr, 1 /* dummy */, flow->last_packet_time_ms / 1000);
+	      ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, packet->iph->daddr, 1 /* dummy */, ndpi_get_current_time(flow));
 	  } else if(packet->iphv6 != NULL) {
 	    u_int32_t h;
 
@@ -1266,7 +1266,7 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	    else
 	      h = ndpi_quick_hash((unsigned char *)&packet->iphv6->ip6_dst, sizeof(packet->iphv6->ip6_dst));
 
-	    ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, h, 1 /* dummy */, flow->last_packet_time_ms / 1000);
+	    ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, h, 1 /* dummy */, ndpi_get_current_time(flow));
 	  }
 	}
 

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -1255,9 +1255,9 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	if(ndpi_struct->ookla_cache != NULL) {
 	  if(packet->iph != NULL) {
 	    if(packet->tcp->source == htons(8080))
-	      ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, packet->iph->saddr, 1 /* dummy */);
+	      ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, packet->iph->saddr, 1 /* dummy */, flow->last_packet_time_ms / 1000);
 	    else
-	      ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, packet->iph->daddr, 1 /* dummy */);
+	      ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, packet->iph->daddr, 1 /* dummy */, flow->last_packet_time_ms / 1000);
 	  } else if(packet->iphv6 != NULL) {
 	    u_int32_t h;
 
@@ -1266,7 +1266,7 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	    else
 	      h = ndpi_quick_hash((unsigned char *)&packet->iphv6->ip6_dst, sizeof(packet->iphv6->ip6_dst));
 
-	    ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, h, 1 /* dummy */);
+	    ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, h, 1 /* dummy */, flow->last_packet_time_ms / 1000);
 	  }
 	}
 

--- a/src/lib/protocols/mining.c
+++ b/src/lib/protocols/mining.c
@@ -44,7 +44,7 @@ u_int32_t make_mining_key(struct ndpi_flow_struct *flow) {
 static void cacheMiningHostTwins(struct ndpi_detection_module_struct *ndpi_struct,
 				 struct ndpi_flow_struct *flow) {
   if(ndpi_struct->mining_cache)
-    ndpi_lru_add_to_cache(ndpi_struct->mining_cache, make_mining_key(flow), NDPI_PROTOCOL_MINING, flow->last_packet_time_ms / 1000);
+    ndpi_lru_add_to_cache(ndpi_struct->mining_cache, make_mining_key(flow), NDPI_PROTOCOL_MINING, ndpi_get_current_time(flow));
 }
 
 /* ************************************************************************** */

--- a/src/lib/protocols/mining.c
+++ b/src/lib/protocols/mining.c
@@ -44,7 +44,7 @@ u_int32_t make_mining_key(struct ndpi_flow_struct *flow) {
 static void cacheMiningHostTwins(struct ndpi_detection_module_struct *ndpi_struct,
 				 struct ndpi_flow_struct *flow) {
   if(ndpi_struct->mining_cache)
-    ndpi_lru_add_to_cache(ndpi_struct->mining_cache, make_mining_key(flow), NDPI_PROTOCOL_MINING);
+    ndpi_lru_add_to_cache(ndpi_struct->mining_cache, make_mining_key(flow), NDPI_PROTOCOL_MINING, flow->last_packet_time_ms / 1000);
 }
 
 /* ************************************************************************** */

--- a/src/lib/protocols/ookla.c
+++ b/src/lib/protocols/ookla.c
@@ -63,7 +63,7 @@ void ndpi_search_ookla(struct ndpi_detection_module_struct* ndpi_struct, struct 
 #ifdef OOKLA_DEBUG
 	  printf("=>>>>>>>> [OOKLA IPv6] Adding %u\n", h);
 #endif
-	  ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, h, 1 /* dummy */);
+	  ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, h, 1 /* dummy */, flow->last_packet_time_ms / 1000);
 	}
 	return;
       } else {
@@ -79,7 +79,8 @@ void ndpi_search_ookla(struct ndpi_detection_module_struct* ndpi_struct, struct 
 	  printf("=>>>>>>>> [OOKLA IPv6] Searching %u\n", h);
 #endif
 	  
-	  if(ndpi_lru_find_cache(ndpi_struct->ookla_cache, h, &dummy, 0 /* Don't remove it as it can be used for other connections */)) {
+	  if(ndpi_lru_find_cache(ndpi_struct->ookla_cache, h, &dummy, 0 /* Don't remove it as it can be used for other connections */,
+				 flow->last_packet_time_ms / 1000)) {
 	    NDPI_LOG_INFO(ndpi_struct, "found ookla tcp connection\n");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_OOKLA, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI_CACHE);
 #ifdef OOKLA_DEBUG
@@ -110,7 +111,8 @@ void ndpi_search_ookla(struct ndpi_detection_module_struct* ndpi_struct, struct 
     if(ndpi_struct->ookla_cache != NULL) {
       u_int16_t dummy;
     
-      if(ndpi_lru_find_cache(ndpi_struct->ookla_cache, addr, &dummy, 0 /* Don't remove it as it can be used for other connections */)) {
+      if(ndpi_lru_find_cache(ndpi_struct->ookla_cache, addr, &dummy, 0 /* Don't remove it as it can be used for other connections */,
+			     flow->last_packet_time_ms / 1000)) {
 	NDPI_LOG_INFO(ndpi_struct, "found ookla tcp connection\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_OOKLA, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI_CACHE);
 #ifdef OOKLA_DEBUG

--- a/src/lib/protocols/ookla.c
+++ b/src/lib/protocols/ookla.c
@@ -63,7 +63,7 @@ void ndpi_search_ookla(struct ndpi_detection_module_struct* ndpi_struct, struct 
 #ifdef OOKLA_DEBUG
 	  printf("=>>>>>>>> [OOKLA IPv6] Adding %u\n", h);
 #endif
-	  ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, h, 1 /* dummy */, flow->last_packet_time_ms / 1000);
+	  ndpi_lru_add_to_cache(ndpi_struct->ookla_cache, h, 1 /* dummy */, ndpi_get_current_time(flow));
 	}
 	return;
       } else {
@@ -80,7 +80,7 @@ void ndpi_search_ookla(struct ndpi_detection_module_struct* ndpi_struct, struct 
 #endif
 	  
 	  if(ndpi_lru_find_cache(ndpi_struct->ookla_cache, h, &dummy, 0 /* Don't remove it as it can be used for other connections */,
-				 flow->last_packet_time_ms / 1000)) {
+				 ndpi_get_current_time(flow))) {
 	    NDPI_LOG_INFO(ndpi_struct, "found ookla tcp connection\n");
 	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_OOKLA, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI_CACHE);
 #ifdef OOKLA_DEBUG
@@ -112,7 +112,7 @@ void ndpi_search_ookla(struct ndpi_detection_module_struct* ndpi_struct, struct 
       u_int16_t dummy;
     
       if(ndpi_lru_find_cache(ndpi_struct->ookla_cache, addr, &dummy, 0 /* Don't remove it as it can be used for other connections */,
-			     flow->last_packet_time_ms / 1000)) {
+			     ndpi_get_current_time(flow))) {
 	NDPI_LOG_INFO(ndpi_struct, "found ookla tcp connection\n");
 	ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_OOKLA, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI_CACHE);
 #ifdef OOKLA_DEBUG

--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -68,7 +68,7 @@ int stun_search_into_zoom_cache(struct ndpi_detection_module_struct *ndpi_struct
 
     if(ndpi_lru_find_cache(ndpi_struct->stun_zoom_cache, key,
                            &dummy, 0 /* Don't remove it as it can be used for other connections */,
-			   flow->last_packet_time_ms / 1000)) {
+			   ndpi_get_current_time(flow))) {
 #ifdef DEBUG_ZOOM_LRU
       printf("[LRU ZOOM] Found");
 #endif
@@ -100,7 +100,7 @@ static void ndpi_int_stun_add_connection(struct ndpi_detection_module_struct *nd
 
     if(ndpi_lru_find_cache(ndpi_struct->stun_cache, key,
 			   &cached_proto, 0 /* Don't remove it as it can be used for other connections */,
-			   flow->last_packet_time_ms / 1000)) {
+			   ndpi_get_current_time(flow))) {
 #ifdef DEBUG_LRU
       printf("[LRU] FOUND %u / %u: no need to cache %u.%u\n", key, cached_proto, proto, app_proto);
 #endif
@@ -113,7 +113,7 @@ static void ndpi_int_stun_add_connection(struct ndpi_detection_module_struct *nd
 
       if(ndpi_lru_find_cache(ndpi_struct->stun_cache, key_rev,
 			     &cached_proto, 0 /* Don't remove it as it can be used for other connections */,
-			     flow->last_packet_time_ms / 1000)) {
+			     ndpi_get_current_time(flow))) {
 #ifdef DEBUG_LRU
 	printf("[LRU] FOUND %u / %u: no need to cache %u.%u\n", key_rev, cached_proto, proto, app_proto);
 #endif
@@ -130,8 +130,8 @@ static void ndpi_int_stun_add_connection(struct ndpi_detection_module_struct *nd
 		 ntohs(packet->udp->source), ntohs(packet->udp->dest));
 #endif
 
-	  ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key, app_proto, flow->last_packet_time_ms / 1000);
-	  ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key_rev, app_proto, flow->last_packet_time_ms / 1000);
+	  ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key, app_proto, ndpi_get_current_time(flow));
+	  ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key_rev, app_proto, ndpi_get_current_time(flow));
 	}
       }
     }
@@ -146,7 +146,7 @@ static void ndpi_int_stun_add_connection(struct ndpi_detection_module_struct *nd
     printf("[LRU ZOOM] ADDING %u [src_port %u]\n", key, ntohs(flow->c_port));
 #endif
     ndpi_lru_add_to_cache(ndpi_struct->stun_zoom_cache, key,
-                          0 /* dummy */, flow->last_packet_time_ms / 1000);
+                          0 /* dummy */, ndpi_get_current_time(flow));
   }
 
   ndpi_set_detected_protocol(ndpi_struct, flow, app_proto, NDPI_PROTOCOL_STUN, confidence);
@@ -234,7 +234,7 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
     u_int32_t key = get_stun_lru_key(flow, 0);
     int rc = ndpi_lru_find_cache(ndpi_struct->stun_cache, key, &proto,
                                  0 /* Don't remove it as it can be used for other connections */,
-				 flow->last_packet_time_ms / 1000);
+				 ndpi_get_current_time(flow));
 
 #ifdef DEBUG_LRU
     printf("[LRU] Searching %u\n", key);
@@ -244,7 +244,7 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
       key = get_stun_lru_key(flow, 1);
       rc = ndpi_lru_find_cache(ndpi_struct->stun_cache, key, &proto,
                                0 /* Don't remove it as it can be used for other connections */,
-			       flow->last_packet_time_ms / 1000);
+			       ndpi_get_current_time(flow));
 
 #ifdef DEBUG_LRU
       printf("[LRU] Searching %u\n", key);

--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -56,7 +56,7 @@ u_int32_t get_stun_lru_key(struct ndpi_flow_struct *flow, u_int8_t rev) {
 int stun_search_into_zoom_cache(struct ndpi_detection_module_struct *ndpi_struct,
                                 struct ndpi_flow_struct *flow)
 {
-  u_int16_t when;
+  u_int16_t dummy;
   u_int32_t key;
 
   if(ndpi_struct->stun_zoom_cache &&
@@ -67,15 +67,12 @@ int stun_search_into_zoom_cache(struct ndpi_detection_module_struct *ndpi_struct
 #endif
 
     if(ndpi_lru_find_cache(ndpi_struct->stun_zoom_cache, key,
-                           &when, 0 /* Don't remove it as it can be used for other connections */)) {
-      u_int16_t tdiff = ((flow->last_packet_time_ms /1000) & 0xFFFF) - when;
-
+                           &dummy, 0 /* Don't remove it as it can be used for other connections */,
+			   flow->last_packet_time_ms / 1000)) {
 #ifdef DEBUG_ZOOM_LRU
-      printf("[LRU ZOOM] Found, diff %d\n", tdiff);
+      printf("[LRU ZOOM] Found");
 #endif
-
-      if(tdiff < 60 /* sec */)
-        return 1;
+      return 1;
     }
   }
   return 0;
@@ -102,7 +99,8 @@ static void ndpi_int_stun_add_connection(struct ndpi_detection_module_struct *nd
     u_int16_t cached_proto;
 
     if(ndpi_lru_find_cache(ndpi_struct->stun_cache, key,
-			   &cached_proto, 0 /* Don't remove it as it can be used for other connections */)) {
+			   &cached_proto, 0 /* Don't remove it as it can be used for other connections */,
+			   flow->last_packet_time_ms / 1000)) {
 #ifdef DEBUG_LRU
       printf("[LRU] FOUND %u / %u: no need to cache %u.%u\n", key, cached_proto, proto, app_proto);
 #endif
@@ -114,7 +112,8 @@ static void ndpi_int_stun_add_connection(struct ndpi_detection_module_struct *nd
       u_int32_t key_rev = get_stun_lru_key(flow, 1);
 
       if(ndpi_lru_find_cache(ndpi_struct->stun_cache, key_rev,
-			     &cached_proto, 0 /* Don't remove it as it can be used for other connections */)) {
+			     &cached_proto, 0 /* Don't remove it as it can be used for other connections */,
+			     flow->last_packet_time_ms / 1000)) {
 #ifdef DEBUG_LRU
 	printf("[LRU] FOUND %u / %u: no need to cache %u.%u\n", key_rev, cached_proto, proto, app_proto);
 #endif
@@ -131,8 +130,8 @@ static void ndpi_int_stun_add_connection(struct ndpi_detection_module_struct *nd
 		 ntohs(packet->udp->source), ntohs(packet->udp->dest));
 #endif
 
-	  ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key, app_proto);
-	  ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key_rev, app_proto);
+	  ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key, app_proto, flow->last_packet_time_ms / 1000);
+	  ndpi_lru_add_to_cache(ndpi_struct->stun_cache, key_rev, app_proto, flow->last_packet_time_ms / 1000);
 	}
       }
     }
@@ -147,7 +146,7 @@ static void ndpi_int_stun_add_connection(struct ndpi_detection_module_struct *nd
     printf("[LRU ZOOM] ADDING %u [src_port %u]\n", key, ntohs(flow->c_port));
 #endif
     ndpi_lru_add_to_cache(ndpi_struct->stun_zoom_cache, key,
-                         (flow->last_packet_time_ms / 1000) & 0xFFFF /* 16 bit */);
+                          0 /* dummy */, flow->last_packet_time_ms / 1000);
   }
 
   ndpi_set_detected_protocol(ndpi_struct, flow, app_proto, NDPI_PROTOCOL_STUN, confidence);
@@ -234,7 +233,8 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
     u_int16_t proto;
     u_int32_t key = get_stun_lru_key(flow, 0);
     int rc = ndpi_lru_find_cache(ndpi_struct->stun_cache, key, &proto,
-                                 0 /* Don't remove it as it can be used for other connections */);
+                                 0 /* Don't remove it as it can be used for other connections */,
+				 flow->last_packet_time_ms / 1000);
 
 #ifdef DEBUG_LRU
     printf("[LRU] Searching %u\n", key);
@@ -243,7 +243,8 @@ static ndpi_int_stun_t ndpi_int_check_stun(struct ndpi_detection_module_struct *
     if(!rc) {
       key = get_stun_lru_key(flow, 1);
       rc = ndpi_lru_find_cache(ndpi_struct->stun_cache, key, &proto,
-                               0 /* Don't remove it as it can be used for other connections */);
+                               0 /* Don't remove it as it can be used for other connections */,
+			       flow->last_packet_time_ms / 1000);
 
 #ifdef DEBUG_LRU
       printf("[LRU] Searching %u\n", key);

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -340,7 +340,8 @@ static void checkTLSSubprotocol(struct ndpi_detection_module_struct *ndpi_struct
       key = make_tls_cert_key(packet, is_from_client);
 
       if(ndpi_lru_find_cache(ndpi_struct->tls_cert_cache, key,
-			     &cached_proto, 0 /* Don't remove it as it can be used for other connections */)) {
+			     &cached_proto, 0 /* Don't remove it as it can be used for other connections */,
+			     flow->last_packet_time_ms / 1000)) {
 	ndpi_protocol ret = { __get_master(ndpi_struct, flow), cached_proto, NDPI_PROTOCOL_UNKNOWN /* unused */, NDPI_PROTOCOL_CATEGORY_UNSPECIFIED, NULL};
 
 	ndpi_set_detected_protocol(ndpi_struct, flow, cached_proto, __get_master(ndpi_struct, flow), NDPI_CONFIDENCE_DPI_CACHE);
@@ -730,7 +731,7 @@ static void processCertificateElements(struct ndpi_detection_module_struct *ndpi
 	if(ndpi_struct->tls_cert_cache) {
 	  u_int32_t key = make_tls_cert_key(packet, 0 /* from the server */);
 
-	  ndpi_lru_add_to_cache(ndpi_struct->tls_cert_cache, key, proto_id);
+	  ndpi_lru_add_to_cache(ndpi_struct->tls_cert_cache, key, proto_id, flow->last_packet_time_ms / 1000);
 	}
       }
     }

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -341,7 +341,7 @@ static void checkTLSSubprotocol(struct ndpi_detection_module_struct *ndpi_struct
 
       if(ndpi_lru_find_cache(ndpi_struct->tls_cert_cache, key,
 			     &cached_proto, 0 /* Don't remove it as it can be used for other connections */,
-			     flow->last_packet_time_ms / 1000)) {
+			     ndpi_get_current_time(flow))) {
 	ndpi_protocol ret = { __get_master(ndpi_struct, flow), cached_proto, NDPI_PROTOCOL_UNKNOWN /* unused */, NDPI_PROTOCOL_CATEGORY_UNSPECIFIED, NULL};
 
 	ndpi_set_detected_protocol(ndpi_struct, flow, cached_proto, __get_master(ndpi_struct, flow), NDPI_CONFIDENCE_DPI_CACHE);
@@ -731,7 +731,7 @@ static void processCertificateElements(struct ndpi_detection_module_struct *ndpi
 	if(ndpi_struct->tls_cert_cache) {
 	  u_int32_t key = make_tls_cert_key(packet, 0 /* from the server */);
 
-	  ndpi_lru_add_to_cache(ndpi_struct->tls_cert_cache, key, proto_id, flow->last_packet_time_ms / 1000);
+	  ndpi_lru_add_to_cache(ndpi_struct->tls_cert_cache, key, proto_id, ndpi_get_current_time(flow));
 	}
       }
     }


### PR DESCRIPTION
Two caches already implemented a similar mechanism: make it generic.