### PR TITLE
Force English content in whatsapp_ip_addresses_download.sh

### DIFF
--- a/utils/whatsapp_ip_addresses_download.sh
+++ b/utils/whatsapp_ip_addresses_download.sh
@@ -12,7 +12,7 @@ IP_LINK_URL='https://developers.facebook.com/docs/whatsapp/guides/network-requir
 
 
 echo "(1) Scraping Facebook WhatsApp IP Adresses and Ranges..."
-ORIGIN="$(curl -s "${IP_LINK_URL}" | sed -ne 's/.*<a href="\([^"]*\)" target="_blank">WhatsApp server IP addresses and ranges (.zip file)<\/a>.*/\1/gp' | sed -e 's/\&amp;/\&/g')"
+ORIGIN="$(curl -H "Accept-Language: en" -s "${IP_LINK_URL}" | sed -ne 's/.*<a href="\([^"]*\)" target="_blank">WhatsApp server IP addresses and ranges (.zip file)<\/a>.*/\1/gp' | sed -e 's/\&amp;/\&/g')"
 is_str_empty "${ORIGIN}" "IP webpage list does not contain any addresses. A REGEX update may be required."
 
 echo "(2) Downloading file... ${ORIGIN}"


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [ X ] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ X ] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [ - ] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):
https://github.com/ntop/nDPI/issues/2700


Describe changes:
Add the Accept-Language header in the cURL command to ensure the fetched page is in English, improving consistency and clarity in the script output.

