### PR TITLE
Optimize performance of ndpi_strnstr() and possible bugfix

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -5782,6 +5782,13 @@ void strnstrUnitTest(void) {
 
   /* Test 13 */
   assert(ndpi_strnstr("abcdef", "abc", 2) == NULL);
+
+  /* Test 14: zero length */
+  assert(strcmp(ndpi_strnstr("", "", 0), "") == 0);
+  assert(strcmp(ndpi_strnstr("string", "", 0), "string") == 0);
+  assert(ndpi_strnstr("", "str", 0) == NULL);
+  assert(ndpi_strnstr("string", "str", 0) == NULL);
+  assert(ndpi_strnstr("str", "string", 0) == NULL);
 }
 
 /* *********************************************** */

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -9737,17 +9737,23 @@ void ndpi_dump_risks_score(FILE *risk_out) {
 
 char *ndpi_strnstr(const char *haystack, const char *needle, size_t len)
 {
-  if (!haystack || !needle || len == 0)
+  if (!haystack || !needle)
   {
     return NULL;
   }
 
-  size_t needle_len = strlen(needle);
-  size_t hs_real_len = strnlen(haystack, len);
+  const size_t needle_len = strlen(needle);
 
   if (needle_len == 0)
   {
     return (char *)haystack;
+  }
+
+  const size_t hs_real_len = strnlen(haystack, len);
+
+  if (needle_len == 1)
+  {
+    return (char *)memchr(haystack, *needle, hs_real_len);
   }
 
   if (needle_len > hs_real_len)
@@ -9755,29 +9761,24 @@ char *ndpi_strnstr(const char *haystack, const char *needle, size_t len)
     return NULL;
   }
 
-  if (needle_len == 1)
-  {
-    return (char *)memchr(haystack, *needle, hs_real_len);
-  }
+  const char *const end_of_search = haystack + hs_real_len - needle_len + 1;
 
   const char *current = haystack;
-  const char *haystack_end = haystack + hs_real_len;
-
-  while (current <= haystack_end - needle_len)
+  while (current < end_of_search)
   {
-    current = (const char *)memchr(current, *needle, haystack_end - current);
+    current = (const char *)memchr(current, *needle, end_of_search - current);
 
     if (!current)
     {
       return NULL;
     }
 
-    if ((current + needle_len <= haystack_end) && memcmp(current, needle, needle_len) == 0)
+    if (memcmp(current, needle, needle_len) == 0)
     {
       return (char *)current;
     }
 
-    current++;
+    ++current;
   }
 
   return NULL;

--- a/tests/performance/strnstr.cpp
+++ b/tests/performance/strnstr.cpp
@@ -71,6 +71,48 @@ char *ndpi_strnstr_opt(const char *haystack, const char *needle, size_t len) {
   return NULL;
 }
 
+char* ndpi_strnstr_opt2(const char* haystack, const char* needle, size_t length_limit) {
+  if (!haystack || !needle) {
+    return nullptr;
+  }
+
+  const size_t needle_len = strlen(needle);
+
+  if (needle_len == 0) {
+    return (char*) haystack;
+  }
+
+  const size_t hs_real_len = strnlen(haystack, length_limit);
+
+  if (needle_len == 1) {
+    return (char *)memchr(haystack, *needle, hs_real_len);
+  }
+
+  if (needle_len > hs_real_len) {
+    return nullptr;
+  }
+
+  const char*const end_of_search = haystack + hs_real_len - needle_len + 1;
+
+  const char *current = haystack;
+  while (current < end_of_search) {
+
+    current = (const char*) memchr(current, *needle, end_of_search - current);
+
+    if (!current) {
+      return nullptr;
+    }
+
+    if (memcmp(current, needle, needle_len) == 0) {
+      return (char*) current;
+    }
+
+    ++current;
+  }
+
+  return nullptr;
+}
+
 std::string random_string(size_t length, std::mt19937 &gen) {
   std::uniform_int_distribution<> dis(0, 255);
   std::string str(length, 0);
@@ -133,6 +175,7 @@ int main() {
       strnstr_impls = {
           {"ndpi_strnstr", ndpi_strnstr},
           {"ndpi_strnstr_opt", ndpi_strnstr_opt},
+          {"ndpi_strnstr_opt2", ndpi_strnstr_opt2},
       };
 
   const int iterations = 100000;


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

#2433 #2439 #2447

Describe changes:

I made some minor changes to the current optimized substring search.

The main changes are:
1. Removed `len == 0` check from the first `if` statement. Now the function doesn't immediately return `NULL` if `len` is zero.  
I believe that the previous behavior was a bug, because if `needle_len` is zero, the function should return `haystack`, because the  empty substring does reside at the start of the empty string.
2. Changed the order of `hs_real_len` computation and `if (needle_len == 0)` check.
3. Removed the if `(needle_len == 1)` check because it only provides a performance benefit in specific cases. If you need to frequently search for single-character substrings, you might want to consider reverting this change.
4. Replaced variable `haystack_end` with variable `end_of_search` (the byte after the last interesting byte).  
Using `end_of_search` inside the `memchr` function instead of `haystack_end` eliminates the need for the `current + needle_len <= haystack_end` check, as it is always positive if `current` is not `NULL`.

I also added the new function to the performance tests.
In practice `ndpi_strnstr_opt2` is slightly faster than `ndpi_strnstr_opt` in most runs, though sometimes `ndpi_strnstr_opt` appears to be faster.