### PR TITLE
Move from PCRE to PCRE2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -21,7 +21,7 @@ A clear and concise description of what happening.
 * OS version: [e.g. 18.04]
 * Architecture: [e.g. arm64]
 * nDPI version or commit hash: [e.g. 4.0-stable or 937357e4bc55610f116f66d15a8e0fc1e260c02c].
-* nDPI compilation flags used: if you are building from source [e.g. --with-pcre --with-local-libgcrypt].
+* nDPI compilation flags used: if you are building from source [e.g. --with-pcre2 --with-local-libgcrypt].
 * Attach the `config.log` file generated after `./configure` ran (if you are building from source).
 
 ## How to reproduce the reported bug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
             os: ubuntu-20.04
             arch: "x86_64"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-sanitizer"
             nBPF: ""
@@ -101,7 +101,7 @@ jobs:
             os: ubuntu-22.04
             arch: "x86_64"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-sanitizer"
             nBPF: ""
@@ -110,7 +110,7 @@ jobs:
             os: ubuntu-20.04
             arch: "x86_64"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-sanitizer"
             nBPF: ""
@@ -120,7 +120,7 @@ jobs:
             os: ubuntu-22.04
             arch: "x86_64"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-sanitizer"
             nBPF: ""
@@ -129,7 +129,7 @@ jobs:
             os: ubuntu-latest
             arch: "x86_64"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-thread-sanitizer"
             nBPF: ""
@@ -137,7 +137,7 @@ jobs:
             os: ubuntu-latest
             arch: "x86_64"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-sanitizer"
             nBPF: "nBPF"
@@ -145,7 +145,7 @@ jobs:
             os: ubuntu-22.04
             arch: "x86_64"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-memory-sanitizer"
             nBPF: ""
@@ -153,7 +153,7 @@ jobs:
             os: macOS-latest
             arch: "x86_64"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "" # Disable sanitizer on macos
             nBPF: ""
@@ -161,7 +161,7 @@ jobs:
             os: macos-12
             arch: "x86_64"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "" # Disable sanitizer on macos
             nBPF: ""
@@ -169,7 +169,7 @@ jobs:
             os: ubuntu-latest
             arch: "arm64"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "" # Disable sanitizer on arm64
             nBPF: ""
@@ -177,7 +177,7 @@ jobs:
             os: ubuntu-latest
             arch: "armhf"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-sanitizer"
             nBPF: ""
@@ -185,7 +185,7 @@ jobs:
             os: ubuntu-latest
             arch: "s390x"
             gcrypt: ""
-            pcre: "--with-pcre"
+            pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: ""
             nBPF: ""
@@ -209,8 +209,8 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 'x86_64') && startsWith(matrix.gcrypt, '--with-local-libgcrypt')
         run: |
           sudo apt-get install libgcrypt20-dev
-      - name: Install Ubuntu Prerequisites (libpcre)
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 'x86_64') && startsWith(matrix.pcre, '--with-pcre')
+      - name: Install Ubuntu Prerequisites (libpcre2)
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 'x86_64') && startsWith(matrix.pcre, '--with-pcre2')
         run: |
           sudo apt-get install libpcre3-dev
       - name: Install Ubuntu Prerequisites (maxminddb)
@@ -266,8 +266,8 @@ jobs:
         if: startsWith(matrix.os, 'macOS') && startsWith(matrix.arch, 'x86_64') && startsWith(matrix.gcrypt, '--with-local-libgcrypt')
         run: |
           brew install libgcrypt
-      - name: Install MacOS Prerequisites (libpcre)
-        if: startsWith(matrix.os, 'macOS') && startsWith(matrix.arch, 'x86_64') && startsWith(matrix.pcre, '--with-pcre')
+      - name: Install MacOS Prerequisites (libpcre2)
+        if: startsWith(matrix.os, 'macOS') && startsWith(matrix.arch, 'x86_64') && startsWith(matrix.pcre, '--with-pcre2')
         run: |
           brew install pcre
       - name: Install MacOS Prerequisites (maxminddb)

--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install libpcre3-dev libmaxminddb-dev lcov
           sudo apt-get install wdiff colordiff
       - name: Configure
-        run: ./autogen.sh --enable-option-checking=fatal --enable-debug-messages --enable-code-coverage --with-pcre --with-maxminddb --enable-tls-sigs
+        run: ./autogen.sh --enable-option-checking=fatal --enable-debug-messages --enable-code-coverage --with-pcre2 --with-maxminddb --enable-tls-sigs
       - name: Build
         run: make all
       - name: Test
@@ -91,7 +91,7 @@ jobs:
           pprof -h
       - name: Configure nDPI library
         run: |
-          ./autogen.sh --enable-gprof --enable-option-checking=fatal --with-pcre --with-maxminddb --enable-tls-sigs
+          ./autogen.sh --enable-gprof --enable-option-checking=fatal --with-pcre2 --with-maxminddb --enable-tls-sigs
       - name: Build nDPI library
         run: |
           make

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
           pprof -h
       - name: Configure nDPI library
         run: |
