### PR TITLE
Added NDPI_PROTOCOL_NTOP assert and removed percentage comparison

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -5957,6 +5957,7 @@ void domainSearchUnitTest() {
   ndpi_domain_classify_add(ndpi_str, sc, NDPI_PROTOCOL_NTOP, ".ntop.org");
   ndpi_domain_classify_add(ndpi_str, sc, NDPI_PROTOCOL_NTOP, domain);
   assert(ndpi_domain_classify_hostname(ndpi_str, sc, &class_id, domain));
+  assert(class_id == NDPI_PROTOCOL_NTOP);
 
   ndpi_domain_classify_add(ndpi_str, sc, NDPI_PROTOCOL_CATEGORY_GAMBLING, "123vc.club");
   assert(ndpi_domain_classify_hostname(ndpi_str, sc, &class_id, "123vc.club"));
@@ -5965,17 +5966,6 @@ void domainSearchUnitTest() {
   /* Subdomain check */
   assert(ndpi_domain_classify_hostname(ndpi_str, sc, &class_id, "blog.ntop.org"));
   assert(class_id == NDPI_PROTOCOL_NTOP);
-
-#ifdef DEBUG_TRACE
-  struct stat st;
-
-  if(stat(fname, &st) == 0) {
-    u_int32_t s = ndpi_domain_classify_size(ndpi_str, sc);
-
-    printf("Size: %u [%.1f %% of the original filename size]\n",
-	   s, (float)(s * 100) / (float)st.st_size);
-  }
-#endif
 
   ndpi_domain_classify_free(sc);
   ndpi_exit_detection_module(ndpi_str);

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -5950,6 +5950,7 @@ void domainSearchUnitTest() {
   char *domain = "ntop.org";
   u_int16_t class_id;
   struct ndpi_detection_module_struct *ndpi_str = ndpi_init_detection_module(NULL);
+  u_int8_t trace = 0;
 
   assert(ndpi_str);
   assert(sc);
@@ -5966,6 +5967,10 @@ void domainSearchUnitTest() {
   /* Subdomain check */
   assert(ndpi_domain_classify_hostname(ndpi_str, sc, &class_id, "blog.ntop.org"));
   assert(class_id == NDPI_PROTOCOL_NTOP);
+
+  u_int32_t s = ndpi_domain_classify_size(sc);
+  if(trace) printf("ndpi_domain_classify size: %u \n",s);
+  
 
   ndpi_domain_classify_free(sc);
   ndpi_exit_detection_module(ndpi_str);


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [NA] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues): https://github.com/ntop/nDPI/issues/2413



Describe changes:
When building with the DEBUG_TRACE flag there was a section in nDPI reader under the search domain unit tests that broke the build.
This section appears to print the percent of the test map size in relation to the size of a file. It could be to see the efficiency of the encoding/zipping of the map entries.
The file handle (fname) was not defined.
I went back in the commit history to investigate the effort of re-instating "fname" definition and realized it has been like that for a while.

Also added an assert to verify the classification id of the original ntop.org domain entry.

This pull request fixes the build but removes the percentage report line
If you can let me know the file name that the comparison should be done against, I am happy to submit another pull request so that the percentage report line is re-instated.


