### PR TITLE
Numeric truncation at `ndpi_main.c:6837'

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1152,7 +1152,7 @@ typedef struct {
 struct ndpi_detection_module_struct {
   NDPI_PROTOCOL_BITMASK detection_bitmask;
 
-  u_int32_t current_ts;
+  u_int64_t current_ts;
   u_int16_t max_packets_to_process;
   u_int16_t num_tls_blocks_to_follow;
   u_int8_t skip_tls_blocks_until_change_cipher:1, enable_ja3_plus:1, _notused:6;


### PR DESCRIPTION
Hi! We've been fuzzing nDPI with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and numeric truncation error was found in `ndpi_main.c:6837`.

In `ndpi_internal_detection_process_packet` function we have found this error on line `6837`. On this line variable `current_time_ms` has type `const u_int64_t` and variable `ndpi_str->current_ts` has type `u_int32_t`, so numeric truncation can happen. I've also checked where else the variable `current_ts` is used and found out that only in `ndpi_main.c` on line 6837. In case of further use of this variable it would be better to change the type `u_int32_t current_ts` to `u_int64_t current_ts` in `ndpi_typedefs.h`.

### Environment

- OS: ubuntu 20.04
- commit: 334b43579e2b1aa4bffa11c4014c4e1fd0b60ba5

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/ndpi):

    ```
    sudo docker build -t oss-sydr-fuzz-ndpi .

    ```

2. Run docker container:

    ```
    docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-ndpi /bin/bash

    ```

3. Run on the following [input](https://github.com/ntop/nDPI/files/11592473/sydr_68d3a05134c0c18be22066d0aaa8b5d51cd2a5e5_num_trunc_0.txt):

    ```
    /nDPI/libfuzzer/fuzz_ndpi_reader sydr_68d3a05134c0c18be22066d0aaa8b5d51cd2a5e5_num_trunc_0.txt

    ```

4. Output:

    ```
    ndpi_main.c:6830:26: runtime error: implicit conversion from type 'u_int64_t' (aka 'unsigned long') of value 18446744073709550616 (64-bit, unsigned) to type 'u_int32_t' (aka 'unsigned int') changed the value to 4294966296 (32-bit, unsigned)
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ndpi_main.c:6830:26
    ```