### PR TITLE
Fixed mistake with the shebang in the file utils/update_every_lists.sh (SC1113)

### DIFF
--- a/utils/update_every_lists.sh
+++ b/utils/update_every_lists.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 cd "$(dirname "${0}")" || exit 1
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

#1436

Describe changes:

There was a mistake with the shebang in the file `utils/update_every_lists.sh`: using `#` for the shebang instead of `#!`.

See [SC1113](https://github.com/koalaman/shellcheck/wiki/SC1113) for more details.