### PR TITLE
Add realtime protocol output to `ndpiReader`.

### DIFF
--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1425,6 +1425,9 @@ void process_ndpi_collected_info(struct ndpi_workflow * workflow, struct ndpi_fl
     flow->flow_payload = flow->ndpi_flow->flow_payload, flow->flow_payload_len = flow->ndpi_flow->flow_payload_len;
     flow->ndpi_flow->flow_payload = NULL; /* We'll free the memory */
 
+    if(workflow->flow_callback != NULL)
+      workflow->flow_callback(workflow, flow, workflow->flow_callback_userdata);
+
     ndpi_free_flow_info_half(flow);
   }
 }

--- a/example/reader_util.h
+++ b/example/reader_util.h
@@ -374,6 +374,9 @@ typedef struct ndpi_workflow {
   struct ndpi_workflow_prefs prefs;
   struct ndpi_stats stats;
 
+  ndpi_workflow_callback_ptr flow_callback;
+  void * flow_callback_userdata;
+
   /* outside referencies */
   pcap_t *pcap_handle;
 
@@ -407,6 +410,13 @@ struct ndpi_proto ndpi_workflow_process_packet(struct ndpi_workflow * workflow,
 					       const struct pcap_pkthdr *header,
 					       const u_char *packet,
 					       ndpi_risk *flow_risk);
+
+
+/* Flow callback for completed flows, before the flow memory will be freed. */
+static inline void ndpi_workflow_set_flow_callback(struct ndpi_workflow * workflow, ndpi_workflow_callback_ptr callback, void * userdata) {
+  workflow->flow_callback = callback;
+  workflow->flow_callback_userdata = userdata;
+}
 
 int ndpi_is_datalink_supported(int datalink_type);
 

--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -290,14 +290,15 @@
 			  ndpi_parse_packet_line_info(ndpi_struct,flow);	\
                         }                                                       \
 
-#define NDPI_IPSEC_PROTOCOL_ESP	   50
-#define NDPI_IPSEC_PROTOCOL_AH	   51
-#define NDPI_GRE_PROTOCOL_TYPE	   0x2F
-#define NDPI_ICMP_PROTOCOL_TYPE	   0x01
-#define NDPI_IGMP_PROTOCOL_TYPE	   0x02
-#define NDPI_EGP_PROTOCOL_TYPE	   0x08
-#define NDPI_OSPF_PROTOCOL_TYPE	   0x59
-#define NDPI_SCTP_PROTOCOL_TYPE	   132
+#define NDPI_IPSEC_PROTOCOL_ESP    50
+#define NDPI_IPSEC_PROTOCOL_AH     51
+#define NDPI_GRE_PROTOCOL_TYPE     0x2F
+#define NDPI_ICMP_PROTOCOL_TYPE    0x01
+#define NDPI_IGMP_PROTOCOL_TYPE    0x02
+#define NDPI_EGP_PROTOCOL_TYPE     0x08
+#define NDPI_OSPF_PROTOCOL_TYPE    0x59
+#define NDPI_VRRP_PROTOCOL_TYPE    112
+#define NDPI_SCTP_PROTOCOL_TYPE    132
 #define NDPI_IPIP_PROTOCOL_TYPE    0x04
 #define NDPI_ICMPV6_PROTOCOL_TYPE  0x3a
 #define NDPI_PGM_PROTOCOL_TYPE     0x71

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4138,7 +4138,7 @@ static u_int16_t guess_protocol_id(struct ndpi_detection_module_struct *ndpi_str
 	}
       }
       return(NDPI_PROTOCOL_IP_ICMPV6);
-    case 112:
+    case NDPI_VRRP_PROTOCOL_TYPE:
       return(NDPI_PROTOCOL_IP_VRRP);
     }
   }

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -1569,7 +1569,7 @@ char *ndpi_get_ip_proto_name(u_int16_t ip_proto, char *name, unsigned int name_l
     snprintf(name, name_len, "PIM");
     break;
 
-  case 112:
+  case NDPI_VRRP_PROTOCOL_TYPE:
     snprintf(name, name_len, "VRRP");
     break;
 
@@ -2849,7 +2849,7 @@ int ndpi_vsnprintf(char * str, size_t size, char const * format, va_list va_args
 struct tm *ndpi_gmtime_r(const time_t *timep,
                          struct tm *result)
 {
-#ifdef WIN32
+#if defined(WIN32)
   gmtime_s(result, timep);
   return result;
 #else

--- a/windows/src/ndpi_define.h
+++ b/windows/src/ndpi_define.h
@@ -283,14 +283,15 @@
 			  ndpi_parse_packet_line_info(ndpi_struct,flow);	\
                         }                                                       \
 
-#define NDPI_IPSEC_PROTOCOL_ESP	   50
-#define NDPI_IPSEC_PROTOCOL_AH	   51
-#define NDPI_GRE_PROTOCOL_TYPE	   0x2F
-#define NDPI_ICMP_PROTOCOL_TYPE	   0x01
-#define NDPI_IGMP_PROTOCOL_TYPE	   0x02
-#define NDPI_EGP_PROTOCOL_TYPE	   0x08
-#define NDPI_OSPF_PROTOCOL_TYPE	   0x59
-#define NDPI_SCTP_PROTOCOL_TYPE	   132
+#define NDPI_IPSEC_PROTOCOL_ESP    50
+#define NDPI_IPSEC_PROTOCOL_AH     51
+#define NDPI_GRE_PROTOCOL_TYPE     0x2F
+#define NDPI_ICMP_PROTOCOL_TYPE    0x01
+#define NDPI_IGMP_PROTOCOL_TYPE    0x02
+#define NDPI_EGP_PROTOCOL_TYPE     0x08
+#define NDPI_OSPF_PROTOCOL_TYPE    0x59
+#define NDPI_VRRP_PROTOCOL_TYPE    112
+#define NDPI_SCTP_PROTOCOL_TYPE    132
 #define NDPI_IPIP_PROTOCOL_TYPE    0x04
 #define NDPI_ICMPV6_PROTOCOL_TYPE  0x3a
 #define NDPI_PGM_PROTOCOL_TYPE     0x71


### PR DESCRIPTION
This is basically a copy'n'pasta from #2059 with some small changes.
Not sure if we want to keep the "realtime protocol output" - behavior.
But at least the flow callback might be coming handy in the future.
I've stumbled on that "I wanna output something from the flow struct, but the memory is already free'd" - issue before and this is a nice workaround.