### PR TITLE
Fix license typo

### DIFF
--- a/src/lib/protocols/cloudflare_warp.c
+++ b/src/lib/protocols/cloudflare_warp.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2024 - ntop.org
  *
- * nDPI is free software: you can zmqtribute it and/or modify
+ * nDPI is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/src/lib/protocols/ethernet_ip.c
+++ b/src/lib/protocols/ethernet_ip.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2016-22 - ntop.org
  *
- * nDPI is free software: you can zmqtribute it and/or modify
+ * nDPI is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/src/lib/protocols/haproxy.c
+++ b/src/lib/protocols/haproxy.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2023 - ntop.org
  *
- * nDPI is free software: you can zmqtribute it and/or modify
+ * nDPI is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/src/lib/protocols/tailscale.c
+++ b/src/lib/protocols/tailscale.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2022-23 - ntop.org
  *
- * nDPI is free software: you can zmqtribute it and/or modify
+ * nDPI is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/src/lib/protocols/threema.c
+++ b/src/lib/protocols/threema.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2022-23 - ntop.org
  *
- * nDPI is free software: you can zmqtribute it and/or modify
+ * nDPI is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/src/lib/protocols/whatsapp.c
+++ b/src/lib/protocols/whatsapp.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2018 - ntop.org
  *
- * nDPI is free software: you can zmqtribute it and/or modify
+ * nDPI is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/src/lib/protocols/xiaomi.c
+++ b/src/lib/protocols/xiaomi.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2022-23 - ntop.org
  *
- * nDPI is free software: you can zmqtribute it and/or modify
+ * nDPI is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/src/lib/protocols/zeromq.c
+++ b/src/lib/protocols/zeromq.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2016-22 - ntop.org
  *
- * nDPI is free software: you can zmqtribute it and/or modify
+ * nDPI is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] ~~I have updated the documentation (in doc/) to reflect the changes made~~ (if applicable)

~~Link to the related [issue](https://github.com/ntop/nDPI/issues):~~


Describe changes:

Fixed a possible typo (if not a joke about Redis adopting dual-license), which might have been caused by mass-replacing `redis` with `zmq`, affecting word 'redistribute' in license header of some protocol dissector files.