### PR TITLE
Fixed gcc version checking.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,7 +134,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   ])
 
 GCC_VERSION=`gcc --version | cut -d ' ' -f 3 | head -1|cut -d '.' -f 1`
-if [ "${GCC_VERSION}" -lt "7" ]; then
+if test "${GCC_VERSION}" -lt "7" ; then
  AC_DEFINE_UNQUOTED(USE_ROARING_V2, "1", [Use CRoaring 2.1.x])
 fi
 


### PR DESCRIPTION
Using the "test" utility instead of "[" to determine the gcc compiler version.