### PR TITLE
CI: remove macos-12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         # macOS-latest == macos-14 on **ARM64**. Also macos-15 is on arm64
         # There are some issues with external dependencies on macOS-14/15. Disable it for the time being
-        os: ["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04", "macOS-12", "macOS-13", "windows-latest"]
+        os: ["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04", "macOS-13", "windows-latest"]
         arch: ["x86_64"]
         gcrypt: ["--with-local-libgcrypt", ""]
         compiler: ["cc"]


### PR DESCRIPTION
It is deprecated and will be removed from GitHub.
See: https://github.com/actions/runner-images/issues/10721


