### PR TITLE
Numeric truncation at `rtcp.c:49`

### DIFF
--- a/src/lib/protocols/rtcp.c
+++ b/src/lib/protocols/rtcp.c
@@ -42,7 +42,7 @@ static void ndpi_search_rtcp(struct ndpi_detection_module_struct *ndpi_struct,
       NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   } else if(packet->udp != NULL) {
     /* Let's check first the RTCP packet length */
-    u_int16_t len, offset = 0, rtcp_section_len;
+    u_int32_t len, offset = 0, rtcp_section_len;
     
     while(offset + 3 < packet->payload_packet_len) {
       len = packet->payload[2+offset] * 256 + packet->payload[2+offset+1];


### PR DESCRIPTION
Hi! We've been fuzzing nDPI with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and we found numeric truncation error in `rtcp:49`.

In function `ndpi_search_rtcp` on line 49 `rtcp_section_len` and `offset` variables has types `u_int16_t`. But due to integer promotion the right side of operator has `int` type, so the numeric truncation may occur. Variable `rtcp_section_len` is used after in operator `offset += rtcp_section_len` on line 55. Variable `offset` participates in the cycle condition `offset + 3 < packet->payload_packet_len`, what means that truncation error may affect the work of cycle. So we suggest to change the type `u_int16_t` of these variables to type `u_int32_t`.

### Environment

- OS: ubuntu 20.04
- commit: 7ffd31ebc3e6c191d0e82a9987bd110d2820bdb8

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/ndpi):

    ```
    sudo docker build -t oss-sydr-fuzz-ndpi .

    ```

2. Run docker container:

    ```
    docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-ndpi /bin/bash

    ```

3. Run on the following [input](https://github.com/ntop/nDPI/files/11957038/sydr_c5c5f727ee380f5fc47d7bb8c16543e084dcebfd_num_trunc_7_unsigned.txt):

    ```
    /nDPI/libfuzzer/fuzz_ndpi_reader_alloc_fail sydr_c5c5f727ee380f5fc47d7bb8c16543e084dcebfd_num_trunc_7_unsigned.txt

    ```

4. Output:

    ```
    protocols/rtcp.c:49:26: runtime error: implicit conversion from type 'int' of value 99744 (32-bit, signed) to type 'u_int16_t' (aka 'unsigned short') changed the value to 34208 (16-bit, unsigned)
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior protocols/rtcp.c:49:26
    ```