### PR TITLE
Fix `ndpi_tot_allocated_memory` calculation if `ndpi_calloc()` used

### DIFF
--- a/src/lib/ndpi_memory.c
+++ b/src/lib/ndpi_memory.c
@@ -64,11 +64,11 @@ void *ndpi_malloc(size_t size) {
 
 void *ndpi_calloc(unsigned long count, size_t size) {
   size_t len = count * size;
-  void *p = ndpi_malloc(len);
+  void *p = _ndpi_malloc ? _ndpi_malloc(len) : malloc(len);
 
   if(p) {
     memset(p, 0, len);
-    __sync_fetch_and_add(&ndpi_tot_allocated_memory, size);
+    __sync_fetch_and_add(&ndpi_tot_allocated_memory, len);
   }
 
   return(p);


### PR DESCRIPTION
- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)