### PR TITLE
bitmap64: fix memory access error

### DIFF
--- a/src/lib/ndpi_bitmap64.c
+++ b/src/lib/ndpi_bitmap64.c
@@ -173,7 +173,10 @@ bool ndpi_bitmap64_isset(ndpi_bitmap64 *_b, u_int64_t value) {
   if(!b)
     return(false);
 
-  if(!b->is_compressed) ndpi_bitmap64_compress(b);
+  if(!b->is_compressed) {
+    if(!ndpi_bitmap64_compress(b))
+      return(false); /* Compresssion failed */
+  }
 
   return(binary_fuse16_contain(value, &b->bitmap));
 }
@@ -200,7 +203,11 @@ u_int32_t ndpi_bitmap64_size(ndpi_bitmap64 *_b) {
   ndpi_bitmap64_t *b = (ndpi_bitmap64_t*)_b;
 
   if(!b) return(0);
-  if(!b->is_compressed) ndpi_bitmap64_compress(b);
-  
+
+  if(!b->is_compressed) {
+    if(!ndpi_bitmap64_compress(b))
+      return(0); /* Compresssion failed */
+  }
+
   return(sizeof(ndpi_bitmap64) + binary_fuse16_size_in_bytes(&b->bitmap));
 }


### PR DESCRIPTION
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==29723==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x562910b70ddb bp 0x7ffcb22c5b70 sp 0x7ffcb22c5a80 T0)
==29723==The signal is caused by a READ memory access.
==29723==Hint: address points to the zero page.
    #0 0x562910b70ddb in binary_fuse16_contain /home/ivan/svnrepos/nDPI/src/lib/./third_party/include/binaryfusefilter.h:492:8
    #1 0x562910b70bbe in ndpi_bitmap64_isset /home/ivan/svnrepos/nDPI/src/lib/ndpi_bitmap64.c:178:10
    #2 0x562910788fd3 in ndpi_domain_classify_longest_prefix /home/ivan/svnrepos/nDPI/src/lib/ndpi_domain_classify.c:261:5
    #3 0x56291078940e in ndpi_domain_classify_contains /home/ivan/svnrepos/nDPI/src/lib/ndpi_domain_classify.c:291:9
    #4 0x56291069a392 in LLVMFuzzerTestOneInput /home/ivan/svnrepos/nDPI/fuzz/fuzz_ds_domain_classify.cpp:52:5
```

Found by oss-fuzz
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67369
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67372


