### PR TITLE
Enable `USE_GLOBAL_CONTEXT` via `CFLAGS` passed to the CC.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,7 +311,7 @@ jobs:
       - name: Configure nDPI on Ubuntu
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 'x86_64')
         run: |
-          AR=${{ matrix.ar }} RANLIB=${{ matrix.ranlib }} ./autogen.sh --enable-option-checking=fatal --enable-debug-messages ${{ matrix.gcrypt }} ${{ matrix.msan }} ${{ matrix.pcre }} ${{ matrix.maxminddb }} --enable-tls-sigs ${{matrix.lto_gold_linker}}
+          AR=${{ matrix.ar }} RANLIB=${{ matrix.ranlib }} ./autogen.sh --enable-option-checking=fatal --enable-debug-messages ${{ matrix.gcrypt }} ${{ matrix.msan }} ${{ matrix.pcre }} ${{ matrix.maxminddb }} --enable-tls-sigs ${{matrix.lto_gold_linker}} ${{matrix.global_context}}
       - name: Configure nDPI on MacOS
         if: startsWith(matrix.os, 'macOS') && startsWith(matrix.arch, 'x86_64') && startsWith(matrix.compiler, 'cc')
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -220,7 +220,7 @@ fi
 GLOBAL_CONTEXT_ENABLED=0
 AS_IF([test "x$enable_global_context_support" != "xno"], [
   AC_CHECK_LIB([pthread], [pthread_mutex_init])
-  AC_DEFINE_UNQUOTED(USE_GLOBAL_CONTEXT, 1, [Use gloabl context feature. Depend on libpthread])
+  NDPI_CFLAGS="${NDPI_CFLAGS} -DUSE_GLOBAL_CONTEXT"
   GLOBAL_CONTEXT_ENABLED=1
 ])
 


### PR DESCRIPTION
 * `ndpi_typedefs.h`: requires to include `ndpi_config.h` for the `HAVE_STRUCT_TIMESPEC` check That will never happen, because `USE_GLOBAL_CONTEXT` is defined inside `ndpi_config.h`. It's better to use `CFLAGS` to achieve the same.

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):


Describe changes:


