### PR TITLE
Flute: fix heap-buffer-overflow

### DIFF
--- a/src/lib/protocols/flute.c
+++ b/src/lib/protocols/flute.c
@@ -44,7 +44,7 @@ static void ndpi_search_flute(struct ndpi_detection_module_struct *ndpi_struct,
     }
 
     u_int16_t lct_hdr_len = packet->payload[2] * 4;
-    if (packet->payload_packet_len <= lct_hdr_len + 43) {
+    if (packet->payload_packet_len <= lct_hdr_len + 43 + NDPI_STATICSTRING_LEN("<FDT")) {
       goto not_flute;
     }
 


### PR DESCRIPTION
```
==13852==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5150000027da at pc 0x5fa4b65d08ac bp 0x7ffc4c57ed60 sp 0x7ffc4c57e508
READ of size 4 at 0x5150000027da thread T0
    #0 0x5fa4b65d08ab in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_pl7m_64k+0x78c8ab) (BuildId: 15b63a623e404a4a0be658cae7336391fc8353db)
    #1 0x5fa4b65d0d80 in memcmp (/home/ivan/svnrepos/nDPI/fuzz/fuzz_ndpi_reader_pl7m_64k+0x78cd80) (BuildId: 15b63a623e404a4a0be658cae7336391fc8353db)
    #2 0x5fa4b68bfe7e in ndpi_search_flute /home/ivan/svnrepos/nDPI/src/lib/protocols/flute.c:52:9
    #3 0x5fa4b6764406 in check_ndpi_detection_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:7571:6
    #4 0x5fa4b67bf703 in check_ndpi_udp_flow_func /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:7606:10

```

Found by oss-fuzz
See: https://oss-fuzz.com/testcase-detail/5261204335689728


