### PR TITLE
Unify ndpi debug logging to always use a u16 protocol id

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -2805,46 +2805,6 @@ static void node_idle_scan_walker(const void *node, ndpi_VISIT which, int depth,
 
 /* *********************************************** */
 
-#if 0
-/**
- * @brief Print debug
- */
-static void debug_printf(u_int32_t protocol, void *id_struct,
-                         ndpi_log_level_t log_level,
-                         const char *format, ...) {
-  va_list va_ap;
-  struct tm result;
-
-  if(log_level <= nDPI_LogLevel) {
-    char buf[8192], out_buf[8192];
-    char theDate[32];
-    const char *extra_msg = "";
-    time_t theTime = time(NULL);
-
-    va_start (va_ap, format);
-
-    if(log_level == NDPI_LOG_ERROR)
-      extra_msg = "ERROR: ";
-    else if(log_level == NDPI_LOG_TRACE)
-      extra_msg = "TRACE: ";
-    else
-      extra_msg = "DEBUG: ";
-
-    memset(buf, 0, sizeof(buf));
-    strftime(theDate, 32, "%d/%b/%Y %H:%M:%S", localtime_r(&theTime,&result));
-    ndpi_snprintf(buf, sizeof(buf)-1, format, va_ap);
-
-    ndpi_snprintf(out_buf, sizeof(out_buf), "%s %s%s", theDate, extra_msg, buf);
-    printf("%s", out_buf);
-    fflush(stdout);
-  }
-
-  va_end(va_ap);
-}
-#endif
-
-/* *********************************************** */
-
 static int is_realtime_protocol(ndpi_protocol proto)
 {
   static u_int16_t const realtime_protos[] = {

--- a/fuzz/fuzz_ds_domain_classify.cpp
+++ b/fuzz/fuzz_ds_domain_classify.cpp
@@ -12,7 +12,7 @@ static struct ndpi_detection_module_struct *ndpi_struct = NULL;
 extern "C" {
 
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
-void ndpi_debug_printf(unsigned int proto, struct ndpi_detection_module_struct *ndpi_str, ndpi_log_level_t log_level,
+void ndpi_debug_printf(uint16_t proto, struct ndpi_detection_module_struct *ndpi_str, ndpi_log_level_t log_level,
                        const char *file_name, const char *func_name, unsigned int line_number, const char *format, ...);
 #endif
 

--- a/fuzz/fuzz_filecfg_malicious_sha1.c
+++ b/fuzz/fuzz_filecfg_malicious_sha1.c
@@ -3,7 +3,7 @@
 #include "fuzz_common_code.h"
 
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
-void ndpi_debug_printf(unsigned int proto, struct ndpi_detection_module_struct *ndpi_str, ndpi_log_level_t log_level,
+void ndpi_debug_printf(uint16_t proto, struct ndpi_detection_module_struct *ndpi_str, ndpi_log_level_t log_level,
                        const char *file_name, const char *func_name, unsigned int line_number, const char *format, ...);
 #endif
 

--- a/src/include/ndpi_replace_printf.h
+++ b/src/include/ndpi_replace_printf.h
@@ -50,7 +50,7 @@
 
 #endif
 
-void ndpi_debug_printf(unsigned int proto, struct ndpi_detection_module_struct *ndpi_str, ndpi_log_level_t log_level,
+void ndpi_debug_printf(u_int16_t proto, struct ndpi_detection_module_struct *ndpi_str, ndpi_log_level_t log_level,
                        const char *file_name, const char *func_name, int line_number, const char *format, ...);
 
 #endif

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -273,7 +273,7 @@ typedef struct ndpi_protocol_bitmask_struct {
 struct ndpi_detection_module_struct;
 
 /* NDPI_DEBUG_FUNCTION_PTR (cast) */
-typedef void (*ndpi_debug_function_ptr) (u_int32_t protocol, struct ndpi_detection_module_struct *module_struct,
+typedef void (*ndpi_debug_function_ptr) (u_int16_t protocol, struct ndpi_detection_module_struct *module_struct,
 					 ndpi_log_level_t log_level, const char *file,
 					 const char *func, unsigned line,
 					 const char *format, ...);

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -3154,7 +3154,7 @@ void set_ndpi_flow_free(void (*__ndpi_flow_free)(void *ptr)) {
 }
 
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
-void ndpi_debug_printf(unsigned int proto, struct ndpi_detection_module_struct *ndpi_str, ndpi_log_level_t log_level,
+void ndpi_debug_printf(u_int16_t proto, struct ndpi_detection_module_struct *ndpi_str, ndpi_log_level_t log_level,
                        const char *file_name, const char *func_name, unsigned int line_number, const char *format, ...) {
   va_list args;
 #define MAX_STR_LEN 250

--- a/tests/dga/dga_evaluate.c
+++ b/tests/dga/dga_evaluate.c
@@ -40,7 +40,7 @@ void help() {
 
 static int verbose_dga_detection = 0;
 
-static void ndpi_dbg_fn(u_int32_t protocol,
+static void ndpi_dbg_fn(u_int16_t protocol,
                         struct ndpi_detection_module_struct *module_struct,
                         ndpi_log_level_t log_level, const char *file,
                         const char *func, unsigned line,


### PR DESCRIPTION
 * fixes SonarCloud complaint

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)
