### PR TITLE
Disable `AX_PTHREAD` for MingW/MSYS builds.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,12 +178,19 @@ if ! test "${with_only_libndpi+set}" = set; then :
         JSONC_LIBS=""
         JSONC_CFLAGS=""
     ])
-    AX_PTHREAD([],[
-        AC_MSG_WARN([POSIX Threads not available. Building library only.])
-        JSONC_LIBS=""
-        JSONC_CFLAGS=""
-        EXTRA_TARGETS=""
-    ])
+    dnl> AX_PTHREAD test does not work along with MingW/MSYS anymore
+    case "$host" in
+      *-*-mingw32*|*-*-msys)
+      ;;
+      *)
+        AX_PTHREAD([],[
+            AC_MSG_WARN([POSIX Threads not available. Building library only.])
+            JSONC_LIBS=""
+            JSONC_CFLAGS=""
+            EXTRA_TARGETS=""
+        ])
+      ;;
+    esac
 fi
 AM_CONDITIONAL([BUILD_UNITTESTS], [test "x$build_unittests" = "xyes"])
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):


Describe changes:


