### PR TITLE
ndpiReader: improve the check on max number of pkts processed per flow

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -1269,7 +1269,8 @@ static void parseOptions(int argc, char **argv) {
 
     case 'T':
       max_num_tcp_dissected_pkts = atoi(optarg);
-      if(max_num_tcp_dissected_pkts < 3) max_num_tcp_dissected_pkts = 3;
+      /* If we enable that, allow at least 3WHS + 1 "real" packet */
+      if(max_num_tcp_dissected_pkts != 0 && max_num_tcp_dissected_pkts < 4) max_num_tcp_dissected_pkts = 4;
       break;
 
     case 'x':
@@ -1282,7 +1283,6 @@ static void parseOptions(int argc, char **argv) {
 
     case 'U':
       max_num_udp_dissected_pkts = atoi(optarg);
-      if(max_num_udp_dissected_pkts < 3) max_num_udp_dissected_pkts = 3;
       break;
 
     case OPTLONG_VALUE_LRU_CACHE_SIZE:

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1705,8 +1705,8 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
     struct ndpi_flow_input_info input_info;
 
     u_int enough_packets =
-      (((proto == IPPROTO_UDP) && ((flow->src2dst_packets + flow->dst2src_packets) > max_num_udp_dissected_pkts))
-       || ((proto == IPPROTO_TCP) && ((flow->src2dst_packets + flow->dst2src_packets) > max_num_tcp_dissected_pkts))) ? 1 : 0;
+      ((proto == IPPROTO_UDP && (max_num_udp_dissected_pkts > 0 && flow->src2dst_packets + flow->dst2src_packets > max_num_udp_dissected_pkts)) ||
+       (proto == IPPROTO_TCP && (max_num_tcp_dissected_pkts > 0 && flow->src2dst_packets + flow->dst2src_packets > max_num_tcp_dissected_pkts))) ? 1 : 0;
 
 #if 0
     printf("%s()\n", __FUNCTION__);


### PR DESCRIPTION
Allow to disable this check.

I don't know how much sense these limits have in the application (especially with those default values...) since we have always had a hard limit on the library itself (`max_packets_to_process` set to 32). The only value might be that they provide different limits for TCP and UDP traffic.

Keep them for the time being...


