### PR TITLE
Fix CodeQL GitHub action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,6 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     env:
-      GO111MODULE: on
       CFLAGS: -Werror
     permissions:
       actions: read
@@ -32,11 +31,10 @@ jobs:
           fetch-depth: 0
       - name: Install Ubuntu Prerequisites
         run: |
-          sudo add-apt-repository ppa:longsleep/golang-backports
           sudo apt-get update
           sudo apt-get install -y libunwind-dev
           sudo apt-get install autoconf automake libtool pkg-config gettext flex bison libpcap-dev
-          sudo apt-get install golang-1.16-go libgoogle-perftools-dev graphviz
+          sudo apt-get install libgoogle-perftools-dev graphviz
           go install github.com/google/pprof@latest
           sudo ln -s ${HOME}/go/bin/pprof /usr/bin/pprof
           pprof -h


### PR DESCRIPTION
For some reansons, the installation of golang-1.16 fails on ubuntu 24.04 (note that ubuntu-latest now is pointing to ubuntu-24.04).

It seems that everything is fine if we use the already installed version of golang