### PR TITLE
Add `-Wno-unused-function` as CFLAG for `third_party/src/gcrypt_lightc`.

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -18,7 +18,7 @@ ifneq ($(OS),Windows_NT)
 CFLAGS     += -fPIC -DPIC
 endif
 CFLAGS     += -I. -I../include -Ithird_party/include -DNDPI_LIB_COMPILATION @NDPI_CFLAGS@ @GPROF_CFLAGS@ @CUSTOM_NDPI@ @ADDITIONAL_INCS@
-CFLAGS_third_party/src/gcrypt_light.c := -Wno-unused-parameter
+CFLAGS_third_party/src/gcrypt_light.c := -Wno-unused-function -Wno-unused-parameter
 CFLAGS_third_party/src/ahocorasick.c := -Wno-unused-function -Wno-unused-parameter
 CFLAGS_third_party/src/roaring.c := -Wno-unused-function -Wno-attributes
 LDFLAGS    += @NDPI_LDFLAGS@


### PR DESCRIPTION
 * fixes failing nDPI build from an external project with clang and `-Wextra`

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)