### PR TITLE
Add missing NDPI_LOG_DBG in some dissectors

### DIFF
--- a/src/lib/protocols/fins.c
+++ b/src/lib/protocols/fins.c
@@ -54,7 +54,9 @@ static void ndpi_search_fins(struct ndpi_detection_module_struct *ndpi_struct,
                              struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
-  
+
+  NDPI_LOG_DBG(ndpi_struct, "search Omron FINS\n");
+
   /* FINS/TCP header is 20 bytes long, but it's usually followed
    * by 10 byte FINS header and command data
    */

--- a/src/lib/protocols/hislip.c
+++ b/src/lib/protocols/hislip.c
@@ -46,6 +46,8 @@ static void ndpi_search_hislip(struct ndpi_detection_module_struct *ndpi_struct,
 {
   struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
 
+  NDPI_LOG_DBG(ndpi_struct, "search HiSLIP\n");
+
   if ((packet->payload_packet_len >= 16) &&
       (memcmp(packet->payload, "HS", 2) == 0) && ((packet->payload[2] - 26) < 0x65) &&
       (ndpi_ntohll(get_u_int64_t(packet->payload, 8)) == (u_int64_t)(packet->payload_packet_len - 16)))

--- a/src/lib/protocols/json-rpc.c
+++ b/src/lib/protocols/json-rpc.c
@@ -34,6 +34,8 @@ static void ndpi_search_json_rpc(struct ndpi_detection_module_struct *ndpi_struc
 {
   struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
 
+  NDPI_LOG_DBG(ndpi_struct, "search JSON-RPC\n");
+
   if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_HTTP ||
       flow->detected_protocol_stack[1] == NDPI_PROTOCOL_HTTP)
   {

--- a/src/lib/protocols/mumble.c
+++ b/src/lib/protocols/mumble.c
@@ -34,6 +34,8 @@ static void ndpi_search_mumble(struct ndpi_detection_module_struct *ndpi_struct,
 {
   struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
 
+  NDPI_LOG_DBG(ndpi_struct, "search Mumble\n");
+
   if (current_pkt_from_client_to_server(ndpi_struct, flow) && 
       packet->payload_packet_len == 12)
   {

--- a/src/lib/protocols/mysql.c
+++ b/src/lib/protocols/mysql.c
@@ -35,6 +35,8 @@ static void ndpi_search_mysql_tcp(struct ndpi_detection_module_struct *ndpi_stru
 {
   struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
 
+  NDPI_LOG_DBG(ndpi_struct, "search MySQL\n");
+
   if(packet->payload_packet_len > 70 && packet->payload_packet_len < 120) {
     u_int32_t length = (packet->payload[2] << 16) + (packet->payload[1] << 8) + packet->payload[0];
 

--- a/src/lib/protocols/opc-ua.c
+++ b/src/lib/protocols/opc-ua.c
@@ -45,6 +45,8 @@ static void ndpi_search_opc_ua(struct ndpi_detection_module_struct *ndpi_struct,
 {
   struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
 
+  NDPI_LOG_DBG(ndpi_struct, "search OPC UA\n");
+
   /* Shortest OPC UA packet I've ever seen */
   if (packet->payload_packet_len >= 16) {
     /* Each OPC UA MessageChunk starts with a 3 byte ASCII code that defines 

--- a/src/lib/protocols/radmin.c
+++ b/src/lib/protocols/radmin.c
@@ -44,6 +44,8 @@ static void ndpi_search_radmin(struct ndpi_detection_module_struct *ndpi_struct,
 {
   struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
 
+  NDPI_LOG_DBG(ndpi_struct, "search Radmin\n");
+
   if (current_pkt_from_client_to_server(ndpi_struct, flow) && packet->payload_packet_len == 10 &&
       !flow->l4.tcp.radmin_stage)
   {

--- a/src/lib/protocols/yojimbo.c
+++ b/src/lib/protocols/yojimbo.c
@@ -39,6 +39,9 @@ static void ndpi_search_yojimbo(struct ndpi_detection_module_struct *ndpi_struct
                                 struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
+
+  NDPI_LOG_DBG(ndpi_struct, "search Yojimbo\n");
+
   uint64_t const magic = 0x4e4554434f444520; // "NETCODE "
 
   if (packet->payload_packet_len < 9)


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Describe changes:

Nothing critical, just adding missing `NDPI_LOG_DBG(ndpi_struct, "search ...")` in some of the dissectors I added.