### PR TITLE
Classifications "by-port"/"by-ip" should never change

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1266,8 +1266,10 @@ struct ndpi_tls_obfuscated_heuristic_matching_set {
 struct ndpi_flow_struct {
   u_int16_t detected_protocol_stack[NDPI_PROTOCOL_SIZE];
 
-  /* init parameter, internal used to set up timestamp,... */
-  u_int16_t guessed_protocol_id, guessed_protocol_id_by_ip, guessed_category, guessed_header_category;
+  u_int16_t guessed_protocol_id;       /* Classification by-port. Set with the first pkt and never updated */
+  u_int16_t guessed_protocol_id_by_ip; /* Classification by-ip. Set with the first pkt and never updated */
+  u_int16_t fast_callback_protocol_id; /* Partial/incomplete classification. Used internally as first callback when iterating all the protocols */
+  u_int16_t guessed_category, guessed_header_category;
   u_int8_t l4_proto, protocol_id_already_guessed:1, fail_with_unknown:1,
     init_finished:1, client_packet_direction:1, packet_direction:1, is_ipv6:1, first_pkt_fully_encrypted:1, skip_entropy_check: 1;
   u_int8_t monitoring:1, _pad:7;

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -7445,8 +7445,11 @@ static u_int32_t check_ndpi_detection_func(struct ndpi_detection_module_struct *
 					   int is_tcp_without_payload) {
   void *func = NULL;
   u_int32_t num_calls = 0;
-  u_int16_t proto_index = ndpi_str->proto_defaults[flow->guessed_protocol_id].protoIdx;
-  u_int16_t proto_id = ndpi_str->proto_defaults[flow->guessed_protocol_id].protoId;
+  /* First callback is associated to classification by-port,
+     if we don't already have a partial classification */
+  u_int16_t fast_callback_protocol_id = flow->fast_callback_protocol_id ? flow->fast_callback_protocol_id : flow->guessed_protocol_id;
+  u_int16_t proto_index = ndpi_str->proto_defaults[fast_callback_protocol_id].protoIdx;
+  u_int16_t proto_id = ndpi_str->proto_defaults[fast_callback_protocol_id].protoId;
   NDPI_PROTOCOL_BITMASK detection_bitmask;
   u_int32_t a;
 
@@ -7459,14 +7462,14 @@ static u_int32_t check_ndpi_detection_func(struct ndpi_detection_module_struct *
       (ndpi_str->callback_buffer[proto_index].ndpi_selection_bitmask & ndpi_selection_packet) ==
       ndpi_str->callback_buffer[proto_index].ndpi_selection_bitmask)
     {
-      if((flow->guessed_protocol_id != NDPI_PROTOCOL_UNKNOWN) &&
-          (ndpi_str->proto_defaults[flow->guessed_protocol_id].func != NULL) &&
+      if((fast_callback_protocol_id != NDPI_PROTOCOL_UNKNOWN) &&
+          (ndpi_str->proto_defaults[fast_callback_protocol_id].func != NULL) &&
           (is_tcp_without_payload == 0 ||
            ((ndpi_str->callback_buffer[proto_index].ndpi_selection_bitmask &
 	     NDPI_SELECTION_BITMASK_PROTOCOL_HAS_PAYLOAD) == 0)))
 	{
-	  ndpi_str->proto_defaults[flow->guessed_protocol_id].func(ndpi_str, flow);
-	  func = ndpi_str->proto_defaults[flow->guessed_protocol_id].func;
+	  ndpi_str->proto_defaults[fast_callback_protocol_id].func(ndpi_str, flow);
+	  func = ndpi_str->proto_defaults[fast_callback_protocol_id].func;
 	  num_calls++;
 	}
     }
@@ -8030,6 +8033,12 @@ ndpi_protocol ndpi_detection_giveup(struct ndpi_detection_module_struct *ndpi_st
   if(ret.proto.app_protocol != NDPI_PROTOCOL_UNKNOWN)
     return(ret);
 
+  /* Partial classification */
+  if(flow->fast_callback_protocol_id != NDPI_PROTOCOL_UNKNOWN) {
+    ndpi_set_detected_protocol(ndpi_str, flow, flow->fast_callback_protocol_id, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI_PARTIAL);
+    ret.proto.app_protocol = flow->detected_protocol_stack[0];
+  }
+
   /* Check some caches */
 
   /* Does it looks like BitTorrent? */
@@ -8575,6 +8584,7 @@ static int ndpi_do_guess(struct ndpi_detection_module_struct *ndpi_str, struct n
 							    ntohs(flow->c_port), ntohs(flow->s_port),
 							    &user_defined_proto);
     flow->guessed_protocol_id_by_ip = ndpi_guess_host_protocol_id(ndpi_str, flow);
+    flow->fast_callback_protocol_id = NDPI_PROTOCOL_UNKNOWN;
 
     ret->protocol_by_ip = flow->guessed_protocol_id_by_ip;
 

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -1144,9 +1144,6 @@ static void check_content_type_and_change_protocol(struct ndpi_detection_module_
     ndpi_check_dga_name(ndpi_struct, flow, flow->host_server_name, 1, 0);
   }
 
-  if(flow->guessed_protocol_id == NDPI_PROTOCOL_UNKNOWN)
-    flow->guessed_protocol_id = NDPI_PROTOCOL_HTTP;
-
   ndpi_check_http_header(ndpi_struct, flow);
 }
 

--- a/src/lib/protocols/mail_imap.c
+++ b/src/lib/protocols/mail_imap.c
@@ -33,7 +33,6 @@
 
 static void ndpi_int_mail_imap_add_connection(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow,
 					      u_int16_t protocol) {
-  flow->guessed_protocol_id = NDPI_PROTOCOL_UNKNOWN; /* Avoid IMAPS to be used s sub-protocol */
   ndpi_set_detected_protocol(ndpi_struct, flow, protocol, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
 }
 

--- a/src/lib/protocols/mail_pop.c
+++ b/src/lib/protocols/mail_pop.c
@@ -49,7 +49,6 @@ static void ndpi_int_mail_pop_add_connection(struct ndpi_detection_module_struct
 					     u_int16_t protocol) {
 
   NDPI_LOG_INFO(ndpi_struct, "mail_pop identified\n");
-  flow->guessed_protocol_id = NDPI_PROTOCOL_UNKNOWN; /* Avoid POP3S to be used s sub-protocol */
   ndpi_set_detected_protocol(ndpi_struct, flow, protocol, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
 }
 

--- a/src/lib/protocols/ssh.c
+++ b/src/lib/protocols/ssh.c
@@ -438,7 +438,7 @@ static void ndpi_search_ssh_tcp(struct ndpi_detection_module_struct *ndpi_struct
 #endif
       
       NDPI_LOG_DBG2(ndpi_struct, "ssh stage 1 passed\n");
-      flow->guessed_protocol_id = NDPI_PROTOCOL_SSH;
+      flow->fast_callback_protocol_id = NDPI_PROTOCOL_SSH;
       
 #ifdef SSH_DEBUG
       printf("[SSH] [completed stage: %u]\n", flow->l4.tcp.ssh_stage);

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1299,9 +1299,9 @@ static int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
 /* **************************************** */
 
 static void ndpi_looks_like_tls(struct ndpi_detection_module_struct *ndpi_struct,
-				struct ndpi_flow_struct *flow) {
-  if(flow->guessed_protocol_id == NDPI_PROTOCOL_UNKNOWN)
-    flow->guessed_protocol_id = __get_master(ndpi_struct, flow);
+                                struct ndpi_flow_struct *flow) {
+  if(flow->fast_callback_protocol_id == NDPI_PROTOCOL_UNKNOWN)
+    flow->fast_callback_protocol_id = __get_master(ndpi_struct, flow);
 }
 
 /* **************************************** */
@@ -3352,9 +3352,8 @@ static void ndpi_search_tls_wrapper(struct ndpi_detection_module_struct *ndpi_st
   int rc = 0;
 
 #ifdef DEBUG_TLS
-  printf("==>> %s() %u [len: %u][version: %u]\n",
+  printf("==>> %s() [len: %u][version: %u]\n",
 	 __FUNCTION__,
-	 flow->guessed_protocol_id_by_ip,
 	 packet->payload_packet_len,
 	 flow->protos.tls_quic.ssl_version);
 #endif

--- a/src/lib/protocols/wireguard.c
+++ b/src/lib/protocols/wireguard.c
@@ -174,7 +174,7 @@ static void ndpi_search_wireguard(struct ndpi_detection_module_struct *ndpi_stru
     u_int32_t receiver_index = get_u_int32_t(payload, 4);
 
     /* We speculate this is wireguard, so let's remember it */
-    flow->guessed_protocol_id = NDPI_PROTOCOL_WIREGUARD;
+    flow->fast_callback_protocol_id = NDPI_PROTOCOL_WIREGUARD;
     
     if (flow->l4.udp.wireguard_stage == 0) {
       flow->l4.udp.wireguard_stage = 3 + packet->packet_direction;

--- a/tests/cfgs/default/result/riot.pcapng.out
+++ b/tests/cfgs/default/result/riot.pcapng.out
@@ -1,14 +1,14 @@
 Guessed flow protos:	1
 
 DPI Packets (TCP):	7	(3.50 pkts/flow)
-Confidence Match by port    : 1 (flows)
+Confidence DPI (partial)    : 1 (flows)
 Confidence DPI              : 1 (flows)
 Num dissector calls: 206 (103.00 diss/flow)
 LRU cache ookla:      0/0/0 (insert/search/found)
-LRU cache bittorrent: 0/3/0 (insert/search/found)
+LRU cache bittorrent: 0/0/0 (insert/search/found)
 LRU cache stun:       0/0/0 (insert/search/found)
 LRU cache tls_cert:   1/1/0 (insert/search/found)
-LRU cache mining:     0/1/0 (insert/search/found)
+LRU cache mining:     0/0/0 (insert/search/found)
 LRU cache msteams:    0/0/0 (insert/search/found)
 LRU cache fpc_dns:    0/1/0 (insert/search/found)
 Automa host:          4/0 (search/found)
@@ -34,4 +34,4 @@ JA Host Stats:
 
 
 	1	TCP 35.234.85.218:443 -> 192.168.26.22:51949 [proto: 91.302/TLS.RiotGames][IP: 284/GoogleCloud][Encrypted][Confidence: DPI][FPC: 91/TLS, Confidence: DPI][DPI packets: 4][cat: Game/8][4 pkts/4338 bytes -> 0 pkts/0 bytes][Goodput ratio: 95/0][0.00 sec][(Negotiated) ALPN: h2][Risk: ** Unidirectional Traffic **][Risk Score: 10][Risk Info: No client to server traffic][TLSv1.2][ServerNames: embed.rgpub.io,sites.rgpub.io,*.embed.rgpub.io,*.sites.rgpub.io][JA3S: 827b71c134bd28975c2d605a06ef00ef][Issuer: C=US, O=IdenTrust, OU=HydrantID Trusted Certificate Service, CN=HydrantID Server CA O1][Subject: CN=embed.rgpub.io, O=Riot Games Inc, L=Los Angeles, ST=California, C=US][Certificate SHA-1: CE:85:16:DF:E3:42:05:16:39:97:1F:6B:7A:53:22:22:C8:DD:66:44][Validity: 2022-12-08 19:52:14 - 2024-01-07 19:51:14][Cipher: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,25,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,75,0,0,0,0,0,0,0,0,0]
-	2	TCP 52.41.135.135:443 -> 192.168.26.22:51817 [proto: 91/TLS][IP: 265/AmazonAWS][Encrypted][Confidence: Match by port][FPC: 265/AmazonAWS, Confidence: IP address][DPI packets: 3][cat: Web/5][3 pkts/4242 bytes -> 0 pkts/0 bytes][Goodput ratio: 96/0][< 1 sec][Risk: ** Susp Entropy **** Unidirectional Traffic **][Risk Score: 20][Risk Info: No client to server traffic / Entropy: 6.927 (Compressed Executable?)][PLAIN TEXT (DigiCert Inc1)][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,33,0,0,66,0,0,0,0]
+	2	TCP 52.41.135.135:443 -> 192.168.26.22:51817 [proto: 91/TLS][IP: 265/AmazonAWS][Encrypted][Confidence: DPI (partial)][FPC: 265/AmazonAWS, Confidence: IP address][DPI packets: 3][cat: Web/5][3 pkts/4242 bytes -> 0 pkts/0 bytes][Goodput ratio: 96/0][< 1 sec][Risk: ** Susp Entropy **** Unidirectional Traffic **][Risk Score: 20][Risk Info: No client to server traffic / Entropy: 6.927 (Compressed Executable?)][PLAIN TEXT (DigiCert Inc1)][Plen Bins: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,33,0,0,66,0,0,0,0]


### PR DESCRIPTION
Add a new variable to keep track of internal partial classification
