### PR TITLE
Add support for roaring_bitmap_xor_inplace

### DIFF
--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -1914,6 +1914,7 @@ extern "C" {
 
   void ndpi_bitmap_and(ndpi_bitmap* a, ndpi_bitmap* b_and);
   void ndpi_bitmap_or(ndpi_bitmap* a, ndpi_bitmap* b_or);
+  void ndpi_bitmap_xor(ndpi_bitmap* a, ndpi_bitmap* b_xor);
 
   ndpi_bitmap_iterator* ndpi_bitmap_iterator_alloc(ndpi_bitmap* b);
   void ndpi_bitmap_iterator_free(ndpi_bitmap* b);

--- a/src/lib/ndpi_bitmap.c
+++ b/src/lib/ndpi_bitmap.c
@@ -115,6 +115,13 @@ void ndpi_bitmap_or(ndpi_bitmap* a, ndpi_bitmap* b_or) {
 
 /* ******************************************* */
 
+/* b = b ^ b_xor */
+void ndpi_bitmap_xor(ndpi_bitmap* a, ndpi_bitmap* b_xor) {
+  roaring_bitmap_xor_inplace((ndpi_bitmap*)a, (ndpi_bitmap*)b_xor);
+}
+
+/* ******************************************* */
+
 ndpi_bitmap_iterator* ndpi_bitmap_iterator_alloc(ndpi_bitmap* b) {
   return(roaring_create_iterator((ndpi_bitmap*)b));
 }


### PR DESCRIPTION
Added `roaring_bitmap_xor_inplace` support to `ndpi_bitmap` wrapper needed for a possible implementation for [#6416](https://github.com/ntop/ntopng/issues/6416). @lucaderi 