### PR TITLE
Remove unused code.

### DIFF
--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -47,11 +47,6 @@ extern "C" {
   void ndpi_tdestroy(void *vrootp, void (*freefct)(void *));
 
   int NDPI_BITMASK_COMPARE(NDPI_PROTOCOL_BITMASK a, NDPI_PROTOCOL_BITMASK b);
-  int NDPI_BITMASK_IS_EMPTY(NDPI_PROTOCOL_BITMASK a);
-  void NDPI_DUMP_BITMASK(NDPI_PROTOCOL_BITMASK a);
-
-
-
 
   u_int16_t ntohs_ndpi_bytestream_to_number(const u_int8_t * str,
 					    u_int16_t max_chars_to_read,
@@ -61,9 +56,6 @@ extern "C" {
 				      u_int16_t * bytes_read);
   u_int64_t ndpi_bytestream_to_number64(const u_int8_t * str, u_int16_t max_chars_to_read,
 					u_int16_t * bytes_read);
-  u_int32_t ndpi_bytestream_dec_or_hex_to_number(const u_int8_t * str,
-						 u_int16_t max_chars_to_read,
-						 u_int16_t * bytes_read);
   u_int64_t ndpi_bytestream_dec_or_hex_to_number64(const u_int8_t * str,
 						   u_int16_t max_chars_to_read,
 						   u_int16_t * bytes_read);

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -367,30 +367,6 @@ u_int16_t ndpi_map_ndpi_id_to_user_proto_id(struct ndpi_detection_module_struct 
 }
 
 /* ************************************************************************************* */
-/* ************************************************************************************* */
-
-#ifdef CODE_UNUSED
-ndpi_port_range *ndpi_build_default_ports_range(ndpi_port_range *ports, u_int16_t portA_low, u_int16_t portA_high,
-                                                u_int16_t portB_low, u_int16_t portB_high, u_int16_t portC_low,
-                                                u_int16_t portC_high, u_int16_t portD_low, u_int16_t portD_high,
-                                                u_int16_t portE_low, u_int16_t portE_high) {
-  int i = 0;
-
-  ports[i].port_low = portA_low, ports[i].port_high = portA_high;
-  i++;
-  ports[i].port_low = portB_low, ports[i].port_high = portB_high;
-  i++;
-  ports[i].port_low = portC_low, ports[i].port_high = portC_high;
-  i++;
-  ports[i].port_low = portD_low, ports[i].port_high = portD_high;
-  i++;
-  ports[i].port_low = portE_low, ports[i].port_high = portE_high;
-
-  return(ports);
-}
-#endif
-
-/* *********************************************************************************** */
 
 ndpi_port_range *ndpi_build_default_ports(ndpi_port_range *ports, u_int16_t portA, u_int16_t portB, u_int16_t portC,
                                           u_int16_t portD, u_int16_t portE) {
@@ -927,12 +903,6 @@ static void init_string_based_protocols(struct ndpi_detection_module_struct *ndp
   /* ************************ */
 
   for(i = 0; tls_certificate_match[i].string_to_match != NULL; i++) {
-#if 0
-    printf("%s() %s / %u\n", __FUNCTION__,
-	   tls_certificate_match[i].string_to_match,
-	   tls_certificate_match[i].protocol_id);
-#endif
-
     if(!is_proto_enabled(ndpi_str, tls_certificate_match[i].protocol_id)) {
       NDPI_LOG_DBG(ndpi_str, "[NDPI] Skip tls cert match for %s/protoId=%d: disabled\n",
 		   tls_certificate_match[i].string_to_match, tls_certificate_match[i].protocol_id);
@@ -8639,44 +8609,6 @@ u_int32_t ndpi_bytestream_to_number(const u_int8_t *str, u_int16_t max_chars_to_
 
 /* ********************************************************************************* */
 
-#ifdef CODE_UNUSED
-u_int32_t ndpi_bytestream_dec_or_hex_to_number(const u_int8_t *str, u_int16_t max_chars_to_read, u_int16_t *bytes_read) {
-  u_int32_t val;
-  val = 0;
-  if(max_chars_to_read <= 2 || str[0] != '0' || str[1] != 'x') {
-    return(ndpi_bytestream_to_number(str, max_chars_to_read, bytes_read));
-  } else {
-    /*use base 16 system */
-    str += 2;
-    max_chars_to_read -= 2;
-    *bytes_read = *bytes_read + 2;
-
-    while(max_chars_to_read > 0) {
-      if(*str >= '0' && *str <= '9') {
-	val *= 16;
-	val += *str - '0';
-      } else if(*str >= 'a' && *str <= 'f') {
-	val *= 16;
-	val += *str + 10 - 'a';
-      } else if(*str >= 'A' && *str <= 'F') {
-	val *= 16;
-	val += *str + 10 - 'A';
-      } else {
-	break;
-      }
-      str++;
-      max_chars_to_read = max_chars_to_read - 1;
-      *bytes_read = *bytes_read + 1;
-    }
-  }
-
-  return(val);
-}
-
-#endif
-
-/* ********************************************************************************* */
-
 u_int64_t ndpi_bytestream_to_number64(const u_int8_t *str, u_int16_t max_chars_to_read, u_int16_t *bytes_read) {
   u_int64_t val;
   val = 0;
@@ -9992,27 +9924,6 @@ int NDPI_BITMASK_COMPARE(NDPI_PROTOCOL_BITMASK a, NDPI_PROTOCOL_BITMASK b) {
 
   return(0);
 }
-
-#ifdef CODE_UNUSED
-int NDPI_BITMASK_IS_EMPTY(NDPI_PROTOCOL_BITMASK a) {
-  unsigned int i;
-
-  for(i = 0; i < NDPI_NUM_FDS_BITS; i++)
-    if(a.fds_bits[i] != 0)
-      return(0);
-
-  return(1);
-}
-
-void NDPI_DUMP_BITMASK(NDPI_PROTOCOL_BITMASK a) {
-  unsigned int i;
-
-  for(i = 0; i < NDPI_NUM_FDS_BITS; i++)
-    printf("[%d=%u]", i, a.fds_bits[i]);
-
-  printf("\n");
-}
-#endif
 
 u_int16_t ndpi_get_api_version() {
   return(NDPI_API_VERSION);

--- a/src/lib/ndpi_serializer.c
+++ b/src/lib/ndpi_serializer.c
@@ -140,32 +140,6 @@ int ndpi_json_string_escape(const char *src, int src_len, char *dst, int dst_max
 
 /* ********************************** */
 
-#if UNUSED
-/*
- * Similar to ndpi_snprintf, this returns the number of bytes actually written
- * in any case (unlike ndpi_snprintf which returns, if the output is truncated,
- * the number of bytes which *would have been* written, and a negative
- * value on failures)
- */
-static inline int ndpi_snappend(char *buf, size_t size, const char *fmt, ...) {
-  int wlen;
-  va_list va;
-
-  va_start(va, fmt);
-  wlen = ndpi_snprintf(buf, size, fmt, va);
-  va_end(va);
-
-  if (wlen < 0)
-    wlen = 0;
-  else if (wlen >= size)
-    wlen = size-1;
-
-  return(wlen);
-}
-#endif
-
-/* ********************************** */
-
 void ndpi_reset_serializer(ndpi_serializer *_serializer) {
   ndpi_private_serializer *serializer = (ndpi_private_serializer*)_serializer;
 
@@ -1254,7 +1228,7 @@ int ndpi_serialize_uint32_double(ndpi_serializer *_serializer,
 
   } else {
 #if 1
-    fprintf(stderr, "TLV serializer does not support double\n");
+    return(-1);
 #else
     ndpi_serialization_type kt;
     u_int8_t type = 0;
@@ -1963,7 +1937,7 @@ int ndpi_serialize_binary_double(ndpi_serializer *_serializer,
     serializer->status.buffer.size_used += rc;
   } else {
 #if 1
-    fprintf(stderr, "TLV serializer does not support double\n");
+    return(-1);
 #else
     serializer->buffer.data[serializer->status.buffer.size_used++] = (ndpi_serialization_string << 4) | ndpi_serialization_double;
 
@@ -2408,14 +2382,6 @@ int ndpi_serialize_end_of_block(ndpi_serializer *_serializer) {
 
 void ndpi_serializer_create_snapshot(ndpi_serializer *_serializer) {
   ndpi_private_serializer *serializer = (ndpi_private_serializer*)_serializer;
-
-#if 0
-  printf("[NDPI] Snapshot status: %s%s%s\n",
-    (serializer->status.flags & NDPI_SERIALIZER_STATUS_COMMA) ? " COMMA" : "",
-    (serializer->status.flags & NDPI_SERIALIZER_STATUS_ARRAY) ? " ARRAY" : "",
-    (serializer->status.flags & NDPI_SERIALIZER_STATUS_EOR)   ? " EOR"   : ""
-  );
-#endif
 
   memcpy(&serializer->snapshot, &serializer->status, sizeof(ndpi_private_serializer_status));
   serializer->has_snapshot = 1;

--- a/utils/check_symbols.sh
+++ b/utils/check_symbols.sh
@@ -29,7 +29,7 @@ for line in `nm -P -u "${NDPI_LIB}"`; do
                     'printf'|'fprintf') SKIP=1 ;;
                 esac
             ;;
-            '[ahocorasick.o]'|'[ndpi_serializer.o]')
+            '[ahocorasick.o]')
                 case "${FOUND_SYMBOL}" in
                     'fprintf') SKIP=1 ;;
                 esac


### PR DESCRIPTION
 * some `#ifdef`ed code dates back to 2019, 2020 and 2021
 * some function signatures were still present in `ndpi_main.h` which may cause linker errors for libnDPI dependee's
 * return an error while trying to serialize a double instead of `fprintf(stderr, ...)`

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)
