### PR TITLE
Debian/Ubuntu packaging: use `--enable-no-sign` to build `*.deb` packages w/o signing those

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,7 +234,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 'x86_64')
         run: |
           sudo apt-get update
-          sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
+          sudo apt-get install autoconf automake debhelper libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
           sudo apt-get install rrdtool librrd-dev parallel
       - name: Install Ubuntu Prerequisites [Mingw-w64] (runs only on ubuntu jobs)
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 'x86_64') && !startsWith(matrix.msan, '--with-') #Only on a few "standard" builds, without any sanitizers
@@ -372,6 +372,13 @@ jobs:
         run: |
           make dist
           ./utils/verify_dist_tarball.sh
+      - name: Build Debian/Ubuntu package
+        if: startsWith(matrix.os, 'ubuntu-24.04') && startsWith(matrix.arch, 'x86_64') && startsWith(matrix.compiler, 'cc')
+        run: |
+          cd packages/ubuntu
+          ./configure --enable-no-sign
+          make
+          cd ../..
       - name: Build nDPI [Mingw-w64] (runs only on ubuntu jobs)
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.arch, 'x86_64') && !startsWith(matrix.msan, '--with-') #Only on a few "standard" builds, without any sanitizers
         run: |

--- a/packages/ubuntu/configure
+++ b/packages/ubuntu/configure
@@ -704,6 +704,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+enable_no_sign
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1326,6 +1327,12 @@ if test -n "$ac_init_help"; then
      short | recursive ) echo "Configuration of Makefile.in 1.0:";;
    esac
   cat <<\_ACEOF
+
+Optional Features:
+  --disable-option-checking  ignore unrecognized --enable/--with options
+  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
+  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-no-sign        do not try to sign any package
 
 Some influential environment variables:
   CC          C compiler command
@@ -3329,6 +3336,19 @@ if test -f /usr/bin/debsigs; then
   SIGN_CMD="/usr/bin/debsigs"
 else
   SIGN_CMD="dpkg-sig"
+fi
+
+# Check whether --enable-no-sign was given.
+if test ${enable_no_sign+y}
+then :
+  enableval=$enable_no_sign;
+fi
+
+if test "${enable_no_sign+set}" = set
+then :
+
+  SIGN_CMD="true"
+
 fi
 
 ac_config_files="$ac_config_files Makefile debian/changelog debian/files debian/control"

--- a/packages/ubuntu/configure.in
+++ b/packages/ubuntu/configure.in
@@ -1,4 +1,4 @@
-AC_INIT([Makefile.in], 1.0)
+AC_INIT([Makefile.in],[1.0])
 
 DATE=`date -R`
 KERNEL=`uname -r`
@@ -29,7 +29,7 @@ MAJOR_RELEASE=`$(dirname "${0}")/../version.sh --major-release`
 GIT_REVISION=`$(dirname "${0}")/../version.sh --revision`
 
 AC_CHECK_LIB([maxminddb], [MMDB_lookup_sockaddr])
-AC_HAVE_HEADERS(maxminddb.h)
+AC_CHECK_HEADERS([maxminddb.h])
 if test ".${ac_cv_lib_maxminddb_MMDB_lookup_sockaddr}" = ".yes" &&
       test ".${ac_cv_header_maxminddb_h}" = ".yes"; then
       GEOIP_DEP=", libmaxminddb0"
@@ -40,6 +40,11 @@ if test -f /usr/bin/debsigs; then
 else
   SIGN_CMD="dpkg-sig"
 fi
+
+AC_ARG_ENABLE(no-sign, AS_HELP_STRING([--enable-no-sign], [do not try to sign any package]))
+AS_IF([test "${enable_no_sign+set}" = set],[
+  SIGN_CMD="true"
+])
 
 AC_CONFIG_FILES([Makefile debian/changelog debian/files debian/control])
 

--- a/packages/ubuntu/debian/control.in
+++ b/packages/ubuntu/debian/control.in
@@ -3,7 +3,7 @@ Section: free
 Priority: optional
 Maintainer: Luca Deri <deri@ntop.org>
 Standards-Version: @NDPI_VERS@
-Build-Depends:
+Build-Depends: debhelper
 Build-Conflicts:
 
 Package: ndpi


### PR DESCRIPTION
 * can be used for local and CI builds

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

