### PR TITLE
fuzzing: extend fuzzing coverage

### DIFF
--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -626,6 +626,7 @@ distdir:
 		-o -name '*.am' \
 		-o -name '*.h' \
 		-o -name '*.cpp' \
+		-o -name '*.options' \
 		-o -name 'ipv4_addresses.txt' \
 		-o -name 'bd_param.txt' \
 		-o -name 'splt_param.txt' \

--- a/fuzz/fuzz_config.cpp
+++ b/fuzz/fuzz_config.cpp
@@ -172,7 +172,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   ndpi_get_ndpi_num_custom_protocols(ndpi_info_mod);
   ndpi_get_ndpi_num_supported_protocols(ndpi_info_mod);
 
-  ndpi_self_check_host_match(stderr);
+  ndpi_self_check_host_match(stdout);
+
+  ndpi_dump_protocols(ndpi_info_mod, stdout);
+  ndpi_generate_options(fuzzed_data.ConsumeIntegralInRange(0, 4), stdout);
+  ndpi_dump_risks_score(stdout);
 
   /* Basic code to try testing this "config" */
   bool_value = fuzzed_data.ConsumeBool();

--- a/fuzz/fuzz_config.options
+++ b/fuzz/fuzz_config.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+close_fd_mask=1

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -8777,6 +8777,7 @@ void ndpi_generate_options(u_int opt, FILE *options_out) {
 
   if (!options_out) return;
   ndpi_str = ndpi_init_detection_module(ndpi_no_prefs);
+  if (!ndpi_str) return;
 
   NDPI_BITMASK_SET_ALL(all);
   ndpi_set_protocol_detection_bitmask2(ndpi_str, &all);
@@ -8819,6 +8820,8 @@ void ndpi_generate_options(u_int opt, FILE *options_out) {
     fprintf(options_out, "%s\n", "WARNING: option -a out of range");
     break;
   }
+
+  ndpi_exit_detection_module(ndpi_str);
 }
 
 /* ****************************************************** */
@@ -9701,7 +9704,6 @@ static int ndpi_is_vowel(char c) {
   case 'y': // Not a real vowel...
   case 'x': // Not a real vowel...
     return(1);
-    break;
 
   default:
     return(0);

--- a/src/lib/third_party/src/gcrypt/aes.c
+++ b/src/lib/third_party/src/gcrypt/aes.c
@@ -191,7 +191,13 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
     if( aes_init_done == 0 )
     {
         aes_gen_tables();
+
+        /* Allow to test both aesni and not aesni data path when fuzzing.
+           We can call aes_gen_tables() at every iteration without any issues
+           (performances asides) */
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         aes_init_done = 1;
+#endif
     }
 
     ctx->rk = RK = ctx->buf;

--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -51,6 +51,8 @@ ls fuzz/fuzz* | grep -v "\." | while read i; do cp $i $OUT/; done
 cp fuzz/*.dict $OUT/
 # Copy seed corpus
 cp fuzz/*.zip $OUT/
+# Copy options
+cp fuzz/*.options $OUT/
 # Copy configuration files
 cp example/protos.txt $OUT/
 cp example/categories.txt $OUT/


### PR DESCRIPTION
Try fuzzing some functions which write to file/file descriptor; to avoid slowing the fuzzer, close its stdout