### PR TITLE
Provide a u64 wrapper for `ndpi_set_config()`

### DIFF
--- a/fuzz/fuzz_common_code.c
+++ b/fuzz/fuzz_common_code.c
@@ -41,7 +41,7 @@ void fuzz_init_detection_module(struct ndpi_detection_module_struct **ndpi_info_
   if(*ndpi_info_mod == NULL) {
     *ndpi_info_mod = ndpi_init_detection_module();
 
-    ndpi_set_config(*ndpi_info_mod, NULL, "log.level", "3");
+    ndpi_set_config_u64(*ndpi_info_mod, NULL, "log.level", 3);
     ndpi_set_config(*ndpi_info_mod, "all", "log", "enable");
 
     ndpi_load_domain_suffixes(*ndpi_info_mod, "public_suffix_list.dat");

--- a/fuzz/fuzz_filecfg_categories.c
+++ b/fuzz/fuzz_filecfg_categories.c
@@ -14,8 +14,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   NDPI_BITMASK_SET_ALL(all);
   ndpi_set_protocol_detection_bitmask2(ndpi_struct, &all);
 
-  ndpi_set_config(ndpi_struct, NULL, "log.level", "3");
-  ndpi_set_config(ndpi_struct, "all", "log", "1");
+  ndpi_set_config_u64(ndpi_struct, NULL, "log.level", 3);
+  ndpi_set_config_u64(ndpi_struct, "all", "log", 1);
 
   fd = buffer_to_file(data, size);
   load_categories_file_fd(ndpi_struct, fd, NULL);

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -2190,6 +2190,8 @@ extern "C" {
 
   ndpi_cfg_error ndpi_set_config(struct ndpi_detection_module_struct *ndpi_str,
                                  const char *proto, const char *param, const char *value);
+  ndpi_cfg_error ndpi_set_config_u64(struct ndpi_detection_module_struct *ndpi_str,
+                                     const char *proto, const char *param, uint64_t value);
   char *ndpi_get_config(struct ndpi_detection_module_struct *ndpi_str,
 			const char *proto, const char *param, char *buf, int buf_len);
   char *ndpi_dump_config(struct ndpi_detection_module_struct *ndpi_str,

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -10825,6 +10825,21 @@ ndpi_cfg_error ndpi_set_config(struct ndpi_detection_module_struct *ndpi_str,
   return NDPI_CFG_NOT_FOUND;
 }
 
+ndpi_cfg_error ndpi_set_config_u64(struct ndpi_detection_module_struct *ndpi_str,
+                                   const char *proto, const char *param, uint64_t value)
+{
+  char value_str[21];
+  int value_len;
+
+  value_len = ndpi_snprintf(value_str, sizeof(value_str), "%llu", (unsigned long long int)value);
+  if (value_len <= 0 || value_len >= (int)sizeof(value_str))
+  {
+    return NDPI_CFG_INVALID_PARAM;
+  }
+
+  return ndpi_set_config(ndpi_str, proto, param, value_str);
+}
+
 char *ndpi_get_config(struct ndpi_detection_module_struct *ndpi_str,
 		      const char *proto, const char *param, char *buf, int buf_len)
 {


### PR DESCRIPTION
An application might want to set a numeric value as an integer e.g. if it was already parsed from a string previously.
