### PR TITLE
Improve TFTP detection with options

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -921,6 +921,10 @@ struct ndpi_flow_udp_struct {
   /* NDPI_PROTOCOL_LINE_CALL */
   u_int8_t line_pkts[2];
   u_int8_t line_base_cnt[2];
+
+  /* NDPI_PROTOCOL_TFTP */
+  u_int16_t tftp_data_num;
+  u_int16_t tftp_ack_num;
 };
 
 /* ************************************************** */

--- a/src/lib/protocols/tftp.c
+++ b/src/lib/protocols/tftp.c
@@ -65,43 +65,69 @@ static void ndpi_search_tftp(struct ndpi_detection_module_struct *ndpi_struct,
         }
 
         {
-          char const * const possible_modes[] = { "netascii", "octet", "mail" };
-          uint8_t mode_found = 0, mode_idx;
+          uint8_t mode_found = 0;
           size_t mode_len;
+          int i;
+          size_t filename_len = 0;
+          const char *string;
+          size_t len = 0;
+          bool first = true;
 
-          for(mode_idx = 0; mode_idx < NDPI_ARRAY_LENGTH(possible_modes); ++mode_idx)
+          /* Skip 2 byte opcode. */
+          for (i = 2; i < packet->payload_packet_len; i++)
           {
-            mode_len = strlen(possible_modes[mode_idx]);
-
-            if (packet->payload_packet_len < mode_len + 1 /* mode is a nul terminated string */)
+            /* Search through the payload until we find a NULL terminated string. */
+            if (packet->payload[i] != '\0')
             {
+              len++;
               continue;
             }
-            if (strncasecmp((char const *)&packet->payload[packet->payload_packet_len - 1 - mode_len],
-                            possible_modes[mode_idx], mode_len) == 0)
+            string = (const char *)&packet->payload[i - len];
+
+            /* Filename should be immediately after opcode followed by the mode. */
+            if (first)
             {
-              mode_found = 1;
-              break;
+              filename_len = len;
+              len = 0;
+              first = false;
+              continue;
             }
+
+            char const * const possible_modes[] = { "netascii", "octet", "mail" };
+            uint8_t mode_idx;
+
+            /* Check the string in the payload against the possible TFTP modes. */
+            for(mode_idx = 0; mode_idx < NDPI_ARRAY_LENGTH(possible_modes); ++mode_idx)
+              {
+                mode_len = strlen(possible_modes[mode_idx]);
+                /* Both are now null terminated */
+                if (len != mode_len)
+                {
+                  continue;
+                }
+                if (strncasecmp(string, possible_modes[mode_idx], mode_len) == 0)
+                {
+                  mode_found = 1;
+                  break;
+                }
+              }
+
+            /* Second string searched must've been the mode, break out before any following options. */
+            break;
           }
 
-          if (mode_found == 0)
+          /* Exclude the flow as TFPT if there was no filename and mode in the first two strings. */
+          if (filename_len == 0 || ndpi_is_printable_buffer(&packet->payload[2], filename_len) == 0 ||
+              mode_found == 0)
           {
             NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
             return;
           }
 
           /* Dissect RRQ/WWQ filename. */
-          size_t filename_len = packet->payload_packet_len - 2 /* Opcode */ - mode_len - 1 /* NUL */;
-
-          if (filename_len == 0 || packet->payload[2] == '\0' || ndpi_is_printable_buffer(&packet->payload[2], filename_len - 1) == 0)
-          {
-            ndpi_set_risk(ndpi_struct, flow, NDPI_MALFORMED_PACKET, "Invalid TFTP RR/WR header: Source/Destination file missing");
-          } else {
-            filename_len = ndpi_min(filename_len, sizeof(flow->protos.tftp.filename) - 1);
-            memcpy(flow->protos.tftp.filename, &packet->payload[2], filename_len);
-            flow->protos.tftp.filename[filename_len] = '\0';
-          }
+          filename_len = ndpi_min(filename_len, sizeof(flow->protos.tftp.filename) - 1);
+          memcpy(flow->protos.tftp.filename, &packet->payload[2], filename_len);
+          flow->protos.tftp.filename[filename_len] = '\0';
 
           /* We have seen enough and do not need any more TFTP packets. */
           NDPI_LOG_INFO(ndpi_struct, "found tftp (RRQ/WWQ)\n");

--- a/src/lib/protocols/tftp.c
+++ b/src/lib/protocols/tftp.c
@@ -165,6 +165,11 @@ static void ndpi_search_tftp(struct ndpi_detection_module_struct *ndpi_struct,
         }
         break;
 
+    case 0x06:
+        /* Option Acknowledgment (OACK) */
+        /* No fixed lengths as it can include the options from the request. */
+        break;
+
     default:
         NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
         return;

--- a/tests/cfgs/default/result/tftp.pcap.out
+++ b/tests/cfgs/default/result/tftp.pcap.out
@@ -1,16 +1,17 @@
-Guessed flow protos:	0
+Guessed flow protos:	2
 
 DPI Packets (UDP):	13	(1.86 pkts/flow)
-Confidence DPI              : 7 (flows)
-Num dissector calls: 319 (45.57 diss/flow)
+Confidence Match by port    : 2 (flows)
+Confidence DPI              : 5 (flows)
+Num dissector calls: 541 (77.29 diss/flow)
 LRU cache ookla:      0/0/0 (insert/search/found)
-LRU cache bittorrent: 0/0/0 (insert/search/found)
+LRU cache bittorrent: 0/6/0 (insert/search/found)
 LRU cache zoom:       0/0/0 (insert/search/found)
 LRU cache stun:       0/0/0 (insert/search/found)
 LRU cache tls_cert:   0/0/0 (insert/search/found)
-LRU cache mining:     0/0/0 (insert/search/found)
+LRU cache mining:     0/2/0 (insert/search/found)
 LRU cache msteams:    0/0/0 (insert/search/found)
-LRU cache stun_zoom:  0/0/0 (insert/search/found)
+LRU cache stun_zoom:  0/2/0 (insert/search/found)
 Automa host:          0/0 (search/found)
 Automa domain:        0/0 (search/found)
 Automa tls cert:      0/0 (search/found)
@@ -25,7 +26,7 @@ TFTP	107	31296	7
 	1	UDP 192.168.0.10:3445 <-> 192.168.0.253:50618 [proto: 96/TFTP][IP: 0/Unknown][ClearText][Confidence: DPI][DPI packets: 4][cat: DataTransfer/4][49 pkts/26853 bytes <-> 49 pkts/2940 bytes][Goodput ratio: 92/7][< 1 sec][bytes ratio: 0.803 (Upload)][IAT c2s/s2c min/avg/max/stddev: 2/2 3/3 9/7 2/2][Pkt Len c2s/s2c min/avg/max/stddev: 69/60 548/60 558/60 69/0][Risk: ** Known Proto on Non Std Port **][Risk Score: 50][PLAIN TEXT (Network Working Group          )][Plen Bins: 51,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,48,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 	2	UDP 172.28.5.170:62058 <-> 172.28.5.91:44618 [proto: 96/TFTP][IP: 0/Unknown][ClearText][Confidence: DPI][DPI packets: 4][cat: DataTransfer/4][2 pkts/92 bytes <-> 2 pkts/1116 bytes][Goodput ratio: 9/92][0.00 sec][Risk: ** Known Proto on Non Std Port **][Risk Score: 50][PLAIN TEXT (BCCCCCC)][Plen Bins: 50,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,50,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 	3	UDP 192.168.0.253:50618 -> 192.168.0.10:69 [proto: 96/TFTP][IP: 0/Unknown][ClearText][Confidence: DPI][DPI packets: 1][cat: DataTransfer/4][1 pkts/62 bytes -> 0 pkts/0 bytes][Goodput ratio: 32/0][< 1 sec][Filename: rfc1350.txt][Risk: ** Unidirectional Traffic **][Risk Score: 10][Risk Info: No server to client traffic][PLAIN TEXT (1350.txt)][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-	4	UDP 172.28.4.53:54626 -> 172.16.5.170:69 [proto: 96/TFTP][IP: 0/Unknown][ClearText][Confidence: DPI][DPI packets: 1][cat: DataTransfer/4][1 pkts/61 bytes -> 0 pkts/0 bytes][Goodput ratio: 31/0][< 1 sec][Risk: ** Malformed Packet **** Unidirectional Traffic **][Risk Score: 20][Risk Info: No server to client traffic / Invalid TFTP RR/WR header: Source/Destination file missing][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	4	UDP 172.28.4.53:54626 -> 172.16.5.170:69 [proto: 96/TFTP][IP: 0/Unknown][ClearText][Confidence: Match by port][DPI packets: 1][cat: DataTransfer/4][1 pkts/61 bytes -> 0 pkts/0 bytes][Goodput ratio: 31/0][< 1 sec][Risk: ** Unidirectional Traffic **][Risk Score: 10][Risk Info: No server to client traffic][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 	5	UDP 172.28.4.53:54627 -> 172.16.5.170:69 [proto: 96/TFTP][IP: 0/Unknown][ClearText][Confidence: DPI][DPI packets: 1][cat: DataTransfer/4][1 pkts/61 bytes -> 0 pkts/0 bytes][Goodput ratio: 31/0][< 1 sec][Filename: sysman.lis][Risk: ** Unidirectional Traffic **][Risk Score: 10][Risk Info: No server to client traffic][PLAIN TEXT (sysman.lis)][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 	6	UDP 172.28.5.91:44618 -> 172.28.5.170:69 [proto: 96/TFTP][IP: 0/Unknown][ClearText][Confidence: DPI][DPI packets: 1][cat: DataTransfer/4][1 pkts/60 bytes -> 0 pkts/0 bytes][Goodput ratio: 30/0][< 1 sec][Filename: zz.bin][Risk: ** Unidirectional Traffic **][Risk Score: 10][Risk Info: No server to client traffic][PLAIN TEXT (zz.bin)][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-	7	UDP 172.28.4.53:54632 -> 172.16.5.170:69 [proto: 96/TFTP][IP: 0/Unknown][ClearText][Confidence: DPI][DPI packets: 1][cat: DataTransfer/4][1 pkts/51 bytes -> 0 pkts/0 bytes][Goodput ratio: 17/0][< 1 sec][Risk: ** Malformed Packet **** Unidirectional Traffic **][Risk Score: 20][Risk Info: No server to client traffic / Invalid TFTP RR/WR header: Source/Destination file missing][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	7	UDP 172.28.4.53:54632 -> 172.16.5.170:69 [proto: 96/TFTP][IP: 0/Unknown][ClearText][Confidence: Match by port][DPI packets: 1][cat: DataTransfer/4][1 pkts/51 bytes -> 0 pkts/0 bytes][Goodput ratio: 17/0][< 1 sec][Risk: ** Unidirectional Traffic **][Risk Score: 10][Risk Info: No server to client traffic][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]


### PR DESCRIPTION
TFTP read/write requests can have optional strings after the filename and mode such as block size and transfer size to speed the transfer. There is also the Option Acknowledgement opcode that contains the option strings that were accepted.

nDPI fails to recognize tftp transactions using options as tftp.