### PR TITLE
Fix `ndpi_strrstr()`

### DIFF
--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -3470,7 +3470,7 @@ char* ndpi_strrstr(const char *haystack, const char *needle) {
   while(true) {
     char *s = strstr(haystack, needle);
     
-    if(s == NULL)
+    if(s == NULL || s[0] == '\0')
       break;
     else {
       ret = s;


### PR DESCRIPTION
```
==6591==ERROR: AddressSanitizer: SEGV on unknown address 0x502000230000 (pc 0x55fbd836a5a0 bp 0x7ffdf4503670 sp 0x7ffdf4502e28 T0)
==6591==The signal is caused by a READ memory access.
    #0 0x55fbd836a5a0 in __sanitizer::internal_strlen(char const*) /src/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_libc.cpp:176:10
    #1 0x55fbd82cfc28 in StrstrCheck(void*, char*, char const*, char const*) /src/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:579:17
    #2 0x55fbd82cfbc2 in strstr /src/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:598:5
    #3 0x55fbd840a04a in ndpi_strrstr /src/ndpi/src/lib/ndpi_utils.c:3471:15
    #4 0x55fbd840ba95 in ndpi_get_host_domain /src/ndpi/src/lib/ndpi_domains.c:149:9
    #5 0x55fbd83ef751 in ndpi_check_dga_name /src/ndpi/src/lib/ndpi_main.c:10748:17
```
Found by oss-fuzz

