### PR TITLE
Fix code scanning alert no. 12: Multiplication result converted to larger type

### DIFF
--- a/src/lib/third_party/include/binaryfusefilter.h
+++ b/src/lib/third_party/include/binaryfusefilter.h
@@ -475,7 +475,7 @@ static inline binary_hashes_t binary_fuse16_hash_batch(uint64_t hash,
 static inline uint32_t binary_fuse16_hash(int index, uint64_t hash,
                                         const binary_fuse16_t *filter) {
     uint64_t h = binary_fuse_mulhi(hash, filter->SegmentCountLength);
-    h += index * filter->SegmentLength;
+    h += (uint64_t)index * filter->SegmentLength;
     // keep the lower 36 bits
     uint64_t hh = hash & ((1ULL << 36) - 1);
     // index 0: right shift by 36; index 1: right shift by 18; index 2: no shift


### PR DESCRIPTION
Fixes [https://github.com/ntop/nDPI/security/code-scanning/12](https://github.com/ntop/nDPI/security/code-scanning/12)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be achieved by casting one of the operands to `uint64_t` before performing the multiplication. This way, the multiplication will be done using `uint64_t`, and the result will not overflow.

The best way to fix this is to cast `index` to `uint64_t` before the multiplication. This change should be made on line 478 of the file `src/lib/third_party/include/binaryfusefilter.h`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
