### PR TITLE
Remove duplicate API for `ndpi_serialize_uint32_double` in ndpi_api.h.

### DIFF
--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -1266,16 +1266,6 @@ extern "C" {
    * @param serializer The serializer handle
    * @param key The field name or ID
    * @param value The field value
-   * @param format The float value format
-   * @return 0 on success, a negative number otherwise
-   */
-  int ndpi_serialize_uint32_double(ndpi_serializer *serializer, u_int32_t key, double value, const char *format /* e.f. "%.2f" */);
-
-  /**
-   * Serialize a 32-bit unsigned int key and a double value
-   * @param serializer The serializer handle
-   * @param key The field name or ID
-   * @param value The field value
    * @param format The double value format
    * @return 0 on success, a negative number otherwise
    */


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):
[link to issue](https://github.com/ntop/nDPI/issues/2478)

Describe changes:
Removed the duplicate declaration of the function `ndpi_serialize_uint32_double`.

Fixes #2478
