### PR TITLE
Fix memleak

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -3920,6 +3920,10 @@ int ndpi_add_string_value_to_automa(void *_automa, char *str, u_int32_t num) {
   ac_pattern.length     = strlen(ac_pattern.astring);
 
   rc = ac_automata_add(automa, &ac_pattern);
+
+  if(rc != ACERR_SUCCESS)
+    ndpi_free(cstr);
+
   return(rc == ACERR_SUCCESS ? 0 : (rc == ACERR_DUPLICATE_PATTERN ? -2 : -1));
 }
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):


Describe changes:

Fix memleak detected via netfilter-ndpi module 
```
unreferenced object 0xffff9085c5b910a0 (size 32):
  comm "modprobe", pid 1236, jiffies 4294672851 (age 2264.513s)
  hex dump (first 32 bytes):
    4f 3d 31 26 31 20 4d 61 69 6c 20 26 20 4d 65 64  O=1&1 Mail & Med
    69 61 20 47 6d 62 48 00 02 00 00 00 71 08 00 00  ia GmbH.....q...
  backtrace:
    [<0000000044711510>] ndpi_strdup+0x1e/0x50 [xt_ndpi]
    [<000000004b32f8a1>] ndpi_add_string_value_to_automa+0x1d/0x90 [xt_ndpi]
    [<00000000574228bc>] ndpi_init_protocol_defaults+0x74ee/0x7670 [xt_ndpi]
    [<00000000109d0649>] ndpi_set_protocol_detection_bitmask2+0x1b/0x40 [xt_ndpi]
    [<000000009c99f9f8>] ndpi_net_init+0x204/0x8f0 [xt_ndpi]
    [<0000000076fce89d>] ops_init+0xdc/0x130
    [<00000000971b580e>] register_pernet_operations+0xb4/0x190
    [<00000000846dbbfe>] register_pernet_subsys+0x1f/0x40
    [<000000003f3923b6>] mirror_status+0x5b/0x320 [dm_mirror]
    [<00000000f4d29bae>] do_one_initcall+0x5a/0x160
    [<000000000d650a73>] do_init_module+0x41/0x1bd
    [<00000000899a1b74>] load_module+0x158b/0x1c40
    [<00000000da63fcd2>] __do_sys_init_module+0x147/0x160
    [<00000000b60d6d20>] do_syscall_64+0x2d/0x40
    [<00000000575b56ba>] entry_SYSCALL_64_after_hwframe+0x44/0xae
```

