### PR TITLE
Fix typo in -P help for ndpiReader

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -678,7 +678,7 @@ static void help(u_int long_help) {
          "                            | <b> = max pattern len to search\n"
          "                            | <c> = max num packets per flow\n"
          "                            | <d> = max packet payload dissection\n"
-         "                            | <d> = max num reported payloads\n"
+         "                            | <e> = max num reported payloads\n"
          "                            | Default: %u:%u:%u:%u:%u\n"
          "  -c <path>                 | Load custom categories from the specified file\n"
          "  -C <path>                 | Write output in CSV format on the specified file\n"


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [X] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):


Describe changes:
Fixes a minor typo in the help message for the -P option in ndpiReader.
Goes from  d = max num reported payloads to  e = max num reported payloads (it repeated a d)
