### PR TITLE
Add `ndpi_domain_classify_finalize()` function

### DIFF
--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -2104,6 +2104,7 @@ extern "C" {
   u_int32_t             ndpi_domain_classify_add_domains(ndpi_domain_classify *s,
 							 u_int8_t class_id,
 							 char *file_path);
+  bool                  ndpi_domain_classify_finalize(ndpi_domain_classify *s);
   bool                  ndpi_domain_classify_contains(ndpi_domain_classify *s,
 						      u_int8_t *class_id /* out */,
 						      const char *domain);

--- a/src/lib/ndpi_domain_classify.c
+++ b/src/lib/ndpi_domain_classify.c
@@ -179,6 +179,22 @@ u_int32_t ndpi_domain_classify_add_domains(ndpi_domain_classify *s,
 
 /* ********************************************************** */
 
+bool ndpi_domain_classify_finalize(ndpi_domain_classify *s) {
+  u_int32_t i;
+
+  if(!s)
+    return(false);
+
+  for(i=0; i<MAX_NUM_NDPI_DOMAIN_CLASSIFICATIONS; i++) {
+    if(s->classes[i].class_id != 0) {
+      ndpi_bitmap64_compress(s->classes[i].domains);
+    }
+  }
+  return(true);
+}
+
+/* ********************************************************** */
+
 static bool is_valid_domain_char(u_char c) {
   if(((c >= 'A')&& (c <= 'Z'))
      || ((c >= 'a')&& (c <= 'z'))

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6959,6 +6959,7 @@ int ndpi_enable_loaded_categories(struct ndpi_detection_module_struct *ndpi_str)
   }
 #else
   ndpi_domain_classify_free(ndpi_str->custom_categories.sc_hostnames);
+  ndpi_domain_classify_finalize(ndpi_str->custom_categories.sc_hostnames_shadow);
   ndpi_str->custom_categories.sc_hostnames        = ndpi_str->custom_categories.sc_hostnames_shadow;
   ndpi_str->custom_categories.sc_hostnames_shadow = ndpi_domain_classify_alloc();
 #endif


### PR DESCRIPTION
The "domain classify" data structure is immutable, because it uses "bitmap64".
Allow to finalize it before starting to process packets (i.e. before calling `ndpi_domain_classify_contains()`) to avoid, in the data-path, all the memory allocations due to compression.

Calling `ndpi_domain_classify_finalize()` is optional.