### PR TITLE
Fix a stack-buffer-overflow error

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -11771,9 +11771,9 @@ static ndpi_cfg_error _set_param_flowrisk_enable_disable(struct ndpi_detection_m
 
   if(strlen(_param) > 5 &&
      strncmp(_param + (strlen(_param) - 5), ".info", 5) == 0)
-    memcpy(param, _param, ndpi_min(strlen(_param) - 5, sizeof(param))); /* Strip trailing ".info" */
+    memcpy(param, _param, ndpi_min(strlen(_param) - 5, sizeof(param) - 1)); /* Strip trailing ".info" */
   else
-    strncpy(param, _param, sizeof(param));
+    strncpy(param, _param, sizeof(param) - 1);
 
   if(strcmp(param, "any") == 0 ||
      strcmp(param, "all") == 0 ||


### PR DESCRIPTION
```
==40795==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7dd7ff94a6a0 at pc 0x5f2e95e21423 bp 0x7ffccfe0f110 sp 0x7ffccfe0e8d0
READ of size 129 at 0x7dd7ff94a6a0 thread T0
    #0 0x5f2e95e21422 in StrtolFixAndCheck(void*, char const*, char**, char*, int) asan_interceptors.cpp.o
    #1 0x5f2e95e0ceb1 in __isoc23_strtol (/home/ivan/svnrepos/nDPI/fuzz/fuzz_filecfg_config+0x7bfeb1) (BuildId: 2cfb818387b5d84d6fa1447db291acb2595493d4)
    #2 0x5f2e95f1d036 in __get_flowrisk_id /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:11524:9
    #3 0x5f2e95f1c3c7 in _set_param_flowrisk_enable_disable /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:11793:17
    #4 0x5f2e95e9e17f in ndpi_set_config /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:12051:12
    #5 0x5f2e95e9cbe5 in load_config_file_fd /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:4985:14
```
Found by oss-fuzz.
See: https://issues.oss-fuzz.com/issues/406446504


