### PR TITLE
Improve ndpi_strlcpy

### DIFF
--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -2246,16 +2246,20 @@ extern "C" {
                     size_t needle_len);
 
   /**
-   * Copies up to -dst_len - 1- characters from -src- to -dst-, ensuring the result is
-   * null-terminated. Measures -src- length and handles potential null pointers.
-   * 
-   * @par dst       = destination buffer
-   * @par src       = source string
-   * @par dst_len   = size of the destination buffer, includes the null terminator
-   * 
-   * @return Length of `src`. If greater or equal to -dst_len-, -dst- has been truncated.
+   * @brief Copies a string from the source to the destination with restrictions on the size of the 
+   * destination buffer and the length of the source.
+   *
+   * This function is similar to `strlcpy`, except that it takes an additional parameter `src_len`, which specifies 
+   * the maximum length of the source. This allows the function to work with non-nullterminated strings.
+   *
+   * @param dst The destination buffer to copy the string to.
+   * @param src The source string to be copied.
+   * @param dst_len The size of the destination buffer.
+   * @param src_len The maximum length of the source string.
+   *
+   * @return `src_len` on success (string may be truncated if `src_len` >= `dst_len`), 0 otherwise.
    */
-  size_t ndpi_strlcpy(char* dst, const char* src, size_t dst_len);
+  size_t ndpi_strlcpy(char* dst, const char* src, size_t dst_len, size_t src_len);
 
 #ifdef __cplusplus
 }

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -11503,19 +11503,22 @@ void* ndpi_memmem(const void* haystack, size_t haystack_len, const void* needle,
   return NULL;
 }
 
-size_t ndpi_strlcpy(char *dst, const char* src, size_t dst_len)
+size_t ndpi_strlcpy(char* dst, const char* src, size_t dst_len, size_t src_len)
 {
-  if (!dst || !src) {
+  if (!dst || !src || dst_len == 0 || src_len == 0) {
     return 0;
   }
-
-  size_t src_len = strlen(src);
-
-  if (dst_len != 0) {
-    size_t len = (src_len < dst_len - 1) ? src_len : dst_len - 1;
-    memcpy(dst, src, len);
-    dst[len] = '\0';
+  
+  /* Optimization: search for a null terminator within src_len. It's important not to search beyond src_len 
+   * as it may not be safe. */
+  const char* null_char = (const char*)memchr(src, '\0', src_len);
+  if (null_char != NULL) {
+    src_len = null_char - src;
   }
+
+  size_t len = ndpi_min(src_len, dst_len-1);
+  memcpy(dst, src, len);
+  dst[len] = '\0';
 
   return src_len;
 }


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Describe changes:

I looked into where and how `strncpy` is used in nDPI, and found that it's mostly used to copy non null-terminated strings, so the previous implementation of `ndpi_strlcpy` doesn't work here (same problem as the original `strlcpy` - trying to copy a non null-terminated src can cause an overflow).

So I added a new parameter `size_t src_len` and improved the function so it can handle non-null-terminated strings as well. Yeah, now it doesn't match its BSD counterpart, but we have `ndpi_strtonum` which has an additional parameter as well.

@IvanNardi @utoni What do you think, guys?