### PR TITLE
ipaddr2list.py, ndpi2timeline.py: reformatted

### DIFF
--- a/example/ndpi2timeline.py
+++ b/example/ndpi2timeline.py
@@ -34,46 +34,46 @@ import json
 protos = {}
 lastId = 1
 
+
 def get_timestamp(seen):
     tok = seen.split(".")
     return int(tok[0]) * 1000 + int(tok[1])
 
+
 def get_record(toks, csv_fields):
     global protos
     global lastId
-    
+
     if len(toks) < 11:
         return None
 
-    record = dict()
+    record = {}
     ndpiProtocol = toks[10]
 
-    ndpi_protos = ndpiProtocol.split(".")    
-    if(len(ndpi_protos) == 1):
+    ndpi_protos = ndpiProtocol.split(".")
+    if len(ndpi_protos) == 1:
         app_proto = ndpi_protos[0]
     else:
         app_proto = ndpi_protos[1]
-    
-    id = protos.get(ndpiProtocol)
-    if(id == None):
+
+    if protos.get(ndpiProtocol) is None:
         lastId = lastId + 1
         protos[ndpiProtocol] = lastId
-        id = lastId
-        #print(ndpiProtocol+"="+str(id))
+        # print(ndpiProtocol + "=" + str(id))
 
     ip_address = toks[5]
     server_name = toks[11]
     record["cat"]  = "flow"
     record["pid"]  = ip_address
-    record["tid"]  = ndpiProtocol # id
+    record["tid"]  = ndpiProtocol  # id
     record["ts"]   = get_timestamp(toks[2])
     record["ph"]   = "X"
     record["name"] = app_proto
 
-    if(server_name == ""):
+    if server_name == "":
         args = {}
     else:
-        args = { "name": server_name }
+        args = {"name": server_name}
     record["args"] = args
     record["dur"]  = get_timestamp(toks[3]) - record["ts"]
 
@@ -82,21 +82,22 @@ def get_record(toks, csv_fields):
         return record
 
     # Otherwise we just add everything we find as a string
-    if(0):
-        idx = 0
-        for tok in toks:
-            name = csv_fields[idx]
-            idx += 1
-            record["args"][name] = str(tok)
+    # if 0:
+    #     idx = 0
+    #     for tok in toks:
+    #         name = csv_fields[idx]
+    #         idx += 1
+    #         record["args"][name] = str(tok)
 
     return record
+
 
 def get_record_dict(filename):
     csv_fields = None
     records = []
-    fin = open(filename, "r");
+    fin = open(filename, "r")
     for line in fin:
-        line = line.replace("\n","")
+        line = line.replace("\n", "")
 
         # Get the legend if present
         if line[0] == '#':
@@ -116,10 +117,10 @@ def get_record_dict(filename):
 
         records.append(record)
 
-    json_dict = dict()
-    json_dict["traceEvents"] = records
+    json_dict = {"traceEvents": records}
 
     return json_dict
+
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
@@ -127,9 +128,9 @@ if __name__ == "__main__":
         sys.exit(0)
 
     record_dict = get_record_dict(sys.argv[1])
-    #print(record_dict)
-    #json_string = json.dumps(json_dict)
-    #print(json_string)
+    # print(record_dict)
+    # json_string = json.dumps(json_dict)
+    # print(json_string)
 
     with open(sys.argv[2], 'w') as fp:
         json.dump(record_dict, fp)

--- a/utils/ipaddr2list.py
+++ b/utils/ipaddr2list.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python3
 
 import sys
-import socket, struct
+import socket
 
-# This scripts is mainly used to create "ip -> protocols" lists.
-# However it is also used to create "ip -> risk" lists
+# These scripts are mainly used to create "ip -> protocols" lists.
+# However, it is also used to create "ip -> risk" lists
 proto = "NDPI_PROTOCOL_XYX"
 append_name = ""
-if len (sys.argv) < 2 :
+if len(sys.argv) < 2:
     print("Usage: ipaddr2list.py <file> <protocol> [file6] [<append_name>]")
-    sys.exit (1)
+    sys.exit(1)
 
-if len (sys.argv) >= 3:
+if len(sys.argv) >= 3:
     proto = sys.argv[2]
 
-if len (sys.argv) >= 5:
+if len(sys.argv) >= 5:
     append_name = sys.argv[4]
-
 
 print("""/*
  *
@@ -41,53 +40,53 @@ print("""/*
 
 """)
 
-print("static ndpi_network "+proto.lower()+append_name+"_protocol_list[] = {")
+print("static ndpi_network " + proto.lower() + append_name + "_protocol_list[] = {")
 
 lines = 0
 with open(sys.argv[1]) as fp:
     for cnt, line in enumerate(fp):
         line = line.rstrip()
 
-        if(line != ""):
+        if line != "":
             lines += 1
             x = line.split("/")
 
-            if(len(x) == 2):
+            if len(x) == 2:
                 ipaddr = x[0]
-                cidr   = x[1]
+                cidr = x[1]
             else:
                 ipaddr = line
                 cidr = "32"
 
-            if(ipaddr != ""):
-                print(" { 0x"+socket.inet_aton(ipaddr).hex().upper()+" /* "+ipaddr+"/"+cidr+" */, "+cidr+", "+proto+" },")
+            if ipaddr != "":
+                print(" { 0x" + socket.inet_aton(ipaddr).hex().upper() + " /* " + ipaddr + "/" + cidr + " */, " + cidr + ", " + proto + " },")
 
 print(" /* End */")
 print(" { 0x0, 0, 0 }")
 print("};")
 
-print("");
-print("static ndpi_network6 "+proto.lower()+append_name+"_protocol_list_6[] = {")
+print("")
+print("static ndpi_network6 " + proto.lower() + append_name + "_protocol_list_6[] = {")
 
-if(len (sys.argv) >= 4):
+if len(sys.argv) >= 4:
 
     with open(sys.argv[3]) as fp:
         for cnt, line in enumerate(fp):
             line = line.rstrip()
 
-            if(line != ""):
+            if line != "":
                 lines += 1
                 x = line.split("/")
 
-                if(len(x) == 2):
+                if len(x) == 2:
                     ipaddr = x[0]
-                    cidr   = x[1]
+                    cidr = x[1]
                 else:
                     ipaddr = line
                     cidr = "128"
 
-                if(ipaddr != ""):
-                    print(" { \""+ipaddr+"\", "+cidr+", "+proto+" },")
+                if ipaddr != "":
+                    print(" { \"" + ipaddr + "\", " + cidr + ", " + proto + " },")
 
 print(" /* End */")
 print(" { NULL, 0, 0 }")


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

#2504

I forgot to include my `ipaddr2list.py` changes into the [previous PR #2504](https://github.com/ntop/nDPI/pull/2504) XD
I also found that file `ndpi2fimeline.py` can be reformatted as well.

Describe changes:

Reformatted Python scripts to match [PEP](https://peps.python.org/).

Also:
1. Changed `dict()` to `{}` for [performance reasons](https://stackoverflow.com/a/17098017).
2. Removed `id` variable as it is unused (and it also shadows the built-in name 'id').
3. Commented out the `if(0):` code as it is unreachable.