### PR TITLE
Fixed invalid unidirectional risk set even if packets from both directions were processed.

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -7781,6 +7781,8 @@ static ndpi_protocol ndpi_internal_detection_process_packet(struct ndpi_detectio
     if(ndpi_init_packet(ndpi_str, flow, current_time_ms, packet_data, packetlen, input_info) != 0)
       return(ret);
 
+    ndpi_connection_tracking(ndpi_str, flow);
+
     goto ret_protocols;
   }
 


### PR DESCRIPTION
I've observed a strange behavior in `nDPId` after updating to the latest `nDPI` commit.
Literally **all** UDP packets had the `Unidirectional Traffic` risk set.

The issue was that if the flow was detected e.g. after the first packet, the risk is never unset even if there were packets coming from both directions.
It is necessary to call `ndpi_connection_tracking()` if the flow was detected after the first packet.


