### PR TITLE
Add strlcpy implementation

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -5630,6 +5630,42 @@ void strtonumUnitTest() {
 
 /* *********************************************** */
 
+void strlcpyUnitTest() {
+  // Test empty string
+  char dst_empty[10] = "";
+  assert(ndpi_strlcpy(dst_empty, "", sizeof(dst_empty)) == 0);
+  assert(dst_empty[0] == '\0');
+
+  // Basic copy test
+  char dst1[10] = "";
+  assert(ndpi_strlcpy(dst1, "abc", sizeof(dst1)) == 3);
+  assert(strcmp(dst1, "abc") == 0);
+
+  // Test with dst_len smaller than src_len
+  char dst2[4] = "";
+  assert(ndpi_strlcpy(dst2, "abcdef", sizeof(dst2)) == 6);
+  assert(strcmp(dst2, "abc") == 0); // Should truncate "abcdef" to "abc"
+
+  // Test with dst_len bigger than src_len
+  char dst3[10] = "";
+  assert(ndpi_strlcpy(dst3, "abc", sizeof(dst3)) == 3);
+  assert(strcmp(dst3, "abc") == 0);
+
+  // Test with dst_len equal to 1 (only null terminator should be copied)
+  char dst4[1];
+  assert(ndpi_strlcpy(dst4, "abc", sizeof(dst4)) == 3);
+  assert(dst4[0] == '\0'); // Should only contain the null terminator
+
+  // Test with NULL source, expecting return value to be 0
+  char dst5[10];
+  assert(ndpi_strlcpy(dst5, NULL, sizeof(dst5)) == 0);
+
+  // Test with NULL destination, should also return 0 without crashing
+  assert(ndpi_strlcpy(NULL, "abc", sizeof(dst5)) == 0);
+}
+
+/* *********************************************** */
+
 void filterUnitTest() {
   ndpi_filter* f = ndpi_filter_alloc();
   u_int32_t v, i;
@@ -5943,6 +5979,7 @@ int main(int argc, char **argv) {
     analysisUnitTest();
     compressedBitmapUnitTest();
     strtonumUnitTest();
+    strlcpyUnitTest();
 #endif
   }
 

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -2233,6 +2233,18 @@ extern "C" {
   void* ndpi_memmem(const void* haystack, size_t haystack_len, const void* needle,
                     size_t needle_len);
 
+  /**
+   * Copies up to -dst_len - 1- characters from -src- to -dst-, ensuring the result is
+   * null-terminated. Measures -src- length and handles potential null pointers.
+   * 
+   * @par dst       = destination buffer
+   * @par src       = source string
+   * @par dst_len   = size of the destination buffer, includes the null terminator
+   * 
+   * @return Length of `src`. If greater or equal to -dst_len-, -dst- has been truncated.
+   */
+  size_t ndpi_strlcpy(char* dst, const char* src, size_t dst_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -11478,3 +11478,20 @@ void* ndpi_memmem(const void* haystack, size_t haystack_len, const void* needle,
 
   return NULL;
 }
+
+size_t ndpi_strlcpy(char *dst, const char* src, size_t dst_len)
+{
+  if (!dst || !src) {
+    return 0;
+  }
+
+  size_t src_len = strlen(src);
+
+  if (dst_len != 0) {
+    size_t len = (src_len < dst_len - 1) ? src_len : dst_len - 1;
+    memcpy(dst, src, len);
+    dst[len] = '\0';
+  }
+
+  return src_len;
+}


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Describe changes:

I'll leave it as a draft to debate whether this stuff is even needed in nDPI... Well, I guess it would be useful.

`strlcpy` is a safe alternative to `strncpy`, originally added to BSD libc (also recently added to glibc). The main advantage of `strlcpy` over `strncpy` is that it always null-terminates the destination buffer, preventing issues that can occur with `strncpy` when the source string is longer than the specified buffer size.

Ofc, `strlcpy` isn't suitable for cases when it's necessary to copy a string without a null-terminator, such as when dealing with fixed-size data structures or binary data... But who uses `strncpy` instead of `memcpy` in such cases?

@IvanNardi @utoni what do you think?