### PR TITLE
oss-fuzz: sync build script with upstream

### DIFF
--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -14,19 +14,47 @@
 # limitations under the License.
 #
 ################################################################################
+
+if [[ "$SANITIZER" != "memory" ]]; then
+	#Disable code instrumentation
+	CFLAGS_SAVE="$CFLAGS"
+	CXXFLAGS_SAVE="$CXXFLAGS"
+	unset CFLAGS
+	unset CXXFLAGS
+	export AFL_NOOPT=1
+fi
+
 # build libpcap
 tar -xvzf libpcap-1.9.1.tar.gz
 cd libpcap-1.9.1
 ./configure --disable-shared
-make -j"$(nproc)"
+make -j$(nproc)
 make install
 cd ..
+
+if [[ "$SANITIZER" != "memory" ]]; then
+	#Re-enable code instrumentation
+	export CFLAGS="${CFLAGS_SAVE}"
+	export CXXFLAGS="${CXXFLAGS_SAVE}"
+	unset AFL_NOOPT
+fi
+
 # build project
 cd ndpi
-sh autogen.sh
-./configure --enable-fuzztargets
-make
-make -C fuzz fuzz_ndpi_reader_seed_corpus.zip
-# copy fuzz executables to output directory
-cp -v fuzz/fuzz_ndpi_reader "$OUT/"
-cp -v fuzz/fuzz_process_packet "$OUT/"
+# Set LDFLAGS variable and `--with-only-libndpi` option as workaround for the
+# "missing dependencies errors" in the introspector build. See #8939
+LDFLAGS="-lpcap" ./autogen.sh --enable-fuzztargets --with-only-libndpi
+make -j$(nproc)
+# Copy fuzzers
+ls fuzz/fuzz* | grep -v "\." | while read i; do cp $i $OUT/; done
+# Copy dictionaries
+cp fuzz/*.dict $OUT/
+# Copy seed corpus
+cp fuzz/*.zip $OUT/
+# Copy configuration files
+cp example/protos.txt $OUT/
+cp example/categories.txt $OUT/
+cp example/risky_domains.txt $OUT/
+cp example/ja3_fingerprints.csv $OUT/
+cp example/sha1_fingerprints.csv $OUT/
+cp fuzz/ipv4_addresses.txt $OUT/


### PR DESCRIPTION
File copied from https://github.com/google/oss-fuzz/blob/master/projects/ndpi/build.sh

The general idea is to keep the build script in our repository and use it from oss-fuzz builder: updating it from our side is easier and faster then passing via an oss-fuzz PR.

The original idea is from @utoni in 3068306b60.

Once this change has been merged, we can update the code in oss-fuzz.