### PR TITLE
Added default port mappings to ndpiReader help -H

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -709,8 +709,8 @@ static void help(u_int long_help) {
            sizeof(((struct ndpi_flow_struct *)0)->protos));
 
     printf("\n\nnDPI supported protocols:\n");
-    printf("%3s %8s %-22s %-10s %-8s %-12s %s\n",
-	   "Id", "Userd-id", "Protocol", "Layer_4", "Nw_Proto", "Breed", "Category");
+    printf("%3s %8s %-22s %-10s %-8s %-12s %-18s %-16s %-16s \n",
+	   "Id", "Userd-id", "Protocol", "Layer_4", "Nw_Proto", "Breed", "Category","Def UDP Port/s","Def TCP Port/s");
     num_threads = 1;
 
     ndpi_dump_protocols(ndpi_str, stdout);

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -709,7 +709,7 @@ static void help(u_int long_help) {
            sizeof(((struct ndpi_flow_struct *)0)->protos));
 
     printf("\n\nnDPI supported protocols:\n");
-    printf("%3s %8s %-22s %-10s %-8s %-12s %-18s %-16s %-16s \n",
+    printf("%3s %8s %-22s %-10s %-8s %-12s %-18s %-20s %-20s \n",
 	   "Id", "Userd-id", "Protocol", "Layer_4", "Nw_Proto", "Breed", "Category","Def UDP Port/s","Def TCP Port/s");
     num_threads = 1;
 

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -709,7 +709,7 @@ static void help(u_int long_help) {
            sizeof(((struct ndpi_flow_struct *)0)->protos));
 
     printf("\n\nnDPI supported protocols:\n");
-    printf("%3s %8s %-22s %-10s %-8s %-12s %-18s %-20s %-20s \n",
+    printf("%3s %8s %-22s %-10s %-8s %-12s %-18s %-31s %-31s \n",
 	   "Id", "Userd-id", "Protocol", "Layer_4", "Nw_Proto", "Breed", "Category","Def UDP Port/s","Def TCP Port/s");
     num_threads = 1;
 

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -9548,7 +9548,7 @@ int ndpi_get_category_id(struct ndpi_detection_module_struct *ndpi_str, char *ca
 /* ****************************************************** */
 
 
-char *ndpi_default_ports_string(char *ports_str,u_int16_t *default_ports){
+static char *default_ports_string(char *ports_str,u_int16_t *default_ports){
 
     //dont display zero ports on help screen
     if (default_ports[0] == 0)
@@ -9585,15 +9585,15 @@ void ndpi_dump_protocols(struct ndpi_detection_module_struct *ndpi_str, FILE *du
     char udp_ports[30] = "";
     char tcp_ports[30] = "";
 
-    fprintf(dump_out, "%3d %8d %-22s %-10s %-8s %-12s %-18s %-20s %-20s\n",
+    fprintf(dump_out, "%3d %8d %-22s %-10s %-8s %-12s %-18s %-31s %-31s\n",
 	   i, ndpi_map_ndpi_id_to_user_proto_id(ndpi_str, i),
 	   ndpi_str->proto_defaults[i].protoName,
 	   ndpi_get_l4_proto_name(ndpi_get_l4_proto_info(ndpi_str, i)),
 	   ndpi_str->proto_defaults[i].isAppProtocol ? "" : "X",
 	   ndpi_get_proto_breed_name(ndpi_str->proto_defaults[i].protoBreed),
 	   ndpi_category_get_name(ndpi_str, ndpi_str->proto_defaults[i].protoCategory),
-     ndpi_default_ports_string(udp_ports,ndpi_str->proto_defaults[i].udp_default_ports),
-     ndpi_default_ports_string(tcp_ports,ndpi_str->proto_defaults[i].tcp_default_ports)
+     default_ports_string(udp_ports,ndpi_str->proto_defaults[i].udp_default_ports),
+     default_ports_string(tcp_ports,ndpi_str->proto_defaults[i].tcp_default_ports)
      );
 
   }

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -9547,19 +9547,56 @@ int ndpi_get_category_id(struct ndpi_detection_module_struct *ndpi_str, char *ca
 
 /* ****************************************************** */
 
+
+char *ndpi_default_ports_string(char *ports_str,u_int16_t *default_ports){
+
+    //dont display zero ports on help screen
+    if (default_ports[0] == 0)
+      //- for readability
+      return "-";
+
+    int j=0;
+    do
+    {
+      //max port len 5(eg 65535) + comma + nul
+      char port[7];
+      sprintf(port,"%d,",default_ports[j]);
+      strcat(ports_str,port);
+      j++;
+    } while (j < MAX_DEFAULT_PORTS && default_ports[j]!= 0);
+
+    //remove last comma
+    ports_str[strlen(ports_str)-1] = '\0';
+
+    return ports_str;
+
+}
+
+/* ****************************************************** */
+
+
 void ndpi_dump_protocols(struct ndpi_detection_module_struct *ndpi_str, FILE *dump_out) {
   int i;
 
   if(!ndpi_str || !dump_out) return;
 
-  for(i = 0; i < (int) ndpi_str->ndpi_num_supported_protocols; i++)
-    fprintf(dump_out, "%3d %8d %-22s %-10s %-8s %-12s %s\n",
+  for(i = 0; i < (int) ndpi_str->ndpi_num_supported_protocols; i++) {
+    //max port size(eg 65535) * 5 + 4 commas + nul
+    char udp_ports[30] = "";
+    char tcp_ports[30] = "";
+
+    fprintf(dump_out, "%3d %8d %-22s %-10s %-8s %-12s %-18s %-20s %-20s\n",
 	   i, ndpi_map_ndpi_id_to_user_proto_id(ndpi_str, i),
 	   ndpi_str->proto_defaults[i].protoName,
 	   ndpi_get_l4_proto_name(ndpi_get_l4_proto_info(ndpi_str, i)),
 	   ndpi_str->proto_defaults[i].isAppProtocol ? "" : "X",
 	   ndpi_get_proto_breed_name(ndpi_str->proto_defaults[i].protoBreed),
-	   ndpi_category_get_name(ndpi_str, ndpi_str->proto_defaults[i].protoCategory));
+	   ndpi_category_get_name(ndpi_str, ndpi_str->proto_defaults[i].protoCategory),
+     ndpi_default_ports_string(udp_ports,ndpi_str->proto_defaults[i].udp_default_ports),
+     ndpi_default_ports_string(tcp_ports,ndpi_str->proto_defaults[i].tcp_default_ports)
+     );
+
+  }
 }
 
 /* ********************************** */


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [X] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue] https://github.com/ntop/nDPI/issues/2125

Describe changes:
Added default port mappings to ndpiReader help.
I didn't make the column width's the max value (5*5+4) because a lot of protocols define 0 or 1 default port/s and it looked very out of place when printed.
I will change this if you guys want me to. 

