### PR TITLE
dns: make subprotocol inspection optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,16 @@ AS_IF([test "x${enable_code_coverage}" = "xyes"],[
 
 AS_IF([test "${enable_npcap+set}" = set],[DISABLE_NPCAP=1],[DISABLE_NPCAP=0])
 
+AC_MSG_CHECKING([whether to do DNS subprotocol inspection])
+AC_ARG_WITH(no-dns-subprotocol-inspection, AS_HELP_STRING([--with-no-dns-subprotocol-inspection], [Build with no support Disable DNS subprotocol inspection]))
+if test "${with_no_dns_subprotocol_inspection+set}" = set; then :
+  AC_DEFINE(DNS_SUBPROTOCOL_INSPECTION, 0, [DNS subprotocol inspection is OFF])
+  AC_MSG_RESULT(no)
+else
+  AC_DEFINE(DNS_SUBPROTOCOL_INSPECTION, 1, [DNS subprotocol inspection is ON])
+  AC_MSG_RESULT(yes)
+fi
+
 LT_INIT
 LT_LIB_M
 PKG_PROG_PKG_CONFIG

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -700,6 +700,7 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
       return;
     }
 
+#ifdef DNS_SUBPROTOCOL_INSPECTION
     /* extract host name server */
     off = sizeof(struct ndpi_dns_packet_header) + payload_offset;
 
@@ -800,6 +801,7 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
 
     flow->protos.dns.num_queries = (u_int8_t)dns_header.num_queries,
       flow->protos.dns.num_answers = (u_int8_t) (dns_header.num_answers + dns_header.authority_rrs + dns_header.additional_rrs);
+#endif /* DNS_SUBPROTOCOL_INSPECTION */
 
 #ifdef DNS_DEBUG
     NDPI_LOG_DBG2(ndpi_struct, "[num_queries=%d][num_answers=%d][reply_code=%u][rsp_type=%u][host_server_name=%s]\n",


### PR DESCRIPTION
Normally DNS will inspect the hostname to try to match a subprotocol. It may be desireable to have all DNS packets match as DNS instead.

Keep the existing behaviour default so that a new configure option is needed to turn off DNS subprotocol inspection.