### PR TITLE
Fixed heap-overflow if compiled with `--enable-tls-sigs`.

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -2250,10 +2250,13 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		tot_signature_algorithms_len = ndpi_min((sizeof(ja3.client.signature_algorithms) / 2) - 1, tot_signature_algorithms_len);
 
 #ifdef TLS_HANDLE_SIGNATURE_ALGORITMS
-		flow->protos.tls_quic.num_tls_signature_algorithms = ndpi_min(tot_signature_algorithms_len / 2, MAX_NUM_TLS_SIGNATURE_ALGORITHMS);
+		size_t size = ndpi_min(tot_signature_algorithms_len / 2, MAX_NUM_TLS_SIGNATURE_ALGORITHMS);
 
-		memcpy(flow->protos.tls_quic.client_signature_algorithms,
-		       &packet->payload[s_offset], 2 /* 16 bit */*flow->protos.tls_quic.num_tls_signature_algorithms);
+		if (s_offset + 2 * size <= packet->payload_packet_len) {
+			flow->protos.tls_quic.num_tls_signature_algorithms = size;
+			memcpy(flow->protos.tls_quic.client_signature_algorithms,
+			       &packet->payload[s_offset], 2 /* 16 bit */ * size);
+		}
 #endif
 
 		for(i=0; i<tot_signature_algorithms_len && s_offset+i<total_len; i++) {

--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -43,7 +43,7 @@ fi
 cd ndpi
 # Set LDFLAGS variable and `--with-only-libndpi` option as workaround for the
 # "missing dependencies errors" in the introspector build. See #8939
-LDFLAGS="-lpcap" ./autogen.sh --enable-fuzztargets --with-only-libndpi
+LDFLAGS="-lpcap" ./autogen.sh --enable-fuzztargets --with-only-libndpi --enable-tls-sigs
 make -j$(nproc)
 # Copy fuzzers
 ls fuzz/fuzz* | grep -v "\." | while read i; do cp $i $OUT/; done


### PR DESCRIPTION
It may be useful to enable `--enable-tls-sigs` in CiFuzz.