### PR TITLE
Fix code scanning alert no. 13: Multiplication result converted to larger type

### DIFF
--- a/src/lib/third_party/include/binaryfusefilter.h
+++ b/src/lib/third_party/include/binaryfusefilter.h
@@ -155,7 +155,7 @@ static inline binary_hashes_t binary_fuse8_hash_batch(uint64_t hash,
 static inline uint32_t binary_fuse8_hash(int index, uint64_t hash,
                                         const binary_fuse8_t *filter) {
     uint64_t h = binary_fuse_mulhi(hash, filter->SegmentCountLength);
-    h += index * filter->SegmentLength;
+    h += (uint64_t)index * filter->SegmentLength;
     // keep the lower 36 bits
     uint64_t hh = hash & ((1ULL << 36) - 1);
     // index 0: right shift by 36; index 1: right shift by 18; index 2: no shift


### PR DESCRIPTION
Fixes [https://github.com/ntop/nDPI/security/code-scanning/13](https://github.com/ntop/nDPI/security/code-scanning/13)

To fix the problem, we need to ensure that the multiplication is performed using the larger integer type (`uint64_t`) to avoid overflow. This can be achieved by casting one of the operands to `uint64_t` before performing the multiplication. This way, the multiplication will be done in the larger type, preventing overflow.

- Cast `index` to `uint64_t` before multiplying it with `filter->SegmentLength`.
- This change should be made on line 158 of the file `src/lib/third_party/include/binaryfusefilter.h`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
