### PR TITLE
Completly disable all pthread related code in the library if `USE_GLOBAL_CONTEXT` macro is not defined.

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -25,8 +25,11 @@ E * ndpi_typedefs.h
 #define __NDPI_TYPEDEFS_H__
 
 #ifndef NDPI_CFFI_PREPROCESSING
+#include "ndpi_config.h"
+#ifdef USE_GLOBAL_CONTEXT
 #define HAVE_STRUCT_TIMESPEC
 #include <pthread.h>
+#endif
 #endif
 
 #include "ndpi_define.h"
@@ -769,7 +772,9 @@ struct ndpi_lru_cache {
   u_int32_t num_entries;
   u_int32_t ttl : 31, shared : 1;
 #ifndef NDPI_CFFI_PREPROCESSING
+#ifdef USE_GLOBAL_CONTEXT
   pthread_mutex_t mutex;
+#endif
 #endif
   struct ndpi_lru_cache_stats stats;
   struct ndpi_lru_cache_entry *entries;

--- a/tests/do.sh.in
+++ b/tests/do.sh.in
@@ -103,7 +103,7 @@ check_results() {
 	      done
 	    fi
 	    if [ $SKIP_PCAP -eq 1 ]; then
-	        printf "%-32s\tSKIPPED\n" "$f"
+	        printf "%-48s\tSKIPPED\n" "$f"
 	        continue
 	    fi
 
@@ -165,7 +165,7 @@ for d in $(find ./cfgs/* -type d -maxdepth 0 2>/dev/null) ; do
         done
     fi
     if [ $SKIP_CFG -eq 1 ]; then
-        printf "Configuration \""$(basename $d)"\" \tSKIPPED\n"
+        printf "Configuration \""$(basename $d)"\" %-18s\tSKIPPED\n"
         continue
     fi
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):


Describe changes:


