### PR TITLE
TLS: fix another interger overflow in certificate processing

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -673,7 +673,7 @@ void processCertificateElements(struct ndpi_detection_module_struct *ndpi_struct
 		    if(flow->protos.tls_quic.server_names == NULL)
 		      flow->protos.tls_quic.server_names = ndpi_strdup(dNSName),
 			flow->protos.tls_quic.server_names_len = strlen(dNSName);
-		    else {
+		    else if((u_int16_t)(flow->protos.tls_quic.server_names_len + dNSName_len + 1) > flow->protos.tls_quic.server_names_len) {
 		      u_int16_t newstr_len = flow->protos.tls_quic.server_names_len + dNSName_len + 1;
 		      char *newstr = (char*)ndpi_realloc(flow->protos.tls_quic.server_names,
 							 flow->protos.tls_quic.server_names_len+1, newstr_len+1);


### PR DESCRIPTION
```
==5374==ERROR: AddressSanitizer: SEGV on unknown address 0x60400001a10d (pc 0x00000056e180 bp 0x7ffcca15ae20 sp 0x7ffcca15abe0 T0)
==5374==The signal is caused by a WRITE memory access.
SCARINESS: 30 (wild-addr-write)
    #0 0x56e180 in processCertificateElements ndpi/src/lib/protocols/tls.c:683:79
    #1 0x56c60f in LLVMFuzzerTestOneInput ndpi/fuzz/fuzz_tls_certificate.c:43:3
```
Found by oss-fuzz
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57448