-          ./autogen.sh --enable-gprof --enable-option-checking=fatal --with-pcre --with-maxminddb --enable-tls-sigs --enable-debug-messages
+          ./autogen.sh --enable-gprof --enable-option-checking=fatal --with-pcre2 --with-maxminddb --enable-tls-sigs --enable-debug-messages
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ On Windows:
 There are three supported ways to build nDPI:
 
 1. MSYS2 (assuming [MSYS2](https://www.msys2.org/) already installed):
-  - msys2 -c "pacman --noconfirm -S --needed --overwrite '\*' git mingw-w64-x86\_64-toolchain automake1.16 automake-wrapper autoconf libtool make mingw-w64-x86\_64-json-c mingw-w64-x86\_64-crt-git mingw-w64-x86\_64-pcre mingw-w64-x86\_64-libpcap"
+  - msys2 -c "pacman --noconfirm -S --needed --overwrite '\*' git mingw-w64-x86\_64-toolchain automake1.16 automake-wrapper autoconf libtool make mingw-w64-x86\_64-json-c mingw-w64-x86\_64-crt-git mingw-w64-x86\_64-pcre2 mingw-w64-x86\_64-libpcap"
 
 2. Mingw-w64
 
@@ -79,7 +79,7 @@ The entire procedure of adding new protocols in detail:
 5. Choose (do not change anything) a selection bitmask from: `src/include/ndpi_define.h`
 6. Set protocol default ports in `ndpi_init_protocol_defaults` in: `src/lib/ndpi_main.c`
 7. Be sure to have nBPF support, cloning `PF_RING` in the same directory where you cloned `nDPI`: `git clone https://github.com/ntop/PF_RING/ && cd PF_RING/userland/nbpf && ./configure && make`
-8. From the `nDPI` root directory, `./autogen.sh --with-pcre` (nBPF and PCRE are usually optional, but they are needed to run/update *all* the unit tests)
+8. From the `nDPI` root directory, `./autogen.sh --with-pcre2` (nBPF and PCRE2 are usually optional, but they are needed to run/update *all* the unit tests)
 9. `make`
 10. `make check`
 11. Update the documentation, adding this new protocol to `doc/protocols.rst`

--- a/configure.ac
+++ b/configure.ac
@@ -359,14 +359,14 @@ AS_IF([test "${with_local_libgcrypt+set}" = set],[
   AC_DEFINE_UNQUOTED(USE_HOST_LIBGCRYPT, 1, [Use locally installed libgcrypt instead of builtin gcrypt-light])
 ])
 
-dnl> PCRE
-PCRE_ENABLED=0
-AC_ARG_WITH(pcre, AS_HELP_STRING([--with-pcre], [Enable nDPI build with libpcre]))
-if test "${with_pcre+set}" = set; then :
-  AC_CHECK_LIB(pcre, pcre_compile, AC_DEFINE_UNQUOTED(HAVE_PCRE, 1, [libpcre(-dev) is present]))
-  if test "x$ac_cv_lib_pcre_pcre_compile" = xyes; then :
-    ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lpcre"
-    PCRE_ENABLED=1
+dnl> PCRE2
+PCRE2_ENABLED=0
+AC_ARG_WITH(pcre2, AS_HELP_STRING([--with-pcre2], [Enable nDPI build with libpcre2]))
+if test "${with_pcre2+set}" = set; then :
+  AC_CHECK_LIB(pcre2-8, pcre2_compile_8, AC_DEFINE_UNQUOTED(HAVE_PCRE2, 1, [libpcre2(-dev) is present]))
+  if test "x$ac_cv_lib_pcre2_8_pcre2_compile_8" = xyes; then :
+    ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lpcre2-8"
+    PCRE2_ENABLED=1
   fi
 fi
 
@@ -420,7 +420,7 @@ AC_SUBST(GPROF_CFLAGS)
 AC_SUBST(GPROF_LIBS)
 AC_SUBST(GPROF_ENABLED)
 AC_SUBST(USE_HOST_LIBGCRYPT)
-AC_SUBST(PCRE_ENABLED)
+AC_SUBST(PCRE2_ENABLED)
 AC_SUBST(NBPF_ENABLED)
 AC_SUBST(HANDLE_TLS_SIGS)
 AC_SUBST(DISABLE_NPCAP)

--- a/src/lib/third_party/include/rce_injection.h
+++ b/src/lib/third_party/include/rce_injection.h
@@ -1,4 +1,4 @@
-#ifdef HAVE_PCRE
+#ifdef HAVE_PCRE2
 
 #ifndef NDPI_RCE_H
 #define NDPI_RCE_H
@@ -8,7 +8,7 @@
 #define N_RCE_REGEX 7
 
 /* Compiled regex */
-static struct pcre_struct *comp_rx[N_RCE_REGEX];
+static struct pcre2_struct *comp_rx[N_RCE_REGEX];
 
 static unsigned int initialized_comp_rx = 0;
 
@@ -615,4 +615,4 @@ static const char *pwsh_commands[] = {
   "-PSConsoleFile"
 };
 
-#endif //HAVE_PCRE
+#endif //HAVE_PCRE2

--- a/tests/do.sh.in
+++ b/tests/do.sh.in
@@ -26,7 +26,7 @@ CMD_COLORDIFF="$(which colordiff)"
 
 EXE_SUFFIX=@EXE_SUFFIX@
 GPROF_ENABLED=@GPROF_ENABLED@
-PCRE_ENABLED=@PCRE_ENABLED@
+PCRE2_ENABLED=@PCRE2_ENABLED@
 PCRE_PCAPS="WebattackRCE.pcap"
 NBPF_ENABLED=@NBPF_ENABLED@
 NBPF_PCAPS="h323-overflow.pcap"
@@ -84,7 +84,7 @@ check_results() {
 		[ $SKIP_PCAP = 1 ] && continue
 	    fi
 	    SKIP_PCAP=0
-	    if [ $PCRE_ENABLED -eq 0 ]; then
+	    if [ $PCRE2_ENABLED -eq 0 ]; then
 	      for p in $PCRE_PCAPS; do
 	        if [ $f = $p ]; then
 	          SKIP_PCAP=1


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues): #2133


Describe changes:

Move from PCRE to PCRE2. PCRE is EOL and won't receive any security updates anymore. Convert to PCRE2 by converting any function PCRE2 new API.

Also update every entry in github workflows and README to point to the new configure flag. (--with-pcre2)
