### PR TITLE
fuzz: simplify fuzzers dependencies in CIFuzz

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -124,9 +124,6 @@ u_int ndpi_verbose_dga_detection = 0;
 static void *(*_ndpi_flow_malloc)(size_t size);
 static void (*_ndpi_flow_free)(void *ptr);
 
-static void *(*_ndpi_malloc)(size_t size);
-static void (*_ndpi_free)(void *ptr);
-
 /* ****************************************** */
 
 static ndpi_risk_info ndpi_known_risks[] = {
@@ -228,51 +225,8 @@ static inline uint8_t flow_is_proto(struct ndpi_flow_struct *flow, u_int16_t p) 
 
 /* ****************************************** */
 
-static volatile long int ndpi_tot_allocated_memory;
-
-/* ****************************************** */
-
-u_int32_t ndpi_get_tot_allocated_memory() {
-  return(__sync_fetch_and_add(&ndpi_tot_allocated_memory, 0));
-}
-
-/* ****************************************** */
-
-void *ndpi_malloc(size_t size) {
-  __sync_fetch_and_add(&ndpi_tot_allocated_memory, size);
-  return(_ndpi_malloc ? _ndpi_malloc(size) : malloc(size));
-}
-
-/* ****************************************** */
-
 void *ndpi_flow_malloc(size_t size) {
   return(_ndpi_flow_malloc ? _ndpi_flow_malloc(size) : ndpi_malloc(size));
-}
-
-/* ****************************************** */
-
-void *ndpi_calloc(unsigned long count, size_t size) {
-  size_t len = count * size;
-  void *p = ndpi_malloc(len);
-
-  if(p) {
-    memset(p, 0, len);
-    __sync_fetch_and_add(&ndpi_tot_allocated_memory, size);
-  }
-
-  return(p);
-}
-
-/* ****************************************** */
-
-void ndpi_free(void *ptr) {
-  if(_ndpi_free) {
-    if(ptr)
-      _ndpi_free(ptr);
-  } else {
-    if(ptr)
-      free(ptr);
-  }
 }
 
 /* ****************************************** */
@@ -285,39 +239,6 @@ void ndpi_flow_free(void *ptr) {
 }
 
 /* ****************************************** */
-
-void *ndpi_realloc(void *ptr, size_t old_size, size_t new_size) {
-  void *ret = ndpi_malloc(new_size);
-
-  if(!ret)
-    return(ret);
-  else {
-    if(ptr != NULL) {
-      memcpy(ret, ptr, (old_size < new_size ? old_size : new_size));
-      ndpi_free(ptr);
-    }
-    return(ret);
-  }
-}
-/* ****************************************** */
-
-char *ndpi_strdup(const char *s) {
-  if(s == NULL ){
-    return NULL;
-  }
-
-  int len = strlen(s);
-  char *m = ndpi_malloc(len + 1);
-
-  if(m) {
-    memcpy(m, s, len);
-    m[len] = '\0';
-  }
-
-  return(m);
-}
-
-/* *********************************************************************************** */
 
 /* Opaque structure defined here */
 struct ndpi_ptree
@@ -2515,16 +2436,10 @@ static int ndpi_add_host_ip_subprotocol(struct ndpi_detection_module_struct *ndp
   return(0);
 }
 
-void set_ndpi_malloc(void *(*__ndpi_malloc)(size_t size)) {
-  _ndpi_malloc = __ndpi_malloc;
-}
 void set_ndpi_flow_malloc(void *(*__ndpi_flow_malloc)(size_t size)) {
   _ndpi_flow_malloc = __ndpi_flow_malloc;
 }
 
-void set_ndpi_free(void (*__ndpi_free)(void *ptr)) {
-  _ndpi_free = __ndpi_free;
-}
 void set_ndpi_flow_free(void (*__ndpi_flow_free)(void *ptr)) {
   _ndpi_flow_free = __ndpi_flow_free;
 }

--- a/src/lib/ndpi_memory.c
+++ b/src/lib/ndpi_memory.c
@@ -1,0 +1,96 @@
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef WIN32
+#include "ndpi_win32.h" /* For __sync_fetch_and_add */
+#endif
+
+/* ****************************************** */
+
+static void *(*_ndpi_malloc)(size_t size);
+static void (*_ndpi_free)(void *ptr);
+
+static volatile long int ndpi_tot_allocated_memory;
+
+/* ****************************************** */
+
+void set_ndpi_malloc(void *(*__ndpi_malloc)(size_t size)) {
+  _ndpi_malloc = __ndpi_malloc;
+}
+
+void set_ndpi_free(void (*__ndpi_free)(void *ptr)) {
+  _ndpi_free = __ndpi_free;
+}
+
+/* ****************************************** */
+
+u_int32_t ndpi_get_tot_allocated_memory() {
+  return(__sync_fetch_and_add(&ndpi_tot_allocated_memory, 0));
+}
+
+/* ****************************************** */
+
+void *ndpi_malloc(size_t size) {
+  __sync_fetch_and_add(&ndpi_tot_allocated_memory, size);
+  return(_ndpi_malloc ? _ndpi_malloc(size) : malloc(size));
+}
+
+/* ****************************************** */
+
+void *ndpi_calloc(unsigned long count, size_t size) {
+  size_t len = count * size;
+  void *p = ndpi_malloc(len);
+
+  if(p) {
+    memset(p, 0, len);
+    __sync_fetch_and_add(&ndpi_tot_allocated_memory, size);
+  }
+
+  return(p);
+}
+
+/* ****************************************** */
+
+void ndpi_free(void *ptr) {
+  if(_ndpi_free) {
+    if(ptr)
+      _ndpi_free(ptr);
+  } else {
+    if(ptr)
+      free(ptr);
+  }
+}
+
+/* ****************************************** */
+
+void *ndpi_realloc(void *ptr, size_t old_size, size_t new_size) {
+  void *ret = ndpi_malloc(new_size);
+
+  if(!ret)
+    return(ret);
+  else {
+    if(ptr != NULL) {
+      memcpy(ret, ptr, (old_size < new_size ? old_size : new_size));
+      ndpi_free(ptr);
+    }
+    return(ret);
+  }
+}
+
+/* ****************************************** */
+
+char *ndpi_strdup(const char *s) {
+  if(s == NULL ){
+    return NULL;
+  }
+
+  int len = strlen(s);
+  char *m = ndpi_malloc(len + 1);
+
+  if(m) {
+    memcpy(m, s, len);
+    m[len] = '\0';
+  }
+
+  return(m);
+}

--- a/windows/nDPI.vcxproj
+++ b/windows/nDPI.vcxproj
@@ -128,6 +128,7 @@
     <ClCompile Include="..\src\lib\ndpi_community_id.c" />
     <ClCompile Include="..\src\lib\ndpi_geoip.c" />
     <ClCompile Include="..\src\lib\ndpi_main.c" />
+    <ClCompile Include="..\src\lib\ndpi_memory.c" />
     <ClCompile Include="..\src\lib\ndpi_serializer.c" />
     <ClCompile Include="..\src\lib\ndpi_utils.c" />
     <ClCompile Include="..\src\lib\protocols\activision.c" />

--- a/windows/nDPI.vcxproj.filters
+++ b/windows/nDPI.vcxproj.filters
@@ -119,6 +119,7 @@
     <ClCompile Include="..\src\lib\ndpi_community_id.c" />
     <ClCompile Include="..\src\lib\ndpi_geoip.c" />
     <ClCompile Include="..\src\lib\ndpi_main.c" />
+    <ClCompile Include="..\src\lib\ndpi_memory.c" />
     <ClCompile Include="..\src\lib\ndpi_serializer.c" />
     <ClCompile Include="..\src\lib\ndpi_utils.c" />
     <ClCompile Include="..\src\lib\protocols\ajp.c" />


### PR DESCRIPTION
CIFuzz (based on oss-fuzz) is the GitHub action/CI job that runs fuzz
targets on pull requests. It only runs the fuzzers affected by a pull
request/commit. Otherwise it will divide up the allotted fuzzing time
among all fuzzers in the project.
Since:
* we have more than 20 fuzzers and most of them use the custom memory
allocation functions (to force allocation failures) even if they are not
strictly about DPI stuff;
* we need to keep fuzzing time relatively small (to avoid waiting for the CI
results for a long time)

it is important that fuzzers dependencies (which are based on *files*
changed by the single commit/PR) are as small as possible.

Bottom line: move all the low-level allocation callbacks to a dedicated
file; this way most of the fuzzers don't depend anymore on `ndpi_main.c`
file (which is touched by every commit/PR).

The goal is to have only the "most important" fuzzers running during (most
of) the CI.