### PR TITLE
Fixed commented out logging macros for Win32 builds.

### DIFF
--- a/src/include/ndpi_private.h
+++ b/src/include/ndpi_private.h
@@ -465,15 +465,11 @@ struct ndpi_detection_module_struct {
 
 #else /* not defined NDPI_ENABLE_DEBUG_MESSAGES */
 # ifdef WIN32
-/* 
-*  Already defined in ndpi_define.h
-* 
 # define NDPI_LOG(mod, ...) { (void)mod; }
 # define NDPI_LOG_ERR(mod, ...) { (void)mod; }
 # define NDPI_LOG_INFO(mod, ...) { (void)mod; }
 # define NDPI_LOG_DBG(mod, ...) { (void)mod; }
 # define NDPI_LOG_DBG2(mod, ...) { (void)mod; }
-*/
 # else
 # define NDPI_LOG(proto, mod, log_level, args...) { /* printf(args); */ }
 # ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Unsure why @lucaderi commented those out, but they're not defined in `ndpi_define.h.in`.
