### PR TITLE
TLS: register TLS dissector only once

### DIFF
--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -98,7 +98,6 @@
 #define MAX_DEFAULT_PORTS                                        5
 
 #define NDPI_EXCLUDE_PROTO(mod,flow) ndpi_exclude_protocol(mod, flow, NDPI_CURRENT_PROTO, __FILE__, __FUNCTION__, __LINE__)
-#define NDPI_EXCLUDE_PROTO_EXT(mod,flow,proto) ndpi_exclude_protocol(mod, flow, proto, __FILE__, __FUNCTION__, __LINE__)
 
 /**
  * macro for getting the string len of a static string

--- a/src/lib/protocols/rtp.c
+++ b/src/lib/protocols/rtp.c
@@ -402,7 +402,6 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
   if(packet->tcp != NULL) {
     if (payload_len < 2) {
       NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-      NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_RTCP);
       return;
     }
     payload += 2; /* Skip the length field */
@@ -419,7 +418,6 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
      flow->rtp_stage == 0 &&
      flow->rtcp_stage == 0) {
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-    NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_RTCP);
     return;
   }
 
@@ -441,7 +439,6 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
         flow->rtp_stage = 0;
         flow->rtcp_stage = 0;
         NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-        NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_RTCP);
       } else {
         get_rtp_info(ndpi_struct, flow, payload, payload_len);
         rtp_get_stream_type(flow->rtp[packet->packet_direction].payload_type,
@@ -477,7 +474,6 @@ static void ndpi_rtp_search(struct ndpi_detection_module_struct *ndpi_struct,
         flow->rtp_stage = 0;
         flow->rtcp_stage = 0;
         NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-        NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_RTCP);
       }
     }
   }
@@ -500,14 +496,12 @@ static void ndpi_search_rtp_tcp(struct ndpi_detection_module_struct *ndpi_struct
 
   if(packet->payload_packet_len < 4){ /* (2) len field + (2) min rtp/rtcp*/
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-    NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_RTCP);
     return;
   }
 
   u_int16_t len = ntohs(get_u_int16_t(payload, 0));
   if(len + sizeof(len) != packet->payload_packet_len) { /*fragmented packets are not handled*/
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-    NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_RTCP);
   } else {
     ndpi_rtp_search(ndpi_struct, flow);
   }
@@ -531,7 +525,6 @@ static void ndpi_search_rtp_udp(struct ndpi_detection_module_struct *ndpi_struct
      || (dest == 9600  /* FINS_PORT */)
      || (dest <= 1023)){
     NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
-    NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_RTCP);
     return;
   }
   ndpi_rtp_search(ndpi_struct, flow);

--- a/src/lib/protocols/smb.c
+++ b/src/lib/protocols/smb.c
@@ -76,8 +76,7 @@ static void ndpi_search_smb_tcp(struct ndpi_detection_module_struct *ndpi_struct
     }
   }
 
-  NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_SMBV1);
-  NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_SMBV23);
+  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
 }
 
 

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -3427,10 +3427,7 @@ static void ndpi_search_tls_wrapper(struct ndpi_detection_module_struct *ndpi_st
   if(flow->tls_quic.obfuscated_heur_state) {
     tls_obfuscated_heur_search_again(ndpi_struct, flow);
   } else if(rc == 0) {
-    if(packet->udp != NULL || flow->stun.maybe_dtls)
-      NDPI_EXCLUDE_PROTO_EXT(ndpi_struct, flow, NDPI_PROTOCOL_DTLS);
-    else
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
   }
 }
 
@@ -3441,18 +3438,7 @@ void init_tls_dissector(struct ndpi_detection_module_struct *ndpi_struct,
   ndpi_set_bitmask_protocol_detection("TLS", ndpi_struct, *id,
 				      NDPI_PROTOCOL_TLS,
 				      ndpi_search_tls_wrapper,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  *id += 1;
-
-  /* *************************************************** */
-
-  ndpi_set_bitmask_protocol_detection("DTLS", ndpi_struct, *id,
-				      NDPI_PROTOCOL_DTLS,
-				      ndpi_search_tls_wrapper,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
 				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
 				      ADD_TO_DETECTION_BITMASK);
 

--- a/windows/src/ndpi_define.h
+++ b/windows/src/ndpi_define.h
@@ -97,7 +97,6 @@
 #define MAX_DEFAULT_PORTS                                        5
 
 #define NDPI_EXCLUDE_PROTO(mod,flow) ndpi_exclude_protocol(mod, flow, NDPI_CURRENT_PROTO, __FILE__, __FUNCTION__, __LINE__)
-#define NDPI_EXCLUDE_PROTO_EXT(mod,flow,proto) ndpi_exclude_protocol(mod, flow, proto, __FILE__, __FUNCTION__, __LINE__)
 
 /**
  * macro for getting the string len of a static string


### PR DESCRIPTION
This is the first, tiny, step into a better separation between "protocols" and "dissectors"


