### PR TITLE
Workaround for fixing GitHub runners on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,9 @@ jobs:
       fail-fast: true
       matrix:
         # ubuntu-latest == ubuntu-22.04
-        # macOS-latest == macos-12
-        os: ["ubuntu-latest", "ubuntu-20.04", "macOS-latest", "macos-13", "windows-latest"]
+        # macOS-latest == macos-14 on **ARM64**
+        # There are some issues with external dependencies on macOS-latest. Disable it for the time being
+        os: ["ubuntu-latest", "ubuntu-20.04", "macOS-12", "macOS-13", "windows-latest"]
         arch: ["x86_64"]
         gcrypt: ["--with-local-libgcrypt", ""]
         compiler: ["cc"]
@@ -160,7 +161,7 @@ jobs:
             msan: "--with-memory-sanitizer"
             nBPF: ""
           - compiler: "cc"
-            os: macOS-latest
+            os: macOS-13
             arch: "x86_64"
             gcrypt: ""
             pcre: "--with-pcre2"
@@ -337,6 +338,7 @@ jobs:
           make all
           make -C example ndpiSimpleIntegration
           #There are somes issues with librrd
+          #make -C rrdtool
       - name: Print nDPI long help
         if: startsWith(matrix.arch, 'x86_64') && !startsWith(matrix.os, 'windows')
         run: |


### PR DESCRIPTION
GitHub switched "macos-latest" from "macos-12" to "macos-14", which is only on ARM64!
https://github.com/actions/runner/issues/3256
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

However we are having some issues build nDPI on macos-14 with external libraries:

```
configure: error: libgpg-error required (because of --with-local-libgcrypt) but not found or too old.
```
See: https://github.com/ntop/nDPI/actions/runs/8869020568/job/24350356867

```
ndpi_utils.c:69:10: fatal error: 'pcre2.h' file not found
         ^~~~~~~~~
1 error generated.
```
See: https://github.com/ntop/nDPI/actions/runs/8869020568/job/24349242251

Everything is still fine with macos-14 and no external dependencies

As workaround, test only macos-12 and macos-13 in our main matrix.

