### PR TITLE
Line: fix heap-buffer-overflow error

### DIFF
--- a/src/lib/protocols/line.c
+++ b/src/lib/protocols/line.c
@@ -63,7 +63,7 @@ static void ndpi_search_line(struct ndpi_detection_module_struct *ndpi_struct,
     if ((packet->payload_packet_len == 46 && ntohl(get_u_int32_t(packet->payload, 0)) == 0xb6130006) ||
 	(packet->payload_packet_len == 8 && ntohl(get_u_int32_t(packet->payload, 0)) == 0xb6070004) ||
 	(packet->payload_packet_len == 16 && ntohl(get_u_int32_t(packet->payload, 0)) == 0xb609000c) ||
-	(ndpi_struct->packet.payload[0] == 0xD0 &&
+	(packet->payload_packet_len >= 2 /* TODO */ && ndpi_struct->packet.payload[0] == 0xD0 &&
 	 (ndpi_struct->packet.payload[1] == 0xB3 || ndpi_struct->packet.payload[1] == 0xB4
 	  || ndpi_struct->packet.payload[1] == 0xDA || ndpi_struct->packet.payload[1] == 0xDB))) {
       ndpi_int_line_add_connection(ndpi_struct, flow);


### PR DESCRIPTION
```
==24482==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6030000001dd at pc 0x561abd2dbda4 bp 0x7ffdcc7370b0 sp 0x7ffdcc7370a8
READ of size 1 at 0x6030000001dd thread T0
    #0 0x561abd2dbda3 in ndpi_search_line /home/ivan/svnrepos/nDPI/src/lib/protocols/line.c:67:4
    #1 0x561abd165f5a in check_ndpi_detection_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5926:6
    #2 0x561abd166d1b in check_ndpi_udp_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5962:10
    #3 0x561abd1666bc in ndpi_check_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5995:12
    #4 0x561abd17774f in ndpi_internal_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:6991:15
    #5 0x561abd1738a7 in ndpi_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:7158:22
    #6 0x561abd0a47fd in LLVMFuzzerTestOneInput /home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet.c:24:5
    #7 0x561abcfb6670 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet+0x48d670) (BuildId: 6011a561322c60a0cdc8c96cf524bff75e7aaf2e)
    #8 0x561abcfa0bff in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet+0x477bff) (BuildId: 6011a561322c60a0cdc8c96cf524bff75e7aaf2e)
    #9 0x561abcfa66c6 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet+0x47d6c6) (BuildId: 6011a561322c60a0cdc8c96cf524bff75e7aaf2e)
    #10 0x561abcfcf2b2 in main (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet+0x4a62b2) (BuildId: 6011a561322c60a0cdc8c96cf524bff75e7aaf2e)
    #11 0x7f079b4be082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16
    #12 0x561abcf9badd in _start (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet+0x472add) (BuildId: 6011a561322c60a0cdc8c96cf524bff75e7aaf2e)

0x6030000001dd is located 0 bytes after 29-byte region [0x6030000001c0,0x6030000001dd)
allocated by thread T0 here:
[...]
```

Found by oss-fuzz
Fix 66bee475a

Not sure about the "best" length check; I simply use the minimum valid value.