### PR TITLE
Numeric truncation at `tls.c:1010`

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1073,7 +1073,7 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
        && (content_type != 0x17 /* Application Data */)
        && (!flow->tls_quic.certificate_processed)) {
       /* Split the element in blocks */
-      u_int16_t processed = 5;
+      u_int32_t processed = 5;
 
       while((processed+4) <= len) {
 	const u_int8_t *block = (const u_int8_t *)&message->buffer[processed];

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1000,7 +1000,8 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
   while(!something_went_wrong) {
-    u_int16_t len, p_len;
+    u_int32_t len;
+    u_int16_t p_len;
     const u_int8_t *p;
     u_int8_t content_type;
 


### PR DESCRIPTION
Hi! We've been fuzzing nDPI with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and numeric truncation error was found in `tls.c:1010`.

In `ndpi_search_tls_tcp` function we have found this error on line `1010`. On this line value `(message->buffer[3] << 8) + message->buffer[4] + 5`, which has `int` type due to integer promotion, can be truncated. Then the variable `len` is used in if operator on line `1012`, that can work out incorrectly. So variable type `u_int16_t len` should be changed to `u_int32_t len`.

### Environment

- OS: ubuntu 20.04
- commit: 334b43579e2b1aa4bffa11c4014c4e1fd0b60ba5

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/ndpi):

    ```
    sudo docker build -t oss-sydr-fuzz-ndpi .

    ```

2. Run docker container:

    ```
    docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-ndpi /bin/bash

    ```

3. Run on the following [input](https://github.com/ntop/nDPI/files/11650537/sydr_dc37d65b367f71e74967d3478cc161b48ad86c7d_num_trunc_0.txt):

    ```
    /nDPI/libfuzzer/fuzz_ndpi_reader sydr_dc37d65b367f71e74967d3478cc161b48ad86c7d_num_trunc_0

    ```

4. Output:

    ```
    protocols/tls.c:1010:11: runtime error: implicit conversion from type 'int' of value 65540 (32-bit, signed) to type 'u_int16_t' (aka 'unsigned short') changed the value to 4 (16-bit, unsigned)
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior protocols/tls.c:1010:11
    ```