### PR TITLE
Fix builds on Windows

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -2839,7 +2839,7 @@ static int is_realtime_protocol(ndpi_protocol proto)
 static void dump_realtime_protocol(struct ndpi_workflow * workflow, struct ndpi_flow_info *flow)
 {
   FILE *out = results_file ? results_file : stdout;
-  char srcip[64], dstip[64];
+  char srcip[70], dstip[70];
   char ip_proto[64], app_name[64];
   char date[64];
   int ret = is_realtime_protocol(flow->detected_protocol);


### PR DESCRIPTION
Quick fix with latest Windows image on GitHub CI, where we got:
```
 ndpiReader.c:2860:38: error: '%s' directive output may be truncated writing up to 64 bytes into a region of size 63 [-Werror=format-truncation=]
 2860 |     snprintf(srcip, sizeof(srcip), "[%s]", flow->src_name);
      |                                      ^~
ndpiReader.c:2860:5: note: 'snprintf' output between 3 and 67 bytes into a destination of size 64
 2860 |     snprintf(srcip, sizeof(srcip), "[%s]", flow->src_name);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ndpiReader.c:2861:38: error: '%s' directive output may be truncated writing up to 64 bytes into a region of size 63 [-Werror=format-truncation=]
 2861 |     snprintf(dstip, sizeof(dstip), "[%s]", flow->dst_name);
      |                                      ^~
ndpiReader.c:2861:5: note: 'snprintf' output between 3 and 67 bytes into a destination of size 64
 2861 |     snprintf(dstip, sizeof(dstip), "[%s]", flow->dst_name);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```


