### PR TITLE
Fixed yet another another "unused function" warning.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Python Bindings (ubuntu-latest)
     runs-on: ubuntu-latest
     env:
-      CFLAGS: -Werror
+      CFLAGS: -Wextra -Werror
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.compiler }}
-      CFLAGS: -Werror
+      CFLAGS: -Wextra -Werror
     strategy:
       fail-fast: true
       matrix:

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -19,6 +19,7 @@ CFLAGS     += -fPIC -DPIC
 endif
 CFLAGS     += -I. -I../include -Ithird_party/include -DNDPI_LIB_COMPILATION @NDPI_CFLAGS@ @GPROF_CFLAGS@ @CUSTOM_NDPI@ @ADDITIONAL_INCS@
 CFLAGS_ndpi_bitmap.c := -Wno-unused-function
+CFLAGS_ndpi_bitmap64_fuse.c := -Wno-unused-function
 CFLAGS_third_party/src/gcrypt_light.c := -Wno-unused-function -Wno-unused-parameter
 CFLAGS_third_party/src/ahocorasick.c := -Wno-unused-function -Wno-unused-parameter
 CFLAGS_third_party/src/roaring.c := -Wno-unused-function -Wno-attributes


### PR DESCRIPTION
 * added `-Wextra` to the CI

```
In file included from ndpi_bitmap64_fuse.c:31:
./third_party/include/binaryfusefilter.h:31:24: error: unused function 'binary_fuse_rotl64' [-Werror,-Wunused-function]
static inline uint64_t binary_fuse_rotl64(uint64_t n, unsigned int c) {

..snip..
```

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)