### PR TITLE
Numeric truncation at `diameter.c:76`

### DIFF
--- a/src/lib/protocols/diameter.c
+++ b/src/lib/protocols/diameter.c
@@ -73,7 +73,7 @@ static int is_diameter(struct ndpi_packet_struct *packet)
       diameter->flags == DIAMETER_ERROR ||
       diameter->flags == DIAMETER_RETRASM)) {
 
-    u_int16_t com_code = diameter->com_code[2] + (diameter->com_code[1] << 8) + (diameter->com_code[0] << 8);
+    u_int32_t com_code = diameter->com_code[2] + (diameter->com_code[1] << 8) + (diameter->com_code[0] << 8);
     
      if(com_code == AC || com_code == AS ||
 	com_code == CC || com_code == CE ||


### PR DESCRIPTION
Hi! We've been fuzzing nDPI with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and we found numeric truncation error in `diameter.c:76`.

In function `is_diameter` on line 76 variable `com_code` has type `u_int16_t`. But on the right side of operator there is an integer type value, so the numeric truncation may occur. Variable `com_code` is used after in `if operator` where it is checked for equality to constant values on line 78. We found an input for fuzz-target which makes `com_code` variable equal to one of these constants after truncation on line 76. That means that that function returns with code 0, which is most likely incorrect. So we suggest to change the type `u_int16_t` of this variable to type `u_int32_t`.

### Environment

- OS: ubuntu 20.04
- commit: 334b43579e2b1aa4bffa11c4014c4e1fd0b60ba5

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/ndpi):

    ```
    sudo docker build -t oss-sydr-fuzz-ndpi .

    ```

2. Run docker container:

    ```
    docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-ndpi /bin/bash

    ```

3. Run on the following [input](https://github.com/ntop/nDPI/files/11957055/sydr_39642e89d3e664c881362684e932beee68506e95_num_trunc_1.txt):

    ```
    /nDPI/libfuzzer/fuzz_ndpi_reader_alloc_fail sydr_39642e89d3e664c881362684e932beee68506e95_num_trunc_1.txt

    ```

4. Output:

    ```
    protocols/diameter.c:76:26: runtime error: implicit conversion from type 'int' of value 65810 (32-bit, signed) to type 'u_int16_t' (aka 'unsigned short') changed the value to 274 (16-bit, unsigned)
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior protocols/diameter.c:76:26
    ```