### PR TITLE
sha256: fix undefined-shift error

### DIFF
--- a/src/lib/third_party/src/ndpi_sha256.c
+++ b/src/lib/third_party/src/ndpi_sha256.c
@@ -48,7 +48,7 @@ void sha256_transform(ndpi_SHA256_CTX *ctx, const u_int8_t data[])
   u_int32_t a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
 
   for (i = 0, j = 0; i < 16; ++i, j += 4)
-    m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
+    m[i] = ((u_int32_t)data[j] << 24) | ((u_int32_t)data[j + 1] << 16) | ((u_int32_t)data[j + 2] << 8) | (data[j + 3]);
   for ( ; i < 64; ++i)
     m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
 


### PR DESCRIPTION
```
third_party/src/ndpi_sha256.c:51:21: runtime error: left shift of 128 by 24 places cannot be represented in type 'int'
```

Found by oss-fuzzer
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65305


