### PR TITLE
Remove some useless checks

### DIFF
--- a/src/lib/protocols/amazon_video.c
+++ b/src/lib/protocols/amazon_video.c
@@ -60,9 +60,7 @@ static void ndpi_search_amazon_video(struct ndpi_detection_module_struct *ndpi_s
 			      struct ndpi_flow_struct *flow) {
   NDPI_LOG_DBG(ndpi_struct, "search amazon_video\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_AMAZON_VIDEO)
-    ndpi_check_amazon_video(ndpi_struct, flow);
+  ndpi_check_amazon_video(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/apple_push.c
+++ b/src/lib/protocols/apple_push.c
@@ -89,9 +89,7 @@ static void ndpi_search_apple_push(struct ndpi_detection_module_struct *ndpi_str
 {
   NDPI_LOG_DBG(ndpi_struct, "search apple_push\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_APPLE_PUSH)
-    ndpi_check_apple_push(ndpi_struct, flow);
+  ndpi_check_apple_push(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/bjnp.c
+++ b/src/lib/protocols/bjnp.c
@@ -17,17 +17,15 @@ static void ndpi_check_bjnp(struct ndpi_detection_module_struct *ndpi_struct, st
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
-  if(packet->udp != NULL) {
-    if(payload_len > 4) {
-      if((memcmp((const char *)packet->payload, "BJNP", 4) == 0)
-	 || (memcmp((const char *)packet->payload, "BNJB", 4) == 0)
-	 || (memcmp((const char *)packet->payload, "BJNB", 4) == 0)
-	 || (memcmp((const char *)packet->payload, "MFNP", 4) == 0)
-	 ) {
-	    NDPI_LOG_INFO(ndpi_struct, "found bjnp\n");
-	    ndpi_int_bjnp_add_connection(ndpi_struct, flow, 0);
-	    return;
-	  }
+  if(payload_len > 4) {
+    if((memcmp((const char *)packet->payload, "BJNP", 4) == 0)
+       || (memcmp((const char *)packet->payload, "BNJB", 4) == 0)
+       || (memcmp((const char *)packet->payload, "BJNB", 4) == 0)
+       || (memcmp((const char *)packet->payload, "MFNP", 4) == 0)
+      ) {
+      NDPI_LOG_INFO(ndpi_struct, "found bjnp\n");
+      ndpi_int_bjnp_add_connection(ndpi_struct, flow, 0);
+      return;
     }
   }
 
@@ -38,10 +36,7 @@ static void ndpi_search_bjnp(struct ndpi_detection_module_struct *ndpi_struct, s
 {
   NDPI_LOG_DBG(ndpi_struct, "search bjnp\n");
 
-  /* skip marked packets */
-  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_BJNP) {
-    ndpi_check_bjnp(ndpi_struct, flow);
-  }
+  ndpi_check_bjnp(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/citrix.c
+++ b/src/lib/protocols/citrix.c
@@ -61,9 +61,7 @@ static void ndpi_search_citrix(struct ndpi_detection_module_struct *ndpi_struct,
 {
   NDPI_LOG_DBG(ndpi_struct, "search citrix\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_CITRIX)
-    ndpi_check_citrix(ndpi_struct, flow);
+  ndpi_check_citrix(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/dropbox.c
+++ b/src/lib/protocols/dropbox.c
@@ -40,28 +40,24 @@ static void ndpi_int_dropbox_add_connection(struct ndpi_detection_module_struct 
 static void ndpi_check_dropbox(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
-  // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
+  u_int16_t dropbox_port = htons(DB_LSP_PORT);
 
-  if(packet->udp != NULL) {
-    u_int16_t dropbox_port = htons(DB_LSP_PORT);
-
-    if(packet->udp->dest == dropbox_port) {    
-      if(packet->udp->source == dropbox_port) {	
-	if(payload_len > 10) {
-	  if(ndpi_strnstr((const char *)packet->payload, "\"host_int\"", payload_len) != NULL) {	    
-	    NDPI_LOG_INFO(ndpi_struct, "found dropbox\n");
-	    ndpi_int_dropbox_add_connection(ndpi_struct, flow, 0);
-	    return;
-	  }
+  if(packet->udp->dest == dropbox_port) {    
+    if(packet->udp->source == dropbox_port) {	
+      if(payload_len > 10) {
+        if(ndpi_strnstr((const char *)packet->payload, "\"host_int\"", payload_len) != NULL) {	    
+          NDPI_LOG_INFO(ndpi_struct, "found dropbox\n");
+          ndpi_int_dropbox_add_connection(ndpi_struct, flow, 0);
+          return;
 	}
-      } else {
-	if(payload_len > 10) {
-	  if(ndpi_strnstr((const char *)packet->payload, "Bus17Cmd", payload_len) != NULL) {	    
-	    NDPI_LOG_INFO(ndpi_struct, "found dropbox\n");
-	    ndpi_int_dropbox_add_connection(ndpi_struct, flow, 0);
-	    return;
-	  }
+      }
+    } else {
+      if(payload_len > 10) {
+        if(ndpi_strnstr((const char *)packet->payload, "Bus17Cmd", payload_len) != NULL) {	    
+          NDPI_LOG_INFO(ndpi_struct, "found dropbox\n");
+          ndpi_int_dropbox_add_connection(ndpi_struct, flow, 0);
+          return;
 	}
       }
     }
@@ -74,10 +70,7 @@ static void ndpi_search_dropbox(struct ndpi_detection_module_struct *ndpi_struct
 {
   NDPI_LOG_DBG(ndpi_struct, "search dropbox\n");
 
-  /* skip marked packets */
-  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_DROPBOX) {
-    ndpi_check_dropbox(ndpi_struct, flow);
-  }
+  ndpi_check_dropbox(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/edonkey.c
+++ b/src/lib/protocols/edonkey.c
@@ -201,10 +201,7 @@ static void ndpi_check_edonkey(struct ndpi_detection_module_struct *ndpi_struct,
 static void ndpi_search_edonkey(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   NDPI_LOG_DBG(ndpi_struct, "search EDONKEY\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_EDONKEY) {
-    ndpi_check_edonkey(ndpi_struct, flow);
-  }
+  ndpi_check_edonkey(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/gtp.c
+++ b/src/lib/protocols/gtp.c
@@ -67,7 +67,7 @@ static void ndpi_check_gtp(struct ndpi_detection_module_struct *ndpi_struct, str
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int32_t payload_len = packet->payload_packet_len;
 
-  if((packet->udp != NULL) && (payload_len > sizeof(struct gtp_header_generic))) {
+  if(payload_len > sizeof(struct gtp_header_generic)) {
     u_int32_t gtp_u  = ntohs(2152);
     u_int32_t gtp_c  = ntohs(2123);
     u_int32_t gtp_prime = ntohs(3386);
@@ -122,9 +122,7 @@ static void ndpi_search_gtp(struct ndpi_detection_module_struct *ndpi_struct, st
 {
   NDPI_LOG_DBG(ndpi_struct, "search gtp\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_GTP)
-    ndpi_check_gtp(ndpi_struct, flow);
+  ndpi_check_gtp(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/lisp.c
+++ b/src/lib/protocols/lisp.c
@@ -76,12 +76,7 @@ static void ndpi_search_lisp(struct ndpi_detection_module_struct *ndpi_struct, s
 {
   NDPI_LOG_DBG(ndpi_struct, "search lisp\n");
 
-  /* skip marked packets */
-  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_LISP) {
- 
-      ndpi_check_lisp(ndpi_struct, flow);
-   
-  }
+  ndpi_check_lisp(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/radius.c
+++ b/src/lib/protocols/radius.c
@@ -41,8 +41,7 @@ static void ndpi_check_radius(struct ndpi_detection_module_struct *ndpi_struct, 
   // const u_int8_t *packet_payload = packet->payload;
   u_int32_t payload_len = packet->payload_packet_len;
 
-  if(packet->udp != NULL &&
-     (packet->udp->dest == htons(RADIUS_PORT) || packet->udp->source == htons(RADIUS_PORT) ||
+  if((packet->udp->dest == htons(RADIUS_PORT) || packet->udp->source == htons(RADIUS_PORT) ||
       packet->udp->dest == htons(RADIUS_PORT_ACC) || packet->udp->source == htons(RADIUS_PORT_ACC) ||
       packet->udp->dest == htons(RADIUS_PORT_ACC_ALTERNATIVE) || packet->udp->source == htons(RADIUS_PORT_ACC_ALTERNATIVE))) {
     struct radius_header *h = (struct radius_header*)packet->payload;
@@ -69,9 +68,7 @@ static void ndpi_search_radius(struct ndpi_detection_module_struct *ndpi_struct,
 {
   NDPI_LOG_DBG(ndpi_struct, "search radius\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_RADIUS)
-    ndpi_check_radius(ndpi_struct, flow);
+  ndpi_check_radius(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/redis_net.c
+++ b/src/lib/protocols/redis_net.c
@@ -76,10 +76,7 @@ static void ndpi_check_redis(struct ndpi_detection_module_struct *ndpi_struct, s
 static void ndpi_search_redis(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   NDPI_LOG_DBG(ndpi_struct, "search Redis\n");
 
-  /* skip marked packets */
-  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_REDIS) {
-    ndpi_check_redis(ndpi_struct, flow);
-  }
+  ndpi_check_redis(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/rtmp.c
+++ b/src/lib/protocols/rtmp.c
@@ -83,10 +83,7 @@ static void ndpi_search_rtmp(struct ndpi_detection_module_struct *ndpi_struct, s
 {
   NDPI_LOG_DBG(ndpi_struct, "search RTMP\n");
 
-  /* skip marked packets */
-  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_RTMP) {
-    ndpi_check_rtmp(ndpi_struct, flow);
-  }
+  ndpi_check_rtmp(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/skype.c
+++ b/src/lib/protocols/skype.c
@@ -43,59 +43,56 @@ static void ndpi_check_skype(struct ndpi_detection_module_struct *ndpi_struct, s
   if(flow->host_server_name[0] != '\0')
     return;
   
-  if(packet->udp != NULL) {    
+  if(flow->packet_counter < 5) {
+    u_int16_t sport = ntohs(packet->udp->source);
+    u_int16_t dport = ntohs(packet->udp->dest);
 
-    if(flow->packet_counter < 5) {
-      u_int16_t sport = ntohs(packet->udp->source);
-      u_int16_t dport = ntohs(packet->udp->dest);
+    /* skype-to-skype */
+    if(is_port(sport, dport, 1119) /* It can be confused with battle.net */
+       || is_port(sport, dport, 80) /* No HTTP-like protocols UDP/80 */
+      ) {
+      ;
+    } else {
+      /* Too many false positives */
+      if(((payload_len == 3) && ((packet->payload[2] & 0x0F)== 0x0d))
+	 ||
+	 ((payload_len >= 16)
+	  && (((packet->payload[0] & 0xC0) >> 6) == 0x02 /* RTPv2 */
+	      || (((packet->payload[0] & 0xF0) >> 4) == 0 /* Zoom */)
+	      || (((packet->payload[0] & 0xF0) >> 4) == 0x07 /* Skype */)
+	     )
+	  && (packet->payload[0] != 0x30) /* Avoid invalid SNMP detection */
+	  && (packet->payload[0] != 0x00) /* Avoid invalid CAPWAP detection */
+	  && (packet->payload[2] == 0x02))) {
 
-      /* skype-to-skype */
-      if(is_port(sport, dport, 1119) /* It can be confused with battle.net */
-	 || is_port(sport, dport, 80) /* No HTTP-like protocols UDP/80 */
-	 ) {
-	;
-      } else {
-	/* Too many false positives */
-	if(((payload_len == 3) && ((packet->payload[2] & 0x0F)== 0x0d))
-	   ||
-	   ((payload_len >= 16)
-	    && (((packet->payload[0] & 0xC0) >> 6) == 0x02 /* RTPv2 */
-		|| (((packet->payload[0] & 0xF0) >> 4) == 0 /* Zoom */)
-		|| (((packet->payload[0] & 0xF0) >> 4) == 0x07 /* Skype */)
-		)
-	    && (packet->payload[0] != 0x30) /* Avoid invalid SNMP detection */
-	    && (packet->payload[0] != 0x00) /* Avoid invalid CAPWAP detection */
-	    && (packet->payload[2] == 0x02))) {
-
-	  if(is_port(sport, dport, 8801)) {
-	    NDPI_LOG_INFO(ndpi_struct, "found ZOOM (in SKYPE_TEAMS code)\n");
-	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZOOM, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
-	  } else if (payload_len >= 16 && packet->payload[0] != 0x01) /* Avoid invalid Cisco HSRP detection / RADIUS */ {
-	    NDPI_LOG_INFO(ndpi_struct, "found SKYPE_TEAMS\n");
-	    ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SKYPE_TEAMS_CALL, NDPI_PROTOCOL_SKYPE_TEAMS, NDPI_CONFIDENCE_DPI);
-	  }
+	if(is_port(sport, dport, 8801)) {
+	  NDPI_LOG_INFO(ndpi_struct, "found ZOOM (in SKYPE_TEAMS code)\n");
+	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ZOOM, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
+	} else if (payload_len >= 16 && packet->payload[0] != 0x01) /* Avoid invalid Cisco HSRP detection / RADIUS */ {
+	  NDPI_LOG_INFO(ndpi_struct, "found SKYPE_TEAMS\n");
+	  ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SKYPE_TEAMS_CALL, NDPI_PROTOCOL_SKYPE_TEAMS, NDPI_CONFIDENCE_DPI);
 	}
+      }
 
-        if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) {
-          const uint8_t id_flags_iv_crc_len = 11;
-          const uint8_t crc_len = sizeof(flow->l4.udp.skype_crc);
-          const uint8_t crc_offset = id_flags_iv_crc_len - crc_len;
+      if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_UNKNOWN) {
+        const uint8_t id_flags_iv_crc_len = 11;
+        const uint8_t crc_len = sizeof(flow->l4.udp.skype_crc);
+        const uint8_t crc_offset = id_flags_iv_crc_len - crc_len;
 
-          /* Look for two pkts with the same crc */
-          if((payload_len >= id_flags_iv_crc_len) &&
-             (packet->payload[2] == 0x02 /* Payload flag */ )) {
-            if(flow->packet_counter == 1) {
-              memcpy(flow->l4.udp.skype_crc, &packet->payload[crc_offset], crc_len);
-            } else {
-              if(memcmp(flow->l4.udp.skype_crc, &packet->payload[crc_offset], crc_len) == 0) {
-                NDPI_LOG_INFO(ndpi_struct, "found SKYPE_TEAMS\n");
-                ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SKYPE_TEAMS, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
-                return;
-              }
+        /* Look for two pkts with the same crc */
+        if((payload_len >= id_flags_iv_crc_len) &&
+           (packet->payload[2] == 0x02 /* Payload flag */ )) {
+          if(flow->packet_counter == 1) {
+            memcpy(flow->l4.udp.skype_crc, &packet->payload[crc_offset], crc_len);
+          } else {
+            if(memcmp(flow->l4.udp.skype_crc, &packet->payload[crc_offset], crc_len) == 0) {
+              NDPI_LOG_INFO(ndpi_struct, "found SKYPE_TEAMS\n");
+              ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_SKYPE_TEAMS, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
+              return;
             }
-            /* No idea if the two pkts need to be consecutive; in doubt wait for some more pkts */
-            return;
           }
+          /* No idea if the two pkts need to be consecutive; in doubt wait for some more pkts */
+          return;
         }
       }
     }
@@ -109,9 +106,7 @@ static void ndpi_search_skype(struct ndpi_detection_module_struct *ndpi_struct, 
 {
   NDPI_LOG_DBG(ndpi_struct, "search skype\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SKYPE_TEAMS)
-    ndpi_check_skype(ndpi_struct, flow);
+  ndpi_check_skype(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/socks45.c
+++ b/src/lib/protocols/socks45.c
@@ -121,13 +121,10 @@ static void ndpi_search_socks(struct ndpi_detection_module_struct *ndpi_struct, 
 {
   NDPI_LOG_DBG(ndpi_struct, "search SOCKS\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS) {
-    ndpi_check_socks4(ndpi_struct, flow);
+  ndpi_check_socks4(ndpi_struct, flow);
 
-    if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS)
-      ndpi_check_socks5(ndpi_struct, flow);
-  }
+  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SOCKS)
+    ndpi_check_socks5(ndpi_struct, flow);
 }
 
 void init_socks_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id)

--- a/src/lib/protocols/spotify.c
+++ b/src/lib/protocols/spotify.c
@@ -72,10 +72,7 @@ static void ndpi_search_spotify(struct ndpi_detection_module_struct *ndpi_struct
 {
   NDPI_LOG_DBG(ndpi_struct, "search spotify\n");
 
-  /* skip marked packets */
-  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SPOTIFY) {
-    ndpi_check_spotify(ndpi_struct, flow);
-  }
+  ndpi_check_spotify(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/vhua.c
+++ b/src/lib/protocols/vhua.c
@@ -43,7 +43,6 @@ static void ndpi_check_vhua(struct ndpi_detection_module_struct *ndpi_struct, st
 
   /* Break after 3 packets. */
   if((flow->packet_counter > 3)
-     || (packet->udp == NULL)
      || (packet->payload_packet_len < sizeof(p0))) {
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   } else if(memcmp(packet->payload, p0, sizeof(p0)) == 0) {
@@ -54,10 +53,7 @@ static void ndpi_check_vhua(struct ndpi_detection_module_struct *ndpi_struct, st
 static void ndpi_search_vhua(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   NDPI_LOG_DBG(ndpi_struct, "search VHUA\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_VHUA) {
-    ndpi_check_vhua(ndpi_struct, flow);
-  }
+  ndpi_check_vhua(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/vxlan.c
+++ b/src/lib/protocols/vxlan.c
@@ -30,7 +30,7 @@ static void ndpi_check_vxlan(struct ndpi_detection_module_struct *ndpi_struct, s
 {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
-  if((packet->udp != NULL) && (packet->payload_packet_len >= sizeof(struct ndpi_vxlanhdr))) {
+  if(packet->payload_packet_len >= sizeof(struct ndpi_vxlanhdr)) {
 
     /*
     *rfc-7348 vxlan header
@@ -60,9 +60,7 @@ static void ndpi_search_vxlan(struct ndpi_detection_module_struct *ndpi_struct, 
 {
   NDPI_LOG_DBG(ndpi_struct, "search vxlan\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_VXLAN)
-    ndpi_check_vxlan(ndpi_struct, flow);
+  ndpi_check_vxlan(ndpi_struct, flow);
 }
 
 void init_vxlan_dissector(struct ndpi_detection_module_struct *ndpi_struct, u_int32_t *id)

--- a/src/lib/protocols/zeromq.c
+++ b/src/lib/protocols/zeromq.c
@@ -84,10 +84,7 @@ static void ndpi_check_zmq(struct ndpi_detection_module_struct *ndpi_struct, str
 static void ndpi_search_zmq(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
   NDPI_LOG_DBG(ndpi_struct, "search ZMQ\n");
 
-  /* skip marked packets */
-  if(flow->detected_protocol_stack[0] != NDPI_PROTOCOL_ZMQ) {
-    ndpi_check_zmq(ndpi_struct, flow);
-  }
+  ndpi_check_zmq(ndpi_struct, flow);
 }
 
 


### PR DESCRIPTION
In the main dissector callbacks the flow protocols are (almost) always unknown. Only two exceptions:
* extra dissection data path
* HTTP sub-protocols