### PR TITLE
CI: use Linux arm64 hosted runners provided directly from GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: true
       matrix:
         # macos-14 and 15 are on **ARM64**
-        os: ["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04", "macOS-13", "macOS-14", "macOS-15"]
+        os: ["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04", "macOS-13", "macOS-14", "macOS-15", "ubuntu-22.04-arm", "ubuntu-24.04-arm"]
         gcrypt: ["--with-local-libgcrypt", ""]
         compiler: ["cc"]
         pcre: [""]
@@ -147,7 +147,7 @@ jobs:
           sudo apt-get install autoconf automake debhelper libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
           sudo apt-get install rrdtool librrd-dev parallel
       - name: Install Ubuntu Prerequisites [Mingw-w64] (runs only on ubuntu jobs)
-        if: startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.msan, '--with-') && !startsWith(matrix.nBPF, 'nBPF') && !startsWith(matrix.global_context, '--without') # Only on a few "standard" builds
+        if: startsWith(matrix.os, 'ubuntu') && !endsWith(matrix.os, 'arm') && !startsWith(matrix.msan, '--with-') && !startsWith(matrix.nBPF, 'nBPF') && !startsWith(matrix.global_context, '--without') # Only on a few "standard" builds
         run: |
           sudo apt-get install gcc-mingw-w64 libc6-dev
       - name: Install Ubuntu Prerequisites (libgcrypt)
@@ -212,7 +212,7 @@ jobs:
           DESTDIR=/tmp/ndpi make install
           ls -alhHR /tmp/ndpi
       - name: Test nDPI [SYMBOLS]
-        if: startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.msan, '--with-') && !startsWith(matrix.nBPF, 'nBPF') && !startsWith(matrix.global_context, '--without') # Only on a few "standard" builds
+        if: startsWith(matrix.os, 'ubuntu') && !endsWith(matrix.os, 'arm') && !startsWith(matrix.msan, '--with-') && !startsWith(matrix.nBPF, 'nBPF') && !startsWith(matrix.global_context, '--without') # Only on a few "standard" builds
         run: |
           ./utils/check_symbols.sh || { FAILED=$?; echo "::error file=${NDPI_LIB}::Unwanted libc symbols found: ${FAILED}. Please make sure to use only ndpi_malloc/ndpi_calloc/ndpi_realloc/ndpi_free wrapper instead of malloc/calloc/realloc/free."; false; }
         env:
@@ -232,14 +232,14 @@ jobs:
           make dist
           ./utils/verify_dist_tarball.sh
       - name: Build Debian/Ubuntu package
-        if: startsWith(matrix.os, 'ubuntu-24.04') && startsWith(matrix.compiler, 'cc')
+        if: startsWith(matrix.os, 'ubuntu-24.04') && !endsWith(matrix.os, 'arm') && startsWith(matrix.compiler, 'cc')
         run: |
           cd packages/ubuntu
           ./configure --enable-no-sign
           make
           cd ../..
       - name: Build nDPI [Mingw-w64] (runs only on ubuntu jobs)
-        if: startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.msan, '--with-') && !startsWith(matrix.nBPF, 'nBPF') && !startsWith(matrix.global_context, '--without') # Only on a few "standard" builds
+        if: startsWith(matrix.os, 'ubuntu') && !endsWith(matrix.os, 'arm') && !startsWith(matrix.msan, '--with-') && !startsWith(matrix.nBPF, 'nBPF') && !startsWith(matrix.global_context, '--without') # Only on a few "standard" builds
         run: |
           make distclean
           ./autogen.sh --enable-option-checking=fatal --enable-debug-messages --enable-tls-sigs --host=x86_64-w64-mingw32

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,4 +1,4 @@
-name: No x86_64 archs
+name: ARM builds with docker
 on:
   push:
     branches:
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        arch: ["arm64", "armhf", "s390x"]
+        arch: ["armhf", "s390x"]
     steps:
       - name: Setup multiarch/qemu-user-static
         run: |
@@ -32,30 +32,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Display qemu specified architecture (arm64 - little endian)
-        if: startsWith(matrix.arch, 'arm64')
-        uses: docker://multiarch/ubuntu-core:arm64-bionic
-        with:
-          args: >
-            bash -c
-            "uname -a &&
-            lscpu | grep Endian
-            "
-      - name: Configure, compile and test using qemu for the specified architecture (arm64 - little endian)
-        if: startsWith(matrix.arch, 'arm64')
-        uses: docker://multiarch/ubuntu-core:arm64-bionic
-        with:
-          args: >
-            bash -c
-            "apt-get -y update &&
-            apt-get -y install git wdiff colordiff autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev rrdtool librrd-dev &&
-            git config --global --add safe.directory $(realpath .) &&
-            env CC=gcc ./autogen.sh --enable-option-checking=fatal --enable-debug-messages &&
-            make -j $(nproc) all &&
-            make -C example ndpiSimpleIntegration &&
-            make -C rrdtool &&
-            make check VERBOSE=1
-            "
       - name: Display qemu specified architecture (armhf - little endian)
         if: startsWith(matrix.arch, 'armhf')
         uses: docker://multiarch/ubuntu-core:armhf-bionic


### PR DESCRIPTION
See: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Native runners are incredibly faster that using docker (as expected...).
