### PR TITLE
Fixed yet another "unused function" warning.

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -18,6 +18,7 @@ ifneq ($(OS),Windows_NT)
 CFLAGS     += -fPIC -DPIC
 endif
 CFLAGS     += -I. -I../include -Ithird_party/include -DNDPI_LIB_COMPILATION @NDPI_CFLAGS@ @GPROF_CFLAGS@ @CUSTOM_NDPI@ @ADDITIONAL_INCS@
+CFLAGS_ndpi_bitmap.c := -Wno-unused-function
 CFLAGS_third_party/src/gcrypt_light.c := -Wno-unused-function -Wno-unused-parameter
 CFLAGS_third_party/src/ahocorasick.c := -Wno-unused-function -Wno-unused-parameter
 CFLAGS_third_party/src/roaring.c := -Wno-unused-function -Wno-attributes


### PR DESCRIPTION
 * seems like clang on `ubuntu-latest` warns about unused static inlined functions

```
In file included from ndpi_bitmap.c:41:
./third_party/include/roaring.h:422:19: error: unused function 'roaring_leading_zeroes' [-Werror,-Wunused-function]
static inline int roaring_leading_zeroes(unsigned long long input_num) {

..snip..
```

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)
