### PR TITLE
Address cache: fix a use-of-uninitialized-value error on cache restore

### DIFF
--- a/src/lib/ndpi_cache.c
+++ b/src/lib/ndpi_cache.c
@@ -446,7 +446,7 @@ u_int32_t ndpi_address_cache_restore(struct ndpi_address_cache *cache, char *pat
   
   if(!fd) return(false);
 
-  while(fscanf(fd, "%32s\t%255s\t%u\n", ip, hostname, &epoch) > 0) {    
+  while(fscanf(fd, "%32s\t%255s\t%u\n", ip, hostname, &epoch) == 3) {
     if(epoch >= epoch_now) { /* Entry not yet expired */
       u_int ttl = epoch-epoch_now;
       ndpi_ip_addr_t addr;


### PR DESCRIPTION
```
==29602==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x563af77d47ac in ndpi_address_cache_restore /home/ivan/svnrepos/nDPI/src/lib/ndpi_cache.c:450:8
    #1 0x563af77d6b52 in ndpi_cache_address_restore /home/ivan/svnrepos/nDPI/src/lib/ndpi_cache.c:518:10
    #2 0x563af77c73e5 in LLVMFuzzerTestOneInput /home/ivan/svnrepos/nDPI/fuzz/fuzz_ds_address_cache.cpp:100:5
```

Found by oss-fuzz.
See: https://oss-fuzz.com/testcase-detail/6653546833707008


