### PR TITLE
Add memmem() implementation

### DIFF
--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -2219,6 +2219,19 @@ extern "C" {
 
   const char *ndpi_lru_cache_idx_to_name(lru_cache_type idx);
 
+  /**
+   * Searches for a subsequence ('needle') within a block of memory ('haystack').
+   *
+   * @par haystack     = pointer to the block of memory where the search is performed
+   * @par haystack_len = length of the haystack block of memory
+   * @par needle       = pointer to the memory block representing the needle to search for
+   * @par needle_len   = length of the needle memory block
+   * 
+   * @return Pointer to the beginning of the needle within the haystack if found;
+   * otherwise, NULL.
+   */
+  void* ndpi_memmem(const void* haystack, size_t haystack_len, const void* needle,
+                    size_t needle_len);
 
 #ifdef __cplusplus
 }

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -11442,9 +11442,8 @@ void* ndpi_memmem(const void* haystack, size_t haystack_len, const void* needle,
     return memchr(haystack, *(int*)needle, haystack_len);
   }
 
-  for (const u_int8_t* h = haystack; h <= (const u_int8_t*)haystack + 
-       haystack_len - needle_len; ++h)
-  {
+  const u_int8_t* h = NULL;
+  for (h = haystack; h <= (const u_int8_t*)haystack+haystack_len-needle_len; ++h) {
     if (!memcmp(h, needle, needle_len))
       return (void*)h;
   }

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -11443,8 +11443,9 @@ void* ndpi_memmem(const void* haystack, size_t haystack_len, const void* needle,
   }
 
   const u_int8_t* h = NULL;
+  const u_int8_t* n = (const u_int8_t*)needle;
   for (h = haystack; h <= (const u_int8_t*)haystack+haystack_len-needle_len; ++h) {
-    if (!memcmp(h, needle, needle_len))
+    if (*h == n[0] && !memcmp(h, needle, needle_len))
       return (void*)h;
   }
 

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -11423,3 +11423,31 @@ char *ndpi_dump_config(struct ndpi_detection_module_struct *ndpi_str,
   }
   return NULL;
 }
+
+void* ndpi_memmem(const void* haystack, size_t haystack_len, const void* needle, size_t needle_len)
+{
+  if (!haystack || !needle) {
+    return NULL;
+  }
+
+  if (needle_len > haystack_len) {
+    return NULL;
+  }
+
+  if ((size_t)(const u_int8_t*)haystack+haystack_len < haystack_len) {
+    return NULL;
+  }
+
+  if (needle_len == 1) {
+    return memchr(haystack, *(int*)needle, haystack_len);
+  }
+
+  for (const u_int8_t* h = haystack; h <= (const u_int8_t*)haystack + 
+       haystack_len - needle_len; ++h)
+  {
+    if (!memcmp(h, needle, needle_len))
+      return (void*)h;
+  }
+
+  return NULL;
+}


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Describe changes:

Although this implementation has O(n*m) complexity in the worst case, in the typical nDPI scenario (searching for a string or byte sequence in a payload with a typical maximum length of 1460/1472 bytes) it performed much better than the other implementations.

Here is the result of a small benchmark searching for the string ```eso.live``` in an 852 byte long array (packet from The Elder Scrolls Online pcap sample):

![image](https://github.com/ntop/nDPI/assets/105977161/8fd2825d-99cb-4c8e-8a69-1bbb24b59469)


