### PR TITLE
CI: update Windows runners

### DIFF
--- a/.github/workflows/build-msbuild.yml
+++ b/.github/workflows/build-msbuild.yml
@@ -11,8 +11,12 @@ on:
     types: [created]
 jobs:
   test:
-    name: MSBuild
-    runs-on: windows-latest
+    name: MSBuild ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ["windows-latest", "windows-11-arm"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,10 +31,10 @@ jobs:
         run: msbuild windows/nDPI.sln -t:rebuild -property:Configuration=Debug
 
       - name: Download Npcap
-        run: Invoke-WebRequest -Uri 'https://npcap.com/dist/npcap-1.71.exe' -OutFile 'C:\npcap-1.71.exe'
+        run: Invoke-WebRequest -Uri 'https://npcap.com/dist/npcap-1.81.exe' -OutFile 'C:\npcap-1.81.exe'
 
       - name: Install Npcap
-        run: C:\npcap-1.71.exe /S /winpcap_mode=yes
+        run: C:\npcap-1.81.exe /S /winpcap_mode=yes
 
       - name: Build ndpiReader (debug)
         run: msbuild windows/nDPI.sln -t:rebuild -property:Configuration=Debug-ndpiReader
@@ -38,6 +42,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts
+          name: build-artifacts-${{ matrix.os }}
           path: windows/bin
           retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,6 +297,8 @@ jobs:
           msys2 -c 'ldd ./example/ndpiReader.exe'
       - name: Tests
         run: |
-          msys2 -c 'NDPI_FORCE_PARALLEL_UTESTS=1 NDPI_SKIP_PARALLEL_BAR=1 ./tests/do.sh'
+          # Don't know why but lately the script in parallel mode is stuck...
+          #msys2 -c 'NDPI_FORCE_PARALLEL_UTESTS=1 NDPI_SKIP_PARALLEL_BAR=1 ./tests/do.sh'
+          msys2 -c './tests/do.sh'
           msys2 -c './tests/do-unit.sh'
           msys2 -c './tests/do-dga.sh'

--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -199,7 +199,9 @@ jobs:
           msys2 -c 'ldd ./example/ndpiReader.exe'
       - name: Tests
         run: |
-          msys2 -c 'NDPI_FORCE_PARALLEL_UTESTS=1 NDPI_SKIP_PARALLEL_BAR=1 ./tests/do.sh'
+          # Don't know why but lately the script in parallel mode is stuck...
+          #msys2 -c 'NDPI_FORCE_PARALLEL_UTESTS=1 NDPI_SKIP_PARALLEL_BAR=1 ./tests/do.sh'
+          msys2 -c './tests/do.sh'
           msys2 -c './tests/do-unit.sh'
           msys2 -c './tests/do-dga.sh'
 


### PR DESCRIPTION
* add CI on Windows 11 on ARM
* workaround fow Windows build where the test script is stuck in parallel mode



