### PR TITLE
Fix string truncation.

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6595,7 +6595,7 @@ int ndpi_load_ip_category(struct ndpi_detection_module_struct *ndpi_str,
   if(!ndpi_str->custom_categories.ipAddresses_shadow)
     return(-1);
 
-  strncpy(ipbuf, ip_address_and_mask, sizeof(ipbuf));
+  strncpy(ipbuf, ip_address_and_mask, sizeof(ipbuf) - 1);
   ipbuf[sizeof(ipbuf) - 1] = '\0';
 
   ptr = strrchr(ipbuf, '/');


### PR DESCRIPTION
ndpi_main.c: In function ‘ndpi_load_ip_category’:
ndpi_main.c:6598:3: warning: ‘strncpy’ specified bound 64 equals destination size [-Wstringop-truncation]
 6598 |   strncpy(ipbuf, ip_address_and_mask, sizeof(ipbuf));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~