### PR TITLE
IRC: simplify detection

### DIFF
--- a/doc/protocols.rst
+++ b/doc/protocols.rst
@@ -32,6 +32,15 @@ Adobe Connect is a web conferencing platform that allows users to conduct online
 References: `Main site: <https://www.adobe.com/products/adobeconnect.html>`_
 
 
+.. _Proto 65:
+
+`NDPI_PROTOCOL_IRC`
+==================
+IRC (Internet Relay Chat) is a text-based chat system for instant messaging.
+
+References: `Wikipiedia: <https://en.wikipedia.org/wiki/IRC>`_ and `Some statistics: <https://netsplit.de/networks/top10.php>`
+
+
 .. _Proto 72:
 
 `NDPI_PROTOCOL_HART_IP`
@@ -84,6 +93,7 @@ References: `Main site: <https://meet.google.com/>`_
 Steam Datagram Relay (SDR) is Valve's virtual private gaming network. Used in all modern games from Valve, but can also be used by developers via the Steamworks SDK for their games.
 
 References: `Main site: <https://partner.steamgames.com/doc/features/multiplayer/steamdatagramrelay>`_
+
 
 .. _Proto 338:
 

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -820,9 +820,6 @@ struct ndpi_flow_tcp_struct {
 
   /* NDPI_PROTOCOL_IRC */
   u_int32_t irc_3a_counter:3;
-  u_int32_t irc_stage2:5;
-  u_int32_t irc_direction:2;
-  u_int32_t irc_0x1000_full:1;
 
   /* NDPI_PROTOCOL_USENET */
   u_int32_t usenet_stage:2;

--- a/src/lib/ndpi_content_match.c.inc
+++ b/src/lib/ndpi_content_match.c.inc
@@ -1611,6 +1611,11 @@ static ndpi_protocol_match host_match[] =
 
    { "threads.net",                      "Threads", NDPI_PROTOCOL_THREADS, NDPI_PROTOCOL_CATEGORY_SOCIAL_NETWORK, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_DEFAULT_LEVEL },
 
+   { "irc.libera.chat",                  "IRC", NDPI_PROTOCOL_IRC, NDPI_PROTOCOL_CATEGORY_CHAT, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_DEFAULT_LEVEL },
+   { "irc.oftc.net",                     "IRC", NDPI_PROTOCOL_IRC, NDPI_PROTOCOL_CATEGORY_CHAT, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_DEFAULT_LEVEL },
+   { "irc.undernet.org",                 "IRC", NDPI_PROTOCOL_IRC, NDPI_PROTOCOL_CATEGORY_CHAT, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_DEFAULT_LEVEL },
+   { "irc.ircnet.com",                   "IRC", NDPI_PROTOCOL_IRC, NDPI_PROTOCOL_CATEGORY_CHAT, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_DEFAULT_LEVEL },
+
 #ifdef CUSTOM_NDPI_PROTOCOLS
 #include "../../../nDPI-custom/custom_ndpi_content_match_host_match.c.inc"
 #endif

--- a/src/lib/protocols/irc.c
+++ b/src/lib/protocols/irc.c
@@ -37,27 +37,13 @@ static void ndpi_int_irc_add_connection(struct ndpi_detection_module_struct *ndp
 
 static u_int8_t ndpi_check_for_NOTICE_or_PRIVMSG(struct ndpi_detection_module_struct *ndpi_struct)
 {
-
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
-  //
-  u_int16_t i;
-  u_int8_t number_of_lines_to_be_searched_for = 0;
-  for (i = 0; i < packet->payload_packet_len - 7; i++) {
-    if (packet->payload[i] == 'N' || packet->payload[i] == 'P') {
-      if (memcmp(&packet->payload[i + 1], "OTICE ", 6) == 0 || memcmp(&packet->payload[i + 1], "RIVMSG ", 7) == 0) {
-	NDPI_LOG_DBG2(ndpi_struct, "found NOTICE or PRIVMSG\n");
-	return 1;
-      }
-    }
-    if (packet->payload[i] == 0x0a) {
-      number_of_lines_to_be_searched_for++;
-      if (number_of_lines_to_be_searched_for == 2) {
-	return 0;
-      }
-    }
-  }
-  return 0;
 
+  if(ndpi_memmem(packet->payload, packet->payload_packet_len, "NOTICE", 6))
+    return 1;
+  if(ndpi_memmem(packet->payload, packet->payload_packet_len, "PRIVMSG", 7))
+    return 1;
+  return 0;
 }
 
 static u_int8_t ndpi_check_for_Nickname(struct ndpi_detection_module_struct *ndpi_struct)
@@ -102,263 +88,18 @@ static u_int8_t ndpi_check_for_cmd(struct ndpi_detection_module_struct *ndpi_str
   return 0;
 }
 
-static u_int8_t ndpi_check_for_IRC_traces(const u_int8_t * ptr, u_int16_t len)
-{
-  u_int16_t i;
-
-  if (len < 4) {
-    return 0;
-  }
-
-  for (i = 0; i < len - 4; i++) {
-    if (ptr[i] == 'i') {
-      if (memcmp(&ptr[i + 1], "rc.", 3) == 0) {
-	return 1;
-      }
-    }
-  }
-  return 0;
-}
-
-
-static u_int8_t ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
-{
-
-  struct ndpi_packet_struct *packet = &ndpi_struct->packet;
-	
-
-  NDPI_LOG_DBG(ndpi_struct, "start fast detect\n");
-
-  /* case 1: len 1460, len 1460, len 1176 several times in one direction, than len = 4, 4096, 8192 in the other direction */
-  if (packet->payload_packet_len == 1460
-      && ((flow->l4.tcp.irc_stage2 == 0 && flow->l4.tcp.irc_direction == 0) || (flow->l4.tcp.irc_stage2 == 3
-										&& flow->l4.tcp.irc_direction ==
-										1 + packet->packet_direction))) {
-    flow->l4.tcp.irc_stage2 = 1;
-    flow->l4.tcp.irc_direction = 1 + packet->packet_direction;
-    return 1;
-  }
-  if (packet->payload_packet_len == 1460 && flow->l4.tcp.irc_stage2 == 1
-      && flow->l4.tcp.irc_direction == 1 + packet->packet_direction) {
-    flow->l4.tcp.irc_stage2 = 2;
-    return 1;
-  }
-  if (packet->payload_packet_len == 1176 && flow->l4.tcp.irc_stage2 == 2
-      && flow->l4.tcp.irc_direction == 1 + packet->packet_direction) {
-    flow->l4.tcp.irc_stage2 = 3;
-    flow->l4.tcp.irc_0x1000_full = 1;
-    return 1;
-  }
-  if (packet->payload_packet_len == 4 && (flow->l4.tcp.irc_stage2 == 3 || flow->l4.tcp.irc_0x1000_full == 1)
-      && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 0x1000
-									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
-									0x2000)) {
-    NDPI_LOG_INFO(ndpi_struct, "found IRC SSL: ->1460,1460,1176,<-4096||8192");
-    ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-    return 1;
-  }
-  /* case 2: len 1448, len 1448, len 1200 several times in one direction, than len = 4, 4096, 8192 in the other direction */
-  if (packet->payload_packet_len == 1448
-      && ((flow->l4.tcp.irc_stage2 == 0 && flow->l4.tcp.irc_direction == 0) || (flow->l4.tcp.irc_stage2 == 6
-										&& flow->l4.tcp.irc_direction ==
-										1 + packet->packet_direction))) {
-    flow->l4.tcp.irc_stage2 = 4;
-    flow->l4.tcp.irc_direction = 1 + packet->packet_direction;
-    NDPI_LOG_DBG2(ndpi_struct, "len = 1448 first\n");
-    return 1;
-  }
-  if (packet->payload_packet_len == 1448 && flow->l4.tcp.irc_stage2 == 4
-      && flow->l4.tcp.irc_direction == 1 + packet->packet_direction) {
-    flow->l4.tcp.irc_stage2 = 5;
-    NDPI_LOG_DBG2(ndpi_struct, "len = 1448 second \n");
-    return 1;
-  }
-  if (packet->payload_packet_len == 1200 && flow->l4.tcp.irc_stage2 == 5
-      && flow->l4.tcp.irc_direction == 1 + packet->packet_direction) {
-    flow->l4.tcp.irc_stage2 = 6;
-    flow->l4.tcp.irc_0x1000_full = 1;
-    NDPI_LOG_DBG2(ndpi_struct, "len = 1200  \n");
-    return 1;
-  }
-  if (packet->payload_packet_len == 4 && (flow->l4.tcp.irc_stage2 == 6 || flow->l4.tcp.irc_0x1000_full == 1)
-      && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 0x1000
-									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
-									0x2000)) {
-    NDPI_LOG_INFO(ndpi_struct, "found IRC SSL: ->1448,1448,1200,<-4096||8192");
-    ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-    return 1;
-  }
-  /* case 3: several packets with len 1380, 1200, 1024, 1448, 1248,
-   * than one packet in the other direction with the len or two times the len. */
-  if (packet->payload_packet_len == 1380 && ((flow->l4.tcp.irc_stage2 == 0 && flow->l4.tcp.irc_direction == 0)
-					     || (flow->l4.tcp.irc_stage2 == 7
-						 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction))) {
-    flow->l4.tcp.irc_stage2 = 7;
-    flow->l4.tcp.irc_direction = 1 + packet->packet_direction;
-    return 1;
-  }
-  if (packet->payload_packet_len == 4 && flow->l4.tcp.irc_stage2 == 7
-      && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 1380
-									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
-									2760)) {
-    NDPI_LOG_INFO(ndpi_struct, "found IRC SSL: ->1380,<-1380||2760");
-    ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-    return 1;
-  }
-  if (packet->payload_packet_len == 1200 && ((flow->l4.tcp.irc_stage2 == 0 && flow->l4.tcp.irc_direction == 0)
-					     || (flow->l4.tcp.irc_stage2 == 8
-						 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction))) {
-    flow->l4.tcp.irc_stage2 = 8;
-    flow->l4.tcp.irc_direction = 1 + packet->packet_direction;
-    return 1;
-  }
-  if (packet->payload_packet_len == 4 && flow->l4.tcp.irc_stage2 == 8
-      && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 1200
-									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
-									2400)) {
-    NDPI_LOG_INFO(ndpi_struct, "found IRC SSL: ->1200,<-1200||2400");
-    ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-    return 1;
-  }
-  if (packet->payload_packet_len == 1024 && ((flow->l4.tcp.irc_stage2 == 0 && flow->l4.tcp.irc_direction == 0)
-					     || (flow->l4.tcp.irc_stage2 == 9
-						 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction))) {
-    flow->l4.tcp.irc_stage2 = 9;
-    flow->l4.tcp.irc_direction = 1 + packet->packet_direction;
-    return 1;
-  }
-  if (packet->payload_packet_len == 4 && (flow->l4.tcp.irc_stage2 == 9 || flow->l4.tcp.irc_stage2 == 15)
-      && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 1024
-									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
-									2048)) {
-    NDPI_LOG_INFO(ndpi_struct, "found IRC SSL: ->1024,<-1024||2048");
-    ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-    return 1;
-  }
-  if (packet->payload_packet_len == 1248 && ((flow->l4.tcp.irc_stage2 == 0 && flow->l4.tcp.irc_direction == 0)
-					     || (flow->l4.tcp.irc_stage2 == 10
-						 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction))) {
-    flow->l4.tcp.irc_stage2 = 10;
-    flow->l4.tcp.irc_direction = 1 + packet->packet_direction;
-    return 1;
-  }
-  if (packet->payload_packet_len == 4 && flow->l4.tcp.irc_stage2 == 10
-      && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 1248
-									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
-									2496)) {
-    NDPI_LOG_INFO(ndpi_struct, "found IRC SSL: ->1248,<-1248||2496");
-    ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-    return 1;
-  }
-  if (packet->payload_packet_len == 1448
-      && (flow->l4.tcp.irc_stage2 == 5 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction)) {
-    flow->l4.tcp.irc_stage2 = 11;
-    return 1;
-  }
-  if (packet->payload_packet_len == 4
-      && (flow->l4.tcp.irc_stage2 == 4 || flow->l4.tcp.irc_stage2 == 5 || flow->l4.tcp.irc_stage2 == 11
-	  || flow->l4.tcp.irc_stage2 == 13)
-      && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && (ntohs(get_u_int16_t(packet->payload, 2)) == 1448
-									|| ntohs(get_u_int16_t(packet->payload, 2)) ==
-									2896)) {
-    NDPI_LOG_INFO(ndpi_struct, "found IRC SSL: ->1448,<-1448||2896");
-    ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-    return 1;
-  }
-  /* case 4 : five packets with len = 1448, one with len 952, than one packet from other direction len = 8192 */
-  if (packet->payload_packet_len == 1448
-      && (flow->l4.tcp.irc_stage2 == 11 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction)) {
-    flow->l4.tcp.irc_stage2 = 12;
-    return 1;
-  }
-  if (packet->payload_packet_len == 1448
-      && (flow->l4.tcp.irc_stage2 == 12 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction)) {
-    flow->l4.tcp.irc_stage2 = 13;
-    return 1;
-  }
-  if (packet->payload_packet_len == 952
-      && (flow->l4.tcp.irc_stage2 == 13 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction)) {
-    flow->l4.tcp.irc_stage2 = 14;
-    return 1;
-  }
-  if (packet->payload_packet_len == 4
-      && flow->l4.tcp.irc_stage2 == 14
-      && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && ntohs(get_u_int16_t(packet->payload, 2)) == 8192) {
-    NDPI_LOG_INFO(ndpi_struct, "found IRC SSL: ->1448,1448,1448,1448,1448,952,<-8192");
-    ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-    return 1;
-  }
-  /* case 5: len 1024, len 1448, len 1448, len 1200, len 1448, len 600 */
-  if (packet->payload_packet_len == 1448
-      && (flow->l4.tcp.irc_stage2 == 9 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction)) {
-    flow->l4.tcp.irc_stage2 = 15;
-    return 1;
-  }
-  if (packet->payload_packet_len == 1448
-      && (flow->l4.tcp.irc_stage2 == 15 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction)) {
-    flow->l4.tcp.irc_stage2 = 16;
-    return 1;
-  }
-  if (packet->payload_packet_len == 1200
-      && (flow->l4.tcp.irc_stage2 == 16 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction)) {
-    flow->l4.tcp.irc_stage2 = 17;
-    return 1;
-  }
-  if (packet->payload_packet_len == 1448
-      && (flow->l4.tcp.irc_stage2 == 17 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction)) {
-    flow->l4.tcp.irc_stage2 = 18;
-    return 1;
-  }
-  if (packet->payload_packet_len == 600
-      && (flow->l4.tcp.irc_stage2 == 18 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction)) {
-    flow->l4.tcp.irc_stage2 = 19;
-    return 1;
-  }
-  if (packet->payload_packet_len == 4
-      && flow->l4.tcp.irc_stage2 == 19
-      && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && ntohs(get_u_int16_t(packet->payload, 2)) == 7168) {
-    NDPI_LOG_INFO(ndpi_struct, "found IRC SSL: ->1024,1448,1448,1200,1448,600,<-7168");
-    ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-    return 1;
-  }
-  /* -> 1024, 1380, -> 2404    */
-  if (packet->payload_packet_len == 1380
-      && (flow->l4.tcp.irc_stage2 == 9 && flow->l4.tcp.irc_direction == 1 + packet->packet_direction)) {
-    flow->l4.tcp.irc_stage2 = 20;
-    return 1;
-  }
-  if (packet->payload_packet_len == 4
-      && flow->l4.tcp.irc_stage2 == 20
-      && flow->l4.tcp.irc_direction == 2 - packet->packet_direction && ntohs(get_u_int16_t(packet->payload, 2)) == 2404) {
-    NDPI_LOG_INFO(ndpi_struct, "found IRC SSL: ->1024,1380 <-2404");
-    ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-    return 1;
-
-  }
-  return 0;
-}
-
-
 static void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
 {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	
   u_int16_t c = 0;
   u_int16_t i = 0;
-  u_int16_t j = 0;
-  u_int16_t h;
   u_int16_t http_content_ptr_len = 0;
-  u_int8_t space = 0;
 
   NDPI_LOG_DBG(ndpi_struct, "search irc\n");
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_IRC && (flow->packet_counter > 10)) {
     NDPI_LOG_DBG(ndpi_struct, "exclude irc, packet_counter > 70\n");
     NDPI_ADD_PROTOCOL_TO_BITMASK(flow->excluded_protocol_bitmask, NDPI_PROTOCOL_IRC);
-    return;
-  }
-
-  if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_IRC &&
-      ndpi_search_irc_ssl_detect_ninety_percent_but_very_fast(ndpi_struct, flow) != 0) {
     return;
   }
 
