### PR TITLE
Fix a crash reported by fuzzing

### DIFF
--- a/src/lib/ndpi_domains.c
+++ b/src/lib/ndpi_domains.c
@@ -135,7 +135,7 @@ const char* ndpi_get_host_domain(struct ndpi_detection_module_struct *ndpi_str,
   char *dot, *first_dc;
   u_int16_t domain_id, len;
   
-  if(!ndpi_str)
+  if(!ndpi_str || !hostname)
     return NULL;
 
   if(ndpi_str->public_domain_suffixes == NULL)


### PR DESCRIPTION
```
==17==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7f8d7c8bc915 bp 0x7ffd25039910 sp 0x7ffd250390c8 T0)
==17==The signal is caused by a READ memory access.
==17==Hint: address points to the zero page.
SCARINESS: 10 (null-deref)
    #0 0x7f8d7c8bc915  (/lib/x86_64-linux-gnu/libc.so.6+0x188915) (BuildId: 0323ab4806bee6f846d9ad4bccfc29afdca49a58)
    #1 0x55f437be04a3 in strlen /src/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc
    #2 0x55f437cfa3cb in ndpi_get_host_domain /src/ndpi/src/lib/ndpi_domains.c:144:9
    #3 0x55f437caf21e in LLVMFuzzerTestOneInput /src/ndpi/fuzz/fuzz_config.cpp:703:3

```

