### PR TITLE
Fix some memory errors triggered by allocation failures

### DIFF
--- a/fuzz/fuzz_ds_ahocorasick.cpp
+++ b/fuzz/fuzz_ds_ahocorasick.cpp
@@ -133,7 +133,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   f = fopen("/dev/null", "w");
   ac_automata_dump(a, f);
-  fclose(f);
+  if (f)
+    fclose(f);
 
   ac_automata_get_stats(a, &stats);
 

--- a/fuzz/fuzz_libinjection.c
+++ b/fuzz/fuzz_libinjection.c
@@ -12,6 +12,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   /* Libinjection: it wants null-terminated string */
 
   query = malloc(size + 1);
+  if (!query)
+    return 0;
   memcpy(query, data, size);
   query[size] = '\0';
 

--- a/fuzz/fuzz_process_packet.c
+++ b/fuzz/fuzz_process_packet.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 
 struct ndpi_detection_module_struct *ndpi_info_mod = NULL;
+struct ndpi_flow_struct ndpi_flow;
 static ndpi_serializer json_serializer = {};
 static ndpi_serializer csv_serializer = {};
 
@@ -18,24 +19,23 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     ndpi_init_serializer(&csv_serializer, ndpi_serialization_format_csv);
   }
 
-  struct ndpi_flow_struct *ndpi_flow = ndpi_flow_malloc(SIZEOF_FLOW_STRUCT);
-  memset(ndpi_flow, 0, SIZEOF_FLOW_STRUCT);
+  memset(&ndpi_flow, 0, SIZEOF_FLOW_STRUCT);
   ndpi_protocol detected_protocol =
-    ndpi_detection_process_packet(ndpi_info_mod, ndpi_flow, Data, Size, 0, NULL);
+    ndpi_detection_process_packet(ndpi_info_mod, &ndpi_flow, Data, Size, 0, NULL);
   ndpi_protocol guessed_protocol =
-    ndpi_detection_giveup(ndpi_info_mod, ndpi_flow, 1, &protocol_was_guessed);
+    ndpi_detection_giveup(ndpi_info_mod, &ndpi_flow, 1, &protocol_was_guessed);
 
   ndpi_reset_serializer(&json_serializer);
   ndpi_reset_serializer(&csv_serializer);
   if (protocol_was_guessed == 0)
   {
-    ndpi_dpi2json(ndpi_info_mod, ndpi_flow, detected_protocol, &json_serializer);
-    ndpi_dpi2json(ndpi_info_mod, ndpi_flow, detected_protocol, &csv_serializer);
+    ndpi_dpi2json(ndpi_info_mod, &ndpi_flow, detected_protocol, &json_serializer);
+    ndpi_dpi2json(ndpi_info_mod, &ndpi_flow, detected_protocol, &csv_serializer);
   } else {
-    ndpi_dpi2json(ndpi_info_mod, ndpi_flow, guessed_protocol, &json_serializer);
-    ndpi_dpi2json(ndpi_info_mod, ndpi_flow, guessed_protocol, &csv_serializer);
+    ndpi_dpi2json(ndpi_info_mod, &ndpi_flow, guessed_protocol, &json_serializer);
+    ndpi_dpi2json(ndpi_info_mod, &ndpi_flow, guessed_protocol, &csv_serializer);
   }
-  ndpi_free_flow(ndpi_flow);
+  ndpi_free_flow_data(&ndpi_flow);
 
   return 0;
 }

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -2509,6 +2509,9 @@ static int ndpi_add_host_ip_subprotocol(struct ndpi_detection_module_struct *ndp
   u_int16_t port = 0; /* Format ip:8.248.73.247:443 */
   char *double_column;
 
+  if(!ndpi_str->protocols_ptree)
+    return(-1);
+
   if(ptr) {
     ptr[0] = '\0';
     ptr++;
@@ -3673,6 +3676,9 @@ char *strsep(char **sp, char *sep) {
 int ndpi_add_ip_risk_mask(struct ndpi_detection_module_struct *ndpi_str,
 			  char *ip, ndpi_risk mask) {
   char *saveptr, *addr = strtok_r(ip, "/", &saveptr);
+
+  if(!ndpi_str->ip_risk_mask_ptree)
+    return(-3);
 
   if(addr) {
     char *cidr = strtok_r(NULL, "\n", &saveptr);
@@ -6483,6 +6489,9 @@ int ndpi_load_ip_category(struct ndpi_detection_module_struct *ndpi_str,
   char *ptr;
   char ipbuf[64];
 
+  if(!ndpi_str->custom_categories.ipAddresses_shadow)
+    return(-1);
+
   strncpy(ipbuf, ip_address_and_mask, sizeof(ipbuf));
   ipbuf[sizeof(ipbuf) - 1] = '\0';
 
@@ -6618,7 +6627,9 @@ int ndpi_fill_ip_protocol_category(struct ndpi_detection_module_struct *ndpi_str
 
   ret->custom_category_userdata = NULL;
 
-  if(ndpi_str->custom_categories.categories_loaded) {
+  if(ndpi_str->custom_categories.categories_loaded &&
+     ndpi_str->custom_categories.ipAddresses) {
+
     ndpi_prefix_t prefix;
     ndpi_patricia_node_t *node;
 

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -2288,6 +2288,7 @@ int ndpi_hash_add_entry(ndpi_str_hash **h, char *key, u_int8_t key_len, void *va
 {
   struct ndpi_str_hash_private **h_priv = (struct ndpi_str_hash_private **)h;
   struct ndpi_str_hash_private *new = ndpi_calloc(1, sizeof(*new));
+  struct ndpi_str_hash_private *found;
   unsigned int hash_value;
 
   if (new == NULL)
@@ -2299,6 +2300,14 @@ int ndpi_hash_add_entry(ndpi_str_hash **h, char *key, u_int8_t key_len, void *va
   new->hash = hash_value;
   new->value = value;
   HASH_ADD_INT(*h_priv, hash, new);
+
+  HASH_FIND_INT(*h_priv, &hash_value, found);
+  if (found == NULL) /* The insertion failed (because of a memory allocation error) */
+  {
+    ndpi_free(new);
+    return 1;
+  }
+
   return 0;
 }
 

--- a/src/lib/third_party/include/uthash.h
+++ b/src/lib/third_party/include/uthash.h
@@ -101,7 +101,7 @@ do {                                                                            
 #endif
 
 #ifndef HASH_NONFATAL_OOM
-#define HASH_NONFATAL_OOM 0
+#define HASH_NONFATAL_OOM 1
 #endif
 
 #if HASH_NONFATAL_OOM


### PR DESCRIPTION
Some low hanging fruits found using nallocfuzz.
See: https://github.com/catenacyber/nallocfuzz
See: https://github.com/google/oss-fuzz/pull/9902

Most of these errors are quite trivial to fix; the only exception is the stuff in the uthash.
If the insertion fails (because of an allocation failure), we need to avoid some memory leaks. But the only way to check if the `HASH_ADD_*` failed, is to perform a new lookup: a bit costly, but we don't use that code in any critical data-path.