### PR TITLE
bins: fix `ndpi_set_bin`, `ndpi_inc_bin` and `ndpi_get_bin_value`

### DIFF
--- a/src/lib/ndpi_analyze.c
+++ b/src/lib/ndpi_analyze.c
@@ -451,7 +451,7 @@ void ndpi_set_bin(struct ndpi_bin *b, u_int16_t slot_id, u_int64_t val) {
   if(!b || !b->u.bins8 || b->num_bins == 0)
     return;
 
-  if(slot_id >= b->num_bins) slot_id = 0;
+  if(slot_id >= b->num_bins) slot_id = b->num_bins - 1;
 
   switch(b->family) {
   case ndpi_bin_family8:
@@ -477,7 +477,7 @@ void ndpi_inc_bin(struct ndpi_bin *b, u_int16_t slot_id, u_int64_t val) {
 
   b->is_empty = 0;
 
-  if(slot_id >= b->num_bins) slot_id = 0;
+  if(slot_id >= b->num_bins) slot_id = b->num_bins - 1;
 
   switch(b->family) {
   case ndpi_bin_family8:
@@ -501,7 +501,7 @@ u_int64_t ndpi_get_bin_value(struct ndpi_bin *b, u_int16_t slot_id) {
   if(!b || !b->u.bins8 || b->num_bins == 0)
     return(0);
 
-  if(slot_id >= b->num_bins) slot_id = 0;
+  if(slot_id >= b->num_bins) slot_id = b->num_bins - 1;
 
   switch(b->family) {
   case ndpi_bin_family8:


### PR DESCRIPTION
When the required slot is too big, use the latest/bigger available bin, not in the first one.


