### PR TITLE
Numeric truncation at `kerberos.c:458`

### DIFF
--- a/src/lib/protocols/kerberos.c
+++ b/src/lib/protocols/kerberos.c
@@ -417,7 +417,7 @@ static void ndpi_search_kerberos(struct ndpi_detection_module_struct *ndpi_struc
 	      || (packet->payload[koffset] == 0x1E)
 	      || (packet->payload[koffset] == 0x0D)
 	      || (packet->payload[koffset] == 0x0E))) {
-	    u_int16_t koffsetp, body_offset = 0, pad_len;
+	    u_int32_t koffsetp, body_offset = 0, pad_len;
 	    u_int8_t msg_type = packet->payload[koffset];
 
 #ifdef KERBEROS_DEBUG


### PR DESCRIPTION
Hi! We've been fuzzing nDPI with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and we found numeric truncation error in `kerberos.c:458`.

In function `ndpi_search_kerberos` on line 458 `body_offset`, `koffset`, `pad_len` variables has types `u_int16_t`. But due to integer promotion the right side of operator has `int` type, so the numeric truncation may occur. Also variable `body_offset` is used in if operator on line 460. For example, at `packet->payload[body_offset]` numeric truncation error is obvious. So we suggest to change the type `u_int16_t` of these variables to type `u_int32_t`.

### Environment

- OS: ubuntu 20.04
- commit: 7ffd31ebc3e6c191d0e82a9987bd110d2820bdb8

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/ndpi):

    ```
    sudo docker build -t oss-sydr-fuzz-ndpi .

    ```

2. Run docker container:

    ```
    docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-ndpi /bin/bash

    ```

3. Run on the following [input](https://github.com/ntop/nDPI/files/11957023/sydr_e5d503700ad4e7b17c1c5ab8c721c99bf48cac22_num_trunc_18_unsigned.txt):

    ```
    /nDPI/libfuzzer/fuzz_ndpi_reader sydr_e5d503700ad4e7b17c1c5ab8c721c99bf48cac22_num_trunc_18_unsigned.txt

    ```

4. Output:

    ```
    protocols/kerberos.c:458:22: runtime error: implicit conversion from type 'int' of value 65548 (32-bit, signed) to type 'u_int16_t' (aka 'unsigned short') changed the value to 12 (16-bit, unsigned)
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior protocols/kerberos.c:458:22
    ```