### PR TITLE
Fix code scanning alert no. 7: Multiplication result converted to larger type

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -5249,7 +5249,7 @@ void analyzeUnitTest() {
   u_int32_t i;
 
   for(i=0; i<256; i++) {
-    ndpi_data_add_value(s, rand()*i);
+    ndpi_data_add_value(s, rand() * (u_int64_t)i);
     // ndpi_data_add_value(s, i+1);
   }
 


### PR DESCRIPTION
Fixes [https://github.com/ntop/nDPI/security/code-scanning/7](https://github.com/ntop/nDPI/security/code-scanning/7)

To fix the problem, we need to ensure that the multiplication is performed using the larger integer type (`u_int64_t`) to avoid overflow. This can be achieved by casting one of the operands to `u_int64_t` before performing the multiplication. Specifically, we can cast `i` to `u_int64_t` before multiplying it with the result of `rand()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
