### PR TITLE
Fix a memory access error and some leaks

### DIFF
--- a/src/lib/ndpi_domains.c
+++ b/src/lib/ndpi_domains.c
@@ -148,7 +148,7 @@ const char* ndpi_get_host_domain(struct ndpi_detection_module_struct *ndpi_str,
 
   dot = strstr(hostname, ret);
 
-  if(dot == NULL)
+  if(dot == NULL || dot == hostname)
     return(hostname);
 
   dot--;

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -2320,7 +2320,7 @@ int ndpi_hash_find_entry(ndpi_str_hash *h, char *key, u_int key_len, u_int16_t *
 
 int ndpi_hash_add_entry(ndpi_str_hash **h, char *key, u_int8_t key_len, u_int16_t value) {
   ndpi_str_hash_priv *h_priv = (ndpi_str_hash_priv *)*h;
-  ndpi_str_hash_priv *item;
+  ndpi_str_hash_priv *item, *ret_found;
 
   if(!key || key_len == 0)
     return(3);
@@ -2349,6 +2349,13 @@ int ndpi_hash_add_entry(ndpi_str_hash **h, char *key, u_int8_t key_len, u_int16_
   item->value16 = value;
 
   HASH_ADD(hh, *((ndpi_str_hash_priv **)h), key[0], key_len, item);
+
+  HASH_FIND(hh, *((ndpi_str_hash_priv **)h), key, key_len, ret_found);
+  if(ret_found == NULL) { /* The insertion failed (because of a memory allocation error) */
+    ndpi_free(item->key);
+    ndpi_free(item);
+    return 4;
+  }
 
   return 0;
 }


### PR DESCRIPTION
```
SCARINESS: 12 (1-byte-read-heap-buffer-overflow)
    #0 0x557f3a5b5100 in ndpi_get_host_domain /src/ndpi/src/lib/ndpi_domains.c:158:8
    #1 0x557f3a59b561 in ndpi_check_dga_name /src/ndpi/src/lib/ndpi_main.c:10412:17
    #2 0x557f3a51163a in process_chlo /src/ndpi/src/lib/protocols/quic.c:1467:7
    #3 0x557f3a469f4b in LLVMFuzzerTestOneInput /src/ndpi/fuzz/fuzz_quic_get_crypto_data.c:44:7
    #4 0x557f3a46abc8 in NaloFuzzerTestOneInput (/out/fuzz_quic_get_crypto_data+0x4cfbc8)
```

Some notes about the leak: if the insertion into the uthash fails (because of an allocation failure), we need to free the just allocated entry. But the only way to check if the `HASH_ADD_*` failed, is to perform a new lookup: a bit costly, but we don't use that code in the fast-path. See also efb261a95c5a

Credits for finding the issues to Philippe Antoine (@catenacyber) and its `nallocfuzz` fuzzing engine
See: https://github.com/catenacyber/nallocfuzz
See: https://github.com/google/oss-fuzz/pull/9902


