### PR TITLE
Wireshar/Lua: improvements, support to tshark and metadata export

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -795,7 +795,7 @@ void extcap_dlts() {
 
 struct ndpi_proto_sorter {
   int id;
-  char name[16];
+  char name[32];
 };
 
 /* ********************************** */
@@ -833,18 +833,23 @@ int cmpFlows(const void *_a, const void *_b) {
 
 void extcap_config() {
   int argidx = 0;
-#if 0
+
   struct ndpi_proto_sorter *protos;
   u_int ndpi_num_supported_protocols;
   int i;
   ndpi_proto_defaults_t *proto_defaults;
-#endif
+  NDPI_PROTOCOL_BITMASK all;
 
   struct ndpi_detection_module_struct *ndpi_str = ndpi_init_detection_module(NULL);
-#if 0
+  if(!ndpi_str) exit(0);
+
+  NDPI_BITMASK_SET_ALL(all);
+  ndpi_set_protocol_detection_bitmask2(ndpi_str, &all);
+
+  ndpi_finalize_initialization(ndpi_str);
+
   ndpi_num_supported_protocols = ndpi_get_ndpi_num_supported_protocols(ndpi_str);
   proto_defaults = ndpi_get_proto_defaults(ndpi_str);
-#endif
 
   /* -i <interface> */
   printf("arg {number=%d}{call=-i}{display=Capture Interface}{type=string}{group=Live Capture}"
@@ -853,15 +858,14 @@ void extcap_config() {
   printf("arg {number=%d}{call=-i}{display=Pcap File to Analyze}{type=fileselect}{mustexist=true}{group=Pcap}"
          "{tooltip=The pcap file to analyze (if the interface is unspecified)}\n", argidx++);
 
-#if 0
-  /* Removed as it breaks! extcap */
+
   protos = (struct ndpi_proto_sorter*)ndpi_malloc(sizeof(struct ndpi_proto_sorter) * ndpi_num_supported_protocols);
   if(!protos) exit(0);
 
   printf("arg {number=%d}{call=--ndpi-proto-filter}{display=nDPI Protocol Filter}{type=selector}{group=Filter}"
          "{tooltip=nDPI Protocol to be filtered}\n", argidx);
 
-  printf("value {arg=%d}{value=%d}{display=%s}{default=true}\n", argidx, 0, "No nDPI filtering");
+  printf("value {arg=%d}{value=%d}{display=%s}{default=true}\n", argidx, (u_int32_t)-1, "No nDPI filtering");
 
   for(i=0; i<(int) ndpi_num_supported_protocols; i++) {
     protos[i].id = i;
@@ -875,7 +879,6 @@ void extcap_config() {
            protos[i].name, protos[i].id);
 
   ndpi_free(protos);
-#endif
 
   ndpi_exit_detection_module(ndpi_str);
 

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1440,7 +1440,8 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
 					   const struct pcap_pkthdr *header,
 					   const u_char *packet,
 					   pkt_timeval when,
-					   ndpi_risk *flow_risk) {
+					   ndpi_risk *flow_risk,
+					   struct ndpi_flow_info **flow_ext) {
   struct ndpi_flow_info *flow = NULL;
   struct ndpi_flow_struct *ndpi_flow = NULL;
   u_int8_t proto;
@@ -1702,6 +1703,7 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
 #endif
 
   *flow_risk = flow->risk;
+  *flow_ext = flow;
 
   return(flow->detected_protocol);
 }
@@ -1851,7 +1853,8 @@ static uint32_t ndpi_is_valid_gre_tunnel(const struct pcap_pkthdr *header,
 struct ndpi_proto ndpi_workflow_process_packet(struct ndpi_workflow * workflow,
 					       const struct pcap_pkthdr *header,
 					       const u_char *packet,
-					       ndpi_risk *flow_risk) {
+					       ndpi_risk *flow_risk,
+					       struct ndpi_flow_info **flow) {
   /*
    * Declare pointers to packet headers
    */
@@ -1900,6 +1903,7 @@ struct ndpi_proto ndpi_workflow_process_packet(struct ndpi_workflow * workflow,
   u_int8_t vlan_packet = 0;
 
   *flow_risk = 0 /* NDPI_NO_RISK */;
+  *flow = NULL;
 
   /* Increment raw packet counter */
   workflow->stats.raw_packet_count++;
@@ -2376,7 +2380,7 @@ struct ndpi_proto ndpi_workflow_process_packet(struct ndpi_workflow * workflow,
   return(packet_processing(workflow, time_ms, vlan_id, tunnel_type, iph, iph6,
 			   header->caplen - ip_offset,
 			   header->caplen, header, packet, header->ts,
-			   flow_risk));
+			   flow_risk, flow));
 }
 
 /* *********************************************** */

--- a/example/reader_util.h
+++ b/example/reader_util.h
@@ -416,7 +416,8 @@ void ndpi_free_flow_info_half(struct ndpi_flow_info *flow);
 struct ndpi_proto ndpi_workflow_process_packet(struct ndpi_workflow * workflow,
 					       const struct pcap_pkthdr *header,
 					       const u_char *packet,
-					       ndpi_risk *flow_risk);
+					       ndpi_risk *flow_risk,
+					       struct ndpi_flow_info **flow);
 
 
 /* Flow callback for completed flows, before the flow memory will be freed. */

--- a/fuzz/fuzz_ndpi_reader.c
+++ b/fuzz/fuzz_ndpi_reader.c
@@ -126,9 +126,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
     if(packet_checked) {
       ndpi_risk flow_risk;
+      struct ndpi_flow_info *flow = NULL; /* unused */
 
       memcpy(packet_checked, pkt, header->caplen);
-      ndpi_workflow_process_packet(workflow, header, packet_checked, &flow_risk);
+      ndpi_workflow_process_packet(workflow, header, packet_checked, &flow_risk, &flow);
       free(packet_checked);
     }
 

--- a/fuzz/fuzz_readerutils_workflow.cpp
+++ b/fuzz/fuzz_readerutils_workflow.cpp
@@ -23,6 +23,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   ndpi_serialization_format serialization_format;
   NDPI_PROTOCOL_BITMASK enabled_bitmask;
   ndpi_risk flow_risk;
+  struct ndpi_flow_info *flow = NULL; /* unused */
   const u_char *pkt;
   struct pcap_pkthdr *header;
   int r, rc;
@@ -95,7 +96,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
       header = NULL;
       r = pcap_next_ex(pcap_handle, &header, &pkt);
       while (r > 0) {
-        ndpi_workflow_process_packet(w, header, pkt, &flow_risk);
+        ndpi_workflow_process_packet(w, header, pkt, &flow_risk, &flow);
         r = pcap_next_ex(pcap_handle, &header, &pkt);
       }
     }

--- a/wireshark/ndpi.lua
+++ b/wireshark/ndpi.lua
@@ -18,8 +18,12 @@
 -- Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 --
 
-function bit(p)
-   return 2 ^ p  -- 0-based indexing
+function bit(p) -- 0-based indexing; returning a UInt64 object!
+   if p < 32 then
+       return UInt64(2 ^ p, 0)
+   else
+       return UInt64(0, 2 ^ (p - 32))
+   end
 end
 
 
@@ -36,8 +40,8 @@ ndpi_fds.flow_score           = ProtoField.new("nDPI Flow Score", "ndpi.flow_sco
 
 
 local flow_risks = {}
--- Wireshark/Lua doesn't handle 64 bit integer very well, so we split the risk mask into two 32 bit integer values
-local num_bits_flow_risks = 32
+--- You can't use a 64 bit integer "as-is" as mask: we choose to use UInt64 object instead
+local num_bits_flow_risks = 64
 flow_risks[0]  = ProtoField.bool("ndpi.flow_risk.unused0", "Reserved", num_bits_flow_risks, nil, bit(0), "nDPI Flow Risk: Reserved bit")
 flow_risks[1]  = ProtoField.bool("ndpi.flow_risk.xss_attack", "XSS attack", num_bits_flow_risks, nil, bit(1), "nDPI Flow Risk: XSS attack")
 flow_risks[2]  = ProtoField.bool("ndpi.flow_risk.sql_injection", "SQL injection", num_bits_flow_risks, nil, bit(2), "nDPI Flow Risk: SQL injection")
@@ -70,34 +74,33 @@ flow_risks[28] = ProtoField.bool("ndpi.flow_risk.possibly_malicious_ja3", "Possi
 flow_risks[29] = ProtoField.bool("ndpi.flow_risk.possibly_malicious_ssl_certificate_sha1", "Possibly Malicious SSL Certificate SHA1 Fingerprint", num_bits_flow_risks, nil, bit(29), "nDPI Flow Risk: Possibly Malicious SSL Certificate SHA1 Fingerprint")
 flow_risks[30] = ProtoField.bool("ndpi.flow_risk.desktop_file_sharing_session", "Desktop/File Sharing Session", num_bits_flow_risks, nil, bit(30), "nDPI Flow Risk: Desktop/File Sharing Session")
 flow_risks[31] = ProtoField.bool("ndpi.flow_risk.uncommon_tls_alpn", "Uncommon TLS ALPN", num_bits_flow_risks, nil, bit(31), "nDPI Flow Risk: Uncommon TLS ALPN")
--- Restart bitmask from 0!
-flow_risks[32] = ProtoField.bool("ndpi.flow_risk.cert_validity_too_long", "TLS certificate validity longer than 13 months", num_bits_flow_risks, nil, bit(0), "nDPI Flow Risk: TLS certificate validity longer than 13 months")
-flow_risks[33] = ProtoField.bool("ndpi.flow_risk.suspicious_extension", "TLS suspicious extension", num_bits_flow_risks, nil, bit(1), "nDPI Flow Risk: TLS suspicious extension")
-flow_risks[34] = ProtoField.bool("ndpi.flow_risk.fatal_alert", "TLS fatal alert detected", num_bits_flow_risks, nil, bit(2), "nDPI Flow Risk: TLS fatal alert")
-flow_risks[35] = ProtoField.bool("ndpi.flow_risk.suspicious_entropy", "Suspicious entropy", num_bits_flow_risks, nil, bit(3), "nDPI Flow Risk: suspicious entropy")
-flow_risks[36] = ProtoField.bool("ndpi.flow_risk.clear_text_credentials", "Cleat-Text credentials", num_bits_flow_risks, nil, bit(4), "nDPI Flow Risk: cleat-text credentials")
-flow_risks[37] = ProtoField.bool("ndpi.flow_risk.dns_large_packet", "DNS large packet", num_bits_flow_risks, nil, bit(5), "nDPI Flow Risk: DNS packet is larger than 512 bytes")
-flow_risks[38] = ProtoField.bool("ndpi.flow_risk.dns_fragmented", "DNS fragmented", num_bits_flow_risks, nil, bit(6), "nDPI Flow Risk: DNS message is fragmented")
-flow_risks[39] = ProtoField.bool("ndpi.flow_risk.invalid_characters", "Invalid characters", num_bits_flow_risks, nil, bit(7), "nDPI Flow Risk: Text contains non-printable characters")
-flow_risks[40] = ProtoField.bool("ndpi.flow_risk.possible_exploit", "Possible Exploit", num_bits_flow_risks, nil, bit(8), "nDPI Flow Risk: Possible exploit attempt detected")
-flow_risks[41] = ProtoField.bool("ndpi.flow_risk.cert_about_to_expire", "TLS cert about to expire", num_bits_flow_risks, nil, bit(9), "nDPI Flow Risk: TLS certificate about to expire")
-flow_risks[42] = ProtoField.bool("ndpi.flow_risk.punycode_idn", "IDN Domain Name", num_bits_flow_risks, nil, bit(10), "nDPI Flow Risk: IDN Domain Name")
-flow_risks[43] = ProtoField.bool("ndpi.flow_risk.error_code_detected", "Error Code Detected", num_bits_flow_risks, nil, bit(11), "nDPI Flow Risk: Error Code Detected")
-flow_risks[44] = ProtoField.bool("ndpi.flow_risk.crawler_bot", "Crawler/Bot Detected", num_bits_flow_risks, nil, bit(12), "nDPI Flow Risk: Crawler/Bot Detected")
-flow_risks[45] = ProtoField.bool("ndpi.flow_risk.anonymous_subscriber", "Anonymous Subscriber", num_bits_flow_risks, nil, bit(13), "nDPI Flow Risk: Anonymous Subscriber")
-flow_risks[46] = ProtoField.bool("ndpi.flow_risk.unidirectional_traffic", "Unidirectional Traffic", num_bits_flow_risks, nil, bit(14), "nDPI Flow Risk: Unidirectional Traffi")
-flow_risks[47] = ProtoField.bool("ndpi.flow_risk.http_obsolete_server", "Obsolete HTTP Server", num_bits_flow_risks, nil, bit(15), "nDPI Flow Risk: Obsolete HTTP Server")
-flow_risks[48] = ProtoField.bool("ndpi.flow_risk.periodic_flow", "Periodic Flow", num_bits_flow_risks, nil, bit(16), "nDPI Flow Risk: Periodic Flow")
-flow_risks[49] = ProtoField.bool("ndpi.flow_risk.minor_issues", "Minor flow issues", num_bits_flow_risks, nil, bit(17), "nDPI Flow Risk: Minor flow issues")
-flow_risks[50] = ProtoField.bool("ndpi.flow_risk.tcp_issues", "TCP connection issues", num_bits_flow_risks, nil, bit(18), "nDPI Flow Risk: TCP connection issues")
-flow_risks[51] = ProtoField.bool("ndpi.flow_risk.fully_encrypted", "Fully encrypted connection", num_bits_flow_risks, nil, bit(19), "nDPI Flow Risk: Fully encrypted connection")
-flow_risks[52] = ProtoField.bool("ndpi.flow_risk.tls_alpn_sni_mismatch", "ALPN/SNI Mismatch", num_bits_flow_risks, nil, bit(20), "nDPI Flow Risk: ALPN/SNI Mismatch")
-flow_risks[53] = ProtoField.bool("ndpi.flow_risk.malware_contact", "Contact with a malware host", num_bits_flow_risks, nil, bit(21), "nDPI Flow Risk: Malware host contacted")
-flow_risks[54] = ProtoField.bool("ndpi.flow_risk.binary_data_transfer", "Attempt to transfer a binary file", num_bits_flow_risks, nil, bit(22), "nDPI Flow Risk: binary data file transfer")
-flow_risks[55] = ProtoField.bool("ndpi.flow_risk.probing_attempt", "Probing attempt", num_bits_flow_risks, nil, bit(23), "nDPI Flow Risk: probing attempt")
+flow_risks[32] = ProtoField.bool("ndpi.flow_risk.cert_validity_too_long", "TLS certificate validity longer than 13 months", num_bits_flow_risks, nil, bit(32), "nDPI Flow Risk: TLS certificate validity longer than 13 months")
+flow_risks[33] = ProtoField.bool("ndpi.flow_risk.suspicious_extension", "TLS suspicious extension", num_bits_flow_risks, nil, bit(33), "nDPI Flow Risk: TLS suspicious extension")
+flow_risks[34] = ProtoField.bool("ndpi.flow_risk.fatal_alert", "TLS fatal alert detected", num_bits_flow_risks, nil, bit(34), "nDPI Flow Risk: TLS fatal alert")
+flow_risks[35] = ProtoField.bool("ndpi.flow_risk.suspicious_entropy", "Suspicious entropy", num_bits_flow_risks, nil, bit(35), "nDPI Flow Risk: suspicious entropy")
+flow_risks[36] = ProtoField.bool("ndpi.flow_risk.clear_text_credentials", "Cleat-Text credentials", num_bits_flow_risks, nil, bit(36), "nDPI Flow Risk: cleat-text credentials")
+flow_risks[37] = ProtoField.bool("ndpi.flow_risk.dns_large_packet", "DNS large packet", num_bits_flow_risks, nil, bit(37), "nDPI Flow Risk: DNS packet is larger than 512 bytes")
+flow_risks[38] = ProtoField.bool("ndpi.flow_risk.dns_fragmented", "DNS fragmented", num_bits_flow_risks, nil, bit(38), "nDPI Flow Risk: DNS message is fragmented")
+flow_risks[39] = ProtoField.bool("ndpi.flow_risk.invalid_characters", "Invalid characters", num_bits_flow_risks, nil, bit(39), "nDPI Flow Risk: Text contains non-printable characters")
+flow_risks[40] = ProtoField.bool("ndpi.flow_risk.possible_exploit", "Possible Exploit", num_bits_flow_risks, nil, bit(40), "nDPI Flow Risk: Possible exploit attempt detected")
+flow_risks[41] = ProtoField.bool("ndpi.flow_risk.cert_about_to_expire", "TLS cert about to expire", num_bits_flow_risks, nil, bit(41), "nDPI Flow Risk: TLS certificate about to expire")
+flow_risks[42] = ProtoField.bool("ndpi.flow_risk.punycode_idn", "IDN Domain Name", num_bits_flow_risks, nil, bit(42), "nDPI Flow Risk: IDN Domain Name")
+flow_risks[43] = ProtoField.bool("ndpi.flow_risk.error_code_detected", "Error Code Detected", num_bits_flow_risks, nil, bit(43), "nDPI Flow Risk: Error Code Detected")
+flow_risks[44] = ProtoField.bool("ndpi.flow_risk.crawler_bot", "Crawler/Bot Detected", num_bits_flow_risks, nil, bit(44), "nDPI Flow Risk: Crawler/Bot Detected")
+flow_risks[45] = ProtoField.bool("ndpi.flow_risk.anonymous_subscriber", "Anonymous Subscriber", num_bits_flow_risks, nil, bit(45), "nDPI Flow Risk: Anonymous Subscriber")
+flow_risks[46] = ProtoField.bool("ndpi.flow_risk.unidirectional_traffic", "Unidirectional Traffic", num_bits_flow_risks, nil, bit(46), "nDPI Flow Risk: Unidirectional Traffi")
+flow_risks[47] = ProtoField.bool("ndpi.flow_risk.http_obsolete_server", "Obsolete HTTP Server", num_bits_flow_risks, nil, bit(47), "nDPI Flow Risk: Obsolete HTTP Server")
+flow_risks[48] = ProtoField.bool("ndpi.flow_risk.periodic_flow", "Periodic Flow", num_bits_flow_risks, nil, bit(48), "nDPI Flow Risk: Periodic Flow")
+flow_risks[49] = ProtoField.bool("ndpi.flow_risk.minor_issues", "Minor flow issues", num_bits_flow_risks, nil, bit(49), "nDPI Flow Risk: Minor flow issues")
+flow_risks[50] = ProtoField.bool("ndpi.flow_risk.tcp_issues", "TCP connection issues", num_bits_flow_risks, nil, bit(50), "nDPI Flow Risk: TCP connection issues")
+flow_risks[51] = ProtoField.bool("ndpi.flow_risk.fully_encrypted", "Fully encrypted connection", num_bits_flow_risks, nil, bit(51), "nDPI Flow Risk: Fully encrypted connection")
+flow_risks[52] = ProtoField.bool("ndpi.flow_risk.tls_alpn_sni_mismatch", "ALPN/SNI Mismatch", num_bits_flow_risks, nil, bit(52), "nDPI Flow Risk: ALPN/SNI Mismatch")
+flow_risks[53] = ProtoField.bool("ndpi.flow_risk.malware_contact", "Contact with a malware host", num_bits_flow_risks, nil, bit(53), "nDPI Flow Risk: Malware host contacted")
+flow_risks[54] = ProtoField.bool("ndpi.flow_risk.binary_data_transfer", "Attempt to transfer a binary file", num_bits_flow_risks, nil, bit(54), "nDPI Flow Risk: binary data file transfer")
+flow_risks[55] = ProtoField.bool("ndpi.flow_risk.probing_attempt", "Probing attempt", num_bits_flow_risks, nil, bit(55), "nDPI Flow Risk: probing attempt")
 
 -- Last one: keep in sync the bitmask when adding new risks!!
-flow_risks[64] = ProtoField.new("Unused", "ndpi.flow_risk.unused", ftypes.UINT32, nil, base.HEX, bit(32) - bit(24))
+flow_risks[64] = ProtoField.new("Unused", "ndpi.flow_risk.unused", ftypes.UINT64, nil, base.HEX, bit(64) - bit(56))
 
 for _,v in pairs(flow_risks) do
   ndpi_fds[#ndpi_fds + 1] = v
@@ -1077,12 +1080,11 @@ function ndpi_proto.dissector(tvb, pinfo, tree)
 	       
 	       for i=0,63 do
 		 if flow_risks[i] ~= nil then
-	            -- Wireshark/Lua doesn't handle 64 bit integer very well, so we split the risk mask into two 32 bit integer values
-	            flow_risk_tree:add(flow_risks[i], trailer_tvb((i < 32 and 12 or 8), 4))
+	            flow_risk_tree:add(flow_risks[i], trailer_tvb(8, 8))
 		 end
 
 	       end
-	       flow_risk_tree:add(flow_risks[64], trailer_tvb(8, 4)) -- Unused bits in flow risk bitmask
+	       flow_risk_tree:add(flow_risks[64], trailer_tvb(8, 8)) -- Unused bits in flow risk bitmask
 	    end
 	    
 	    if(flow_score > 0) then

--- a/wireshark/ndpi.lua
+++ b/wireshark/ndpi.lua
@@ -761,13 +761,13 @@ function dns_dissector(tvb, pinfo, tree)
    local dns_response = f_dns_response()
    if(dns_response ~= nil) then
       local dns_ret_code = f_dns_ret_code()
-      local dns_response = tonumber(getval(dns_response))
+      local dns_response = dns_response() -- conversion to true/false. We can't use tonumber() on Bool
       local srckey = tostring(pinfo.src)
       local dstkey = tostring(pinfo.dst)
       local dns_query_name = f_dns_query_name()
       dns_query_name = getval(dns_query_name)
 
-      if(dns_response == 0) then
+      if(dns_response == false) then
 	 -- DNS Query
 	 if(dns_client_queries[srckey] == nil) then dns_client_queries[srckey] = 0 end
 	 dns_client_queries[srckey] = dns_client_queries[srckey] + 1


### PR DESCRIPTION
Some improvements on the extcap logic used by Wireshark (via Lua plugin)
In particular:
* add support to tshark
```
ivan@ivan-Latitude-E6540:~/svnrepos/wireshark(master)$ ./wireshark-master/run/tshark -i ndpi -o extcap.ndpi.i:/home/ivan/svnrepos/nDPI/tests/pcap/anydesk.pcapng -Y "ndpi.metadata.ja3c"
Capturing on 'nDPI interface: ndpi'
   16   0.711243 51.83.238.219 TLS.AnyDesk 192.168.149.129 1648  80 → 43535 [PSH, ACK] Seq=1301 Ack=264 Win=64240 Len=1300
   72 22635396.570357 192.168.1.178 TLS.AnyDesk 192.168.1.187 1808  Server Hello, Certificate
   85 22635396.727688 192.168.1.187 TLS.AnyDesk 192.168.1.178 1161  Server Hello, Certificate, Certificate Request, Server Hello Done
  128 71748350.379472 195.181.174.176 TLS.AnyDesk 192.168.1.128 1440  Certificate, Server Key Exchange, Certificate Request, Server Hello Done
4 packets captured

```
* export of (a few) metadata
![Screenshot from 2024-06-25 12-09-43](https://github.com/ntop/nDPI/assets/12729895/7b28ba95-eb59-4f01-b190-712ada85fd01)


Further details on the commit messages

