### PR TITLE
ndpiReader: fix statistic about total number of flows

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -2828,7 +2828,6 @@ static void node_idle_scan_walker(const void *node, ndpi_VISIT which, int depth,
         undetected_flows_deleted = 1;
 
       ndpi_flow_info_free_data(flow);
-      ndpi_thread_info[thread_id].workflow->stats.ndpi_flow_count--;
 
       /* adding to a queue (we can't delete it from the tree inline ) */
       ndpi_thread_info[thread_id].idle_flows[ndpi_thread_info[thread_id].num_idle_flows++] = flow;


### PR DESCRIPTION
When capturing live traffic, accounting and export of expired flows is
 wrong (see #2617).
Let's try to fix some statistics, at least


