### PR TITLE
Micro-optimizations of 'ndpi_strncasestr' and 'LINE_*' macros

### DIFF
--- a/src/include/ndpi_private.h
+++ b/src/include/ndpi_private.h
@@ -72,25 +72,16 @@ typedef struct default_ports_tree_node {
 } default_ports_tree_node_t;
 
 
-#define LINE_EQUALS(ndpi_int_one_line_struct, string_to_compare) \
-  ((ndpi_int_one_line_struct).len == strlen(string_to_compare) && \
-   LINE_CMP(ndpi_int_one_line_struct, string_to_compare, strlen(string_to_compare)) == 1)
-
 #define LINE_STARTS(ndpi_int_one_line_struct, string_to_compare) \
-  ((ndpi_int_one_line_struct).len >= strlen(string_to_compare) && \
-   LINE_CMP(ndpi_int_one_line_struct, string_to_compare, strlen(string_to_compare)) == 1)
+  ((ndpi_int_one_line_struct).ptr != NULL && \
+   (ndpi_int_one_line_struct).len >= strlen(string_to_compare) && \
+   strncasecmp((const char *)((ndpi_int_one_line_struct).ptr), string_to_compare, strlen(string_to_compare)) == 0)
 
 #define LINE_ENDS(ndpi_int_one_line_struct, string_to_compare) \
   ((ndpi_int_one_line_struct).len >= strlen(string_to_compare) && \
-   ndpi_strncasestr((const char *)((ndpi_int_one_line_struct).ptr) + \
-                    ((ndpi_int_one_line_struct).len - strlen(string_to_compare)), \
-                    string_to_compare, strlen(string_to_compare)) == \
-   (const char *)((ndpi_int_one_line_struct).ptr) + ((ndpi_int_one_line_struct).len - strlen(string_to_compare)))
-
-#define LINE_CMP(ndpi_int_one_line_struct, string_to_compare, string_to_compare_length) \
-  ((ndpi_int_one_line_struct).ptr != NULL && \
-   ndpi_strncasestr((const char *)((ndpi_int_one_line_struct).ptr), string_to_compare, \
-                    string_to_compare_length) == (const char *)((ndpi_int_one_line_struct).ptr))
+   strncasecmp((const char *)((ndpi_int_one_line_struct).ptr) + \
+              ((ndpi_int_one_line_struct).len - strlen(string_to_compare)), \
+              string_to_compare, strlen(string_to_compare)) == 0)
 
 #define NDPI_MAX_PARSE_LINES_PER_PACKET                         64
 

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -10520,10 +10520,18 @@ const char * ndpi_strncasestr(const char *s, const char *find, size_t len) {
 
   const size_t s_len = strnlen(s, len);
 
+  /* If 'find' is longer than 's', no match is possible */
+  if (find_len > s_len) {
+    return NULL;
+  }
+
   const char *const end_of_search = s + s_len - find_len + 1;
 
+  /* Cache the lowercased first character of 'find' */
+  const unsigned char fc = tolower((unsigned char) *find);
+
   for (; s < end_of_search; ++s) {
-    if (tolower((unsigned char)*s) == tolower((unsigned char)*find)) {
+    if (tolower((unsigned char)*s) == fc) {
       if (strncasecmp(s + 1, find + 1, find_len - 1) == 0) {
         return s;
       }


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Describe changes:

#2664

I don't see much point in using `ndpi_strncasestr` in these macros, so I replaced it with `strncasecmp`. I also removed `LINE_EQUALS` and `LINE_CMP` macros because they weren't used anywhere else in the code.

Regarding `ndpi_strncasestr` - I added a missing check and caching of the lowercased first character of `find`, a tiny but useful optimization.