@@ -382,14 +123,14 @@ static void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct
 	    if (flow->l4.tcp.irc_3a_counter == 7) {	/* ':' == 0x3a */
 	      NDPI_LOG_INFO(ndpi_struct, "found irc. 0x3a. seven times.");
 	      ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-	      goto detected_irc;
+	      return;
 	    }
 	  }
 	}
 	if (flow->l4.tcp.irc_3a_counter == 7) {	/* ':' == 0x3a */
 	  NDPI_LOG_INFO(ndpi_struct, "found irc. 0x3a. seven times.");
 	  ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
-	  goto detected_irc;
+	  return;
 	}
       }
 
@@ -469,38 +210,6 @@ static void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct
     }
   }
 
-  /**
-   * Trying to primarily detect the HTTP Web based IRC chat patterns based on the HTTP headers
-   * during the User login time.When the HTTP data gets posted using the POST method ,patterns
-   * will be searched in the HTTP content.
-   */
-  if ((flow->detected_protocol_stack[0] != NDPI_PROTOCOL_IRC) && (flow->l4.tcp.irc_stage == 0)
-      && (packet->payload_packet_len > 5)) {
-    //HTTP POST Method being employed
-    if (memcmp(packet->payload, "POST ", 5) == 0) {
-      ndpi_parse_packet_line_info(ndpi_struct, flow);
-      if (packet->parsed_lines) {
-	u_int16_t http_header_len = (u_int16_t)((packet->line[packet->parsed_lines - 1].ptr - packet->payload) + 2);
-	if (packet->payload_packet_len > http_header_len) {
-	  http_content_ptr_len = packet->payload_packet_len - http_header_len;
-	}
-	if ((ndpi_check_for_IRC_traces(packet->line[0].ptr, packet->line[0].len))
-	    || ((packet->http_url_name.ptr)
-		&& (ndpi_check_for_IRC_traces(packet->http_url_name.ptr, packet->http_url_name.len)))
-	    || ((packet->referer_line.ptr)
-		&& (ndpi_check_for_IRC_traces(packet->referer_line.ptr, packet->referer_line.len)))) {
-	  NDPI_LOG_DBG2(ndpi_struct,
-			"IRC detected from the Http URL/ Referer header ");
-	  flow->l4.tcp.irc_stage = 1;
-	  // HTTP POST Request body is not in the same packet.
-	  if (!http_content_ptr_len) {
-	    return;
-	  }
-	}
-      }
-    }
-  }
-
   if ((flow->detected_protocol_stack[0] != NDPI_PROTOCOL_IRC) && (flow->l4.tcp.irc_stage == 1)) {
     if ((((packet->payload_packet_len - http_content_ptr_len) > 10)
 	 && (memcmp(packet->payload + http_content_ptr_len, "interface=", 10) == 0)
@@ -511,107 +220,6 @@ static void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct
       NDPI_LOG_INFO(ndpi_struct, "found IRC: Nickname, cmd,  one time");
       ndpi_int_irc_add_connection(ndpi_struct, flow, NDPI_CONFIDENCE_DPI);
       return;
-    }
-  }
-
- detected_irc:
-  NDPI_LOG_DBG2(ndpi_struct, "detected_irc:");
-
-  if (flow->detected_protocol_stack[0] == NDPI_PROTOCOL_IRC) {
-    /* maybe this can be deleted at the end */
-
-    if (packet->payload[packet->payload_packet_len - 2] != 0x0d
-	&& packet->payload[packet->payload_packet_len - 1] == 0x0a) {
-      NDPI_LOG_DBG2(ndpi_struct, "ndpi_parse_packet_line_info_any(ndpi_struct, flow);");
-      ndpi_parse_packet_line_info_any(ndpi_struct);
-    } else if (packet->payload[packet->payload_packet_len - 2] == 0x0d) {
-      ndpi_parse_packet_line_info(ndpi_struct, flow);
-    } else {
-      return;
-    }
-    for (i = 0; i < packet->parsed_lines; i++) {
-      if (packet->line[i].len > 6 && memcmp(packet->line[i].ptr, "NOTICE ", 7) == 0) {
-	NDPI_LOG_DBG2(ndpi_struct, "NOTICE");
-	for (j = 7; j < packet->line[i].len - 9; j++) {
-	  if (packet->line[i].ptr[j] == ':') {
-	    if (memcmp(&packet->line[i].ptr[j + 1], "DCC SEND ", 9) == 0
-		|| memcmp(&packet->line[i].ptr[j + 1], "DCC CHAT ", 9) == 0) {
-	      NDPI_LOG_INFO(ndpi_struct,
-			    "found NOTICE and DCC CHAT or DCC SEND.");
-	    }
-	  }
-	}
-      }
-      if (packet->payload_packet_len > 0 && packet->payload[0] == 0x3a /* 0x3a = ':' */ ) {
-	NDPI_LOG_DBG2(ndpi_struct, "3a");
-	for (j = 1; j < packet->line[i].len - 9; j++) {
-	  if (packet->line[i].ptr[j] == ' ') {
-	    j++;
-	    if (packet->line[i].ptr[j] == 'P') {
-	      NDPI_LOG_DBG2(ndpi_struct, "P");
-	      j++;
-	      if (memcmp(&packet->line[i].ptr[j], "RIVMSG ", 7) == 0)
-		NDPI_LOG_DBG2(ndpi_struct, "RIVMSG");
-	      h = j + 7;
-	      goto read_privmsg;
-	    }
-	  }
-	}
-      }
-      if (packet->line[i].len > 7 && (memcmp(packet->line[i].ptr, "PRIVMSG ", 8) == 0)) {
-	NDPI_LOG_DBG2(ndpi_struct, "PRIVMSG	");
-	h = 7;
-      read_privmsg:
-	for (j = h; j < packet->line[i].len - 9; j++) {
-	  if (packet->line[i].ptr[j] == ':') {
-	    if (memcmp(&packet->line[i].ptr[j + 1], "xdcc ", 5) == 0) {
-	      NDPI_LOG_DBG2(ndpi_struct, "xdcc should match.");
-	    }
-	    j += 2;
-	    if (j + 4 < packet->line[i].len &&
-            memcmp(&packet->line[i].ptr[j], "DCC ", 4) == 0) {
-	      j += 4;
-	      NDPI_LOG_DBG2(ndpi_struct, "found DCC.");
-		  if ((j + 5 < packet->line[i].len &&
-		       memcmp(&packet->line[i].ptr[j], "SEND ", 5) == 0) ||
-		      (j + 4 < packet->line[i].len &&
-		       memcmp(&packet->line[i].ptr[j], "CHAT", 4) == 0) ||
-		      (j + 4 < packet->line[i].len &&
-		       memcmp(&packet->line[i].ptr[j], "chat", 4) == 0) ||
-		      (j + 7 < packet->line[i].len &&
-		       memcmp(&packet->line[i].ptr[j], "sslchat", 7) == 0) ||
-		      (j + 5 < packet->line[i].len &&
-		       memcmp(&packet->line[i].ptr[j], "TSEND", 5) == 0)) {
-		NDPI_LOG_DBG2(ndpi_struct, "found CHAT,chat,sslchat,TSEND.");
-		j += 4;
-
-		while (packet->line[i].len > j &&
-		       ((packet->line[i].ptr[j] >= 'a' && packet->line[i].ptr[j] <= 'z')
-			|| (packet->line[i].ptr[j] >= 'A' && packet->line[i].ptr[j] <= 'Z')
-			|| (packet->line[i].ptr[j] >= '0' && packet->line[i].ptr[j] <= '9')
-			|| (packet->line[i].ptr[j] >= ' ')
-			|| (packet->line[i].ptr[j] >= '.')
-			|| (packet->line[i].ptr[j] >= '-'))) {
-
-		  if (packet->line[i].ptr[j] == ' ') {
-		    space++;
-		    NDPI_LOG_DBG2(ndpi_struct, "space %u.", space);
-		  }
-		  if (space == 3) {
-		    j++;
-		    NDPI_LOG_DBG2(ndpi_struct, "read port.");
-		  }
-
-
-		  j++;
-		}
-
-	      }
-	    }
-	  }
-	}
-
-      }
     }
   }
 }


### PR DESCRIPTION
IRC has its best times well behind, but there are still some servers using it.

We should try to simplify the detection logic, still based on OpenDPI logic.

Let's start with some easy changes:
* try to detect TLS connection via standard hostname/SNI matching, removing an old heuristic (we have never had any trace matching it);
* add some basic server names;
* once we detect that the flow is IRC, we don't have to perform anything else;
* remove HTTP stuff; real HTTP flows never trigger that data path
* use `ndpi_memmem()` when possible


