### PR TITLE
Fix compilation with GCC-7 and latest RoaringBitmap code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -170,7 +170,9 @@ AS_IF([test "x${enable_tls_sigs}" = "xyes"],[
   HANDLE_TLS_SIGS=""
 ])
 
-NDPI_CFLAGS="-W -Wall -Wno-unused-parameter -Wno-unused-function -Wno-address-of-packed-member ${NDPI_CFLAGS}"
+NDPI_CFLAGS="-W -Wall -Wno-unused-parameter -Wno-unused-function -Wno-address-of-packed-member ${NDPI_CFLAGS} -Wno-attributes"
+#Workaround for RoaringBitmap with gcc-7
+NDPI_CFLAGS="-Wno-attributes ${NDPI_CFLAGS}"
 
 AS_IF([test "${with_lto_and_gold_linker+set}" = set], [
        NDPI_CFLAGS="${NDPI_CFLAGS} -flto -fuse-ld=gold -Wno-unused-command-line-argument"

--- a/windows/nDPI.vcxproj
+++ b/windows/nDPI.vcxproj
@@ -203,6 +203,7 @@
     <ClCompile Include="..\src\lib\protocols\z3950.c" />
     <ClCompile Include="..\src\lib\protocols\zabbix.c" />
     <ClCompile Include="..\src\lib\third_party\src\ahocorasick.c" />
+    <ClCompile Include="..\src\lib\third_party\src\roaring.c" />
     <ClCompile Include="..\src\lib\protocols\armagetron.c" />
     <ClCompile Include="..\src\lib\protocols\bgp.c" />
     <ClCompile Include="..\src\lib\protocols\bittorrent.c" />

--- a/windows/nDPI.vcxproj.filters
+++ b/windows/nDPI.vcxproj.filters
@@ -167,6 +167,7 @@
     <ClCompile Include="..\src\lib\protocols\z3950.c" />
     <ClCompile Include="..\src\lib\protocols\zabbix.c" />
     <ClCompile Include="..\src\lib\third_party\src\ahocorasick.c">
+    <ClCompile Include="..\src\lib\third_party\src\roaring.c">
       <Filter>third_party</Filter>
     </ClCompile>
     <ClCompile Include="..\src\lib\third_party\src\ndpi_sha1.c">


### PR DESCRIPTION
Latest RoaringBitmap version (introduced with bf413afb) triggers a new warning with GCC-7:

```
ivan@ivan-Latitude-E6540:~/svnrepos/nDPI(dev)$ CC=gcc-7 CXX=g++-7 ./autogen.sh && make -s
autoreconf: Entering directory `.'
[...]
third_party/src/roaring.c:1815:1: warning: ‘no_sanitize’ attribute directive ignored [-Wattributes]
 static inline int array_container_cardinality(const array_container_t *array) {
 ^~~~~~
third_party/src/roaring.c:1964:5: warning: ‘no_sanitize’ attribute directive ignored [-Wattributes]
     const array_container_t *container2) {
[..]
```

The core issue is that `no_sanitize` attribute is defined only for GCC >= 8.
That breaks the CI since we still use GCC-7 and `-Werror`: add a simple workaround.

Fix compilation on Windows