### PR TITLE
Thrift: fix heap-buffer-overflow

### DIFF
--- a/src/lib/protocols/thrift.c
+++ b/src/lib/protocols/thrift.c
@@ -120,7 +120,7 @@ static void thrift_set_method(struct ndpi_detection_module_struct *ndpi_struct,
     ndpi_set_risk(ndpi_struct, flow, NDPI_INVALID_CHARACTERS, "Invalid method name");
     flow->protos.thrift.method[0] = '\0';
   } else {
-    strncpy(flow->protos.thrift.method, method, method_length);
+    strncpy(flow->protos.thrift.method, method, ndpi_min(sizeof(flow->protos.thrift.method), method_length));
   }
 }
 


### PR DESCRIPTION
```
==17436==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x619000000918 at pc 0x555890aa73ca bp 0x7ffc7dfb8400 sp 0x7ffc7dfb7bc0
WRITE of size 320 at 0x619000000918 thread T0
    #0 0x555890aa73c9 in __interceptor_strncpy (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_alloc_fail+0x5683c9) (BuildId: 0e490e64c6df5c04fcbece70b3651007bf1b62a3)
    #1 0x555890d6e2f2 in thrift_set_method /home/ivan/svnrepos/nDPI/src/lib/protocols/thrift.c:123:5
    #2 0x555890d6da20 in ndpi_dissect_strict_hdr /home/ivan/svnrepos/nDPI/src/lib/protocols/thrift.c:170:3
    #3 0x555890d6d2bc in ndpi_search_thrift_tcp_udp /home/ivan/svnrepos/nDPI/src/lib/protocols/thrift.c:244:7
    #4 0x555890c659aa in check_ndpi_detection_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5940:6
    #5 0x555890c663b7 in check_ndpi_tcp_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:5988:12
    #6 0x555890c66057 in ndpi_check_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:6007:12
    #7 0x555890c7719f in ndpi_internal_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:7005:15
    #8 0x555890c732f7 in ndpi_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:7172:22
    #9 0x555890b2771a in packet_processing /home/ivan/svnrepos/nDPI/fuzz/../example/reader_util.c:1714:31
    #10 0x555890b22dee in ndpi_workflow_process_packet /home/ivan/svnrepos/nDPI/fuzz/../example/reader_util.c:2431:10
    #11 0x555890af9fc2 in LLVMFuzzerTestOneInput /home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader.c:141:7
    #12 0x555890a0b740 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_alloc_fail+0x4cc740) (BuildId: 0e490e64c6df5c04fcbece70b3651007bf1b62a3)
    #13 0x5558909f5ccf in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_alloc_fail+0x4b6ccf) (BuildId: 0e490e64c6df5c04fcbece70b3651007bf1b62a3)
    #14 0x5558909fb796 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_alloc_fail+0x4bc796) (BuildId: 0e490e64c6df5c04fcbece70b3651007bf1b62a3)
    #15 0x555890a24382 in main (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_alloc_fail+0x4e5382) (BuildId: 0e490e64c6df5c04fcbece70b3651007bf1b62a3)
    #16 0x7f2349853082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16
    #17 0x5558909f0bad in _start (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_alloc_fail+0x4b1bad) (BuildId: 0e490e64c6df5c04fcbece70b3651007bf1b62a3)

0x619000000918 is located 0 bytes after 920-byte region [0x619000000580,0x619000000918)
allocated by thread T0 here:
```

Found by oss-fuzz
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60070