### PR TITLE
Fix some warnings reported by CODESonar

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -1963,7 +1963,7 @@ static void printFlow(u_int32_t id, struct ndpi_flow_info *flow, u_int16_t threa
       fprintf(out, "[Payload: ");
 
       for(i=0; i<flow->flow_payload_len; i++)
-	fprintf(out, "%c", isspace(flow->flow_payload[i]) ? '.' : flow->flow_payload[i]);
+	fprintf(out, "%c", ndpi_isspace(flow->flow_payload[i]) ? '.' : flow->flow_payload[i]);
 
       fprintf(out, "]");
     }

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -129,7 +129,7 @@ int ndpi_analyze_payload(struct ndpi_flow_info *flow,
 #ifdef DEBUG_PAYLOAD
   u_int16_t i;
   for(i=0; i<payload_len; i++)
-    printf("%c", isprint(payload[i]) ? payload[i] : '.');
+    printf("%c", ndpi_isprint(payload[i]) ? payload[i] : '.');
   printf("\n");
 #endif
 
@@ -247,7 +247,7 @@ static void print_payload_stat(struct payload_stats *p, FILE *out) {
   fprintf(out, "\t[");
 
   for(i=0; i<p->pattern_len; i++) {
-    fprintf(out, "%c", isprint(p->pattern[i]) ? p->pattern[i] : '.');
+    fprintf(out, "%c", ndpi_isprint(p->pattern[i]) ? p->pattern[i] : '.');
   }
 
   fprintf(out, "]");
@@ -255,7 +255,7 @@ static void print_payload_stat(struct payload_stats *p, FILE *out) {
   fprintf(out, "[");
 
   for(i=0; i<p->pattern_len; i++) {
-    fprintf(out, "%s%02X", (i > 0) ? " " : "", isprint(p->pattern[i]) ? p->pattern[i] : '.');
+    fprintf(out, "%s%02X", (i > 0) ? " " : "", ndpi_isprint(p->pattern[i]) ? p->pattern[i] : '.');
   }
 
   fprintf(out, "]");

--- a/src/lib/ndpi_analyze.c
+++ b/src/lib/ndpi_analyze.c
@@ -148,7 +148,7 @@ float ndpi_data_average(struct ndpi_analyze_struct *s) {
   if((!s) || (s->num_data_entries == 0))
     return(0);
 
-  return((s->num_data_entries == 0) ? 0 : ((float)s->sum_total / (float)s->num_data_entries));
+  return((float)s->sum_total / (float)s->num_data_entries);
 }
 
 /* ********************************************************************************* */

--- a/src/lib/ndpi_classify.c
+++ b/src/lib/ndpi_classify.c
@@ -559,9 +559,9 @@ ndpi_classify (const unsigned short *pkt_len, const pkt_timeval *pkt_time,
 void
 ndpi_update_params (classifier_type_codes_t param_type, const char *param_file)
 {
-  float param;
+  float param = 0.0;
   FILE *fp;
-  int count = 0;
+  int count;
 
   switch (param_type) {
   case (SPLT_PARAM_TYPE):
@@ -711,7 +711,7 @@ ndpi_log_timestamp(char *log_ts, uint32_t log_ts_len)
 {
   pkt_timeval tv;
   time_t nowtime;
-  struct tm nowtm_r;
+  struct tm nowtm_r = { 0 };
   char tmbuf[NDPI_TIMESTAMP_LEN];
 
   gettimeofday(&tv, NULL);

--- a/src/lib/ndpi_domain_classify.c
+++ b/src/lib/ndpi_domain_classify.c
@@ -224,7 +224,7 @@ bool ndpi_domain_classify_contains(ndpi_domain_classify *s,
   if((!strcmp(dot, ".arpa")) || (!strcmp(dot, ".local"))) return(false);
 
   /* This is a number or a numeric IP or similar */
-  if(isdigit(domain[len-1]) && isdigit(domain[0])) {
+  if(ndpi_isdigit(domain[len-1]) && isdigit(domain[0])) {
 #ifdef DEBUG_CONTAINS
     printf("[contains] %s INVALID\n", domain);
 #endif

--- a/src/lib/ndpi_serializer.c
+++ b/src/lib/ndpi_serializer.c
@@ -74,7 +74,7 @@ static int ndpi_is_number(const char *str, u_int32_t str_len) {
   unsigned int i;
 
   for(i = 0; i < str_len; i++)
-    if(!isdigit((int)str[i])) return(0);
+    if(!ndpi_isdigit(str[i])) return(0);
 
   return(1);
 }

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -696,7 +696,7 @@ static inline int ndpi_is_other_char(char c) {
 /* ******************************************************************** */
 
 static int _ndpi_is_valid_char(char c) {
-  if(ispunct(c) && (!ndpi_is_other_char(c)))
+  if(ndpi_ispunct(c) && (!ndpi_is_other_char(c)))
     return(0);
   else
     return(ndpi_isdigit(c)
@@ -722,7 +722,7 @@ static int ndpi_find_non_eng_bigrams(struct ndpi_detection_module_struct *ndpi_s
 				     char *str) {
   char s[3];
 
-  if((isdigit((int)str[0]) && isdigit((int)str[1]))
+  if((ndpi_isdigit(str[0]) && ndpi_isdigit(str[1]))
      || ndpi_is_other_char(str[0])
      || ndpi_is_other_char(str[1])
      )
@@ -741,7 +741,7 @@ int ndpi_has_human_readeable_string(struct ndpi_detection_module_struct *ndpi_st
 				    char *buffer, u_int buffer_size,
 				    u_int8_t min_string_match_len,
 				    char *outbuf, u_int outbuf_len) {
-  u_int ret = 0, i = 0, do_cr = 0, len = 0, o_idx = 0, being_o_idx = 0;
+  u_int ret = 0, i, do_cr = 0, len = 0, o_idx = 0, being_o_idx = 0;
 
   if(buffer_size <= 0)
     return(0);
@@ -768,7 +768,7 @@ int ndpi_has_human_readeable_string(struct ndpi_detection_module_struct *ndpi_st
 	len += 1;
       }
 
-      // printf("->> %c%c\n", isprint(buffer[i]) ? buffer[i] : '.', isprint(buffer[i+1]) ? buffer[i+1] : '.');
+      // printf("->> %c%c\n", ndpi_isprint(buffer[i]) ? buffer[i] : '.', ndpi_isprint(buffer[i+1]) ? buffer[i+1] : '.');
       if(do_cr) {
 	if(len > min_string_match_len)
 	  ret = 1;

--- a/src/lib/protocols/checkmk.c
+++ b/src/lib/protocols/checkmk.c
@@ -60,7 +60,7 @@ static void ndpi_search_checkmk(struct ndpi_detection_module_struct *ndpi_struct
      * this will detect the OpenSession command of the Data Stream Interface (DSI) protocol
      * which is exclusively used by the Apple Filing Protocol (AFP) on TCP/IP networks
      */
-    if (packet->payload_packet_len >= 15 && packet->payload_packet_len < 100
+    if (packet->payload_packet_len < 100
         && memcmp(packet->payload, "<<<check_mk>>>", 14) == 0) {
 
       NDPI_LOG_DBG(ndpi_struct, "Check_MK: Flow detected.\n");

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -253,7 +253,7 @@ static u_int8_t ndpi_grab_dns_name(struct ndpi_packet_struct *packet,
 	  
 	  hostname_is_valid = 0;
 	  
-	  if (isprint(c) == 0) {
+	  if (ndpi_isprint(c) == 0) {
 	    _hostname[j++] = '?';
 	  } else {
 	    _hostname[j++] = '_';

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -122,7 +122,7 @@ static int ndpi_search_http_tcp_again(struct ndpi_detection_module_struct *ndpi_
 /* *********************************************** */
 
 static int ndpi_http_is_print(char c) {
-  if(isprint(c) || (c == '\t') || (c == '\r') || (c == '\n'))
+  if(ndpi_isprint(c) || (c == '\t') || (c == '\r') || (c == '\n'))
     return(1);
   else
     return(0);
@@ -568,11 +568,11 @@ static void ndpi_check_user_agent(struct ndpi_detection_module_struct *ndpi_stru
        * We assume at least one non alpha char.
        * e.g. ' ', '-' or ';' ...
        */
-      if (isalpha(ua[i]) == 0)
+      if (ndpi_isalpha(ua[i]) == 0)
       {
         break;
       }
-      if (isupper(ua[i]) != 0)
+      if (isupper((unsigned char)ua[i]) != 0)
       {
         upper_case_count++;
       }
@@ -771,7 +771,7 @@ static void ndpi_check_http_server(struct ndpi_detection_module_struct *ndpi_str
 	char buf[16] = { '\0' };
 
 	for(i=off, j=0; (i<server_len) && (j<sizeof(buf)-1)
-	      && (isdigit(server[i]) || (server[i] == '.')); i++)
+	      && (ndpi_isdigit(server[i]) || (server[i] == '.')); i++)
 	  buf[j++] = server[i];
 
 	if(sscanf(buf, "%d.%d.%d", &a, &b, &c) == 3) {
@@ -790,7 +790,7 @@ static void ndpi_check_http_server(struct ndpi_detection_module_struct *ndpi_str
 
       /* Check server content */
       for(i=0; i<server_len; i++) {
-	if(!isprint(server[i])) {
+	if(!ndpi_isprint(server[i])) {
 	  ndpi_set_risk(ndpi_struct, flow, NDPI_HTTP_SUSPICIOUS_HEADER, "Suspicious Agent");
 	  break;
 	}
@@ -816,7 +816,7 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
      && (packet->host_line.len > 0)) {
     int len = packet->http_url_name.len + packet->host_line.len + 1;
 
-    if(isdigit(packet->host_line.ptr[0])
+    if(ndpi_isdigit(packet->host_line.ptr[0])
        && (packet->host_line.len < 21))
       ndpi_check_numeric_ip(ndpi_struct, flow, (char*)packet->host_line.ptr, packet->host_line.len);
 

--- a/src/lib/protocols/kerberos.c
+++ b/src/lib/protocols/kerberos.c
@@ -487,7 +487,7 @@ static void ndpi_search_kerberos(struct ndpi_detection_module_struct *ndpi_struc
 
 		  name_offset += 1;
 		  if(name_offset < packet->payload_packet_len - 1 &&
-		     isprint(packet->payload[name_offset+1]) == 0) /* Isn't printable ? */
+		     ndpi_isprint(packet->payload[name_offset+1]) == 0) /* Isn't printable ? */
 		  {
 		    name_offset++;
 		  }

--- a/src/lib/protocols/mqtt.c
+++ b/src/lib/protocols/mqtt.c
@@ -180,15 +180,9 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 	if (pt == PUBLISH) {
 		// payload CAN be zero bytes length (section 3.3.3 of MQTT standard)
 		u_int8_t qos = (u_int8_t) (flags & 0x06);
-		u_int8_t retain = (u_int8_t) (flags & 0x01);
 		u_int8_t dup = (u_int8_t) (flags & 0x04);
 		if (qos > 2) { // qos values possible are 0,1,2
 			NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid PUBLISH qos\n");
-			NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MQTT);
-			return;
-		}
-		if (retain > 1) { // retain flag possible 0,1
-			NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid PUBLISH retain\n");
 			NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_MQTT);
 			return;
 		}

--- a/src/lib/protocols/protobuf.c
+++ b/src/lib/protocols/protobuf.c
@@ -92,11 +92,6 @@ protobuf_dissect_varint(struct ndpi_packet_struct const * const packet,
     }
   }
 
-  if (i == 10)
-  {
-    return -1;
-  }
-
   *offset += i + 1;
   return 0;
 }

--- a/src/lib/protocols/tcp_udp.c
+++ b/src/lib/protocols/tcp_udp.c
@@ -56,8 +56,7 @@ void ndpi_search_tcp_or_udp(struct ndpi_detection_module_struct *ndpi_struct, st
   if(packet->iph /* IPv4 Only: we need to support packet->iphv6 at some point */) {
     proto = ndpi_search_tcp_or_udp_raw(ndpi_struct,
 				       flow,
-				       packet->iph ? packet->iph->protocol :
-				       packet->iphv6->ip6_hdr.ip6_un1_nxt,
+				       flow->l4_proto,
 				       ntohl(packet->iph->saddr), 
 				       ntohl(packet->iph->daddr));
 

--- a/src/lib/protocols/telegram.c
+++ b/src/lib/protocols/telegram.c
@@ -75,7 +75,7 @@ static void ndpi_search_telegram(struct ndpi_detection_module_struct *ndpi_struc
       u_int16_t sport = ntohs(packet->udp->source), dport = ntohs(packet->udp->dest);
 
       if(is_telegram_port_range(sport) || is_telegram_port_range(dport)) {
-	u_int i=0, found = 0;
+	u_int i, found = 0;
 
 	for(i=0; i<packet->payload_packet_len; i++) {
 	  if(packet->payload[i] == 0xFF) {

--- a/src/lib/third_party/src/gcrypt_light.c
+++ b/src/lib/third_party/src/gcrypt_light.c
@@ -344,8 +344,14 @@ static gcry_error_t _gcry_cipher_crypt (gcry_cipher_hd_t h,
                         src ? src:(const unsigned char *)in, (unsigned char *)out);
             break;
         case GCRY_CIPHER_MODE_GCM:
-            if(encrypt) return MBEDTLS_ERR_GCM_NOT_SUPPORT;
-            if(!( h->s_key && h->s_auth && h->s_iv && !h->s_crypt_ok)) return MBEDTLS_ERR_GCM_MISSING_KEY;
+            if(encrypt) {
+                ndpi_free(src);
+                return MBEDTLS_ERR_GCM_NOT_SUPPORT;
+            }
+            if(!( h->s_key && h->s_auth && h->s_iv && !h->s_crypt_ok)) {
+                ndpi_free(src);
+                return MBEDTLS_ERR_GCM_MISSING_KEY;
+            }
             h->taglen = 16;
             rv = mbedtls_gcm_crypt_and_tag(h->ctx.gcm,
                         MBEDTLS_GCM_DECRYPT,

--- a/src/lib/third_party/src/ndpi_patricia.c
+++ b/src/lib/third_party/src/ndpi_patricia.c
@@ -40,7 +40,6 @@
 */
 
 #include <assert.h> /* assert */
-#include <ctype.h> /* isdigit */
 #include <errno.h> /* errno */
 #include <math.h> /* sin */
 #include <stddef.h> /* NULL */
@@ -76,8 +75,6 @@ static u_char* ndpi_prefix_tochar (ndpi_prefix_t * prefix)
   if(family == AF_INET) return ((u_char *) & prefix->add.sin);
   else if(family == AF_INET6) return ((u_char *) & prefix->add.sin6);
   else /* if(family == AF_MAC) */ return ((u_char *) & prefix->add.mac);
-
-  return ((u_char *) & prefix->add.sin);
 }
 
 static int ndpi_comp_with_mask (void *addr, void *dest, u_int mask) {
@@ -103,7 +100,7 @@ static int ndpi_my_inet_pton (int af, const char *src, void *dst)
       int c, val;
 
       c = *src++;
-      if(!isdigit (c))
+      if(!ndpi_isdigit (c))
 	return (-1);
       val = 0;
       do {
@@ -111,7 +108,7 @@ static int ndpi_my_inet_pton (int af, const char *src, void *dst)
 	if(val > 255)
 	  return (0);
 	c = *src++;
-      } while (c && isdigit (c));
+      } while (c && ndpi_isdigit (c));
       xp[i] = (u_char)val;
       if(c == '\0')
 	break;

--- a/src/lib/third_party/src/strptime.c
+++ b/src/lib/third_party/src/strptime.c
@@ -130,8 +130,8 @@ strptime(const char* buf, const char* fmt, struct tm* tm)
 		alt_format = 0;
 
 		/* Eat up white-space. */
-		if (isspace(c)) {
-			while (isspace(*bp))
+		if (ndpi_isspace(c)) {
+			while (ndpi_isspace(*bp))
 				bp++;
 
 			fmt++;
@@ -397,7 +397,7 @@ strptime(const char* buf, const char* fmt, struct tm* tm)
 	case 'n':	/* Any kind of white-space. */
 	case 't':
 		LEGAL_ALT(0);
-		while (isspace(*bp))
+		while (ndpi_isspace(*bp))
 			bp++;
 		break;
 

--- a/utils/check_symbols.sh
+++ b/utils/check_symbols.sh
@@ -19,7 +19,7 @@ for line in `nm -P -u "${NDPI_LIB}"`; do
     fi
 
     #printf '%s\n' "${line}"
-    FOUND_SYMBOL="$(printf '%s' "${line}" | grep '^\(malloc\|calloc\|realloc\|free\|printf\|fprintf\)$' || true)"
+    FOUND_SYMBOL="$(printf '%s' "${line}" | grep '^\(malloc\|calloc\|realloc\|free\|printf\|fprintf\|isdigit\|isalpha\|isalnum\|isspace\|isprint\|ispunct\)$' || true)"
 
     if [ ! -z "${FOUND_SYMBOL}" ]; then
         SKIP=0
@@ -60,6 +60,6 @@ done
 
 printf 'Unwanted symbols found: %s\n' "${FAIL_COUNT}"
 if [ ${FAIL_COUNT} -gt 0 ]; then
-    printf '%s\n' 'Please make sure to use only ndpi_malloc/ndpi_calloc/ndpi_realloc/ndpi_free wrapper instead of malloc/calloc/realloc/free'
+    printf '%s\n' 'Please make sure to use only ndpi_malloc/ndpi_calloc/ndpi_realloc/ndpi_free/ndpi_isdigit/ndpi_isalpha/ndpi_isalnum/ndpi_isspace/ndpi_isprint/ndpi_ispunct wrapper instead of malloc/calloc/realloc/free/isdigit/isalpha/isalnum/isspace/isprint/ispunct'
 fi
 exit ${FAIL_COUNT}


### PR DESCRIPTION
Remove some unreached/duplicated code.

Add error checking for `atoi()` calls.

About `isdigit()` and similar functions. The warning reported is:
```
Negative Character Value help
isdigit() is invoked here with an argument of signed type char, but only
has defined behavior for int arguments that are either representable
as unsigned char or equal to the value of macro EOF(-1).
Casting the argument to unsigned char will avoid the undefined behavior.
In a number of libc implementations, isdigit() is implemented using lookup
tables (arrays): passing in a negative value can result in a read underrun.
```
Switching to our macros fix that.
Add a check to `check_symbols.sh` to avoid using the original functions
from libc.


