### PR TITLE
Zoom: fix integer overflow

### DIFF
--- a/src/lib/protocols/zoom.c
+++ b/src/lib/protocols/zoom.c
@@ -184,7 +184,7 @@ static void ndpi_search_zoom(struct ndpi_detection_module_struct *ndpi_struct,
   } else if(packet->payload_packet_len > 36 &&
             memcmp(packet->payload, tomatch_p2p, 3) == 0 &&
             *(u_int32_t *)&packet->payload[packet->payload_packet_len - 4] == 0) {
-    u_int32_t ip_len, uuid_len;
+    u_int64_t ip_len, uuid_len;
 
     /* Check if it is a Peer-To-Peer call.
        We have been identifing such flows using the "stun_zoom" LRU cache; let's


### PR DESCRIPTION
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==29508==ERROR: AddressSanitizer: SEGV on unknown address 0x50710145d51d (pc 0x55cb788f25fe bp 0x7ffcfefa15f0 sp 0x7ffcfefa1240 T0)
==29508==The signal is caused by a READ memory access.
    #0 0x55cb788f25fe in ndpi_search_zoom /home/ivan/svnrepos/nDPI/src/lib/protocols/zoom.c:210:24
    #1 0x55cb787e9418 in check_ndpi_detection_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:7174:6
    #2 0x55cb7883f753 in check_ndpi_udp_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:7209:10
    #3 0x55cb7883bc9d in ndpi_check_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:7240:12
```
Found by oss-fuzzer
See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69520


