### PR TITLE
Remove `struct ndpi_packet_struct` from the public API

### DIFF
--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -107,11 +107,6 @@ extern "C" {
   extern void ndpi_set_proto_subprotocols(struct ndpi_detection_module_struct *ndpi_mod,
 				      int protoId, ...);
 
-  extern int ndpi_packet_src_ip_eql(const struct ndpi_packet_struct *packet, const ndpi_ip_addr_t * ip);
-  extern int ndpi_packet_dst_ip_eql(const struct ndpi_packet_struct *packet, const ndpi_ip_addr_t * ip);
-  extern void ndpi_packet_src_ip_get(const struct ndpi_packet_struct *packet, ndpi_ip_addr_t * ip);
-  extern void ndpi_packet_dst_ip_get(const struct ndpi_packet_struct *packet, ndpi_ip_addr_t * ip);
-
   extern int ndpi_parse_ip_string(const char *ip_str, ndpi_ip_addr_t *parsed_ip);
   extern char *ndpi_get_ip_string(const ndpi_ip_addr_t * ip, char *buf, u_int buf_len);
   extern u_int8_t ndpi_is_ipv6(const ndpi_ip_addr_t *ip);
@@ -177,8 +172,6 @@ extern "C" {
 
   int64_t ndpi_asn1_ber_decode_length(const unsigned char *payload, int payload_len, u_int16_t *value_len);
   char* ndpi_intoav4(unsigned int addr, char* buf, u_int16_t bufLen);
-  int ndpi_current_pkt_from_client_to_server(const struct ndpi_packet_struct *packet, const struct ndpi_flow_struct *flow);
-  int ndpi_current_pkt_from_server_to_client(const struct ndpi_packet_struct *packet, const struct ndpi_flow_struct *flow);
   int ndpi_seen_flow_beginning(const struct ndpi_flow_struct *flow);
 
 #ifdef __cplusplus

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -965,49 +965,6 @@ struct ndpi_int_one_line_struct {
   u_int16_t len;
 };
 
-struct ndpi_packet_struct {
-  const struct ndpi_iphdr *iph;
-  const struct ndpi_ipv6hdr *iphv6;
-  const struct ndpi_tcphdr *tcp;
-  const struct ndpi_udphdr *udp;
-  const u_int8_t *generic_l4_ptr;	/* is set only for non tcp-udp traffic */
-  const u_int8_t *payload;
-
-  u_int64_t current_time_ms;
-
-  struct ndpi_int_one_line_struct line[NDPI_MAX_PARSE_LINES_PER_PACKET];
-  /* HTTP headers */
-  struct ndpi_int_one_line_struct host_line;
-  struct ndpi_int_one_line_struct forwarded_line;
-  struct ndpi_int_one_line_struct referer_line;
-  struct ndpi_int_one_line_struct content_line;
-  struct ndpi_int_one_line_struct content_disposition_line;
-  struct ndpi_int_one_line_struct accept_line;
-  struct ndpi_int_one_line_struct authorization_line;
-  struct ndpi_int_one_line_struct user_agent_line;
-  struct ndpi_int_one_line_struct http_url_name;
-  struct ndpi_int_one_line_struct http_encoding;
-  struct ndpi_int_one_line_struct http_transfer_encoding;
-  struct ndpi_int_one_line_struct http_contentlen;
-  struct ndpi_int_one_line_struct http_cookie;
-  struct ndpi_int_one_line_struct http_origin;
-  struct ndpi_int_one_line_struct http_x_session_type;
-  struct ndpi_int_one_line_struct server_line;
-  struct ndpi_int_one_line_struct http_method;
-  struct ndpi_int_one_line_struct http_response; /* the first "word" in this pointer is the
-						    response code in the packet (200, etc) */
-  u_int8_t http_num_headers; /* number of found (valid) header lines in HTTP request or response */
-
-  u_int16_t l3_packet_len;
-  u_int16_t payload_packet_len;
-  u_int16_t parsed_lines;
-  u_int16_t empty_line_position;
-  u_int8_t tcp_retransmission;
-
-  u_int8_t packet_lines_parsed_complete:1,
-    packet_direction:1, empty_line_position_set:1, http_check_content:1, pad:4;
-};
-
 struct ndpi_detection_module_struct;
 struct ndpi_flow_struct;
 
@@ -1249,6 +1206,49 @@ typedef struct {
   u_int16_t l7_protocol;
 } nbpf_filter;
 #endif
+
+struct ndpi_packet_struct {
+  const struct ndpi_iphdr *iph;
+  const struct ndpi_ipv6hdr *iphv6;
+  const struct ndpi_tcphdr *tcp;
+  const struct ndpi_udphdr *udp;
+  const u_int8_t *generic_l4_ptr;	/* is set only for non tcp-udp traffic */
+  const u_int8_t *payload;
+
+  u_int64_t current_time_ms;
+
+  struct ndpi_int_one_line_struct line[NDPI_MAX_PARSE_LINES_PER_PACKET];
+  /* HTTP headers */
+  struct ndpi_int_one_line_struct host_line;
+  struct ndpi_int_one_line_struct forwarded_line;
+  struct ndpi_int_one_line_struct referer_line;
+  struct ndpi_int_one_line_struct content_line;
+  struct ndpi_int_one_line_struct content_disposition_line;
+  struct ndpi_int_one_line_struct accept_line;
+  struct ndpi_int_one_line_struct authorization_line;
+  struct ndpi_int_one_line_struct user_agent_line;
+  struct ndpi_int_one_line_struct http_url_name;
+  struct ndpi_int_one_line_struct http_encoding;
+  struct ndpi_int_one_line_struct http_transfer_encoding;
+  struct ndpi_int_one_line_struct http_contentlen;
+  struct ndpi_int_one_line_struct http_cookie;
+  struct ndpi_int_one_line_struct http_origin;
+  struct ndpi_int_one_line_struct http_x_session_type;
+  struct ndpi_int_one_line_struct server_line;
+  struct ndpi_int_one_line_struct http_method;
+  struct ndpi_int_one_line_struct http_response; /* the first "word" in this pointer is the
+						    response code in the packet (200, etc) */
+  u_int8_t http_num_headers; /* number of found (valid) header lines in HTTP request or response */
+
+  u_int16_t l3_packet_len;
+  u_int16_t payload_packet_len;
+  u_int16_t parsed_lines;
+  u_int16_t empty_line_position;
+  u_int8_t tcp_retransmission;
+
+  u_int8_t packet_lines_parsed_complete:1,
+    packet_direction:1, empty_line_position_set:1, http_check_content:1, pad:4;
+};
 
 struct ndpi_detection_module_struct {
   NDPI_PROTOCOL_BITMASK detection_bitmask;

--- a/src/lib/protocols/icecast.c
+++ b/src/lib/protocols/icecast.c
@@ -28,6 +28,9 @@
 
 #include "ndpi_api.h"
 
+extern int ndpi_current_pkt_from_client_to_server(const struct ndpi_detection_module_struct *ndpi_str, const struct ndpi_flow_struct *flow);
+extern int ndpi_current_pkt_from_server_to_client(const struct ndpi_detection_module_struct *ndpi_str, const struct ndpi_flow_struct *flow);
+
 static void ndpi_int_icecast_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_ICECAST, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
@@ -60,12 +63,12 @@ static void ndpi_search_icecast_tcp(struct ndpi_detection_module_struct *ndpi_st
     }
   }
 
-  if(ndpi_current_pkt_from_client_to_server(packet, flow)
+  if(ndpi_current_pkt_from_client_to_server(ndpi_struct, flow)
       && (flow->packet_counter < 10)) {
     return;
   }
 
-  if(ndpi_current_pkt_from_server_to_client(packet, flow)) {
+  if(ndpi_current_pkt_from_server_to_client(ndpi_struct, flow)) {
     /* server answer, now test Server for Icecast */
 
     ndpi_parse_packet_line_info(ndpi_struct, flow);


### PR DESCRIPTION
Right now, the only instance of `struct ndpi_packet_struct` is embedded into `struct ndpi_detection_module_struct`. Since the latter is a private structure (because of `NDPI_LIB_COMPILATION` ) there is no way for the application to get a pointer to `ndpi_struct->packet`.

Bottom line: the application can't use any API functions having `struct ndpi_packet_struct *` as parameter. Remove them all (since they are completly unused and unusable).

There are no public helper functions to initialize/populate/deinit a `struct ndpi_packet_struct` object, so the application can't neither create its own instance of this object.

Protect `struct ndpi_packet_struct` via the same define `NDPI_LIB_COMPILATION`.

