### PR TITLE
Zoom: fix heap-buffer-overflow

### DIFF
--- a/src/lib/protocols/zoom.c
+++ b/src/lib/protocols/zoom.c
@@ -162,6 +162,9 @@ static int zoom_search_again(struct ndpi_detection_module_struct *ndpi_struct,
 {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
+  if(ndpi_struct->packet.payload_packet_len == 0)
+    return keep_extra_dissection(flow);
+
   if(!flow->l4.udp.zoom_p2p &&
      is_sfu_5(ndpi_struct, flow)) {
     ndpi_int_zoom_add_connection(ndpi_struct, flow);


### PR DESCRIPTION
```
=================================================================
==30923==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x50400023cc34 at pc 0x591f8b5dd546 bp 0x7ffe5ffc3530 sp 0x7ffe5ffc3528
READ of size 1 at 0x50400023cc34 thread T0
    #0 0x591f8b5dd545 in is_sfu_5 /home/ivan/svnrepos/nDPI/src/lib/protocols/zoom.c:146:6
    #1 0x591f8b5dda11 in zoom_search_again /home/ivan/svnrepos/nDPI/src/lib/protocols/zoom.c:166:6
    #2 0x591f8b22182f in ndpi_process_extra_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:8156:9
    #3 0x591f8b236f88 in ndpi_internal_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:8793:5
```
Found by oss-fuzz
See: https://issues.oss-fuzz.com/issues/379072455


