### PR TITLE
fix/README.md_file_name_changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The entire procedure of adding new protocols in detail:
 1. Add new protocol together with its unique ID to: `src/include/ndpi_protocol_ids.h`
 2. Create a new protocol in: `src/lib/protocols/`
 3. Variables to be kept for the duration of the entire flow (as state variables) need to be placed in: `src/include/ndpi_typedefs.h` in `ndpi_flow_tcp_struct` (for TCP only), `ndpi_flow_udp_struct` (for UDP only), or `ndpi_flow_struct` (for both).
-4. Add a new entry for the search function for the new protocol in: `src/include/ndpi_protocols.h`
+4. Add a new entry for the search function for the new protocol in: `src/include/ndpi_private.h`
 5. Choose (do not change anything) a selection bitmask from: `src/include/ndpi_define.h`
 6. Set protocol default ports in `ndpi_init_protocol_defaults` in: `src/lib/ndpi_main.c`
 7. Be sure to have nBPF support, cloning `PF_RING` in the same directory where you cloned `nDPI`: `git clone https://github.com/ntop/PF_RING/ && cd PF_RING/userland/nbpf && ./configure && make`. You can ignore the `/bin/sh: 1: ../lib/pfring_config: not found` error


### PR DESCRIPTION
I was going to create a new protocol for ERSPAN. A protocol has to be created as per the directions given in the README.md. While going through the instructions, I got to know that we have **add a new entry for the search function** for the new protocol in: **src/include/ndpi_protocols.h**. 

**But the thing is that, there is no src/include/ndpi_protocols.h.**

Screenshots below will clarify the above:

![Image](https://github.com/user-attachments/assets/c4b25887-e0a1-458a-b671-5519618020d5)

src/include directory:

![Image](https://github.com/user-attachments/assets/a6e6664d-3212-419b-a1b5-65bda1599bd8)

**The file name is now changed to ndpi_protocols.h to ndpi_private.h.
I have edited the README.md**

**Issue: Update README.md #2839
Issue number: #2839**

**Please consider this PR.**