### PR TITLE
Fixed OpenWRT arm related build issues.

### DIFF
--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -310,9 +310,10 @@
 #define get_u_int16_t(X,O)  (*(u_int16_t *)((&(((u_int8_t *)X)[O]))))
 #define get_u_int32_t(X,O)  (*(u_int32_t *)((&(((u_int8_t *)X)[O]))))
 #if defined(__arm__)
-static inline u_int64_t get_u_int64_t(const u_int8_t* X, int O)
+#include <stdint.h>
+static inline uint64_t get_u_int64_t(const uint8_t* X, int O)
 {
-  u_int64_t tmp;
+  uint64_t tmp;
   memcpy(&tmp, X + O, sizeof(tmp));
   return tmp;
 }

--- a/src/lib/third_party/src/roaring.c
+++ b/src/lib/third_party/src/roaring.c
@@ -4298,7 +4298,6 @@ int run_run_container_ixor(
 
 #ifndef WIN32
 #include "ndpi_config.h"
-#include "ndpi_typedefs.h"
 
 #define NDPI_REPLACE_FPRINTF
 #include "../../ndpi_replace_printf.h"


### PR DESCRIPTION
Sorry, the previous PR was not fixing the issue.
Those old-style `u_int?_t` typedef's require including `ndpi_typedefs.h`.

// Edit: Including `ndpi_typedefs.h` is not a solution here. So I've switched to `uint?_t` from `stdint.h`.