### PR TITLE
A new interface for dissectors registration

### DIFF
--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -36,11 +36,6 @@ extern "C" {
 #define NDPI_DETECTION_ONLY_IPV4              ( 1 << 0 )
 #define NDPI_DETECTION_ONLY_IPV6              ( 1 << 1 )
 
-#define ADD_TO_DETECTION_BITMASK              1
-#define NO_ADD_TO_DETECTION_BITMASK           0
-#define SAVE_DETECTION_BITMASK_AS_UNKNOWN     1
-#define NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN  0
-
   /*
     In case a custom DGA function is used, the fucntion
     below must be overwritten,
@@ -487,18 +482,6 @@ extern "C" {
   void ndpi_check_subprotocol_risk(struct ndpi_detection_module_struct *ndpi_str,
 				 struct ndpi_flow_struct *flow, u_int16_t subprotocol_id);
 
-  /**
-   * Exclude protocol from search
-   *
-   * @par    ndpi_struct         = the detection module
-   * @par    flow                = the flow where match the host
-   * @par    master_protocol_id  = value of the ID associated to the master protocol detected
-   *
-   */
-  void ndpi_exclude_protocol(struct ndpi_detection_module_struct *ndpi_struct,
-			     struct ndpi_flow_struct *flow,
-			     u_int16_t master_protocol_id,
-			     const char *_file, const char *_func,int _line);
   /**
    * Check if the string -bigram_to_match- match with a bigram of -automa-
    *

--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -86,18 +86,9 @@
 
 #define NDPI_SELECTION_BITMASK_PROTOCOL_SIZE			u_int32_t
 
-/**
- * convenience macro to check for excluded protocol
- * a protocol is excluded if the flow is known and either the protocol is not detected at all
- * or the excluded bitmask contains the protocol
- */
-#define NDPI_FLOW_PROTOCOL_EXCLUDED(ndpi_struct,flow,protocol) ((flow) != NULL && \
-								( NDPI_COMPARE_PROTOCOL_TO_BITMASK((ndpi_struct)->detection_bitmask, (protocol)) == 0 || \
-								  NDPI_COMPARE_PROTOCOL_TO_BITMASK((flow)->excluded_protocol_bitmask, (protocol)) != 0 ) )
-
 #define MAX_DEFAULT_PORTS                                        5
 
-#define NDPI_EXCLUDE_PROTO(mod,flow) ndpi_exclude_protocol(mod, flow, NDPI_CURRENT_PROTO, __FILE__, __FUNCTION__, __LINE__)
+#define NDPI_EXCLUDE_DISSECTOR(mod,flow) exclude_dissector(mod, flow, mod->current_dissector_idx, __FILE__, __FUNCTION__, __LINE__)
 
 /**
  * macro for getting the string len of a static string
@@ -139,9 +130,11 @@
 #define NDPI_ISSET_BIT(num, n)  (num & (1ULL << ( n )))
 #define NDPI_ZERO_BIT(num)      num = 0
 
+#define NDPI_MAX_NUM_DISSECTORS                 288      /* Multiple of 32, i.e. NDPI_BITS */
+#define NDPI_NUM_FDS_BITS_DISSECTORS            howmanybits(NDPI_MAX_NUM_DISSECTORS, NDPI_BITS)
 #define NDPI_DISSECTOR_BITMASK                  ndpi_dissector_bitmask_struct_t
 #define NDPI_DISSECTOR_BITMASK_IS_SET(p, n)     NDPI_ISSET(&(p), (n))
-#define NDPI_DISSECTOR_BITMASK_SET(p, n)        NDPI_SET(&(p), (n) & NDPI_NUM_BITS_MASK)
+#define NDPI_DISSECTOR_BITMASK_SET(p, n)        NDPI_SET(&(p), (n))
 
 /* this is a very very tricky macro *g*,
  * the compiler will remove all shifts here if the protocol is static...

--- a/src/include/ndpi_private.h
+++ b/src/include/ndpi_private.h
@@ -53,10 +53,14 @@ typedef struct {
 } ndpi_tls_cert_name_match;
 
 struct call_function_struct {
-  NDPI_PROTOCOL_BITMASK detection_bitmask;
+  char name[16];                /* Used only for logging/debugging */
   void (*func) (struct ndpi_detection_module_struct *, struct ndpi_flow_struct *flow);
   NDPI_SELECTION_BITMASK_PROTOCOL_SIZE ndpi_selection_bitmask;
   u_int16_t dissector_idx;
+  /* We don't need to keep track of the list of protocols handled by this dissector */
+  u_int16_t first_protocol_id;  /* ID of the first protocol registered with this dissector.
+                                   It is used ONLY for logging, because logging configuration
+                                   is (still) for protocol, not for dissector */
 };
 
 struct subprotocol_conf_struct {
@@ -367,6 +371,7 @@ struct ndpi_detection_module_struct {
   u_int32_t callback_buffer_size_udp;
   u_int32_t callback_buffer_size_non_tcp_udp;
   u_int32_t callback_buffer_num;
+  u_int32_t current_dissector_idx;
 
   default_ports_tree_node_t *tcpRoot, *udpRoot;
 
@@ -617,14 +622,13 @@ struct ndpi_detection_module_struct {
 
 /* Generic */
 
-void ndpi_set_bitmask_protocol_detection(char *label,
-                                         struct ndpi_detection_module_struct *ndpi_struct,
-                                         u_int16_t ndpi_protocol_id,
-                                         void (*func) (struct ndpi_detection_module_struct *,
-                                                       struct ndpi_flow_struct *flow),
-                                         const NDPI_SELECTION_BITMASK_PROTOCOL_SIZE ndpi_selection_bitmask,
-                                         u_int8_t b_save_bitmask_unknow,
-                                         u_int8_t b_add_detection_bitmask);
+void register_dissector(char *dissector_name, struct ndpi_detection_module_struct *ndpi_str,
+                        void (*func)(struct ndpi_detection_module_struct *,
+                                     struct ndpi_flow_struct *flow),
+                        const NDPI_SELECTION_BITMASK_PROTOCOL_SIZE ndpi_selection_bitmask,
+                        int num_protocol_ids, ...);
+void exclude_dissector(struct ndpi_detection_module_struct *ndpi_str, struct ndpi_flow_struct *flow,
+                       u_int16_t dissector_idx, const char *_file, const char *_func, int _line) ;
 
 char *strptime(const char *s, const char *format, struct tm *tm);
 

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -273,13 +273,11 @@ typedef struct ndpi_protocol_bitmask_struct {
 } ndpi_protocol_bitmask_struct_t;
 
 
-#define NDPI_MAX_NUM_DISSECTORS         288      /* Multiple of 32, i.e. 8 * sizeof(ndpi_ndpi_mask) */
 #ifdef NDPI_CFFI_PREPROCESSING
 #undef NDPI_NUM_FDS_BITS_DISSECTORS
 #define NDPI_NUM_FDS_BITS_DISSECTORS    9
-#else
-#define NDPI_NUM_FDS_BITS_DISSECTORS    NDPI_MAX_NUM_DISSECTORS / (8 * sizeof(ndpi_ndpi_mask))
 #endif
+
 typedef struct ndpi_dissector_bitmask_struct {
   ndpi_ndpi_mask fds_bits[NDPI_NUM_FDS_BITS_DISSECTORS];
 } ndpi_dissector_bitmask_struct_t;

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -507,24 +507,25 @@ u_int8_t ndpi_is_subprotocol_informative(u_int16_t protoId) {
     return(0);
   }
 }
+
 /* ********************************************************************************** */
 
-void ndpi_exclude_protocol(struct ndpi_detection_module_struct *ndpi_str, struct ndpi_flow_struct *flow,
-                           u_int16_t protocol_id, const char *_file, const char *_func, int _line) {
-  if(ndpi_is_valid_protoId(protocol_id)) {
+void exclude_dissector(struct ndpi_detection_module_struct *ndpi_str, struct ndpi_flow_struct *flow,
+                       u_int16_t dissector_idx, const char *_file, const char *_func, int _line) {
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
-    if(ndpi_str && ndpi_str->cfg.log_level >= NDPI_LOG_DEBUG && ndpi_str->ndpi_debug_printf != NULL) {
-      (*(ndpi_str->ndpi_debug_printf))(protocol_id, ndpi_str, NDPI_LOG_DEBUG, _file, _func, _line, "exclude %s\n",
-				       ndpi_get_proto_name(ndpi_str, protocol_id));
-    }
-#else
-    (void)ndpi_str;
-    (void)_file;
-    (void)_func;
-    (void)_line;
-#endif
-    NDPI_DISSECTOR_BITMASK_SET(flow->excluded_dissectors_bitmask, ndpi_str->proto_defaults[protocol_id].dissector_idx);
+  /* TODO */
+  if(ndpi_str->cfg.log_level >= NDPI_LOG_DEBUG && ndpi_str->ndpi_debug_printf != NULL) {
+    (*(ndpi_str->ndpi_debug_printf))(ndpi_str->callback_buffer[dissector_idx].first_protocol_id,
+                                     ndpi_str, NDPI_LOG_DEBUG, _file, _func, _line, "exclude %s\n",
+                                     ndpi_str->callback_buffer[dissector_idx].name);
   }
+#else
+  (void)ndpi_str;
+  (void)_file;
+  (void)_func;
+  (void)_line;
+#endif
+  NDPI_DISSECTOR_BITMASK_SET(flow->excluded_dissectors_bitmask, dissector_idx);
 }
 
 /* ********************************************************************************** */
@@ -5724,14 +5725,14 @@ int load_protocols_file_fd(struct ndpi_detection_module_struct *ndpi_str, FILE *
 
 /* ******************************************************************** */
 
-void ndpi_set_bitmask_protocol_detection(char *label, struct ndpi_detection_module_struct *ndpi_str,
-                                         u_int16_t ndpi_protocol_id,
-                                         void (*func)(struct ndpi_detection_module_struct *,
-                                                      struct ndpi_flow_struct *flow),
-                                         const NDPI_SELECTION_BITMASK_PROTOCOL_SIZE ndpi_selection_bitmask,
-                                         u_int8_t b_save_bitmask_unknow, u_int8_t b_add_detection_bitmask) {
-  (void)label;
-
+void register_dissector(char *dissector_name, struct ndpi_detection_module_struct *ndpi_str,
+                        void (*func)(struct ndpi_detection_module_struct *,
+                                     struct ndpi_flow_struct *flow),
+                        const NDPI_SELECTION_BITMASK_PROTOCOL_SIZE ndpi_selection_bitmask,
+                        int num_protocol_ids, ...)
+{
+  va_list ap;
+  int i, dissector_enabled = 0, first_protocol_id = -1;
   u_int32_t idx = ndpi_str->callback_buffer_num;
 
   if(idx >= NDPI_MAX_NUM_DISSECTORS) {
@@ -5746,46 +5747,48 @@ void ndpi_set_bitmask_protocol_detection(char *label, struct ndpi_detection_modu
     return;
   }
 
-  if(is_proto_enabled(ndpi_str, ndpi_protocol_id)) {
-    NDPI_LOG_DBG2(ndpi_str,
-		  "[NDPI] ndpi_set_bitmask_protocol_detection: %s : [callback_buffer] idx= %u, [proto_defaults] "
-		  "protocol_id=%u\n",
-		  label, idx, ndpi_protocol_id);
-
-    if(ndpi_str->proto_defaults[ndpi_protocol_id].dissector_idx != 0) {
-      NDPI_LOG_DBG2(ndpi_str, "[NDPI] Internal error: protocol %s/%u has been already registered\n", label,
-		    ndpi_protocol_id);
+  va_start(ap, num_protocol_ids);
+  for(i = 0; i < num_protocol_ids; i++) {
+    int ndpi_protocol_id = va_arg(ap, int);
+    if(!is_proto_enabled(ndpi_str, ndpi_protocol_id)) {
+      NDPI_LOG_DBG(ndpi_str, "Protocol %d not enabled for dissector %s\n",
+                   ndpi_protocol_id, dissector_name);
     } else {
-      NDPI_LOG_DBG2(ndpi_str, "[NDPI] Adding %s with protocol id %d\n", label, ndpi_protocol_id);
+
+      if(ndpi_str->proto_defaults[ndpi_protocol_id].dissector_idx != 0) {
+        NDPI_LOG_ERR(ndpi_str, "Internal error: protocol %d/%s has been already registered (%d/%d)\n",
+                     ndpi_protocol_id, dissector_name,
+                     ndpi_str->proto_defaults[ndpi_protocol_id].dissector_idx,
+                     idx);
+        /* TODO */
+      } else {
+
+        if(first_protocol_id == -1)
+          first_protocol_id = ndpi_protocol_id;
+
+        ndpi_str->proto_defaults[ndpi_protocol_id].dissector_idx = idx;
+        ndpi_str->proto_defaults[ndpi_protocol_id].func = func;
+      }
+      dissector_enabled = 1;
     }
-
-    /*
-      Set function and index protocol within proto_default structure for port protocol detection
-      and callback_buffer function for DPI protocol detection
-    */
-    ndpi_str->proto_defaults[ndpi_protocol_id].dissector_idx = idx;
-    ndpi_str->proto_defaults[ndpi_protocol_id].func = ndpi_str->callback_buffer[idx].func = func;
-    ndpi_str->callback_buffer[idx].dissector_idx = idx;
-
-    /*
-      Set ndpi_selection_bitmask for protocol
-    */
-    ndpi_str->callback_buffer[idx].ndpi_selection_bitmask = ndpi_selection_bitmask;
-
-    /*
-      Reset protocol detection bitmask via NDPI_PROTOCOL_UNKNOWN and than add specify protocol bitmast to callback
-      buffer.
-    */
-    if(b_save_bitmask_unknow)
-      NDPI_SAVE_AS_BITMASK(ndpi_str->callback_buffer[idx].detection_bitmask, NDPI_PROTOCOL_UNKNOWN);
-    if(b_add_detection_bitmask)
-      NDPI_ADD_PROTOCOL_TO_BITMASK(ndpi_str->callback_buffer[idx].detection_bitmask, ndpi_protocol_id);
-
-  } else {
-    NDPI_LOG_DBG(ndpi_str, "[NDPI] Protocol %s/%u disabled\n", label, ndpi_protocol_id);
   }
+  va_end(ap);
 
-  ndpi_str->callback_buffer_num++;
+  if(dissector_enabled) {
+    NDPI_LOG_DBG2(ndpi_str, "Dissector %s enabled. Registering %d...\n", dissector_name, idx);
+
+    memcpy(ndpi_str->callback_buffer[idx].name, dissector_name,
+           ndpi_min(sizeof(ndpi_str->callback_buffer[idx].name) - 1, strlen(dissector_name)));
+    ndpi_str->callback_buffer[idx].func = func;
+    ndpi_str->callback_buffer[idx].dissector_idx = idx;
+    ndpi_str->callback_buffer[idx].ndpi_selection_bitmask = ndpi_selection_bitmask;
+    ndpi_str->callback_buffer[idx].first_protocol_id = first_protocol_id; /* Just for logging */
+
+    ndpi_str->callback_buffer_num++;
+  } else {
+    NDPI_LOG_DBG(ndpi_str, "Dissector %s disabled\n", dissector_name);
+  }
+  return;
 }
 
 /* ******************************************************************** */
@@ -6584,7 +6587,7 @@ static int ndpi_callback_init(struct ndpi_detection_module_struct *ndpi_str) {
 
   ndpi_enabled_callbacks_init(ndpi_str, 0);
 
-  NDPI_LOG_DBG(ndpi_str, "Tot num dissectors: %d (TCP: %d, TCP_NO_PAYLOAD: %d, UDP: %d, NO_TCP_UDP: %d\n",
+  NDPI_LOG_DBG(ndpi_str, "Tot num dissectors: %d (TCP: %d, TCP_NO_PAYLOAD: %d, UDP: %d, NO_TCP_UDP: %d)\n",
                ndpi_str->callback_buffer_size,
                ndpi_str->callback_buffer_size_tcp_payload,
                ndpi_str->callback_buffer_size_tcp_no_payload,
@@ -7736,7 +7739,6 @@ static void ndpi_connection_tracking(struct ndpi_detection_module_struct *ndpi_s
 static u_int32_t check_ndpi_subprotocols(struct ndpi_detection_module_struct * const ndpi_str,
                                          struct ndpi_flow_struct * const flow,
                                          NDPI_SELECTION_BITMASK_PROTOCOL_SIZE const ndpi_selection_packet,
-                                         NDPI_PROTOCOL_BITMASK detection_bitmask,
                                          u_int16_t detected_protocol)
 {
   u_int32_t num_calls = 0, a;
@@ -7757,9 +7759,8 @@ static u_int32_t check_ndpi_subprotocols(struct ndpi_detection_module_struct * c
 
     if((ndpi_str->callback_buffer[subproto_index].ndpi_selection_bitmask & ndpi_selection_packet) ==
        ndpi_str->callback_buffer[subproto_index].ndpi_selection_bitmask &&
-       !NDPI_DISSECTOR_BITMASK_IS_SET(flow->excluded_dissectors_bitmask, subproto_index) &&
-       NDPI_BITMASK_COMPARE(ndpi_str->callback_buffer[subproto_index].detection_bitmask,
-			    detection_bitmask) != 0) {
+       !NDPI_DISSECTOR_BITMASK_IS_SET(flow->excluded_dissectors_bitmask, subproto_index)) {
+      ndpi_str->current_dissector_idx = subproto_index;
       ndpi_str->callback_buffer[subproto_index].func(ndpi_str, flow);
       num_calls++;
     }
@@ -7781,17 +7782,15 @@ static u_int32_t check_ndpi_detection_func(struct ndpi_detection_module_struct *
      if we don't already have a partial classification */
   u_int16_t fast_callback_protocol_id = flow->fast_callback_protocol_id ? flow->fast_callback_protocol_id : flow->guessed_protocol_id;
   u_int16_t dissector_idx = ndpi_str->proto_defaults[fast_callback_protocol_id].dissector_idx;
-  NDPI_PROTOCOL_BITMASK detection_bitmask;
   u_int32_t a;
-
-  NDPI_SAVE_AS_BITMASK(detection_bitmask, flow->detected_protocol_stack[0]);
 
   if(fast_callback_protocol_id != NDPI_PROTOCOL_UNKNOWN &&
      ndpi_str->proto_defaults[fast_callback_protocol_id].func &&
      !NDPI_DISSECTOR_BITMASK_IS_SET(flow->excluded_dissectors_bitmask, dissector_idx) &&
      (ndpi_str->callback_buffer[dissector_idx].ndpi_selection_bitmask & ndpi_selection_packet) ==
-     ndpi_str->callback_buffer[dissector_idx].ndpi_selection_bitmask &&
-     NDPI_BITMASK_COMPARE(ndpi_str->callback_buffer[dissector_idx].detection_bitmask, detection_bitmask) != 0) {
+     ndpi_str->callback_buffer[dissector_idx].ndpi_selection_bitmask) {
+
+    ndpi_str->current_dissector_idx = dissector_idx;
     ndpi_str->proto_defaults[fast_callback_protocol_id].func(ndpi_str, flow);
     func = ndpi_str->proto_defaults[fast_callback_protocol_id].func;
     num_calls++;
@@ -7807,10 +7806,9 @@ static u_int32_t check_ndpi_detection_func(struct ndpi_detection_module_struct *
         if((func != callback_buffer[a].func) &&
 	   (callback_buffer[a].ndpi_selection_bitmask & ndpi_selection_packet) ==
 	   callback_buffer[a].ndpi_selection_bitmask &&
-	   !NDPI_DISSECTOR_BITMASK_IS_SET(flow->excluded_dissectors_bitmask, dissector_idx) &&
-	   NDPI_BITMASK_COMPARE(callback_buffer[a].detection_bitmask,
-				detection_bitmask) != 0)
+	   !NDPI_DISSECTOR_BITMASK_IS_SET(flow->excluded_dissectors_bitmask, dissector_idx))
 	  {
+            ndpi_str->current_dissector_idx = dissector_idx;
 	    callback_buffer[a].func(ndpi_str, flow);
 	    num_calls++;
 
@@ -7822,9 +7820,9 @@ static u_int32_t check_ndpi_detection_func(struct ndpi_detection_module_struct *
       }
     }
 
-  num_calls += check_ndpi_subprotocols(ndpi_str, flow, ndpi_selection_packet, detection_bitmask,
+  num_calls += check_ndpi_subprotocols(ndpi_str, flow, ndpi_selection_packet,
                                        flow->detected_protocol_stack[0]);
-  num_calls += check_ndpi_subprotocols(ndpi_str, flow, ndpi_selection_packet, detection_bitmask,
+  num_calls += check_ndpi_subprotocols(ndpi_str, flow, ndpi_selection_packet,
                                        flow->detected_protocol_stack[1]);
 
   return num_calls;

--- a/src/lib/protocols/activision.c
+++ b/src/lib/protocols/activision.c
@@ -45,7 +45,7 @@ static void ndpi_search_activision(struct ndpi_detection_module_struct *ndpi_str
 
   if (packet->payload_packet_len < 18)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -55,20 +55,20 @@ static void ndpi_search_activision(struct ndpi_detection_module_struct *ndpi_str
     {
       if (ntohs(get_u_int16_t(packet->payload, 0)) != 0x0c02)
       {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
       }
     } else {
       if (ntohs(get_u_int16_t(packet->payload, 0)) != 0x0d02)
       {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
       }
     }
 
     if (packet->payload_packet_len < 29)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -81,13 +81,13 @@ static void ndpi_search_activision(struct ndpi_detection_module_struct *ndpi_str
   } else if (packet->packet_direction == 0) {
     if (packet->payload[0] != 0x29)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   } else if (packet->packet_direction == 1) {
     if (packet->payload[0] != 0x28)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
@@ -100,11 +100,8 @@ static void ndpi_search_activision(struct ndpi_detection_module_struct *ndpi_str
 
 void init_activision_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Activision", ndpi_struct,
-    NDPI_PROTOCOL_ACTIVISION,
-    ndpi_search_activision,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("Activision", ndpi_struct,
+                     ndpi_search_activision,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_ACTIVISION);
 }

--- a/src/lib/protocols/afp.c
+++ b/src/lib/protocols/afp.c
@@ -58,7 +58,7 @@ static void ndpi_search_afp(struct ndpi_detection_module_struct *ndpi_struct, st
 	as they are not an indication that this flow is not AFP	
       */
       if(flow->packet_counter > 5)
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -72,17 +72,15 @@ static void ndpi_search_afp(struct ndpi_detection_module_struct *ndpi_struct, st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_afp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("AFP", ndpi_struct,
-				      NDPI_PROTOCOL_AFP,
-				      ndpi_search_afp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("AFP", ndpi_struct,
+                     ndpi_search_afp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_AFP);
 }
 

--- a/src/lib/protocols/ajp.c
+++ b/src/lib/protocols/ajp.c
@@ -72,7 +72,7 @@ static void ndpi_check_ajp(struct ndpi_detection_module_struct *ndpi_struct,
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 
   if (packet->payload_packet_len < sizeof(ajp_hdr)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -89,7 +89,7 @@ static void ndpi_check_ajp(struct ndpi_detection_module_struct *ndpi_struct,
 
     } else {
       NDPI_LOG_DBG(ndpi_struct, "Invalid AJP request type");
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     }
   } else if (ajp_hdr.len > 0 && ajp_hdr.magic == AJP_CONTAINER_TO_SERVER) {
     if (ajp_hdr.code == AJP_SEND_BODY_CHUNK || ajp_hdr.code == AJP_SEND_HEADERS
@@ -100,11 +100,11 @@ static void ndpi_check_ajp(struct ndpi_detection_module_struct *ndpi_struct,
 
     } else {
       NDPI_LOG_DBG(ndpi_struct, "Invalid AJP response type");
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     }
   } else {
     NDPI_LOG_DBG(ndpi_struct,"Invalid AJP packet\n");
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
@@ -122,9 +122,8 @@ static void ndpi_search_ajp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_ajp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("AJP", ndpi_struct,
-				      NDPI_PROTOCOL_AJP, ndpi_search_ajp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("AJP", ndpi_struct,
+                     ndpi_search_ajp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_AJP);
 }

--- a/src/lib/protocols/alicloud.c
+++ b/src/lib/protocols/alicloud.c
@@ -44,7 +44,7 @@ static void ndpi_search_alicloud(struct ndpi_detection_module_struct *ndpi_struc
 
   if (packet->payload_packet_len < 8)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -64,17 +64,14 @@ static void ndpi_search_alicloud(struct ndpi_detection_module_struct *ndpi_struc
 
   if (flow->packet_counter > 3)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 void init_alicloud_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("AliCloud", ndpi_struct,
-    NDPI_PROTOCOL_ALICLOUD,
-    ndpi_search_alicloud,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("AliCloud", ndpi_struct,
+                     ndpi_search_alicloud,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ALICLOUD);
 }

--- a/src/lib/protocols/amazon_video.c
+++ b/src/lib/protocols/amazon_video.c
@@ -54,7 +54,7 @@ static void ndpi_check_amazon_video(struct ndpi_detection_module_struct *ndpi_st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_amazon_video(struct ndpi_detection_module_struct *ndpi_struct,
@@ -66,10 +66,8 @@ static void ndpi_search_amazon_video(struct ndpi_detection_module_struct *ndpi_s
 
 
 void init_amazon_video_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("AMAZON_VIDEO", ndpi_struct,
-				      NDPI_PROTOCOL_AMAZON_VIDEO,
-				      ndpi_search_amazon_video,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("AMAZON_VIDEO", ndpi_struct,
+                     ndpi_search_amazon_video,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_AMAZON_VIDEO);
 }

--- a/src/lib/protocols/among_us.c
+++ b/src/lib/protocols/among_us.c
@@ -43,15 +43,15 @@ static void ndpi_search_among_us(struct ndpi_detection_module_struct *ndpi_struc
   {
     ndpi_int_among_us_add_connection(ndpi_struct, flow);
   } else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 void init_among_us_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection(
-    "AmongUs", ndpi_struct,
-    NDPI_PROTOCOL_AMONG_US, ndpi_search_among_us, NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN, ADD_TO_DETECTION_BITMASK);
+  register_dissector("AmongUs", ndpi_struct,
+                     ndpi_search_among_us,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_AMONG_US);
 }
 

--- a/src/lib/protocols/amqp.c
+++ b/src/lib/protocols/amqp.c
@@ -69,16 +69,14 @@ static void ndpi_search_amqp(struct ndpi_detection_module_struct *ndpi_struct, s
 		}
 
 	if(flow->packet_counter > 5)
-		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+		NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_amqp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-	ndpi_set_bitmask_protocol_detection("AMQP", ndpi_struct,
-					    NDPI_PROTOCOL_AMQP,
-					    ndpi_search_amqp,
-					    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-					    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-					    ADD_TO_DETECTION_BITMASK);
+  register_dissector("AMQP", ndpi_struct,
+                     ndpi_search_amqp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_AMQP);
 }
 

--- a/src/lib/protocols/apple_push.c
+++ b/src/lib/protocols/apple_push.c
@@ -83,7 +83,7 @@ static void ndpi_check_apple_push(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_apple_push(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -96,11 +96,9 @@ static void ndpi_search_apple_push(struct ndpi_detection_module_struct *ndpi_str
 
 void init_apple_push_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("APPLE_PUSH", ndpi_struct,
-				      NDPI_PROTOCOL_APPLE_PUSH,
-				      ndpi_search_apple_push,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("APPLE_PUSH", ndpi_struct,
+                     ndpi_search_apple_push,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_APPLE_PUSH);
 }
 

--- a/src/lib/protocols/armagetron.c
+++ b/src/lib/protocols/armagetron.c
@@ -66,17 +66,15 @@ static void ndpi_search_armagetron_udp(struct ndpi_detection_module_struct *ndpi
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 
 void init_armagetron_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Armagetron", ndpi_struct,
-				      NDPI_PROTOCOL_ARMAGETRON,
-				      ndpi_search_armagetron_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Armagetron", ndpi_struct,
+                     ndpi_search_armagetron_udp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_ARMAGETRON);
 }

--- a/src/lib/protocols/atg.c
+++ b/src/lib/protocols/atg.c
@@ -52,14 +52,12 @@ static void ndpi_search_atg(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_atg_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("ATG", ndpi_struct,
-				      NDPI_PROTOCOL_ATG,
-				      ndpi_search_atg,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("ATG", ndpi_struct,
+                     ndpi_search_atg,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ATG);
 }

--- a/src/lib/protocols/avast.c
+++ b/src/lib/protocols/avast.c
@@ -39,7 +39,7 @@ static void ndpi_search_avast(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < 6)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -50,16 +50,13 @@ static void ndpi_search_avast(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_avast_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("AVAST",
-                                      ndpi_struct,
-                                      NDPI_PROTOCOL_AVAST,
-                                      ndpi_search_avast,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("AVAST", ndpi_struct,
+                     ndpi_search_avast,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_AVAST);
 }

--- a/src/lib/protocols/avast_securedns.c
+++ b/src/lib/protocols/avast_securedns.c
@@ -41,7 +41,7 @@ static void ndpi_search_avast_securedns(struct ndpi_detection_module_struct *ndp
       ntohl(get_u_int32_t(packet->payload, 11)) != 0x00013209 ||
       flow->packet_counter > 1)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -51,16 +51,13 @@ static void ndpi_search_avast_securedns(struct ndpi_detection_module_struct *ndp
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_avast_securedns_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("AVAST SecureDNS",
-                                      ndpi_struct,
-                                      NDPI_PROTOCOL_AVAST_SECUREDNS,
-                                      ndpi_search_avast_securedns,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("AVAST SecureDNS", ndpi_struct,
+                     ndpi_search_avast_securedns,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_AVAST_SECUREDNS);
 }

--- a/src/lib/protocols/bacnet.c
+++ b/src/lib/protocols/bacnet.c
@@ -60,25 +60,25 @@ static void ndpi_search_bacnet(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < sizeof(*bvlc))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (bvlc->type != 0x81)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (bvlc->function > 0x0b)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (ntohs(bvlc->length) != packet->payload_packet_len)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -89,11 +89,8 @@ static void ndpi_search_bacnet(struct ndpi_detection_module_struct *ndpi_struct,
   
 void init_bacnet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("BACnet", ndpi_struct,
-                                      NDPI_PROTOCOL_BACNET,
-                                      ndpi_search_bacnet,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK
-                                     );
+  register_dissector("BACnet", ndpi_struct,
+                     ndpi_search_bacnet,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_BACNET);
 }

--- a/src/lib/protocols/beckhoff_ads.c
+++ b/src/lib/protocols/beckhoff_ads.c
@@ -109,15 +109,13 @@ static void ndpi_search_beckhoff_ads(struct ndpi_detection_module_struct *ndpi_s
   }
 
 not_beckhoff_ads:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_beckhoff_ads_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("BeckhoffADS", ndpi_struct,
-              NDPI_PROTOCOL_BECKHOFF_ADS,
-              ndpi_search_beckhoff_ads,
-              NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-              ADD_TO_DETECTION_BITMASK);
+  register_dissector("BeckhoffADS", ndpi_struct,
+                     ndpi_search_beckhoff_ads,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_BECKHOFF_ADS);
 }

--- a/src/lib/protocols/bfcp.c
+++ b/src/lib/protocols/bfcp.c
@@ -74,15 +74,13 @@ static void ndpi_search_bfcp(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
 not_bfcp:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_bfcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("BFCP", ndpi_struct,
-                                      NDPI_PROTOCOL_BFCP,
-                                      ndpi_search_bfcp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("BFCP", ndpi_struct,
+                     ndpi_search_bfcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_BFCP);
 }

--- a/src/lib/protocols/bfd.c
+++ b/src/lib/protocols/bfd.c
@@ -66,14 +66,12 @@ static void ndpi_search_bfd(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 void init_bfd_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("BFD", ndpi_struct,
-                                      NDPI_PROTOCOL_BFD,
-                                      ndpi_search_bfd,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("BFD", ndpi_struct,
+                     ndpi_search_bfd,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_BFD);
 }

--- a/src/lib/protocols/bgp.c
+++ b/src/lib/protocols/bgp.c
@@ -51,17 +51,15 @@ static void ndpi_search_bgp(struct ndpi_detection_module_struct *ndpi_struct, st
     } 
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_bgp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("BGP", ndpi_struct,
-				      NDPI_PROTOCOL_BGP,
-				      ndpi_search_bgp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("BGP", ndpi_struct,
+                     ndpi_search_bgp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_BGP);
 }
 

--- a/src/lib/protocols/bitcoin.c
+++ b/src/lib/protocols/bitcoin.c
@@ -52,18 +52,16 @@ static void ndpi_search_bitcoin(struct ndpi_detection_module_struct *ndpi_struct
       }
     }
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ************************************************************************** */
 
 void init_bitcoin_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Bitcoin", ndpi_struct,
-				      NDPI_PROTOCOL_BITCOIN,
-				      ndpi_search_bitcoin,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Bitcoin", ndpi_struct,
+                     ndpi_search_bitcoin,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_BITCOIN);
 }
 

--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -518,7 +518,7 @@ static void ndpi_skip_bittorrent(struct ndpi_detection_module_struct *ndpi_struc
   if(search_into_bittorrent_cache(ndpi_struct, flow))
     ndpi_add_connection_as_bittorrent(ndpi_struct, flow, -1, 0, NDPI_CONFIDENCE_DPI_CACHE);
   else
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ************************************* */
@@ -541,7 +541,7 @@ static void ndpi_search_bittorrent(struct ndpi_detection_module_struct *ndpi_str
       if(is_port(sport, dport, 3544) /* teredo */
 	 || is_port(sport, dport, 5246) || is_port(sport, dport, 5247) /* CAPWAP */) {
       exclude_bt:
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 	return;
       }
     }
@@ -655,10 +655,8 @@ static void ndpi_search_bittorrent(struct ndpi_detection_module_struct *ndpi_str
 
 void init_bittorrent_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("BitTorrent", ndpi_struct,
-				      NDPI_PROTOCOL_BITTORRENT,
-				      ndpi_search_bittorrent,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("BitTorrent", ndpi_struct,
+                     ndpi_search_bittorrent,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_BITTORRENT);
 }

--- a/src/lib/protocols/bjnp.c
+++ b/src/lib/protocols/bjnp.c
@@ -29,7 +29,7 @@ static void ndpi_check_bjnp(struct ndpi_detection_module_struct *ndpi_struct, st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_bjnp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -42,10 +42,8 @@ static void ndpi_search_bjnp(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_bjnp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("BJNP", ndpi_struct,
-				      NDPI_PROTOCOL_BJNP,
-				      ndpi_search_bjnp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("BJNP", ndpi_struct,
+                     ndpi_search_bjnp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_BJNP);
 }

--- a/src/lib/protocols/blizzard.c
+++ b/src/lib/protocols/blizzard.c
@@ -81,7 +81,7 @@ static void search_blizzard_tcp(struct ndpi_detection_module_struct* ndpi_struct
 
   /* TODO: other patterns */
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void search_blizzard_udp(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow)
@@ -131,7 +131,7 @@ static void search_blizzard_udp(struct ndpi_detection_module_struct* ndpi_struct
 
   /* TODO: other patterns */
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_blizzard(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow)
@@ -144,10 +144,9 @@ static void ndpi_search_blizzard(struct ndpi_detection_module_struct* ndpi_struc
 
 void init_blizzard_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Blizzard", ndpi_struct,
-				      NDPI_PROTOCOL_BLIZZARD, ndpi_search_blizzard,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Blizzard", ndpi_struct,
+                     ndpi_search_blizzard,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_BLIZZARD);
 }
 

--- a/src/lib/protocols/c1222.c
+++ b/src/lib/protocols/c1222.c
@@ -50,7 +50,7 @@ static void ndpi_search_c1222(struct ndpi_detection_module_struct *ndpi_struct,
   if ((packet->payload_packet_len < 50) || (packet->payload[0] != 0x60) ||
       ((u_int8_t)(packet->payload_packet_len-2) != packet->payload[1]))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -59,15 +59,13 @@ static void ndpi_search_c1222(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_c1222_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("ANSI_C1222", ndpi_struct,
-                                      NDPI_PROTOCOL_C1222,
-                                      ndpi_search_c1222,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("ANSI_C1222", ndpi_struct,
+                     ndpi_search_c1222,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_C1222);
 }

--- a/src/lib/protocols/can.c
+++ b/src/lib/protocols/can.c
@@ -54,13 +54,13 @@ static void ndpi_search_can(struct ndpi_detection_module_struct *ndpi_struct,
 
   u_int64_t const signature = 0x49534f3131383938; // "ISO11898"
   if (packet->payload_packet_len < sizeof(struct can_hdr)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   struct can_hdr const * const can_header = (struct can_hdr *)packet->payload;
   if (ndpi_ntohll(can_header->signature) != signature) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -73,10 +73,8 @@ static void ndpi_search_can(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_can_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Controller_Area_Network", ndpi_struct,
-                                      NDPI_PROTOCOL_CAN,
-                                      ndpi_search_can,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Controller_Area_Network", ndpi_struct,
+                     ndpi_search_can,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_CAN);
 }

--- a/src/lib/protocols/capwap.c
+++ b/src/lib/protocols/capwap.c
@@ -115,7 +115,7 @@ static void ndpi_search_setup_capwap(struct ndpi_detection_module_struct *ndpi_s
     }
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 
  capwap_found:
@@ -133,10 +133,8 @@ static void ndpi_search_capwap(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_capwap_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("CAPWAP", ndpi_struct,
-				      NDPI_PROTOCOL_CAPWAP,
-				      ndpi_search_capwap,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("CAPWAP", ndpi_struct,
+                     ndpi_search_capwap,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_CAPWAP);
 }

--- a/src/lib/protocols/cassandra.c
+++ b/src/lib/protocols/cassandra.c
@@ -71,12 +71,12 @@ static void ndpi_search_cassandra(struct ndpi_detection_module_struct *ndpi_stru
       (!ndpi_validate_cassandra_response(packet->payload[0]) ||
        !ndpi_validate_cassandra_request(packet->payload[0])))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
   
   if (flow->packet_direction_counter[packet->packet_direction] > 2) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
   
@@ -93,12 +93,8 @@ static void ndpi_search_cassandra(struct ndpi_detection_module_struct *ndpi_stru
 }
 
 void init_cassandra_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-
-  ndpi_set_bitmask_protocol_detection("Cassandra",
-                                      ndpi_struct,
-                                      NDPI_PROTOCOL_CASSANDRA,
-                                      ndpi_search_cassandra,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Cassandra", ndpi_struct,
+                     ndpi_search_cassandra,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_CASSANDRA);
 }

--- a/src/lib/protocols/ceph.c
+++ b/src/lib/protocols/ceph.c
@@ -48,15 +48,13 @@ static void ndpi_search_ceph(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_ceph_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Ceph", ndpi_struct,
-				      NDPI_PROTOCOL_CEPH,
-				      ndpi_search_ceph,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Ceph", ndpi_struct,
+                     ndpi_search_ceph,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_CEPH);
 }

--- a/src/lib/protocols/checkmk.c
+++ b/src/lib/protocols/checkmk.c
@@ -52,7 +52,7 @@ static void ndpi_search_checkmk(struct ndpi_detection_module_struct *ndpi_struct
 	as they are not an indication that this flow is not AFP
       */
       if(flow->packet_counter > 6)
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -69,16 +69,14 @@ static void ndpi_search_checkmk(struct ndpi_detection_module_struct *ndpi_struct
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_checkmk_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("CHECKMK", ndpi_struct,
-				      NDPI_PROTOCOL_CHECKMK,
-				      ndpi_search_checkmk,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("CHECKMK", ndpi_struct,
+                     ndpi_search_checkmk,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_CHECKMK);
 }

--- a/src/lib/protocols/cip.c
+++ b/src/lib/protocols/cip.c
@@ -59,15 +59,13 @@ static void ndpi_search_cip(struct ndpi_detection_module_struct *ndpi_struct,
     /* TODO add TCP dissection */
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_cip_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("CIP", ndpi_struct,
-				      NDPI_PROTOCOL_CIP,
-				      ndpi_search_cip,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("CIP", ndpi_struct,
+                     ndpi_search_cip,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_CIP);
 }

--- a/src/lib/protocols/ciscovpn.c
+++ b/src/lib/protocols/ciscovpn.c
@@ -59,18 +59,16 @@ static void ndpi_search_ciscovpn(struct ndpi_detection_module_struct *ndpi_struc
     }
     
     if(flow->num_processed_pkts > 5)
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);    
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);    
   } else
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);  
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);  
 }
 
 
 void init_ciscovpn_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("CiscoVPN", ndpi_struct,
-				      NDPI_PROTOCOL_CISCOVPN,
-				      ndpi_search_ciscovpn,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("CiscoVPN", ndpi_struct,
+                     ndpi_search_ciscovpn,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_CISCOVPN);
 }

--- a/src/lib/protocols/citrix.c
+++ b/src/lib/protocols/citrix.c
@@ -55,7 +55,7 @@ static void ndpi_check_citrix(struct ndpi_detection_module_struct *ndpi_struct, 
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_citrix(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -68,10 +68,8 @@ static void ndpi_search_citrix(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_citrix_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Citrix", ndpi_struct,
-				      NDPI_PROTOCOL_CITRIX,
-				      ndpi_search_citrix,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Citrix", ndpi_struct,
+                     ndpi_search_citrix,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_CITRIX);
 }

--- a/src/lib/protocols/cloudflare_warp.c
+++ b/src/lib/protocols/cloudflare_warp.c
@@ -79,16 +79,14 @@ static void ndpi_search_cloudflare_warp(struct ndpi_detection_module_struct *ndp
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_cloudflare_warp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("CloudflareWarp", ndpi_struct,
-                                      NDPI_PROTOCOL_CLOUDFLARE_WARP,
-                                      ndpi_search_cloudflare_warp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("CloudflareWarp", ndpi_struct,
+                     ndpi_search_cloudflare_warp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_CLOUDFLARE_WARP);
 }

--- a/src/lib/protocols/cnp-ip.c
+++ b/src/lib/protocols/cnp-ip.c
@@ -51,15 +51,13 @@ static void ndpi_search_cnp_ip(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_cnp_ip_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("CNP-IP", ndpi_struct,
-                                      NDPI_PROTOCOL_CNP_IP,
-                                      ndpi_search_cnp_ip,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("CNP-IP", ndpi_struct,
+                     ndpi_search_cnp_ip,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_CNP_IP);
 }

--- a/src/lib/protocols/coap.c
+++ b/src/lib/protocols/coap.c
@@ -119,7 +119,7 @@ static void ndpi_search_coap(struct ndpi_detection_module_struct *ndpi_struct,
 
     if((!isCoAPport(s_port) && !isCoAPport(d_port))
        || (packet->payload_packet_len < 4) ) {   // header too short
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -142,7 +142,7 @@ static void ndpi_search_coap(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 }
 
@@ -151,10 +151,9 @@ static void ndpi_search_coap(struct ndpi_detection_module_struct *ndpi_struct,
  */
 void init_coap_dissector (struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection ("COAP", ndpi_struct,
-				       NDPI_PROTOCOL_COAP,
-				       ndpi_search_coap,
-				       NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				       SAVE_DETECTION_BITMASK_AS_UNKNOWN, ADD_TO_DETECTION_BITMASK);
+  register_dissector("COAP", ndpi_struct,
+                     ndpi_search_coap,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_COAP);
 }
 

--- a/src/lib/protocols/cod_mobile.c
+++ b/src/lib/protocols/cod_mobile.c
@@ -66,16 +66,14 @@ static void ndpi_search_cod_mobile(struct ndpi_detection_module_struct *ndpi_str
   }
 
   if (flow->packet_counter >= 4) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 void init_cod_mobile_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("CoD_Mobile", ndpi_struct,
-                                      NDPI_PROTOCOL_COD_MOBILE,
-                                      ndpi_search_cod_mobile,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("CoD_Mobile", ndpi_struct,
+                     ndpi_search_cod_mobile,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_COD_MOBILE);
 }

--- a/src/lib/protocols/collectd.c
+++ b/src/lib/protocols/collectd.c
@@ -169,7 +169,7 @@ static void ndpi_search_collectd(struct ndpi_detection_module_struct *ndpi_struc
             block_length < COLLECTD_ENCR_AES256_MIN_BLOCK_SIZE ||
             ndpi_int_collectd_dissect_username(flow, packet) != 0)
         {
-          NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+          NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         } else {
           ndpi_int_collectd_add_connection(ndpi_struct, flow);
         }
@@ -180,7 +180,7 @@ static void ndpi_search_collectd(struct ndpi_detection_module_struct *ndpi_struc
 
   if (num_blocks < COLLECTD_MIN_BLOCKS_REQUIRED)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -192,11 +192,8 @@ static void ndpi_search_collectd(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_collectd_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("collectd", ndpi_struct,
-    NDPI_PROTOCOL_COLLECTD,
-    ndpi_search_collectd,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("collectd", ndpi_struct,
+                     ndpi_search_collectd,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_COLLECTD);
 }

--- a/src/lib/protocols/corba.c
+++ b/src/lib/protocols/corba.c
@@ -55,16 +55,14 @@ static void ndpi_search_corba(struct ndpi_detection_module_struct *ndpi_struct, 
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_corba_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Corba", ndpi_struct,
-				      NDPI_PROTOCOL_CORBA,
-				      ndpi_search_corba,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Corba", ndpi_struct,
+                     ndpi_search_corba,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_CORBA);
 }

--- a/src/lib/protocols/cpha.c
+++ b/src/lib/protocols/cpha.c
@@ -48,15 +48,13 @@ static void ndpi_search_cpha(struct ndpi_detection_module_struct *ndpi_struct, s
      ) {
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_CPHA, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
   } else
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);      
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);      
 }
 
 
 void init_cpha_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("CPHA", ndpi_struct,
-				      NDPI_PROTOCOL_CPHA,
-				      ndpi_search_cpha,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* TODO: ipv6 support? */
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("CPHA", ndpi_struct,
+                     ndpi_search_cpha,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* TODO: ipv6 support? */
+                     1, NDPI_PROTOCOL_CPHA);
 }

--- a/src/lib/protocols/crossfire.c
+++ b/src/lib/protocols/crossfire.c
@@ -64,16 +64,14 @@ static void ndpi_search_crossfire_tcp_udp(struct ndpi_detection_module_struct *n
     /* TODO: add more CrossFire TCP signatures*/
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_crossfire_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Crossfire", ndpi_struct,
-				      NDPI_PROTOCOL_CROSSFIRE,
-				      ndpi_search_crossfire_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Crossfire", ndpi_struct,
+                     ndpi_search_crossfire_tcp_udp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_CROSSFIRE);
 }

--- a/src/lib/protocols/crynet.c
+++ b/src/lib/protocols/crynet.c
@@ -45,13 +45,13 @@ static void ndpi_search_crynet(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < 26)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (packet->payload_packet_len != packet->payload[0] + 10)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -60,7 +60,7 @@ static void ndpi_search_crynet(struct ndpi_detection_module_struct *ndpi_struct,
       packet->payload[20] != 0x07 ||
       ntohs(get_u_int16_t(packet->payload, 24)) != 0x0307)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -69,11 +69,8 @@ static void ndpi_search_crynet(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_crynet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("CryNetwork", ndpi_struct,
-    NDPI_PROTOCOL_CRYNET,
-    ndpi_search_crynet,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("CryNetwork", ndpi_struct,
+                     ndpi_search_crynet,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_CRYNET);
 }

--- a/src/lib/protocols/dcerpc.c
+++ b/src/lib/protocols/dcerpc.c
@@ -90,16 +90,14 @@ static void ndpi_search_dcerpc(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
   if(packet->payload_packet_len>1)
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_dcerpc_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("DCERPC", ndpi_struct,
-				      NDPI_PROTOCOL_DCERPC,
-				      ndpi_search_dcerpc,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("DCERPC", ndpi_struct,
+                     ndpi_search_dcerpc,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_DCERPC);
 }

--- a/src/lib/protocols/dhcp.c
+++ b/src/lib/protocols/dhcp.c
@@ -127,7 +127,7 @@ static void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struc
 #ifdef DHCP_DEBUG
         NDPI_LOG_DBG2(ndpi_struct, "[DHCP] Invalid message type %d. Not dhcp\n", msg_type);
 #endif
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
       }
 
@@ -194,16 +194,14 @@ static void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struc
         }
       }
     } else
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 
 void init_dhcp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("DHCP", ndpi_struct,
-				      NDPI_PROTOCOL_DHCP,
-				      ndpi_search_dhcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("DHCP", ndpi_struct,
+                     ndpi_search_dhcp_udp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_DHCP);
 }

--- a/src/lib/protocols/dhcpv6.c
+++ b/src/lib/protocols/dhcpv6.c
@@ -53,16 +53,14 @@ static void ndpi_search_dhcpv6_udp(struct ndpi_detection_module_struct *ndpi_str
 		return;
 	}
 
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_dhcpv6_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("DHCPV6", ndpi_struct,
-				      NDPI_PROTOCOL_DHCPV6,
-				      ndpi_search_dhcpv6_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("DHCPV6", ndpi_struct,
+                     ndpi_search_dhcpv6_udp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_DHCPV6);
 }

--- a/src/lib/protocols/diameter.c
+++ b/src/lib/protocols/diameter.c
@@ -101,15 +101,15 @@ static void ndpi_search_diameter(struct ndpi_detection_module_struct *ndpi_struc
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_diameter_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Diameter", ndpi_struct,
-				      NDPI_PROTOCOL_DIAMETER, ndpi_search_diameter,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN, ADD_TO_DETECTION_BITMASK);
+  register_dissector("Diameter", ndpi_struct,
+                     ndpi_search_diameter,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_DIAMETER);
 }
 

--- a/src/lib/protocols/dicom.c
+++ b/src/lib/protocols/dicom.c
@@ -51,17 +51,16 @@ static void ndpi_search_dicom(struct ndpi_detection_module_struct *ndpi_struct,
 				 NDPI_PROTOCOL_DICOM,
 				 NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
     } else
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   } else
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ********************************* */
 
 void init_dicom_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("DICOM", ndpi_struct,
-				      NDPI_PROTOCOL_DICOM, ndpi_search_dicom,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("DICOM", ndpi_struct,
+                     ndpi_search_dicom,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_DICOM);
 }

--- a/src/lib/protocols/dingtalk.c
+++ b/src/lib/protocols/dingtalk.c
@@ -48,15 +48,13 @@ static void ndpi_search_dingtalk(struct ndpi_detection_module_struct *ndpi_struc
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_dingtalk_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("DingTalk", ndpi_struct,
-				      NDPI_PROTOCOL_DINGTALK,
-				      ndpi_search_dingtalk,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("DingTalk", ndpi_struct,
+                     ndpi_search_dingtalk,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_DINGTALK);
 }

--- a/src/lib/protocols/discord.c
+++ b/src/lib/protocols/discord.c
@@ -72,16 +72,13 @@ static void ndpi_search_discord(struct ndpi_detection_module_struct *ndpi_struct
   }
 
   if (flow->packet_counter >= 5)
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_discord_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Discord", ndpi_struct,
-    NDPI_PROTOCOL_DISCORD,
-    ndpi_search_discord,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("Discord", ndpi_struct,
+                     ndpi_search_discord,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_DISCORD);
 }

--- a/src/lib/protocols/dlep.c
+++ b/src/lib/protocols/dlep.c
@@ -67,15 +67,13 @@ static void ndpi_search_dlep(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_dlep_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("DLEP", ndpi_struct,
-                                      NDPI_PROTOCOL_DLEP,
-                                      ndpi_search_dlep,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("DLEP", ndpi_struct,
+                     ndpi_search_dlep,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_DLEP);
 }

--- a/src/lib/protocols/dnp3.c
+++ b/src/lib/protocols/dnp3.c
@@ -49,18 +49,16 @@ static void ndpi_search_dnp3_tcp(struct ndpi_detection_module_struct *ndpi_struc
       return;
     }
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
    
 }
 
 /* ******************************************************** */
 
 void init_dnp3_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-	
-  ndpi_set_bitmask_protocol_detection("DNP3", ndpi_struct,
-				      NDPI_PROTOCOL_DNP3,
-				      ndpi_search_dnp3_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+
+  register_dissector("DNP3", ndpi_struct,
+                     ndpi_search_dnp3_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_DNP3);
 }

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -802,7 +802,7 @@ static void search_dns(struct ndpi_detection_module_struct *ndpi_struct, struct 
     printf("[DNS] invalid packet\n");
 #endif
     if(flow->extra_packets_func == NULL) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     } else {
       ndpi_set_risk(ndpi_struct, flow, NDPI_MALFORMED_PACKET, "Invalid DNS Header");
     }
@@ -955,7 +955,7 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
           ntohs(get_u_int16_t(packet->payload, 2)) != 0 &&
           ntohs(get_u_int16_t(packet->payload, 4)) != 0)
       {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
       }
     }
@@ -969,7 +969,7 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
   if(!(s_port == DNS_PORT || d_port == DNS_PORT ||
        s_port == MDNS_PORT || d_port == MDNS_PORT ||
        d_port == LLMNR_PORT)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -979,7 +979,7 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
      we must be able to detect these protocols on the first packet
   */
   if(packet->payload_packet_len < sizeof(struct ndpi_dns_packet_header) + payload_offset) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -989,10 +989,8 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
 /* *********************************************** */
 
 void init_dns_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("DNS", ndpi_struct,
-				      NDPI_PROTOCOL_DNS,
-				      ndpi_search_dns,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("DNS", ndpi_struct,
+                     ndpi_search_dns,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_DNS);
 }

--- a/src/lib/protocols/dnscrypt.c
+++ b/src/lib/protocols/dnscrypt.c
@@ -62,16 +62,16 @@ static void ndpi_search_dnscrypt(struct ndpi_detection_module_struct *ndpi_struc
      * Wait for at least one packet per direction, up to a max
      * Required as we need to wait for the server response which contains the ASCII pattern below.
      */
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 }
 
 void init_dnscrypt_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection(
-    "DNScrypt", ndpi_struct,
-    NDPI_PROTOCOL_DNSCRYPT, ndpi_search_dnscrypt, NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN, ADD_TO_DETECTION_BITMASK);
+  register_dissector("DNScrypt", ndpi_struct,
+                     ndpi_search_dnscrypt,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_DNSCRYPT);
 }
 

--- a/src/lib/protocols/dofus.c
+++ b/src/lib/protocols/dofus.c
@@ -129,7 +129,7 @@ static void ndpi_search_dofus(struct ndpi_detection_module_struct *ndpi_struct, 
     }
   }
 exclude:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 
 maybe_dofus:
@@ -141,11 +141,9 @@ maybe_dofus:
 
 void init_dofus_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Dofus", ndpi_struct,
-				      NDPI_PROTOCOL_DOFUS,
-				      ndpi_search_dofus,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Dofus", ndpi_struct,
+                     ndpi_search_dofus,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_DOFUS);
 }
 

--- a/src/lib/protocols/drda.c
+++ b/src/lib/protocols/drda.c
@@ -83,7 +83,7 @@ static void ndpi_search_drda(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
  no_drda:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
@@ -92,10 +92,8 @@ static void ndpi_search_drda(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_drda_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("DRDA", ndpi_struct,
-				      NDPI_PROTOCOL_DRDA,
-				      ndpi_search_drda,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("DRDA", ndpi_struct,
+                     ndpi_search_drda,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_DRDA);
 }

--- a/src/lib/protocols/dropbox.c
+++ b/src/lib/protocols/dropbox.c
@@ -63,7 +63,7 @@ static void ndpi_check_dropbox(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_dropbox(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -76,10 +76,8 @@ static void ndpi_search_dropbox(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_dropbox_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("DROPBOX", ndpi_struct,
-				      NDPI_PROTOCOL_DROPBOX,
-				      ndpi_search_dropbox,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("DROPBOX", ndpi_struct,
+                     ndpi_search_dropbox,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_DROPBOX);
 }

--- a/src/lib/protocols/eaq.c
+++ b/src/lib/protocols/eaq.c
@@ -74,17 +74,15 @@ static void ndpi_search_eaq(struct ndpi_detection_module_struct *ndpi_struct, st
 
   } while(0);
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 
 }
 
 
 void init_eaq_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("EAQ", ndpi_struct,
-				      NDPI_PROTOCOL_EAQ,
-				      ndpi_search_eaq,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("EAQ", ndpi_struct,
+                     ndpi_search_eaq,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_EAQ);
 }

--- a/src/lib/protocols/edonkey.c
+++ b/src/lib/protocols/edonkey.c
@@ -44,7 +44,7 @@ static void ndpi_search_edonkey(struct ndpi_detection_module_struct *ndpi_struct
     protocol = packet->payload[0];
     /* 0xE3: Edonkey, 0xC5: eMule extensions, 0xD4: eMule compressed */
     if(protocol != 0xE3 && protocol != 0xC5 && protocol != 0xD4) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
     message_length = packet->payload_packet_len - 5;
@@ -54,17 +54,15 @@ static void ndpi_search_edonkey(struct ndpi_detection_module_struct *ndpi_struct
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_edonkey_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("eDonkey", ndpi_struct,
-				      NDPI_PROTOCOL_EDONKEY,
-				      ndpi_search_edonkey,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("eDonkey", ndpi_struct,
+                     ndpi_search_edonkey,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_EDONKEY);
 }
 

--- a/src/lib/protocols/egd.c
+++ b/src/lib/protocols/egd.c
@@ -49,15 +49,13 @@ static void ndpi_search_egd(struct ndpi_detection_module_struct *ndpi_struct, st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_egd_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("EthernetGlobalData", ndpi_struct,
-                                      NDPI_PROTOCOL_EGD,
-                                      ndpi_search_egd,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("EthernetGlobalData", ndpi_struct,
+                     ndpi_search_egd,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_EGD);
 }

--- a/src/lib/protocols/elastic_search.c
+++ b/src/lib/protocols/elastic_search.c
@@ -49,20 +49,20 @@ static void ndpi_search_elasticsearch(struct ndpi_detection_module_struct *ndpi_
 
   if (packet->payload_packet_len < 6)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (ntohs(get_u_int16_t(packet->payload, 0)) != 0x4553 /* "ES" */)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   message_length = ntohl(get_u_int32_t(packet->payload, 2));
   if (packet->payload_packet_len < message_length + 6)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -73,11 +73,8 @@ static void ndpi_search_elasticsearch(struct ndpi_detection_module_struct *ndpi_
   
 void init_elasticsearch_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Elasticsearch", ndpi_struct,
-                                      NDPI_PROTOCOL_ELASTICSEARCH,
-                                      ndpi_search_elasticsearch,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK
-                                     );
+  register_dissector("Elasticsearch", ndpi_struct,
+                     ndpi_search_elasticsearch,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ELASTICSEARCH);
 }

--- a/src/lib/protocols/epicgames.c
+++ b/src/lib/protocols/epicgames.c
@@ -54,7 +54,7 @@ static void ndpi_search_epicgames(struct ndpi_detection_module_struct *ndpi_stru
       flow->l4.udp.epicgames_word = ntohl(get_u_int32_t(packet->payload, 0));
       return;
     } else {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   } else if(flow->l4.udp.epicgames_stage == 2 - packet->packet_direction) {
@@ -63,23 +63,21 @@ static void ndpi_search_epicgames(struct ndpi_detection_module_struct *ndpi_stru
       ndpi_int_epicgames_add_connection(ndpi_struct, flow);
       return;
     } else {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
 
   if(flow->packet_counter >= 4) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 }
 
 void init_epicgames_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("EpicGames", ndpi_struct,
-                                      NDPI_PROTOCOL_EPICGAMES,
-                                      ndpi_search_epicgames,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("EpicGames", ndpi_struct,
+                     ndpi_search_epicgames,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_EPICGAMES);
 }

--- a/src/lib/protocols/ethereum.c
+++ b/src/lib/protocols/ethereum.c
@@ -86,7 +86,7 @@ static void ndpi_search_ethereum_udp(struct ndpi_detection_module_struct *ndpi_s
       return;
     }
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ************************************************************************** */
@@ -132,7 +132,7 @@ static void ndpi_search_ethereum_tcp(struct ndpi_detection_module_struct *ndpi_s
     } 
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ************************************************************************** */
@@ -151,11 +151,9 @@ static void ndpi_search_ethereum(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_ethereum_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Ethereum", ndpi_struct,
-				      NDPI_PROTOCOL_ETHEREUM,
-				      ndpi_search_ethereum,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Ethereum", ndpi_struct,
+                     ndpi_search_ethereum,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ETHEREUM);
 }
 

--- a/src/lib/protocols/ethernet_ip.c
+++ b/src/lib/protocols/ethernet_ip.c
@@ -56,15 +56,13 @@ static void ndpi_search_ethernet_ip(struct ndpi_detection_module_struct *ndpi_st
     }
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow); /* No luck this time */
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow); /* No luck this time */
 }
   
 
 void init_ethernet_ip_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("EthernetIP", ndpi_struct,
-				      NDPI_PROTOCOL_ETHERNET_IP,
-				      ndpi_search_ethernet_ip,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("EthernetIP", ndpi_struct,
+                     ndpi_search_ethernet_ip,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ETHERNET_IP);
 }

--- a/src/lib/protocols/ethersbus.c
+++ b/src/lib/protocols/ethersbus.c
@@ -57,15 +57,13 @@ static void ndpi_search_ethersbus(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_ethersbus_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Ether-S-Bus", ndpi_struct,
-                                      NDPI_PROTOCOL_ETHERSBUS,
-                                      ndpi_search_ethersbus,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Ether-S-Bus", ndpi_struct,
+                     ndpi_search_ethersbus,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_ETHERSBUS);
 }

--- a/src/lib/protocols/ethersio.c
+++ b/src/lib/protocols/ethersio.c
@@ -54,14 +54,12 @@ static void ndpi_search_ethersio(struct ndpi_detection_module_struct *ndpi_struc
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 void init_ethersio_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("EtherSIO", ndpi_struct,
-                                      NDPI_PROTOCOL_ETHERSIO,
-                                      ndpi_search_ethersio,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("EtherSIO", ndpi_struct,
+                     ndpi_search_ethersio,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_ETHERSIO);
 }

--- a/src/lib/protocols/fastcgi.c
+++ b/src/lib/protocols/fastcgi.c
@@ -160,7 +160,7 @@ static void ndpi_search_fastcgi(struct ndpi_detection_module_struct *ndpi_struct
 
   if (packet->payload_packet_len < sizeof(struct FCGI_Header))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -168,21 +168,21 @@ static void ndpi_search_fastcgi(struct ndpi_detection_module_struct *ndpi_struct
 
   if (fcgi_hdr->version != 0x01)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   fcgi_type = (enum FCGI_Type)fcgi_hdr->type;
   if (fcgi_type < FCGI_MIN || fcgi_type > FCGI_MAX)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   content_len = ntohs(fcgi_hdr->contentLength);
   if (packet->payload_packet_len != sizeof(*fcgi_hdr) + content_len + fcgi_hdr->paddingLength)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -237,11 +237,8 @@ static int ndpi_search_fastcgi_extra(struct ndpi_detection_module_struct * ndpi_
 
 void init_fastcgi_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("FastCGI", ndpi_struct,
-    NDPI_PROTOCOL_FASTCGI,
-    ndpi_search_fastcgi,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("FastCGI", ndpi_struct,
+                     ndpi_search_fastcgi,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_FASTCGI);
 }

--- a/src/lib/protocols/fins.c
+++ b/src/lib/protocols/fins.c
@@ -106,16 +106,13 @@ static void ndpi_search_fins(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
 not_fins:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_fins_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("FINS", ndpi_struct,
-                                      NDPI_PROTOCOL_FINS,
-                                      ndpi_search_fins,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK
-                                     );
+  register_dissector("FINS", ndpi_struct,
+                     ndpi_search_fins,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_FINS);
 }

--- a/src/lib/protocols/fix.c
+++ b/src/lib/protocols/fix.c
@@ -59,16 +59,14 @@ static void ndpi_search_fix(struct ndpi_detection_module_struct *ndpi_struct, st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_fix_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("FIX", ndpi_struct,
-				      NDPI_PROTOCOL_FIX,
-				      ndpi_search_fix,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("FIX", ndpi_struct,
+                     ndpi_search_fix,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_FIX);
 }

--- a/src/lib/protocols/flute.c
+++ b/src/lib/protocols/flute.c
@@ -59,15 +59,13 @@ static void ndpi_search_flute(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
 not_flute:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_flute_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("FLUTE", ndpi_struct,
-                                      NDPI_PROTOCOL_FLUTE,
-                                      ndpi_search_flute,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("FLUTE", ndpi_struct,
+                     ndpi_search_flute,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_FLUTE);
 }

--- a/src/lib/protocols/ftp_control.c
+++ b/src/lib/protocols/ftp_control.c
@@ -589,13 +589,13 @@ static void ndpi_check_ftp_control(struct ndpi_detection_module_struct *ndpi_str
     
   /* Exclude SMTP, which uses similar commands. */
   if(packet->tcp->dest == twentyfive || packet->tcp->source == twentyfive) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   /* Break after 8 packets. */
   if(flow->packet_counter > 8) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -671,10 +671,8 @@ static void ndpi_search_ftp_control(struct ndpi_detection_module_struct *ndpi_st
 /* *************************************************************** */
 
 void init_ftp_control_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("FTP_CONTROL", ndpi_struct,
-				      NDPI_PROTOCOL_FTP_CONTROL,
-				      ndpi_search_ftp_control,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("FTP_CONTROL", ndpi_struct,
+                     ndpi_search_ftp_control,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_FTP_CONTROL);
 }

--- a/src/lib/protocols/ftp_data.c
+++ b/src/lib/protocols/ftp_data.c
@@ -238,7 +238,7 @@ static void ndpi_check_ftp_data(struct ndpi_detection_module_struct *ndpi_struct
     }
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_ftp_data(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow) {
@@ -250,10 +250,8 @@ static void ndpi_search_ftp_data(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_ftp_data_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("FTP_DATA", ndpi_struct,
-				      NDPI_PROTOCOL_FTP_DATA,
-				      ndpi_search_ftp_data,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("FTP_DATA", ndpi_struct,
+                     ndpi_search_ftp_data,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_FTP_DATA);
 }

--- a/src/lib/protocols/gaijin_entertainment.c
+++ b/src/lib/protocols/gaijin_entertainment.c
@@ -63,15 +63,13 @@ static void ndpi_search_gaijin(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_gaijin_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("GaijinEntertainment", ndpi_struct,
-                                      NDPI_PROTOCOL_GAIJIN,
-                                      ndpi_search_gaijin,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("GaijinEntertainment", ndpi_struct,
+                     ndpi_search_gaijin,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_GAIJIN);
 }

--- a/src/lib/protocols/gearman.c
+++ b/src/lib/protocols/gearman.c
@@ -47,15 +47,13 @@ static void ndpi_search_gearman(struct ndpi_detection_module_struct *ndpi_struct
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_gearman_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Gearman", ndpi_struct,
-				      NDPI_PROTOCOL_GEARMAN,
-				      ndpi_search_gearman,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Gearman", ndpi_struct,
+                     ndpi_search_gearman,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_GEARMAN);
 }

--- a/src/lib/protocols/gearup_booster.c
+++ b/src/lib/protocols/gearup_booster.c
@@ -44,7 +44,7 @@ static void ndpi_search_gearup_booster(struct ndpi_detection_module_struct *ndpi
 
   if (packet->udp->source != htons(9999) && packet->udp->dest != htons(9999))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -52,7 +52,7 @@ static void ndpi_search_gearup_booster(struct ndpi_detection_module_struct *ndpi
   {
     if (packet->packet_direction != 0 || packet->udp->dest != htons(9999))
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
@@ -62,7 +62,7 @@ static void ndpi_search_gearup_booster(struct ndpi_detection_module_struct *ndpi
     // mobile version
     if (ntohl(get_u_int32_t(packet->payload, 0)) == 0x00000000)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   } else if (packet->payload_packet_len == 8)
@@ -71,11 +71,11 @@ static void ndpi_search_gearup_booster(struct ndpi_detection_module_struct *ndpi
     if (ntohl(get_u_int32_t(packet->payload, 0)) == 0x00000000 ||
         packet->payload[7] != 0x00 || packet->payload[6] != 0x00 || packet->payload[5] != 0x00)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   } else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -84,11 +84,9 @@ static void ndpi_search_gearup_booster(struct ndpi_detection_module_struct *ndpi
 
 void init_gearup_booster_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("GeaUP_Booster", ndpi_struct,
-				      NDPI_PROTOCOL_GEARUP_BOOSTER,
-				      ndpi_search_gearup_booster,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("GeaUP_Booster", ndpi_struct,
+                     ndpi_search_gearup_booster,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_GEARUP_BOOSTER);
 }
 

--- a/src/lib/protocols/genshin_impact.c
+++ b/src/lib/protocols/genshin_impact.c
@@ -67,7 +67,7 @@ static void ndpi_search_genshin_impact(struct ndpi_detection_module_struct *ndpi
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
@@ -75,11 +75,8 @@ static void ndpi_search_genshin_impact(struct ndpi_detection_module_struct *ndpi
 
 void init_genshin_impact_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("GenshinImpact",
-                                      ndpi_struct,
-                                      NDPI_PROTOCOL_GENSHIN_IMPACT,
-                                      ndpi_search_genshin_impact,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("GenshinImpact", ndpi_struct,
+                     ndpi_search_genshin_impact,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_GENSHIN_IMPACT);
 }

--- a/src/lib/protocols/git.c
+++ b/src/lib/protocols/git.c
@@ -68,7 +68,7 @@ static void ndpi_search_git(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
@@ -76,10 +76,8 @@ static void ndpi_search_git(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_git_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Git", ndpi_struct,
-				      NDPI_PROTOCOL_GIT,
-				      ndpi_search_git,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Git", ndpi_struct,
+                     ndpi_search_git,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_GIT);
 }

--- a/src/lib/protocols/gnutella.c
+++ b/src/lib/protocols/gnutella.c
@@ -76,17 +76,15 @@ static void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struc
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_gnutella_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Gnutella", ndpi_struct,
-				      NDPI_PROTOCOL_GNUTELLA,
-				      ndpi_search_gnutella,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Gnutella", ndpi_struct,
+                     ndpi_search_gnutella,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_GNUTELLA);
 }
 

--- a/src/lib/protocols/gtp.c
+++ b/src/lib/protocols/gtp.c
@@ -115,7 +115,7 @@ static void ndpi_check_gtp(struct ndpi_detection_module_struct *ndpi_struct, str
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 }
 
@@ -129,10 +129,8 @@ static void ndpi_search_gtp(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_gtp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("GTP", ndpi_struct,
-				      NDPI_PROTOCOL_GTP,
-				      ndpi_search_gtp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("GTP", ndpi_struct,
+                     ndpi_search_gtp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_GTP);
 }

--- a/src/lib/protocols/guildwars2.c
+++ b/src/lib/protocols/guildwars2.c
@@ -49,16 +49,14 @@ static void ndpi_search_guildwars2_tcp(struct ndpi_detection_module_struct *ndpi
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_guildwars2_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("GuildWars2", ndpi_struct,
-				      NDPI_PROTOCOL_GUILDWARS2,
-				      ndpi_search_guildwars2_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("GuildWars2", ndpi_struct,
+                     ndpi_search_guildwars2_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_GUILDWARS2);
 }

--- a/src/lib/protocols/h323.c
+++ b/src/lib/protocols/h323.c
@@ -68,15 +68,13 @@ static void ndpi_search_h323(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_h323_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("H323", ndpi_struct,
-      NDPI_PROTOCOL_H323,
-      ndpi_search_h323,
-      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-      ADD_TO_DETECTION_BITMASK);
+  register_dissector("H323", ndpi_struct,
+                     ndpi_search_h323,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_H323);
 }

--- a/src/lib/protocols/haproxy.c
+++ b/src/lib/protocols/haproxy.c
@@ -39,13 +39,13 @@ static void ndpi_search_haproxy(struct ndpi_detection_module_struct *ndpi_struct
 
   if (packet->payload_packet_len < NDPI_STATICSTRING_LEN("PROXY TCP"))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (strncmp((char *)packet->payload, "PROXY TCP", NDPI_STATICSTRING_LEN("PROXY TCP")) != 0)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -53,13 +53,13 @@ static void ndpi_search_haproxy(struct ndpi_detection_module_struct *ndpi_struct
   haproxy_end = (uint8_t *)ndpi_strnstr((char *)packet->payload, "\r\n", packet->payload_packet_len);
   if (haproxy_end == NULL)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
   haproxy_end += 2;
   if (packet->payload_packet_len - (haproxy_end - packet->payload) == 0)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -68,10 +68,8 @@ static void ndpi_search_haproxy(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_haproxy_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("HAProxy", ndpi_struct,
-                                      NDPI_PROTOCOL_HAPROXY,
-                                      ndpi_search_haproxy,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("HAProxy", ndpi_struct,
+                     ndpi_search_haproxy,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_HAPROXY);
 }

--- a/src/lib/protocols/hart-ip.c
+++ b/src/lib/protocols/hart-ip.c
@@ -97,15 +97,13 @@ static void ndpi_search_hart_ip(struct ndpi_detection_module_struct *ndpi_struct
   }
   
 not_hart_ip:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_hart_ip_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("HART-IP", ndpi_struct,
-                                      NDPI_PROTOCOL_HART_IP,
-                                      ndpi_search_hart_ip,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("HART-IP", ndpi_struct,
+                     ndpi_search_hart_ip,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_HART_IP);
 }

--- a/src/lib/protocols/hcl_notes.c
+++ b/src/lib/protocols/hcl_notes.c
@@ -49,7 +49,7 @@ static void ndpi_check_hcl_notes(struct ndpi_detection_module_struct *ndpi_struc
 
   } else if(flow->l4.tcp.hcl_notes_packet_id <= 3) return;
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_hcl_notes(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -62,11 +62,9 @@ static void ndpi_search_hcl_notes(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_hcl_notes_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("HCL_Notes", ndpi_struct,
-				      NDPI_PROTOCOL_HCL_NOTES,
-				      ndpi_search_hcl_notes,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("HCL_Notes", ndpi_struct,
+                     ndpi_search_hcl_notes,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_HCL_NOTES);
 }
 

--- a/src/lib/protocols/hislip.c
+++ b/src/lib/protocols/hislip.c
@@ -56,15 +56,13 @@ static void ndpi_search_hislip(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_hislip_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("HiSLIP", ndpi_struct,
-              NDPI_PROTOCOL_HISLIP,
-              ndpi_search_hislip,
-              NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-              ADD_TO_DETECTION_BITMASK);
+  register_dissector("HiSLIP", ndpi_struct,
+                     ndpi_search_hislip,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_HISLIP);
 }

--- a/src/lib/protocols/hl7.c
+++ b/src/lib/protocols/hl7.c
@@ -66,15 +66,13 @@ static void ndpi_search_hl7(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_hl7_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("HL7", ndpi_struct,
-              NDPI_PROTOCOL_HL7,
-              ndpi_search_hl7,
-              NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-              ADD_TO_DETECTION_BITMASK);
+  register_dissector("HL7", ndpi_struct,
+                     ndpi_search_hl7,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_HL7);
 }

--- a/src/lib/protocols/hots.c
+++ b/src/lib/protocols/hots.c
@@ -60,16 +60,14 @@ void ndpi_search_hots(struct ndpi_detection_module_struct *ndpi_struct, struct n
       break;
     }
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_hots_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("HOTS", ndpi_struct,
-				      NDPI_PROTOCOL_HOTS,
-				      ndpi_search_hots,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* Only IPv4 UDP traffic is expected. */
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("HOTS", ndpi_struct,
+                     ndpi_search_hots,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* Only IPv4 UDP traffic is expected. */
+                     1, NDPI_PROTOCOL_HOTS);
 }

--- a/src/lib/protocols/hpvirtgrp.c
+++ b/src/lib/protocols/hpvirtgrp.c
@@ -51,7 +51,7 @@ static void ndpi_search_hpvirtgrp(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
@@ -59,11 +59,8 @@ static void ndpi_search_hpvirtgrp(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_hpvirtgrp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("HP Virtual Machine Group Management",
-                                      ndpi_struct,
-                                      NDPI_PROTOCOL_HPVIRTGRP,
-                                      ndpi_search_hpvirtgrp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("HP Virtual Machine Group Management", ndpi_struct,
+                     ndpi_search_hpvirtgrp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_HPVIRTGRP);
 }

--- a/src/lib/protocols/hsrp.c
+++ b/src/lib/protocols/hsrp.c
@@ -77,15 +77,13 @@ static void ndpi_search_hsrp(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_hsrp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("HSRP", ndpi_struct,
-				      NDPI_PROTOCOL_HSRP,
-				      ndpi_search_hsrp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("HSRP", ndpi_struct,
+                     ndpi_search_hsrp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_HSRP);
 }

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -1689,7 +1689,7 @@ static void ndpi_check_http_tcp(struct ndpi_detection_module_struct *ndpi_struct
       }
       /* The first pkt is neither a request nor a response -> no http */
       NDPI_LOG_DBG2(ndpi_struct, "Neither req nor response -> exclude\n");
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
     NDPI_LOG_DBG2(ndpi_struct, "Request where expected\n");
@@ -1767,7 +1767,7 @@ static void ndpi_search_http_tcp(struct ndpi_detection_module_struct *ndpi_struc
 				 struct ndpi_flow_struct *flow) {
   /* Break after 20 packets. */
   if(flow->packet_counter > 20) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -1823,10 +1823,8 @@ char* ndpi_get_http_content_type(struct ndpi_flow_struct *flow) {
 
 
 void init_http_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("HTTP",ndpi_struct,
-				      NDPI_PROTOCOL_HTTP,
-				      ndpi_search_http_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("HTTP", ndpi_struct,
+                     ndpi_search_http_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_HTTP);
 }

--- a/src/lib/protocols/http2.c
+++ b/src/lib/protocols/http2.c
@@ -43,7 +43,7 @@ void ndpi_search_http2(struct ndpi_detection_module_struct *ndpi_struct,
   NDPI_LOG_DBG(ndpi_struct, "search http2\n");
 
   if(packet->payload_packet_len < NDPI_STATICSTRING_LEN(magic)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -52,15 +52,13 @@ void ndpi_search_http2(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_http2_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("HTTP2", ndpi_struct,
-                                      NDPI_PROTOCOL_HTTP2,
-                                      ndpi_search_http2,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("HTTP2", ndpi_struct,
+                     ndpi_search_http2,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_HTTP2);
 }

--- a/src/lib/protocols/i3d.c
+++ b/src/lib/protocols/i3d.c
@@ -50,7 +50,7 @@ static void ndpi_search_i3d(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < 74)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -71,17 +71,14 @@ static void ndpi_search_i3d(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 }
 
 void init_i3d_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("i3D", ndpi_struct,
-    NDPI_PROTOCOL_I3D,
-    ndpi_search_i3d,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("i3D", ndpi_struct,
+                     ndpi_search_i3d,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_I3D);
 }

--- a/src/lib/protocols/iax.c
+++ b/src/lib/protocols/iax.c
@@ -82,7 +82,7 @@ static void ndpi_search_setup_iax(struct ndpi_detection_module_struct *ndpi_stru
 
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 
 }
 
@@ -98,10 +98,8 @@ static void ndpi_search_iax(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_iax_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("IAX", ndpi_struct,
-				      NDPI_PROTOCOL_IAX,
-				      ndpi_search_iax,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("IAX", ndpi_struct,
+                     ndpi_search_iax,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_IAX);
 }

--- a/src/lib/protocols/icecast.c
+++ b/src/lib/protocols/icecast.c
@@ -84,16 +84,14 @@ static void ndpi_search_icecast_tcp(struct ndpi_detection_module_struct *ndpi_st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_icecast_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("IceCast", ndpi_struct,
-				      NDPI_PROTOCOL_ICECAST,
-				      ndpi_search_icecast_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("IceCast", ndpi_struct,
+                     ndpi_search_icecast_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ICECAST);
 }

--- a/src/lib/protocols/iec60870-5-104.c
+++ b/src/lib/protocols/iec60870-5-104.c
@@ -68,15 +68,13 @@ static void ndpi_search_iec60870_tcp(struct ndpi_detection_module_struct *ndpi_s
     }
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);   
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);   
 }
 
 
 void init_104_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("IEC60870", ndpi_struct,
-				      NDPI_PROTOCOL_IEC60870,
-				      ndpi_search_iec60870_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("IEC60870", ndpi_struct,
+                     ndpi_search_iec60870_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_IEC60870);
 }

--- a/src/lib/protocols/iec62056.c
+++ b/src/lib/protocols/iec62056.c
@@ -58,15 +58,13 @@ static void ndpi_search_iec62056(struct ndpi_detection_module_struct *ndpi_struc
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_iec62056_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("IEC62056", ndpi_struct,
-                                      NDPI_PROTOCOL_IEC62056,
-                                      ndpi_search_iec62056,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("IEC62056", ndpi_struct,
+                     ndpi_search_iec62056,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_IEC62056);
 }

--- a/src/lib/protocols/ieee-c37118.c
+++ b/src/lib/protocols/ieee-c37118.c
@@ -63,15 +63,13 @@ static void ndpi_search_ieee_c37118(struct ndpi_detection_module_struct *ndpi_st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_ieee_c37118_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("IEEE-C37118", ndpi_struct,
-                                      NDPI_PROTOCOL_IEEE_C37118,
-                                      ndpi_search_ieee_c37118,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("IEEE-C37118", ndpi_struct,
+                     ndpi_search_ieee_c37118,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_IEEE_C37118);
 }

--- a/src/lib/protocols/imo.c
+++ b/src/lib/protocols/imo.c
@@ -61,7 +61,7 @@ static void ndpi_search_imo(struct ndpi_detection_module_struct *ndpi_struct, st
     ndpi_int_imo_add_connection(ndpi_struct, flow);
   } else {
     if(flow->num_processed_pkts > 5)
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     else
       flow->l4.udp.imo_last_one_byte_pkt = 0;
   }
@@ -69,11 +69,9 @@ static void ndpi_search_imo(struct ndpi_detection_module_struct *ndpi_struct, st
 
 
 void init_imo_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("IMO", ndpi_struct,
-                                      NDPI_PROTOCOL_IMO,
-                                      ndpi_search_imo,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("IMO", ndpi_struct,
+                     ndpi_search_imo,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_IMO);
 }
 

--- a/src/lib/protocols/ipp.c
+++ b/src/lib/protocols/ipp.c
@@ -52,16 +52,14 @@ static void ndpi_search_ipp(struct ndpi_detection_module_struct *ndpi_struct, st
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_ipp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("IPP", ndpi_struct,
-				      NDPI_PROTOCOL_IPP,
-				      ndpi_search_ipp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("IPP", ndpi_struct,
+                     ndpi_search_ipp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_IPP);
 }

--- a/src/lib/protocols/ipsec.c
+++ b/src/lib/protocols/ipsec.c
@@ -39,7 +39,7 @@ static void ndpi_int_ipsec_add_connection(struct ndpi_detection_module_struct * 
   switch (isakmp_type)
   {
     case ISAKMP_INVALID:
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     case ISAKMP_MALFORMED:
       NDPI_LOG_INFO(ndpi_struct, "found malformed ISAKMP (UDP)\n");
@@ -138,7 +138,7 @@ static void ndpi_search_ipsec(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < 28)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -148,7 +148,7 @@ static void ndpi_search_ipsec(struct ndpi_detection_module_struct *ndpi_struct,
     isakmp_offset = 4;
     if (packet->payload_packet_len < 32)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
@@ -157,7 +157,7 @@ static void ndpi_search_ipsec(struct ndpi_detection_module_struct *ndpi_struct,
   {
     if (packet->payload[isakmp_offset + 17] != 0x10 /* Major Version 1 */)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     } else {
       /* Version 1 is obsolete, but still used by some embedded devices. */
@@ -169,7 +169,7 @@ static void ndpi_search_ipsec(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (ntohl(get_u_int32_t(packet->payload, isakmp_offset + 24)) != (u_int32_t)packet->payload_packet_len - isakmp_offset)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -185,12 +185,9 @@ static void ndpi_search_ipsec(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_ipsec_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("IPSec", ndpi_struct,
-    NDPI_PROTOCOL_IPSEC,
-    ndpi_search_ipsec,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("IPSec", ndpi_struct,
+                     ndpi_search_ipsec,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_IPSEC);
 }
 

--- a/src/lib/protocols/iqiyi.c
+++ b/src/lib/protocols/iqiyi.c
@@ -52,15 +52,13 @@ static void ndpi_search_iqiyi(struct ndpi_detection_module_struct *ndpi_struct, 
 
   /* Add more iQiyi signatures */
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_iqiyi_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("iQIYI", ndpi_struct,
-                                      NDPI_PROTOCOL_IQIYI,
-                                      ndpi_search_iqiyi,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("iQIYI", ndpi_struct,
+                     ndpi_search_iqiyi,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_IQIYI);
 }

--- a/src/lib/protocols/irc.c
+++ b/src/lib/protocols/irc.c
@@ -99,7 +99,7 @@ static void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct
   NDPI_LOG_DBG(ndpi_struct, "search irc\n");
   if((flow->detected_protocol_stack[0] != NDPI_PROTOCOL_IRC && (flow->packet_counter > 10))
      || (flow->packet_counter >= 10)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -226,11 +226,9 @@ static void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_irc_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("IRC", ndpi_struct,
-				      NDPI_PROTOCOL_IRC,
-				      ndpi_search_irc_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("IRC", ndpi_struct,
+                     ndpi_search_irc_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_IRC);
 }
 

--- a/src/lib/protocols/iso9506-1-mms.c
+++ b/src/lib/protocols/iso9506-1-mms.c
@@ -68,16 +68,14 @@ static void ndpi_search_iso9506_1_mms(struct ndpi_detection_module_struct *ndpi_
   }
 
   if (flow->packet_direction_counter[packet->packet_direction] > 2) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 void init_iso9506_1_mms_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("ISO9506-1-MMS", ndpi_struct,
-				      NDPI_PROTOCOL_ISO9506_1_MMS,
-				      ndpi_search_iso9506_1_mms,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("ISO9506-1-MMS", ndpi_struct,
+                     ndpi_search_iso9506_1_mms,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ISO9506_1_MMS);
 }

--- a/src/lib/protocols/jabber.c
+++ b/src/lib/protocols/jabber.c
@@ -86,7 +86,7 @@ static void ndpi_search_jabber_tcp(struct ndpi_detection_module_struct *ndpi_str
         return;
       }
     }
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -134,18 +134,16 @@ static void ndpi_search_jabber_tcp(struct ndpi_detection_module_struct *ndpi_str
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 }
 
 
 void init_jabber_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Jabber", ndpi_struct,
-				      NDPI_PROTOCOL_JABBER,
-				      ndpi_search_jabber_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Jabber", ndpi_struct,
+                      ndpi_search_jabber_tcp,
+                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_JABBER);
 }
 

--- a/src/lib/protocols/jrmi.c
+++ b/src/lib/protocols/jrmi.c
@@ -49,16 +49,14 @@ static void ndpi_search_jrmi(struct ndpi_detection_module_struct *ndpi_struct, s
 		}
 	}
 	
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_jrmi_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-	ndpi_set_bitmask_protocol_detection("JRMI", ndpi_struct,
-					    NDPI_PROTOCOL_JRMI,
-					    ndpi_search_jrmi,
-					    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-					    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-					    ADD_TO_DETECTION_BITMASK);
+  register_dissector("JRMI", ndpi_struct,
+                     ndpi_search_jrmi,
+                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_JRMI);
 }
 

--- a/src/lib/protocols/json-rpc.c
+++ b/src/lib/protocols/json-rpc.c
@@ -58,15 +58,13 @@ static void ndpi_search_json_rpc(struct ndpi_detection_module_struct *ndpi_struc
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_json_rpc_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("JSON-RPC", ndpi_struct,
-				      NDPI_PROTOCOL_JSON_RPC,
-				      ndpi_search_json_rpc,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("JSON-RPC", ndpi_struct,
+                     ndpi_search_json_rpc,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_JSON_RPC);
 }

--- a/src/lib/protocols/kafka.c
+++ b/src/lib/protocols/kafka.c
@@ -52,7 +52,7 @@ static void ndpi_search_kafka(struct ndpi_detection_module_struct *ndpi_struct,
   if (packet->payload_packet_len < 8 /* min. required packet length */ ||
       ntohl(get_u_int32_t(packet->payload, 0)) != (uint32_t)(packet->payload_packet_len - 4))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -62,19 +62,19 @@ static void ndpi_search_kafka(struct ndpi_detection_module_struct *ndpi_struct,
   {
     if (packet->payload_packet_len < 14)
     {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
     }
 
     const uint16_t client_id_len = ntohs(get_u_int16_t(packet->payload, 12));
     if (client_id_len + 12 + 2 > packet->payload_packet_len)
     {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
     }
     if (ndpi_is_printable_buffer(&packet->payload[14], client_id_len) == 0)
     {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
     }
 
@@ -82,15 +82,13 @@ static void ndpi_search_kafka(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_kafka_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Kafka", ndpi_struct,
-				      NDPI_PROTOCOL_APACHE_KAFKA,
-				      ndpi_search_kafka,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Kafka", ndpi_struct,
+                     ndpi_search_kafka,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_APACHE_KAFKA);
 }

--- a/src/lib/protocols/kakaotalk_voice.c
+++ b/src/lib/protocols/kakaotalk_voice.c
@@ -61,17 +61,15 @@ static void ndpi_search_kakaotalk_voice(struct ndpi_detection_module_struct *ndp
     } 
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_kakaotalk_voice_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("KakaoTalk_Voice", ndpi_struct,
-				      NDPI_PROTOCOL_KAKAOTALK_VOICE,
-				      ndpi_search_kakaotalk_voice,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("KakaoTalk_Voice", ndpi_struct,
+                     ndpi_search_kakaotalk_voice,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                      1, NDPI_PROTOCOL_KAKAOTALK_VOICE);
 }
 

--- a/src/lib/protocols/kcp.c
+++ b/src/lib/protocols/kcp.c
@@ -66,7 +66,7 @@ static void ndpi_search_kcp(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < sizeof(*kcp_header))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -78,14 +78,14 @@ static void ndpi_search_kcp(struct ndpi_detection_module_struct *ndpi_struct,
     case IKCP_CMD_WINS:
       break;
     default:
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
   }
 
   uint32_t const kcp_pdu_length = le32toh(kcp_header->length);
   if (kcp_pdu_length + sizeof(*kcp_header) != packet->payload_packet_len)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -94,11 +94,8 @@ static void ndpi_search_kcp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_kcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("KCP", ndpi_struct,
-    NDPI_PROTOCOL_KCP,
-    ndpi_search_kcp,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("KCP", ndpi_struct,
+                     ndpi_search_kcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_KCP);
 }

--- a/src/lib/protocols/kerberos.c
+++ b/src/lib/protocols/kerberos.c
@@ -314,7 +314,7 @@ static void ndpi_search_kerberos(struct ndpi_detection_module_struct *ndpi_struc
   u_int16_t original_payload_packet_len = 0;
 
   if((sport != KERBEROS_PORT) && (dport != KERBEROS_PORT)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
   
@@ -672,7 +672,7 @@ static void ndpi_search_kerberos(struct ndpi_detection_module_struct *ndpi_struc
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static int ndpi_search_kerberos_extra(struct ndpi_detection_module_struct *ndpi_struct,
@@ -698,10 +698,8 @@ static int ndpi_search_kerberos_extra(struct ndpi_detection_module_struct *ndpi_
 }
 
 void init_kerberos_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("Kerberos", ndpi_struct,
-				      NDPI_PROTOCOL_KERBEROS,
-				      ndpi_search_kerberos,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Kerberos", ndpi_struct,
+                     ndpi_search_kerberos,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_KERBEROS);
 }

--- a/src/lib/protocols/kismet.c
+++ b/src/lib/protocols/kismet.c
@@ -45,7 +45,7 @@ static void ndpi_search_kismet(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < NDPI_STATICSTRING_LEN("*KISMET: "))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -55,16 +55,13 @@ static void ndpi_search_kismet(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_kismet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("kismet", ndpi_struct,
-    NDPI_PROTOCOL_KISMET,
-    ndpi_search_kismet,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("kismet", ndpi_struct,
+                     ndpi_search_kismet,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_KISMET);
 }

--- a/src/lib/protocols/knxnet_ip.c
+++ b/src/lib/protocols/knxnet_ip.c
@@ -115,15 +115,13 @@ static void ndpi_search_knxnet_ip(struct ndpi_detection_module_struct *ndpi_stru
   }
 
 not_knxnet_ip:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_knxnet_ip_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("KNXnet_IP", ndpi_struct,
-                                      NDPI_PROTOCOL_KNXNET_IP,
-                                      ndpi_search_knxnet_ip,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("KNXnet_IP", ndpi_struct,
+                     ndpi_search_knxnet_ip,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_KNXNET_IP);
 }

--- a/src/lib/protocols/lagofast.c
+++ b/src/lib/protocols/lagofast.c
@@ -42,20 +42,20 @@ static void ndpi_search_lagofast(struct ndpi_detection_module_struct *ndpi_struc
 
   NDPI_LOG_DBG(ndpi_struct, "search LagoFast\n");
   if (packet->payload_packet_len < 6) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   // LagoFast identifier
   if (get_u_int32_t(packet->payload, 0) != htonl(0x006e5d03)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   // Check encoded length
   const uint16_t encoded_length = ntohs(get_u_int16_t(packet->payload, 4));
   if (packet->payload_packet_len != encoded_length + 6 /* identifier + length */) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -64,11 +64,9 @@ static void ndpi_search_lagofast(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_lagofast_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("LagoFast", ndpi_struct,
-				      NDPI_PROTOCOL_LAGOFAST,
-				      ndpi_search_lagofast,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("LagoFast", ndpi_struct,
+                     ndpi_search_lagofast,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                      1, NDPI_PROTOCOL_LAGOFAST);
 }
 

--- a/src/lib/protocols/ldap.c
+++ b/src/lib/protocols/ldap.c
@@ -66,17 +66,15 @@ static void ndpi_search_ldap(struct ndpi_detection_module_struct *ndpi_struct, s
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_ldap_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("LDAP", ndpi_struct,
-				      NDPI_PROTOCOL_LDAP,
-				      ndpi_search_ldap,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("LDAP", ndpi_struct,
+                     ndpi_search_ldap,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_LDAP);
 }
 

--- a/src/lib/protocols/ldp.c
+++ b/src/lib/protocols/ldp.c
@@ -111,15 +111,13 @@ static void ndpi_search_ldp(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_ldp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("LDP", ndpi_struct,
-                                      NDPI_PROTOCOL_LDP,
-                                      ndpi_search_ldp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("LDP", ndpi_struct,
+                     ndpi_search_ldp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_LDP);
 }

--- a/src/lib/protocols/line.c
+++ b/src/lib/protocols/line.c
@@ -98,7 +98,7 @@ static void ndpi_search_line(struct ndpi_detection_module_struct *ndpi_struct,
             if(flow->l4.udp.line_base_cnt[0] != flow->l4.udp.line_base_cnt[1])
               ndpi_int_line_add_connection(ndpi_struct, flow);
             else
-              NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+              NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 	  }
           return;
         }
@@ -106,16 +106,14 @@ static void ndpi_search_line(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 }
 
 void init_line_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("LineCall", ndpi_struct,
-				      NDPI_PROTOCOL_LINE_CALL,
-				      ndpi_search_line,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("LineCall", ndpi_struct,
+                     ndpi_search_line,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                      1, NDPI_PROTOCOL_LINE_CALL);
 }

--- a/src/lib/protocols/lisp.c
+++ b/src/lib/protocols/lisp.c
@@ -69,7 +69,7 @@ static void ndpi_check_lisp(struct ndpi_detection_module_struct *ndpi_struct, st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_lisp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -82,11 +82,9 @@ static void ndpi_search_lisp(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_lisp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("LISP", ndpi_struct,
-				      NDPI_PROTOCOL_LISP,
-				      ndpi_search_lisp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("LISP", ndpi_struct,
+                     ndpi_search_lisp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_LISP);
 }
 

--- a/src/lib/protocols/lol_wild_rift.c
+++ b/src/lib/protocols/lol_wild_rift.c
@@ -69,15 +69,13 @@ static void ndpi_search_lolwildrift(struct ndpi_detection_module_struct *ndpi_st
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_lolwildrift_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("LoLWildRift", ndpi_struct,
-                                      NDPI_PROTOCOL_LOLWILDRIFT,
-                                      ndpi_search_lolwildrift,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("LoLWildRift", ndpi_struct,
+                     ndpi_search_lolwildrift,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                      1, NDPI_PROTOCOL_LOLWILDRIFT);
 }

--- a/src/lib/protocols/lustre.c
+++ b/src/lib/protocols/lustre.c
@@ -74,15 +74,13 @@ static void ndpi_search_lustre(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_lustre_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Lustre", ndpi_struct,
-				      NDPI_PROTOCOL_LUSTRE,
-				      ndpi_search_lustre,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION /* Ipv4 only; Lustre doesn't support IPv6 */,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Lustre", ndpi_struct,
+                     ndpi_search_lustre,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION, /* Ipv4 only; Lustre doesn't support IPv6 */
+                      1, NDPI_PROTOCOL_LUSTRE);
 }

--- a/src/lib/protocols/mail_imap.c
+++ b/src/lib/protocols/mail_imap.c
@@ -352,16 +352,14 @@ static void ndpi_search_mail_imap_tcp(struct ndpi_detection_module_struct *ndpi_
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_mail_imap_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("MAIL_IMAP", ndpi_struct,
-				      NDPI_PROTOCOL_MAIL_IMAP,
-				      ndpi_search_mail_imap_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MAIL_IMAP", ndpi_struct,
+                     ndpi_search_mail_imap_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MAIL_IMAP);
 }

--- a/src/lib/protocols/mail_pop.c
+++ b/src/lib/protocols/mail_pop.c
@@ -231,7 +231,7 @@ static void ndpi_search_mail_pop_tcp(struct ndpi_detection_module_struct
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
@@ -267,10 +267,8 @@ static void popInitExtraPacketProcessing(struct ndpi_flow_struct *flow) {
 /* **************************************** */
 
 void init_mail_pop_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("MAIL_POP", ndpi_struct,
-				      NDPI_PROTOCOL_MAIL_POP,
-				      ndpi_search_mail_pop_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MAIL_POP", ndpi_struct,
+                     ndpi_search_mail_pop_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MAIL_POP);
 }

--- a/src/lib/protocols/mail_smtp.c
+++ b/src/lib/protocols/mail_smtp.c
@@ -292,7 +292,7 @@ static void ndpi_search_mail_smtp_tcp(struct ndpi_detection_module_struct *ndpi_
 		flow->l4.tcp.ftp_imap_pop_smtp.auth_done = 1;
 	      } else {
 		flow->host_server_name[0] = '\0';
-		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+		NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 		return;
 	      }
 	    }
@@ -397,7 +397,7 @@ static void ndpi_search_mail_smtp_tcp(struct ndpi_detection_module_struct *ndpi_
   }
 
   if((!flow->extra_packets_func) || (flow->packet_counter > 12))
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* **************************************** */
@@ -471,10 +471,8 @@ static void smtpInitExtraPacketProcessing(struct ndpi_flow_struct *flow) {
 /* **************************************** */
 
 void init_mail_smtp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("MAIL_SMTP", ndpi_struct,
-				      NDPI_PROTOCOL_MAIL_SMTP,
-				      ndpi_search_mail_smtp_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MAIL_SMTP", ndpi_struct,
+                     ndpi_search_mail_smtp_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MAIL_SMTP);
 }

--- a/src/lib/protocols/megaco.c
+++ b/src/lib/protocols/megaco.c
@@ -47,16 +47,14 @@ static void ndpi_search_megaco(struct ndpi_detection_module_struct *ndpi_struct,
     } 
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_megaco_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Megaco", ndpi_struct,
-				      NDPI_PROTOCOL_MEGACO,
-				      ndpi_search_megaco,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Megaco", ndpi_struct,
+                     ndpi_search_megaco,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                      1, NDPI_PROTOCOL_MEGACO);
 }

--- a/src/lib/protocols/melsec.c
+++ b/src/lib/protocols/melsec.c
@@ -50,16 +50,14 @@ static void ndpi_search_melsec(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
   if (flow->packet_counter > 2) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 void init_melsec_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("MELSEC", ndpi_struct,
-				      NDPI_PROTOCOL_MELSEC,
-				      ndpi_search_melsec,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MELSEC", ndpi_struct,
+                     ndpi_search_melsec,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MELSEC);
 }

--- a/src/lib/protocols/memcached.c
+++ b/src/lib/protocols/memcached.c
@@ -112,7 +112,7 @@ static void ndpi_search_memcached(struct ndpi_detection_module_struct *ndpi_stru
 
   if (packet->tcp != NULL) {
     if (packet->payload_packet_len < MEMCACHED_MIN_LEN) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -120,13 +120,13 @@ static void ndpi_search_memcached(struct ndpi_detection_module_struct *ndpi_stru
   }
   else if (packet->udp != NULL) {
     if (packet->payload_packet_len < MEMCACHED_MIN_UDP_LEN) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
     if ((offset[4] == 0x00 && offset[5] == 0x00) ||
 	offset[6] != 0x00 || offset[7] != 0x00) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -170,17 +170,13 @@ static void ndpi_search_memcached(struct ndpi_detection_module_struct *ndpi_stru
   if (*matches >= MEMCACHED_MIN_MATCH)
     ndpi_int_memcached_add_connection(ndpi_struct, flow);
   else if(flow->packet_counter > 5)
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);    
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);    
 }
 
-void init_memcached_dissector(
-			      struct ndpi_detection_module_struct *ndpi_struct)
+void init_memcached_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("MEMCACHED",
-				      ndpi_struct,
-				      NDPI_PROTOCOL_MEMCACHED,
-				      ndpi_search_memcached,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MEMCACHED", ndpi_struct,
+                     ndpi_search_memcached,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MEMCACHED);
 }

--- a/src/lib/protocols/merakicloud.c
+++ b/src/lib/protocols/merakicloud.c
@@ -46,15 +46,13 @@ static void ndpi_search_merakicloud(struct ndpi_detection_module_struct *ndpi_st
     ndpi_int_merakicloud_add_connection(ndpi_struct, flow);
     return;
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_merakicloud_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("MerakiCloud", ndpi_struct,
-				      NDPI_PROTOCOL_MERAKI_CLOUD,
-				      ndpi_search_merakicloud,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MerakiCloud", ndpi_struct,
+                     ndpi_search_merakicloud,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                      1, NDPI_PROTOCOL_MERAKI_CLOUD);
 }

--- a/src/lib/protocols/mgcp.c
+++ b/src/lib/protocols/mgcp.c
@@ -97,17 +97,15 @@ static void ndpi_search_mgcp(struct ndpi_detection_module_struct *ndpi_struct, s
     }
   } while(0);
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_mgcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("MGCP", ndpi_struct,
-				      NDPI_PROTOCOL_MGCP,
-				      ndpi_search_mgcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);  
+  register_dissector("MGCP", ndpi_struct,
+                     ndpi_search_mgcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                      1, NDPI_PROTOCOL_MGCP);
 }
 

--- a/src/lib/protocols/mikrotik.c
+++ b/src/lib/protocols/mikrotik.c
@@ -40,7 +40,7 @@ static void ndpi_search_mikrotik(struct ndpi_detection_module_struct *ndpi_struc
       u_int16_t offset;
     
       if (packet->payload_packet_len < 8) {
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 	return;
       } else {
 	offset = 4;
@@ -103,15 +103,14 @@ static void ndpi_search_mikrotik(struct ndpi_detection_module_struct *ndpi_struc
 				 NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
     }
   } else
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ********************************* */
 
 void init_mikrotik_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("MIKROTIK", ndpi_struct,
-				      NDPI_PROTOCOL_MIKROTIK, ndpi_search_mikrotik,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MIKROTIK", ndpi_struct,
+                     ndpi_search_mikrotik,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                      1, NDPI_PROTOCOL_MIKROTIK);
 }

--- a/src/lib/protocols/mining.c
+++ b/src/lib/protocols/mining.c
@@ -58,7 +58,7 @@ static void ndpi_search_mining(struct ndpi_detection_module_struct *ndpi_struct,
 
   /* Quick test: we are looking for only Json format */
   if(packet->payload[0] != '{') {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -89,18 +89,16 @@ static void ndpi_search_mining(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ************************************************************************** */
 
 void init_mining_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Mining", ndpi_struct,
-				      NDPI_PROTOCOL_MINING,
-				      ndpi_search_mining,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Mining", ndpi_struct,
+                     ndpi_search_mining,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MINING);
 }
 

--- a/src/lib/protocols/modbus.c
+++ b/src/lib/protocols/modbus.c
@@ -61,18 +61,16 @@ static void ndpi_search_modbus_tcp(struct ndpi_detection_module_struct *ndpi_str
       }
     }
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
    
 }
 
 
 
 void init_modbus_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-	
-  ndpi_set_bitmask_protocol_detection("Modbus", ndpi_struct,
-				      NDPI_PROTOCOL_MODBUS,
-				      ndpi_search_modbus_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+
+  register_dissector("Modbus", ndpi_struct,
+                     ndpi_search_modbus_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MODBUS);
 }

--- a/src/lib/protocols/monero.c
+++ b/src/lib/protocols/monero.c
@@ -55,7 +55,7 @@ static void ndpi_search_monero(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < 8)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -65,15 +65,13 @@ static void ndpi_search_monero(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_monero_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Monero", ndpi_struct,
-                                      NDPI_PROTOCOL_MONERO,
-                                      ndpi_search_monero,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Monero", ndpi_struct,
+                     ndpi_search_monero,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MONERO);
 }

--- a/src/lib/protocols/mongodb.c
+++ b/src/lib/protocols/mongodb.c
@@ -68,7 +68,7 @@ static void ndpi_check_mongodb(struct ndpi_detection_module_struct *ndpi_struct,
   uint32_t responseFlags;
 
   if (packet->payload_packet_len <= sizeof(mongodb_hdr)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -81,7 +81,7 @@ static void ndpi_check_mongodb(struct ndpi_detection_module_struct *ndpi_struct,
      || (le32toh(mongodb_hdr.message_length) > 1000000) /* Used to avoid false positives */
      ) {
     NDPI_LOG_DBG(ndpi_struct, "Invalid MONGODB length");
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -115,7 +115,7 @@ static void ndpi_check_mongodb(struct ndpi_detection_module_struct *ndpi_struct,
 
   default:
     NDPI_LOG_DBG(ndpi_struct, "Invalid MONGODB length");
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     break;
   }
 }
@@ -125,7 +125,7 @@ static void ndpi_search_mongodb(struct ndpi_detection_module_struct *ndpi_struct
 {
   // Break after 6 packets.
   if(flow->packet_counter > 6) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -139,9 +139,8 @@ static void ndpi_search_mongodb(struct ndpi_detection_module_struct *ndpi_struct
 
 
 void init_mongodb_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("MongoDB", ndpi_struct,
-				      NDPI_PROTOCOL_MONGODB, ndpi_search_mongodb,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MongoDB", ndpi_struct,
+                     ndpi_search_mongodb,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MONGODB);
 }

--- a/src/lib/protocols/mpegdash.c
+++ b/src/lib/protocols/mpegdash.c
@@ -49,7 +49,7 @@ static void ndpi_search_mpegdash_http(struct ndpi_detection_module_struct *ndpi_
   {
     if (flow->packet_counter > 2)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     }
     return;
   }
@@ -83,16 +83,14 @@ static void ndpi_search_mpegdash_http(struct ndpi_detection_module_struct *ndpi_
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 }
 
 void init_mpegdash_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("MpegDash", ndpi_struct,
-				      NDPI_PROTOCOL_MPEGDASH,
-				      ndpi_search_mpegdash_http,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MpegDash", ndpi_struct,
+                     ndpi_search_mpegdash_http,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MPEGDASH);
 }

--- a/src/lib/protocols/mpegts.c
+++ b/src/lib/protocols/mpegts.c
@@ -48,17 +48,15 @@ static void ndpi_search_mpegts(struct ndpi_detection_module_struct *ndpi_struct,
   }    
 
  no_mpegts:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_mpegts_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("MPEG_TS", ndpi_struct,
-				      NDPI_PROTOCOL_MPEGTS,
-				      ndpi_search_mpegts,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MPEG_TS", ndpi_struct,
+                     ndpi_search_mpegts,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                      1, NDPI_PROTOCOL_MPEGTS);
 }
 

--- a/src/lib/protocols/mqtt.c
+++ b/src/lib/protocols/mqtt.c
@@ -93,7 +93,7 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 	struct ndpi_packet_struct *packet = &ndpi_struct->packet;
 	if (flow->packet_counter > 10) {
 		NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt .. mandatory header not found!\n");
-		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+		NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 		return;
 	}
 
@@ -105,20 +105,20 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 		      packet->payload_packet_len);
 	if (packet->payload_packet_len < 2) {
 		NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt .. mandatory header not found!\n");
-		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+		NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 		return;
 	}
 	// we extract the remaining length
 	rl = get_var_int(&packet->payload[1], packet->payload_packet_len - 1, &rl_len);
 	if (rl < 0) {
 		NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt .. invalid length!\n");
-		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+		NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 		return;
 	}
 	NDPI_LOG_DBG(ndpi_struct, "Mqtt: msg_len %d\n", (unsigned long long)rl);
 	if (packet->payload_packet_len != rl + 1 + rl_len) {
 		NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt .. maximum packet size exceeded!\n");
-		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+		NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 		return;
 	}
 	// we extract the packet type
@@ -126,7 +126,7 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 	NDPI_LOG_DBG2(ndpi_struct,"====>>>> Mqtt packet type: [%d]\n",pt);
 	if ((pt == 0) || (pt == 15)) {
 		NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt .. invalid packet type!\n");
-		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+		NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 		return;
 	}
 	// we extract the flags
@@ -137,12 +137,12 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 					(pt == PUBCOMP) || (pt == SUBACK) || (pt == UNSUBACK) || (pt == PINGREQ) ||
 					(pt == PINGRESP) || (pt == DISCONNECT)) && (flags > 0)) {
 		NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid Packet-Flag combination flag!=0\n");
-		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+		NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 		return;
 	}
 	if (((pt == PUBREL) || (pt == SUBSCRIBE) || (pt == UNSUBSCRIBE)) && (flags != 2)) {
 		NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid Packet-Flag combination flag!=2\n");
-		NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+		NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 		return;
 	}
 	NDPI_LOG_DBG2(ndpi_struct,"====>>>> Passed first stage of identification\n");
@@ -151,7 +151,7 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 			(pt == PUBREC) || (pt == PUBCOMP) || (pt == UNSUBACK)) {
 		if (packet->payload_packet_len != 4) { // these packets are always 4 bytes long
 			NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid Packet-Length < 4 \n");
-			NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+			NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 			return;
 		} else {
 			NDPI_LOG_INFO(ndpi_struct, "found Mqtt CONNACK/PUBACK/PUBREL/PUBREC/PUBCOMP/UNSUBACK\n");
@@ -162,7 +162,7 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 	if ((pt == PINGREQ) || (pt == PINGRESP) || (pt == DISCONNECT)) {
 		if (packet->payload_packet_len != 2) { // these packets are always 2 bytes long
 			NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid Packet-Length <2 \n");
-			NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+			NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 			return;
 		} else {
 			NDPI_LOG_INFO(ndpi_struct, "found Mqtt PING/PINGRESP/DISCONNECT\n");
@@ -183,25 +183,25 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 		u_int8_t dup = (u_int8_t) (flags & 0x08) >> 3;
 		if (qos > 2) { // qos values possible are 0,1,2
 			NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid PUBLISH qos\n");
-			NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+			NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 			return;
 		}
 		if (qos == 0) {
 			if (dup != 0) {
 				NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid PUBLISH qos0 and dup combination\n");
-				NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+				NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 				return;
 			}
 			if (packet->payload_packet_len < 5) { // at least topic (3Bytes + 2Bytes fixed header)
 				NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid PUBLISH qos0 size\n");
-				NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+				NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 				return;
 			}
 		}
 		if ((qos == 1) || (qos == 2)) {
 			if (packet->payload_packet_len < 7 ) { // at least topic + pkt identifier (3Bytes + 2Bytes + 2Bytes fixed header)
 				NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid PUBLISH qos1&2\n");
-				NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+				NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 				return;
 			}
 		}
@@ -212,7 +212,7 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 	if (pt == SUBSCRIBE) {
 		if (packet->payload_packet_len < 8) { // at least one topic+filter is required in the payload
 			NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid SUBSCRIBE\n");
-			NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+			NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 			return;
 		} else {
 			NDPI_LOG_INFO(ndpi_struct, "found Mqtt SUBSCRIBE\n");
@@ -223,7 +223,7 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 	if (pt == SUBACK ) {
 		if (packet->payload_packet_len <5 ) { // must have at least a response code
 			NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid SUBACK\n");
-			NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+			NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 			return;
 		} else {
 			NDPI_LOG_INFO(ndpi_struct, "found Mqtt SUBACK\n");
@@ -234,7 +234,7 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
 	if (pt == UNSUBSCRIBE) {
 		if (packet->payload_packet_len < 7) { // at least a topic
 			NDPI_LOG_DBG(ndpi_struct, "Excluding Mqtt invalid UNSUBSCRIBE\n");
-			NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+			NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 			return;
 		} else {
 			NDPI_LOG_INFO(ndpi_struct, "found Mqtt UNSUBSCRIBE\n");
@@ -249,11 +249,10 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
  */
 void init_mqtt_dissector (struct ndpi_detection_module_struct *ndpi_struct)
 {
-	ndpi_set_bitmask_protocol_detection ("MQTT", ndpi_struct,
-			NDPI_PROTOCOL_MQTT,
-			ndpi_search_mqtt,
-			NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-			SAVE_DETECTION_BITMASK_AS_UNKNOWN, ADD_TO_DETECTION_BITMASK);
+  register_dissector("MQTT", ndpi_struct,
+                     ndpi_search_mqtt,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MQTT);
 }
 
 

--- a/src/lib/protocols/msdo.c
+++ b/src/lib/protocols/msdo.c
@@ -60,17 +60,14 @@ static void ndpi_search_msdo(struct ndpi_detection_module_struct *ndpi_struct, s
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_msdo_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("MSDO", ndpi_struct,
-              NDPI_PROTOCOL_MSDO,
-              ndpi_search_msdo,
-              NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-              ADD_TO_DETECTION_BITMASK);
-
+  register_dissector("MSDO", ndpi_struct,
+                     ndpi_search_msdo,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MSDO);
 }

--- a/src/lib/protocols/mssql_tds.c
+++ b/src/lib/protocols/mssql_tds.c
@@ -58,7 +58,7 @@ static void ndpi_search_mssql_tds(struct ndpi_detection_module_struct *ndpi_stru
        to this potocol and it can cause false positives 
      */
      || (packet->tcp->dest == ntohs(102))) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
   
@@ -72,16 +72,14 @@ static void ndpi_search_mssql_tds(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_mssql_tds_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("MsSQL_TDS", ndpi_struct,
-				      NDPI_PROTOCOL_MSSQL_TDS,
-				      ndpi_search_mssql_tds,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MsSQL_TDS", ndpi_struct,
+                     ndpi_search_mssql_tds,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MSSQL_TDS);
 }

--- a/src/lib/protocols/mumble.c
+++ b/src/lib/protocols/mumble.c
@@ -58,15 +58,13 @@ static void ndpi_search_mumble(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
 not_mumble:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_mumble_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Mumble", ndpi_struct,
-                                      NDPI_PROTOCOL_MUMBLE,
-                                      ndpi_search_mumble,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Mumble", ndpi_struct,
+                     ndpi_search_mumble,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                      1, NDPI_PROTOCOL_MUMBLE);
 }

--- a/src/lib/protocols/munin.c
+++ b/src/lib/protocols/munin.c
@@ -50,13 +50,13 @@ static void ndpi_search_munin(struct ndpi_detection_module_struct *ndpi_struct,
   // "# munin node at "
   if (packet->payload_packet_len < NDPI_STATICSTRING_LEN(munin_prefix))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (memcmp(packet->payload, munin_prefix, NDPI_STATICSTRING_LEN(munin_prefix)) != 0)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -81,11 +81,8 @@ static void ndpi_search_munin(struct ndpi_detection_module_struct *ndpi_struct,
   
 void init_munin_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Munin", ndpi_struct,
-				      NDPI_PROTOCOL_MUNIN,
-				      ndpi_search_munin,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK
-				      );
+  register_dissector("Munin", ndpi_struct,
+                     ndpi_search_munin,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MUNIN);
 }

--- a/src/lib/protocols/mysql.c
+++ b/src/lib/protocols/mysql.c
@@ -58,16 +58,14 @@ static void ndpi_search_mysql_tcp(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_mysql_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("MySQL", ndpi_struct,
-				      NDPI_PROTOCOL_MYSQL,
-				      ndpi_search_mysql_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("MySQL", ndpi_struct,
+                     ndpi_search_mysql_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                      1, NDPI_PROTOCOL_MYSQL);
 }

--- a/src/lib/protocols/nano.c
+++ b/src/lib/protocols/nano.c
@@ -76,15 +76,13 @@ static void ndpi_search_nano(struct ndpi_detection_module_struct *ndpi_struct, s
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_nano_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Nano", ndpi_struct,
-                                      NDPI_PROTOCOL_NANO,
-                                      ndpi_search_nano,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Nano", ndpi_struct,
+                     ndpi_search_nano,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_NANO);
 }

--- a/src/lib/protocols/natpmp.c
+++ b/src/lib/protocols/natpmp.c
@@ -173,7 +173,7 @@ static void ndpi_search_natpmp(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (natpmp_is_valid(packet, &natpmp_type) == 0)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -190,11 +190,8 @@ static void ndpi_search_natpmp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_natpmp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("NAT-PMP", ndpi_struct,
-    NDPI_PROTOCOL_NATPMP,
-    ndpi_search_natpmp,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("NAT-PMP", ndpi_struct,
+                     ndpi_search_natpmp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_NATPMP);
 }

--- a/src/lib/protocols/nats.c
+++ b/src/lib/protocols/nats.c
@@ -49,7 +49,7 @@ static void ndpi_search_nats_tcp(struct ndpi_detection_module_struct *ndpi_struc
     int i;
 
     if(packet->payload_packet_len <= 4)
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 
     for(i=0; commands[i] != NULL; i++) {
       int len = ndpi_min(strlen(commands[i]), packet->payload_packet_len);
@@ -67,17 +67,15 @@ static void ndpi_search_nats_tcp(struct ndpi_detection_module_struct *ndpi_struc
       }
     }
 
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 
 
 void init_nats_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("Nats", ndpi_struct,
-				      NDPI_PROTOCOL_NATS,
-				      ndpi_search_nats_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Nats", ndpi_struct,
+                     ndpi_search_nats_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_NATS);
 }

--- a/src/lib/protocols/nest_log_sink.c
+++ b/src/lib/protocols/nest_log_sink.c
@@ -42,13 +42,13 @@ static void ndpi_search_nest_log_sink(struct ndpi_detection_module_struct *ndpi_
     NDPI_LOG_DBG(ndpi_struct, "search nest_log_sink\n");
 
     if (packet->payload_packet_len < NEST_LOG_SINK_MIN_LEN) {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
     }
 
     if (ntohs(packet->tcp->source) != NEST_LOG_SINK_PORT &&
             ntohs(packet->tcp->dest) != NEST_LOG_SINK_PORT) {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
     }
 
@@ -63,14 +63,10 @@ static void ndpi_search_nest_log_sink(struct ndpi_detection_module_struct *ndpi_
     }
 }
 
-void init_nest_log_sink_dissector(
-        struct ndpi_detection_module_struct *ndpi_struct)
+void init_nest_log_sink_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-    ndpi_set_bitmask_protocol_detection("NEST_LOG_SINK",
-            ndpi_struct,
-            NDPI_PROTOCOL_NEST_LOG_SINK,
-            ndpi_search_nest_log_sink,
-            NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-            SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-            ADD_TO_DETECTION_BITMASK);
+  register_dissector("NEST_LOG_SINK", ndpi_struct,
+                     ndpi_search_nest_log_sink,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_NEST_LOG_SINK);
 }

--- a/src/lib/protocols/netbios.c
+++ b/src/lib/protocols/netbios.c
@@ -410,17 +410,15 @@ static void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct
 
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ****************************************************************** */
 
 void init_netbios_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("NETBIOS", ndpi_struct,
-				      NDPI_PROTOCOL_NETBIOS,
-				      ndpi_search_netbios,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("NETBIOS", ndpi_struct,
+                     ndpi_search_netbios,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_NETBIOS);
 }

--- a/src/lib/protocols/netease_games.c
+++ b/src/lib/protocols/netease_games.c
@@ -73,15 +73,13 @@ static void ndpi_search_netease(struct ndpi_detection_module_struct *ndpi_struct
 
   /* TODO: add more NetEase Games signatures */
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_netease_games_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("NetEaseGames", ndpi_struct,
-                                      NDPI_PROTOCOL_NETEASE_GAMES,
-                                      ndpi_search_netease,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("NetEaseGames", ndpi_struct,
+                     ndpi_search_netease,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_NETEASE_GAMES);
 }

--- a/src/lib/protocols/netflow.c
+++ b/src/lib/protocols/netflow.c
@@ -119,7 +119,7 @@ static void ndpi_search_netflow(struct ndpi_detection_module_struct *ndpi_struct
     case 7:
     case 9:
       if((n == 0) || (n > 30)) {
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 	return;
       }
       
@@ -142,7 +142,7 @@ static void ndpi_search_netflow(struct ndpi_detection_module_struct *ndpi_struct
       }
 
       if((expected_len > 0) && (expected_len != payload_len)) {
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 	return;
       }
 
@@ -154,7 +154,7 @@ static void ndpi_search_netflow(struct ndpi_detection_module_struct *ndpi_struct
 	u_int16_t ipfix_len = n;
 
 	if(ipfix_len != payload_len) {
-	  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 	  return;
 	}
       }    
@@ -162,7 +162,7 @@ static void ndpi_search_netflow(struct ndpi_detection_module_struct *ndpi_struct
       break;
       
     default:
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -179,16 +179,14 @@ static void ndpi_search_netflow(struct ndpi_detection_module_struct *ndpi_struct
       return;
     }
   } else
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_netflow_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("NetFlow", ndpi_struct,
-				      NDPI_PROTOCOL_NETFLOW,
-				      ndpi_search_netflow,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("NetFlow", ndpi_struct,
+                     ndpi_search_netflow,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_NETFLOW);
 }
 

--- a/src/lib/protocols/nexon.c
+++ b/src/lib/protocols/nexon.c
@@ -57,17 +57,15 @@ static void ndpi_search_nexon(struct ndpi_detection_module_struct *ndpi_struct, 
 
   /* TODO: detect UDP traffic */
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 
 }
 
 
 void init_nexon_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Nexon", ndpi_struct,
-				      NDPI_PROTOCOL_NEXON,
-				      ndpi_search_nexon,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Nexon", ndpi_struct,
+                     ndpi_search_nexon,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_NEXON);
 }

--- a/src/lib/protocols/nfs.c
+++ b/src/lib/protocols/nfs.c
@@ -84,17 +84,15 @@ static void ndpi_search_nfs(struct ndpi_detection_module_struct *ndpi_struct, st
 	return;
 
   exclude_nfs:
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_nfs_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("NFS", ndpi_struct,
-				      NDPI_PROTOCOL_NFS,
-				      ndpi_search_nfs,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("NFS", ndpi_struct,
+                     ndpi_search_nfs,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_NFS);
 }
 

--- a/src/lib/protocols/nintendo.c
+++ b/src/lib/protocols/nintendo.c
@@ -51,15 +51,13 @@ static void ndpi_search_nintendo(struct ndpi_detection_module_struct *ndpi_struc
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_nintendo_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("Nintendo", ndpi_struct,
-				      NDPI_PROTOCOL_NINTENDO,
-				      ndpi_search_nintendo,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Nintendo", ndpi_struct,
+                     ndpi_search_nintendo,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_NINTENDO);
 }
 

--- a/src/lib/protocols/noe.c
+++ b/src/lib/protocols/noe.c
@@ -67,17 +67,15 @@ static void ndpi_search_noe(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_noe_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("NOE", ndpi_struct,
-				      NDPI_PROTOCOL_NOE,
-				      ndpi_search_noe,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("NOE", ndpi_struct,
+                     ndpi_search_noe,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_NOE);
 }
 

--- a/src/lib/protocols/nomachine.c
+++ b/src/lib/protocols/nomachine.c
@@ -67,14 +67,12 @@ static void ndpi_search_nomachine(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 void init_nomachine_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("NoMachine", ndpi_struct,
-                                      NDPI_PROTOCOL_NOMACHINE,
-                                      ndpi_search_nomachine,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("NoMachine", ndpi_struct,
+                     ndpi_search_nomachine,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_NOMACHINE);
 }

--- a/src/lib/protocols/non_tcp_udp.c
+++ b/src/lib/protocols/non_tcp_udp.c
@@ -157,103 +157,28 @@ static void ndpi_search_in_non_tcp_udp(struct ndpi_detection_module_struct
     set_protocol_and_bmask(NDPI_PROTOCOL_IP_VRRP);
     break;
   }
+
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_non_tcp_udp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  
-  /* always add non tcp/udp if one protocol is compiled in */
-  NDPI_SAVE_AS_BITMASK(ndpi_struct->callback_buffer[ndpi_struct->callback_buffer_num].detection_bitmask, NDPI_PROTOCOL_UNKNOWN);
-
-  ndpi_set_bitmask_protocol_detection("AH", ndpi_struct,
-				      NDPI_PROTOCOL_IP_AH,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("ESP", ndpi_struct,
-                                      NDPI_PROTOCOL_IP_ESP,
-                                      ndpi_search_in_non_tcp_udp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-                                      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("IP_GRE", ndpi_struct,
-				      NDPI_PROTOCOL_IP_GRE,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("IP_ICMP", ndpi_struct,
-				      NDPI_PROTOCOL_IP_ICMP,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("IP_IGMP", ndpi_struct,
-				      NDPI_PROTOCOL_IP_IGMP,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("IP_EGP", ndpi_struct,
-				      NDPI_PROTOCOL_IP_EGP,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("IP_SCTP", ndpi_struct,
-				      NDPI_PROTOCOL_IP_SCTP,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("IP_PGM", ndpi_struct,
-				      NDPI_PROTOCOL_IP_PGM,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("IP_OSPF", ndpi_struct,
-				      NDPI_PROTOCOL_IP_OSPF,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("IP_IP_IN_IP", ndpi_struct,
-				      NDPI_PROTOCOL_IP_IP_IN_IP,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("IP_ICMPV6", ndpi_struct,
-				      NDPI_PROTOCOL_IP_ICMPV6,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("IP_PIM", ndpi_struct,
-				      NDPI_PROTOCOL_IP_PIM,
-				      ndpi_search_in_non_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-				      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
-
-  ndpi_set_bitmask_protocol_detection("VRRP", ndpi_struct,
-                                      NDPI_PROTOCOL_IP_VRRP,
-                                      ndpi_search_in_non_tcp_udp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
-                                      NO_SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Non_TCP_UDP", ndpi_struct,
+                     ndpi_search_in_non_tcp_udp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
+                     13,
+                     NDPI_PROTOCOL_IP_ESP,
+                     NDPI_PROTOCOL_IP_AH,
+                     NDPI_PROTOCOL_IP_GRE,
+                     NDPI_PROTOCOL_IP_ICMP,
+                     NDPI_PROTOCOL_IP_IGMP,
+                     NDPI_PROTOCOL_IP_EGP,
+                     NDPI_PROTOCOL_IP_SCTP,
+                     NDPI_PROTOCOL_IP_PGM,
+                     NDPI_PROTOCOL_IP_OSPF,
+                     NDPI_PROTOCOL_IP_IP_IN_IP,
+                     NDPI_PROTOCOL_IP_ICMPV6,
+                     NDPI_PROTOCOL_IP_PIM,
+                     NDPI_PROTOCOL_IP_VRRP);
 }

--- a/src/lib/protocols/ntp.c
+++ b/src/lib/protocols/ntp.c
@@ -56,17 +56,15 @@ static void ndpi_search_ntp_udp(struct ndpi_detection_module_struct *ndpi_struct
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_ntp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("NTP", ndpi_struct,
-				      NDPI_PROTOCOL_NTP,
-				      ndpi_search_ntp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("NTP", ndpi_struct,
+                     ndpi_search_ntp_udp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_NTP);
 }
 

--- a/src/lib/protocols/oicq.c
+++ b/src/lib/protocols/oicq.c
@@ -59,19 +59,19 @@ static void ndpi_search_oicq(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < sizeof(*hdr))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (hdr->flag != 0x02)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (ntohs(hdr->version) != 0x3b0b)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -79,7 +79,7 @@ static void ndpi_search_oicq(struct ndpi_detection_module_struct *ndpi_struct,
   if (command == 0x0000 || (command > 0x00b5 && command < 0x03f7) ||
       command > 0x03f7)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -90,11 +90,8 @@ static void ndpi_search_oicq(struct ndpi_detection_module_struct *ndpi_struct,
   
 void init_oicq_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("OICQ", ndpi_struct,
-                                      NDPI_PROTOCOL_OICQ,
-                                      ndpi_search_oicq,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK
-                                     );
+  register_dissector("OICQ", ndpi_struct,
+                     ndpi_search_oicq,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_OICQ);
 }

--- a/src/lib/protocols/ookla.c
+++ b/src/lib/protocols/ookla.c
@@ -92,7 +92,7 @@ void ndpi_search_ookla(struct ndpi_detection_module_struct* ndpi_struct, struct 
   NDPI_LOG_DBG(ndpi_struct, "Ookla detection\n");
 
   if(ntohs(flow->s_port) != ookla_port && ntohs(flow->c_port) != ookla_port) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -113,16 +113,14 @@ void ndpi_search_ookla(struct ndpi_detection_module_struct* ndpi_struct, struct 
     return;
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ************************************************************* */
 
 void init_ookla_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("Ookla", ndpi_struct,
-				      NDPI_PROTOCOL_OOKLA,
-				      ndpi_search_ookla,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Ookla", ndpi_struct,
+                     ndpi_search_ookla,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_OOKLA);
 }

--- a/src/lib/protocols/opc-ua.c
+++ b/src/lib/protocols/opc-ua.c
@@ -66,15 +66,13 @@ static void ndpi_search_opc_ua(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_opc_ua_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("OPC-UA", ndpi_struct,
-				      NDPI_PROTOCOL_OPC_UA,
-				      ndpi_search_opc_ua,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("OPC-UA", ndpi_struct,
+                     ndpi_search_opc_ua,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_OPC_UA);
 }

--- a/src/lib/protocols/openflow.c
+++ b/src/lib/protocols/openflow.c
@@ -53,16 +53,14 @@ static void ndpi_search_openflow(struct ndpi_detection_module_struct *ndpi_struc
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_openflow_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("OpenFlow", ndpi_struct,
-              NDPI_PROTOCOL_OPENFLOW,
-              ndpi_search_openflow,
-              NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-              ADD_TO_DETECTION_BITMASK);
+  register_dissector("OpenFlow", ndpi_struct,
+                     ndpi_search_openflow,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_OPENFLOW);
 }
 

--- a/src/lib/protocols/openvpn.c
+++ b/src/lib/protocols/openvpn.c
@@ -461,7 +461,7 @@ static void ndpi_search_openvpn(struct ndpi_detection_module_struct* ndpi_struct
   if(packet->payload_packet_len > 10 &&
      ntohl(*(u_int32_t *)&packet->payload[4 + 2 * (packet->tcp != NULL)]) == 0x2112A442) {
     NDPI_LOG_DBG2(ndpi_struct, "Avoid collision with STUN\n");
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -491,16 +491,14 @@ static void ndpi_search_openvpn(struct ndpi_detection_module_struct* ndpi_struct
     ndpi_set_risk(ndpi_struct, flow, NDPI_OBFUSCATED_TRAFFIC, "Obfuscated OpenVPN");
   } else if(flow->ovpn_alg_standard_state == 1 &&
             flow->ovpn_alg_heur_opcode_state == 1) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 
 }
 
 void init_openvpn_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("OpenVPN", ndpi_struct,
-				      NDPI_PROTOCOL_OPENVPN,
-				      ndpi_search_openvpn,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("OpenVPN", ndpi_struct,
+                     ndpi_search_openvpn,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_OPENVPN);
 }

--- a/src/lib/protocols/openwire.c
+++ b/src/lib/protocols/openwire.c
@@ -47,15 +47,13 @@ static void ndpi_search_openwire(struct ndpi_detection_module_struct *ndpi_struc
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_openwire_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("OpenWire", ndpi_struct,
-				      NDPI_PROTOCOL_OPENWIRE,
-				      ndpi_search_openwire,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("OpenWire", ndpi_struct,
+                     ndpi_search_openwire,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_OPENWIRE);
 }

--- a/src/lib/protocols/oracle.c
+++ b/src/lib/protocols/oracle.c
@@ -56,16 +56,14 @@ static void ndpi_search_oracle(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_oracle_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Oracle", ndpi_struct,
-				      NDPI_PROTOCOL_ORACLE,
-				      ndpi_search_oracle,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Oracle", ndpi_struct,
+                     ndpi_search_oracle,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ORACLE);
 }

--- a/src/lib/protocols/paltalk.c
+++ b/src/lib/protocols/paltalk.c
@@ -57,15 +57,13 @@ static void ndpi_search_paltalk(struct ndpi_detection_module_struct *ndpi_struct
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_paltalk_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Paltalk", ndpi_struct,
-              NDPI_PROTOCOL_PALTALK,
-              ndpi_search_paltalk,
-              NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-              ADD_TO_DETECTION_BITMASK);
+  register_dissector("Paltalk", ndpi_struct,
+                     ndpi_search_paltalk,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_PALTALK);
 }

--- a/src/lib/protocols/path_of_exile.c
+++ b/src/lib/protocols/path_of_exile.c
@@ -66,15 +66,13 @@ static void ndpi_search_pathofexile(struct ndpi_detection_module_struct *ndpi_st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_pathofexile_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("PathofExile", ndpi_struct,
-              NDPI_PROTOCOL_PATHOFEXILE,
-              ndpi_search_pathofexile,
-              NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-              ADD_TO_DETECTION_BITMASK);
+  register_dissector("PathofExile", ndpi_struct,
+                     ndpi_search_pathofexile,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_PATHOFEXILE);
 }

--- a/src/lib/protocols/pfcp.c
+++ b/src/lib/protocols/pfcp.c
@@ -56,14 +56,12 @@ static void ndpi_search_pfcp(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 void init_pfcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("PFCP", ndpi_struct,
-                                      NDPI_PROTOCOL_PFCP,
-                                      ndpi_search_pfcp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("PFCP", ndpi_struct,
+                     ndpi_search_pfcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_PFCP);
 }

--- a/src/lib/protocols/postgres.c
+++ b/src/lib/protocols/postgres.c
@@ -119,17 +119,15 @@ static void ndpi_search_postgres_tcp(struct ndpi_detection_module_struct
 		}
 	}
 
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_postgres_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("PostgreSQL", ndpi_struct,
-				      NDPI_PROTOCOL_POSTGRES,
-				      ndpi_search_postgres_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("PostgreSQL", ndpi_struct,
+                     ndpi_search_postgres_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_POSTGRES);
 }
 

--- a/src/lib/protocols/pptp.c
+++ b/src/lib/protocols/pptp.c
@@ -53,16 +53,14 @@ static void ndpi_search_pptp(struct ndpi_detection_module_struct
 		return;
 	}
 
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_pptp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("PPTP", ndpi_struct,
-				      NDPI_PROTOCOL_PPTP,
-				      ndpi_search_pptp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("PPTP", ndpi_struct,
+                     ndpi_search_pptp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_PPTP);
 }

--- a/src/lib/protocols/profinet_io.c
+++ b/src/lib/protocols/profinet_io.c
@@ -72,16 +72,13 @@ static void ndpi_search_profinet_io(struct ndpi_detection_module_struct *ndpi_st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_profinet_io_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("PROFINET_IO", ndpi_struct,
-                                      NDPI_PROTOCOL_PROFINET_IO,
-                                      ndpi_search_profinet_io,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK
-                                     );
+  register_dissector("PROFINET_IO", ndpi_struct,
+                     ndpi_search_profinet_io,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_PROFINET_IO);
 }

--- a/src/lib/protocols/ptpv2.c
+++ b/src/lib/protocols/ptpv2.c
@@ -63,15 +63,13 @@ static void ndpi_search_ptpv2_udp(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_ptpv2_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("PTPv2", ndpi_struct,
-              NDPI_PROTOCOL_PTPV2,
-              ndpi_search_ptpv2_udp,
-              NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-              ADD_TO_DETECTION_BITMASK);
+  register_dissector("PTPv2", ndpi_struct,
+                     ndpi_search_ptpv2_udp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_PTPV2);
 }

--- a/src/lib/protocols/qq.c
+++ b/src/lib/protocols/qq.c
@@ -53,17 +53,15 @@ static void ndpi_search_qq(struct ndpi_detection_module_struct *ndpi_struct, str
         ndpi_int_qq_add_connection(ndpi_struct, flow);
       } else {
         if(flow->num_processed_pkts > 4)
-          NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+          NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       }
 }
 
 
 void init_qq_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("QQ", ndpi_struct,
-				      NDPI_PROTOCOL_QQ,
-				      ndpi_search_qq,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("QQ", ndpi_struct,
+                     ndpi_search_qq,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_QQ);
 }

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -1977,7 +1977,7 @@ static void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
       if(ret == -1) {
         NDPI_LOG_DBG2(ndpi_struct, "Keep looking for SH by client\n");
         if(flow->packet_counter > 10 /* TODO */)
-          NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+          NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 	return;
       }
       ret = may_be_gquic_rej(ndpi_struct);
@@ -1988,7 +1988,7 @@ static void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
 	return;
       }
     }
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -2006,7 +2006,7 @@ static void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
 
   if(!is_version_supported(version)) {
     NDPI_LOG_DBG(ndpi_struct, "Unsupported version 0x%x\n", version);
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -2029,7 +2029,7 @@ static void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
    */
   clear_payload = get_clear_payload(ndpi_struct, flow, version, &clear_payload_len);
   if(!clear_payload) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -2061,7 +2061,7 @@ static void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
     flow->max_extra_packets_to_check = 24; /* TODO */
     flow->extra_packets_func = ndpi_search_quic_extra;
   } else if(!crypto_data) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
@@ -2069,8 +2069,8 @@ static void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_quic_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("QUIC", ndpi_struct,
-				      NDPI_PROTOCOL_QUIC, ndpi_search_quic,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN, ADD_TO_DETECTION_BITMASK);
+  register_dissector("QUIC", ndpi_struct,
+                     ndpi_search_quic,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_QUIC);
 }

--- a/src/lib/protocols/radius_proto.c
+++ b/src/lib/protocols/radius_proto.c
@@ -48,7 +48,7 @@ static void ndpi_check_radius(struct ndpi_detection_module_struct *ndpi_struct, 
     struct radius_header *h = (struct radius_header*)packet->payload;
     /* RFC2865: The minimum length is 20 and maximum length is 4096. */
     if((payload_len < 20) || (payload_len > 4096)) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
     
@@ -61,7 +61,7 @@ static void ndpi_check_radius(struct ndpi_detection_module_struct *ndpi_struct, 
     }
   }
   if(flow->packet_counter > 3)
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 }
 
@@ -75,10 +75,8 @@ static void ndpi_search_radius(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_radius_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Radius", ndpi_struct,
-				      NDPI_PROTOCOL_RADIUS,
-				      ndpi_search_radius,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Radius", ndpi_struct,
+                     ndpi_search_radius,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_RADIUS);
 }

--- a/src/lib/protocols/radmin.c
+++ b/src/lib/protocols/radmin.c
@@ -85,15 +85,13 @@ static void ndpi_search_radmin(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_radmin_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Radmin", ndpi_struct,
-				      NDPI_PROTOCOL_RADMIN,
-				      ndpi_search_radmin,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Radmin", ndpi_struct,
+                     ndpi_search_radmin,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_RADMIN);
 }

--- a/src/lib/protocols/raft.c
+++ b/src/lib/protocols/raft.c
@@ -61,7 +61,7 @@ static void ndpi_search_raft(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < sizeof(*raft_header))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -77,7 +77,7 @@ static void ndpi_search_raft(struct ndpi_detection_module_struct *ndpi_struct,
       break;
 
     default:
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
   }
 
@@ -98,11 +98,9 @@ static void ndpi_search_raft(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_raft_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Raft", ndpi_struct,
-                                      NDPI_PROTOCOL_RAFT,
-                                      ndpi_search_raft,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Raft", ndpi_struct,
+                     ndpi_search_raft,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_RAFT);
 }
 

--- a/src/lib/protocols/raknet.c
+++ b/src/lib/protocols/raknet.c
@@ -79,7 +79,7 @@ static void exclude_proto(struct ndpi_detection_module_struct *ndpi_struct,
        other protocols too. Keep the generic classification, for the time being */
     ndpi_int_raknet_add_connection(ndpi_struct, flow);
   } else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
@@ -393,10 +393,8 @@ static void ndpi_search_raknet(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_raknet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RakNet", ndpi_struct,
-				      NDPI_PROTOCOL_RAKNET,
-				      ndpi_search_raknet,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("RakNet", ndpi_struct,
+                     ndpi_search_raknet,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_RAKNET);
 }

--- a/src/lib/protocols/rdp.c
+++ b/src/lib/protocols/rdp.c
@@ -110,7 +110,7 @@ static void ndpi_search_rdp(struct ndpi_detection_module_struct *ndpi_struct,
 	}
       }
     }
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   } else if(packet->udp != NULL) {
     u_int16_t s_port = ntohs(packet->udp->source);
     u_int16_t d_port = ntohs(packet->udp->dest);
@@ -137,7 +137,7 @@ static void ndpi_search_rdp(struct ndpi_detection_module_struct *ndpi_struct,
 	  }
 	} else {
 	  if(memcmp(flow->l4.udp.rdp_from_srv, packet->payload, 3) != 0)
-	    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 	  else {
 	    flow->l4.udp.rdp_from_srv_pkts = 2 /* stage 2 */;
 
@@ -163,7 +163,7 @@ static void ndpi_search_rdp(struct ndpi_detection_module_struct *ndpi_struct,
 	  }
 	} else {
 	  if(memcmp(flow->l4.udp.rdp_to_srv, packet->payload, 3) != 0)
-	    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 	  else {
 	    flow->l4.udp.rdp_to_srv_pkts = 2 /* stage 2 */;
 	    
@@ -175,7 +175,7 @@ static void ndpi_search_rdp(struct ndpi_detection_module_struct *ndpi_struct,
 	}
       }
     } else
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
@@ -183,10 +183,8 @@ static void ndpi_search_rdp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_rdp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RDP", ndpi_struct,
-				      NDPI_PROTOCOL_RDP,
-				      ndpi_search_rdp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("RDP", ndpi_struct,
+                     ndpi_search_rdp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_RDP);
 }

--- a/src/lib/protocols/resp.c
+++ b/src/lib/protocols/resp.c
@@ -66,15 +66,13 @@ static void ndpi_search_resp(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
 exclude:
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_resp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RESP", ndpi_struct,
-				      NDPI_PROTOCOL_RESP,
-				      ndpi_search_resp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("RESP", ndpi_struct,
+                     ndpi_search_resp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_RESP);
 }

--- a/src/lib/protocols/riotgames.c
+++ b/src/lib/protocols/riotgames.c
@@ -63,17 +63,14 @@ static void ndpi_search_riotgames(struct ndpi_detection_module_struct *ndpi_stru
    * Please add new patterns for games made by RiotGames here
    */
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 }
 
 void init_riotgames_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RiotGames", ndpi_struct,
-    NDPI_PROTOCOL_RIOTGAMES,
-    ndpi_search_riotgames,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("RiotGames", ndpi_struct,
+                     ndpi_search_riotgames,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_RIOTGAMES);
 }

--- a/src/lib/protocols/ripe_atlas.c
+++ b/src/lib/protocols/ripe_atlas.c
@@ -47,7 +47,7 @@ static void ndpi_search_ripe_atlas(struct ndpi_detection_module_struct *ndpi_str
   NDPI_LOG_DBG(ndpi_struct, "search (Magellan) Ripe Atlas Tool\n");
 
   if (packet->payload_packet_len != 25) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -56,15 +56,13 @@ static void ndpi_search_ripe_atlas(struct ndpi_detection_module_struct *ndpi_str
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_ripe_atlas_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RipeAtlas", ndpi_struct,
-				      NDPI_PROTOCOL_RIPE_ATLAS,
-				      ndpi_search_ripe_atlas,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("RipeAtlas", ndpi_struct,
+                     ndpi_search_ripe_atlas,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_RIPE_ATLAS);
 }

--- a/src/lib/protocols/rmcp.c
+++ b/src/lib/protocols/rmcp.c
@@ -58,27 +58,27 @@ static void ndpi_search_rmcp(struct ndpi_detection_module_struct *ndpi_struct,
   NDPI_LOG_DBG(ndpi_struct, "search RMCP\n");
 
   if (packet->payload_packet_len < sizeof(struct rmcp_header)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   struct rmcp_header const * const rmcp_header = (struct rmcp_header *)packet->payload;
 
   if (rmcp_header->version != 0x06 || rmcp_header->reserved != 0x00) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (rmcp_header->type != 0 && rmcp_header->sequence == 0xFF) {
     // No ACK allowed if SEQUENCE number is 255.
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (rmcp_header->class != 0x06 /* Alert Standard Forum (ASF)*/
       && rmcp_header->class != 0x07 /* Intelligent Platform Management Interface (IPMI) */)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -88,11 +88,9 @@ static void ndpi_search_rmcp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_rmcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RMCP", ndpi_struct,
-                                      NDPI_PROTOCOL_RMCP,
-                                      ndpi_search_rmcp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("RMCP", ndpi_struct,
+                     ndpi_search_rmcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_RMCP);
 }
 

--- a/src/lib/protocols/roughtime.c
+++ b/src/lib/protocols/roughtime.c
@@ -77,7 +77,7 @@ static void ndpi_search_roughtime(struct ndpi_detection_module_struct *ndpi_stru
 
   if (packet->payload_packet_len < 4)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -88,7 +88,7 @@ static void ndpi_search_roughtime(struct ndpi_detection_module_struct *ndpi_stru
   if (number_of_tags < 1 || packet->payload_packet_len < minimum_length ||
       number_of_tags > NDPI_ARRAY_LENGTH(valid_tags))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -96,7 +96,7 @@ static void ndpi_search_roughtime(struct ndpi_detection_module_struct *ndpi_stru
     u_int32_t tag_offset = le32toh(get_u_int32_t(packet->payload, 4 + (number_of_tags - 2) * 4));
     if (packet->payload_packet_len < 4 + (number_of_tags - 1) * 4 + tag_offset)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
@@ -116,7 +116,7 @@ static void ndpi_search_roughtime(struct ndpi_detection_module_struct *ndpi_stru
     }
     if (j == NDPI_ARRAY_LENGTH(valid_tags))
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
@@ -126,11 +126,8 @@ static void ndpi_search_roughtime(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_roughtime_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Roughtime", ndpi_struct,
-    NDPI_PROTOCOL_ROUGHTIME,
-    ndpi_search_roughtime,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("Roughtime", ndpi_struct,
+                     ndpi_search_roughtime,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ROUGHTIME);
 }

--- a/src/lib/protocols/rsh.c
+++ b/src/lib/protocols/rsh.c
@@ -71,12 +71,12 @@ static void ndpi_search_rsh(struct ndpi_detection_module_struct * ndpi_struct,
         {
           if (ndpi_isdigit(packet->payload[i]) == 0)
           {
-            NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+            NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
             return;
           }
         }
       } else {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       }
       return;
 
@@ -84,7 +84,7 @@ static void ndpi_search_rsh(struct ndpi_detection_module_struct * ndpi_struct,
       if (packet->payload_packet_len < 3 ||
           packet->payload[packet->payload_packet_len - 1] != '\0')
       {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
       }
 
@@ -103,7 +103,7 @@ static void ndpi_search_rsh(struct ndpi_detection_module_struct * ndpi_struct,
               ndpi_is_printable_buffer((uint8_t const *)dissected_info[i - 1],
                                        (dissected_info[i] - dissected_info[i - 1])) == 0)
           {
-            NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+            NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
             return;
           }
 
@@ -111,7 +111,7 @@ static void ndpi_search_rsh(struct ndpi_detection_module_struct * ndpi_struct,
           {
             if (dissected_info[NDPI_ARRAY_LENGTH(dissected_info) - 1] == NULL)
             {
-              NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+              NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
               return;
             }
             break;
@@ -144,7 +144,7 @@ static void ndpi_search_rsh(struct ndpi_detection_module_struct * ndpi_struct,
       return;
 
     default:
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
   }
 }
@@ -152,9 +152,8 @@ static void ndpi_search_rsh(struct ndpi_detection_module_struct * ndpi_struct,
 
 void init_rsh_dissector(struct ndpi_detection_module_struct * ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RSH", ndpi_struct,
-                                      NDPI_PROTOCOL_RSH, ndpi_search_rsh,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("RSH", ndpi_struct,
+                     ndpi_search_rsh,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_RSH);
 }

--- a/src/lib/protocols/rsync.c
+++ b/src/lib/protocols/rsync.c
@@ -54,16 +54,14 @@ static void ndpi_search_rsync(struct ndpi_detection_module_struct *ndpi_struct, 
     }
   }
   if(flow->packet_counter > 5)
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_rsync_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RSYNC", ndpi_struct,
-				      NDPI_PROTOCOL_RSYNC,
-				      ndpi_search_rsync,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("RSYNC", ndpi_struct,
+                     ndpi_search_rsync,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_RSYNC);
 }

--- a/src/lib/protocols/rtmp.c
+++ b/src/lib/protocols/rtmp.c
@@ -46,7 +46,7 @@ static void ndpi_check_rtmp(struct ndpi_detection_module_struct *ndpi_struct, st
      See: https://en.wikipedia.org/w/index.php?title=Real-Time_Messaging_Protocol&section=12#Handshake */
 
   if(!ndpi_seen_flow_beginning(flow)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -80,7 +80,7 @@ static void ndpi_check_rtmp(struct ndpi_detection_module_struct *ndpi_struct, st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_rtmp(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -93,11 +93,9 @@ static void ndpi_search_rtmp(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_rtmp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RTMP", ndpi_struct,
-				      NDPI_PROTOCOL_RTMP,
-				      ndpi_search_rtmp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("RTMP", ndpi_struct,
+                     ndpi_search_rtmp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_RTMP);
 }
 

--- a/src/lib/protocols/rtps.c
+++ b/src/lib/protocols/rtps.c
@@ -57,16 +57,13 @@ static void ndpi_search_rtps(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_rtps_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RTPS", ndpi_struct,
-                                      NDPI_PROTOCOL_RTPS,
-                                      ndpi_search_rtps,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK
-                                     );
+  register_dissector("RTPS", ndpi_struct,
+                     ndpi_search_rtps,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_RTPS);
 }

--- a/src/lib/protocols/rtsp.c
+++ b/src/lib/protocols/rtsp.c
@@ -67,16 +67,14 @@ static void ndpi_search_rtsp_tcp_udp(struct ndpi_detection_module_struct *ndpi_s
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_rtsp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RTSP", ndpi_struct,
-				      NDPI_PROTOCOL_RTSP,
-				      ndpi_search_rtsp_tcp_udp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("RTSP", ndpi_struct,
+                     ndpi_search_rtsp_tcp_udp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_RTSP);
 }

--- a/src/lib/protocols/rx.c
+++ b/src/lib/protocols/rx.c
@@ -88,7 +88,7 @@ static void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
 
   /* Check that packet is long enough */
   if (payload_len < sizeof(struct ndpi_rx_header)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
   
@@ -111,7 +111,7 @@ static void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
   
   /* TYPE field */
   if((header->type < RX_DATA) || (header->type > RX_VERS)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -164,11 +164,11 @@ static void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
       case RX_VERS:
 	goto security;
       default:
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 	return;
     } // switch
   } else { // FLAG
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -176,7 +176,7 @@ static void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
   /* SECURITY field */
   if(header->security > 3)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
   
@@ -194,7 +194,7 @@ static void ndpi_check_rx(struct ndpi_detection_module_struct *ndpi_struct,
     /* https://www.central.org/frameless/numbers/rxservice.html. */
     else
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   } else {
@@ -214,11 +214,9 @@ static void ndpi_search_rx(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_rx_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("RX", ndpi_struct,
-				      NDPI_PROTOCOL_RX,
-				      ndpi_search_rx,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("RX", ndpi_struct,
+                     ndpi_search_rx,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_RX);
 }
 

--- a/src/lib/protocols/s7comm.c
+++ b/src/lib/protocols/s7comm.c
@@ -65,15 +65,13 @@ static void ndpi_search_s7comm(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_s7comm_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("S7Comm", ndpi_struct,
-                                      NDPI_PROTOCOL_S7COMM,
-                                      ndpi_search_s7comm,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("S7Comm", ndpi_struct,
+                     ndpi_search_s7comm,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_S7COMM);
 }

--- a/src/lib/protocols/sd_rtn.c
+++ b/src/lib/protocols/sd_rtn.c
@@ -80,16 +80,14 @@ static void ndpi_search_sd_rtn(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_sd_rtn_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("SD-RTN", ndpi_struct,
-				      NDPI_PROTOCOL_SD_RTN,
-				      ndpi_search_sd_rtn,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("SD-RTN", ndpi_struct,
+                     ndpi_search_sd_rtn,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_SD_RTN);
 }
 

--- a/src/lib/protocols/sflow.c
+++ b/src/lib/protocols/sflow.c
@@ -52,16 +52,14 @@ static void ndpi_search_sflow(struct ndpi_detection_module_struct *ndpi_struct, 
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_sflow_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("sFlow", ndpi_struct,
-				      NDPI_PROTOCOL_SFLOW,
-				      ndpi_search_sflow,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("sFlow", ndpi_struct,
+                     ndpi_search_sflow,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_SFLOW);
 }
 

--- a/src/lib/protocols/sip.c
+++ b/src/lib/protocols/sip.c
@@ -236,7 +236,7 @@ static void ndpi_search_sip(struct ndpi_detection_module_struct *ndpi_struct, st
   NDPI_LOG_DBG(ndpi_struct, "Searching for SIP\n");
 
   if(flow->packet_counter >= 8) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
   
@@ -251,7 +251,7 @@ static void ndpi_search_sip(struct ndpi_detection_module_struct *ndpi_struct, st
     }
 
     if(!isprint(packet_payload[0])) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
@@ -274,11 +274,9 @@ static void ndpi_search_sip(struct ndpi_detection_module_struct *ndpi_struct, st
 /* ********************************************************** */
 
 void init_sip_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("SIP", ndpi_struct,
-				      NDPI_PROTOCOL_SIP,
-				      ndpi_search_sip,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,/* Fix courtesy of Miguel Quesada <mquesadab@gmail.com> */
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("SIP", ndpi_struct,
+                     ndpi_search_sip,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SIP);
 }
 

--- a/src/lib/protocols/skinny.c
+++ b/src/lib/protocols/skinny.c
@@ -87,16 +87,14 @@ static void ndpi_search_skinny(struct ndpi_detection_module_struct *ndpi_struct,
       }
     }
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_skinny_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("CiscoSkinny", ndpi_struct,
-				      NDPI_PROTOCOL_SKINNY,
-				      ndpi_search_skinny,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("CiscoSkinny", ndpi_struct,
+                     ndpi_search_skinny,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SKINNY);
 }

--- a/src/lib/protocols/slp.c
+++ b/src/lib/protocols/slp.c
@@ -101,7 +101,7 @@ static int slp_check_packet_length(struct ndpi_detection_module_struct *ndpi_str
   struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
 
   if (packet->payload_packet_len != packet_length) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return 1;
   }
 
@@ -113,25 +113,25 @@ static int slp_check_fid(struct ndpi_detection_module_struct *ndpi_struct,
                          enum function_id fid, uint8_t slp_version)
 {
   if (fid <= FID_UNKNOWN) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return 1;
   }
 
   switch (slp_version) {
     case 0x01:
       if (fid >= FID_MAX_v1) {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return 1;
       }
       break;
     case 0x02:
       if (fid >= FID_MAX) {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return 1;
       }
       break;
     default:
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return 1;
   }
 
@@ -199,7 +199,7 @@ static void ndpi_search_slp_v1(struct ndpi_detection_module_struct *ndpi_struct,
   NDPI_LOG_DBG(ndpi_struct, "search Service Location Protocol v1\n");
 
   if (packet->payload_packet_len < sizeof(*hdr)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -222,7 +222,7 @@ static int ndpi_search_slp_v2(struct ndpi_detection_module_struct *ndpi_struct,
   NDPI_LOG_DBG(ndpi_struct, "search Service Location Protocol v2\n");
 
   if (packet->payload_packet_len < sizeof(*hdr)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return 1;
   }
 
@@ -316,17 +316,15 @@ static void ndpi_search_slp(struct ndpi_detection_module_struct *ndpi_struct,
       }
       break;
     default:
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       break;
   }
 }
 
 void init_slp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Service_Location_Protocol", ndpi_struct,
-                                      NDPI_PROTOCOL_SERVICE_LOCATION,
-                                      ndpi_search_slp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Service_Location_Protocol", ndpi_struct,
+                     ndpi_search_slp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SERVICE_LOCATION);
 }

--- a/src/lib/protocols/smb.c
+++ b/src/lib/protocols/smb.c
@@ -76,16 +76,14 @@ static void ndpi_search_smb_tcp(struct ndpi_detection_module_struct *ndpi_struct
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_smb_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("SMB", ndpi_struct,
-				      NDPI_PROTOCOL_SMBV23,
-				      ndpi_search_smb_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("SMB", ndpi_struct,
+                     ndpi_search_smb_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SMBV23);
 }

--- a/src/lib/protocols/smpp.c
+++ b/src/lib/protocols/smpp.c
@@ -48,7 +48,7 @@ static void ndpi_search_smpp_tcp(struct ndpi_detection_module_struct* ndpi_struc
   if (flow->detected_protocol_stack[0] != NDPI_PROTOCOL_SMPP){
     // min SMPP packet length = 16 bytes
     if (packet->payload_packet_len < 16) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
     // get PDU length
@@ -60,7 +60,7 @@ static void ndpi_search_smpp_tcp(struct ndpi_detection_module_struct* ndpi_struc
 
     // if PDU size was invalid, try the following TCP segments, 3 attempts max
     if(flow->packet_counter > 3) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
     // verify PDU length
@@ -100,7 +100,7 @@ static void ndpi_search_smpp_tcp(struct ndpi_detection_module_struct* ndpi_struc
     u_int32_t pdu_type = ntohl(get_u_int32_t(packet->payload, 4));
     // first byte of PDU type is either 0x00 of 0x80
     if(!(packet->payload[4] == 0x00 || packet->payload[4] == 0x80)) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
     // remove 0x80, get request type pdu
@@ -305,17 +305,15 @@ static void ndpi_search_smpp_tcp(struct ndpi_detection_module_struct* ndpi_struc
       }
     }
 
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 
 void init_smpp_dissector(struct ndpi_detection_module_struct* ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("SMPP", ndpi_struct,
-				      NDPI_PROTOCOL_SMPP,
-				      ndpi_search_smpp_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("SMPP", ndpi_struct,
+                     ndpi_search_smpp_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SMPP);
 }

--- a/src/lib/protocols/snmp_proto.c
+++ b/src/lib/protocols/snmp_proto.c
@@ -64,7 +64,7 @@ static void ndpi_search_snmp(struct ndpi_detection_module_struct *ndpi_struct,
      (packet->udp->dest != snmp_port) &&
      (packet->udp->source != trap_port) &&
      (packet->udp->dest != trap_port)) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -141,15 +141,13 @@ static void ndpi_search_snmp(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_snmp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("SNMP", ndpi_struct,
-				      NDPI_PROTOCOL_SNMP,
-				      ndpi_search_snmp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("SNMP", ndpi_struct,
+                     ndpi_search_snmp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_SNMP);
 }
 

--- a/src/lib/protocols/soap.c
+++ b/src/lib/protocols/soap.c
@@ -66,7 +66,7 @@ static void ndpi_search_soap(struct ndpi_detection_module_struct *ndpi_struct,
       ndpi_int_soap_add_connection(ndpi_struct, flow);
     }
     else {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     }
   }
 
@@ -82,9 +82,9 @@ static void ndpi_search_soap(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_soap_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection(
-    "SOAP", ndpi_struct,
-    NDPI_PROTOCOL_SOAP, ndpi_search_soap, NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN, ADD_TO_DETECTION_BITMASK);
+  register_dissector("SOAP", ndpi_struct,
+                     ndpi_search_soap,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SOAP);
 }
 

--- a/src/lib/protocols/socks45.c
+++ b/src/lib/protocols/socks45.c
@@ -112,7 +112,7 @@ static void ndpi_search_socks(struct ndpi_detection_module_struct *ndpi_struct, 
   NDPI_LOG_DBG(ndpi_struct, "search SOCKS\n");
 
   if(flow->packet_counter >= 10) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -124,11 +124,9 @@ static void ndpi_search_socks(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_socks_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("SOCKS", ndpi_struct,
-				      NDPI_PROTOCOL_SOCKS,
-				      ndpi_search_socks,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK); 
+  register_dissector("SOCKS", ndpi_struct,
+                     ndpi_search_socks,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SOCKS);
 }
 

--- a/src/lib/protocols/softether.c
+++ b/src/lib/protocols/softether.c
@@ -304,7 +304,7 @@ static void ndpi_search_softether(struct ndpi_detection_module_struct *ndpi_stru
   if(packet->payload_packet_len == 1) {
 
     if((packet->payload[0] != 0x41) || (flow->packet_counter > 2))	
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);	
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);	
 
     return;
   }
@@ -323,7 +323,7 @@ static void ndpi_search_softether(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ***************************************************** */
@@ -348,11 +348,8 @@ static int ndpi_search_softether_again(struct ndpi_detection_module_struct *ndpi
 /* ***************************************************** */
   
 void init_softether_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("Softether", ndpi_struct,
-				      NDPI_PROTOCOL_SOFTETHER,
-				      ndpi_search_softether,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK
-				      );
+  register_dissector("Softether", ndpi_struct,
+                     ndpi_search_softether,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_SOFTETHER);
 }

--- a/src/lib/protocols/someip.c
+++ b/src/lib/protocols/someip.c
@@ -101,7 +101,7 @@ static void ndpi_search_someip(struct ndpi_detection_module_struct *ndpi_struct,
   if (packet->payload_packet_len < 16) {
     NDPI_LOG_DBG(ndpi_struct,
 	     "Excluding SOME/IP .. mandatory header not found (not enough data for all fields)\n");
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
   
@@ -122,7 +122,7 @@ static void ndpi_search_someip(struct ndpi_detection_module_struct *ndpi_struct,
   u_int32_t someip_len = ntohl(someip_data_cover_32(&packet->payload[4]));
   if (packet->payload_packet_len != (someip_len + 8)) {
     NDPI_LOG_DBG(ndpi_struct, "Excluding SOME/IP .. Length field invalid!\n");
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -130,7 +130,7 @@ static void ndpi_search_someip(struct ndpi_detection_module_struct *ndpi_struct,
   NDPI_LOG_DBG2(ndpi_struct,"====>>>> SOME/IP protocol version: [%d]\n",protocol_version);
   if (protocol_version != LEGAL_PROTOCOL_VERSION){
     NDPI_LOG_DBG(ndpi_struct, "Excluding SOME/IP .. invalid protocol version!\n");
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -144,7 +144,7 @@ static void ndpi_search_someip(struct ndpi_detection_module_struct *ndpi_struct,
       (message_type != SOMEIP_REQUEST_NO_RETURN_ACK) && (message_type != SOMEIP_NOTIFICATION_ACK) && (message_type != SOMEIP_RESPONSE) && 
       (message_type != SOMEIP_ERROR) && (message_type != SOMEIP_RESPONSE_ACK) && (message_type != SOMEIP_ERROR_ACK)) {
     NDPI_LOG_DBG(ndpi_struct, "Excluding SOME/IP .. invalid message type!\n");
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -152,7 +152,7 @@ static void ndpi_search_someip(struct ndpi_detection_module_struct *ndpi_struct,
   NDPI_LOG_DBG2(ndpi_struct,"====>>>> SOME/IP return code: [%d]\n", return_code);
   if ((return_code >= E_RETURN_CODE_LEGAL_THRESHOLD)) {
     NDPI_LOG_DBG(ndpi_struct, "Excluding SOME/IP .. invalid return code!\n");
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 	
@@ -165,7 +165,7 @@ static void ndpi_search_someip(struct ndpi_detection_module_struct *ndpi_struct,
     }											
     else{
       NDPI_LOG_DBG(ndpi_struct, "Excluding SOME/IP, invalid header for Magic Cookie\n");
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
@@ -179,7 +179,7 @@ static void ndpi_search_someip(struct ndpi_detection_module_struct *ndpi_struct,
     }											
     else{
       NDPI_LOG_DBG(ndpi_struct, "Excluding SOME/IP, invalid header for Magic Cookie ACK\n");
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
@@ -195,11 +195,10 @@ static void ndpi_search_someip(struct ndpi_detection_module_struct *ndpi_struct,
  */
 void init_someip_dissector (struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection ("SOME/IP", ndpi_struct,
-				       NDPI_PROTOCOL_SOMEIP,
-				       ndpi_search_someip,
-				       NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				       SAVE_DETECTION_BITMASK_AS_UNKNOWN, ADD_TO_DETECTION_BITMASK);
+  register_dissector("SOME/IP", ndpi_struct,
+                     ndpi_search_someip,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SOMEIP);
 }
 
 

--- a/src/lib/protocols/sonos.c
+++ b/src/lib/protocols/sonos.c
@@ -57,16 +57,14 @@ void ndpi_search_sonos(struct ndpi_detection_module_struct *ndpi_struct, struct 
     }
   }
   
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_sonos_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Sonos", ndpi_struct,
-				      NDPI_PROTOCOL_SONOS,
-				      ndpi_search_sonos,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* Only IPv4 UDP traffic is expected. */
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Sonos", ndpi_struct,
+                     ndpi_search_sonos,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* Only IPv4 UDP traffic is expected. */
+                     1, NDPI_PROTOCOL_SONOS);
 }

--- a/src/lib/protocols/source_engine.c
+++ b/src/lib/protocols/source_engine.c
@@ -89,18 +89,15 @@ static void ndpi_search_source_engine(struct ndpi_detection_module_struct *ndpi_
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ***************************************************** */
   
 void init_source_engine_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Source_Engine", ndpi_struct,
-                                      NDPI_PROTOCOL_SOURCE_ENGINE,
-                                      ndpi_search_source_engine,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK
-                                     );
+  register_dissector("Source_Engine", ndpi_struct,
+                     ndpi_search_source_engine,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_SOURCE_ENGINE);
 }

--- a/src/lib/protocols/spotify.c
+++ b/src/lib/protocols/spotify.c
@@ -65,7 +65,7 @@ static void ndpi_check_spotify(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_spotify(struct ndpi_detection_module_struct *ndpi_struct, struct ndpi_flow_struct *flow)
@@ -78,11 +78,9 @@ static void ndpi_search_spotify(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_spotify_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("SPOTIFY", ndpi_struct,
-				      NDPI_PROTOCOL_SPOTIFY,
-				      ndpi_search_spotify,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("SPOTIFY", ndpi_struct,
+                     ndpi_search_spotify,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SPOTIFY);
 }
 

--- a/src/lib/protocols/ssdp.c
+++ b/src/lib/protocols/ssdp.c
@@ -255,16 +255,14 @@ static void ndpi_search_ssdp(struct ndpi_detection_module_struct *ndpi_struct, s
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_ssdp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("SSDP", ndpi_struct,
-				      NDPI_PROTOCOL_SSDP,
-				      ndpi_search_ssdp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("SSDP", ndpi_struct,
+                     ndpi_search_ssdp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_SSDP);
 }

--- a/src/lib/protocols/ssh.c
+++ b/src/lib/protocols/ssh.c
@@ -530,17 +530,15 @@ static void ndpi_search_ssh_tcp(struct ndpi_detection_module_struct *ndpi_struct
 #endif
 
   NDPI_LOG_DBG(ndpi_struct, "excluding ssh at stage %d\n", flow->l4.tcp.ssh_stage);
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ************************************************************************ */
 
 void init_ssh_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("SSH", ndpi_struct,
-				      NDPI_PROTOCOL_SSH,
-				      ndpi_search_ssh_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("SSH", ndpi_struct,
+                     ndpi_search_ssh_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SSH);
 }

--- a/src/lib/protocols/steam.c
+++ b/src/lib/protocols/steam.c
@@ -50,15 +50,13 @@ static void ndpi_search_steam(struct ndpi_detection_module_struct *ndpi_struct,
 
   /* TODO: implement Steam Remote Play detection */
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_steam_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Steam", ndpi_struct,
-                                      NDPI_PROTOCOL_STEAM,
-                                      ndpi_search_steam,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Steam", ndpi_struct,
+                     ndpi_search_steam,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_STEAM);
 }

--- a/src/lib/protocols/steam_datagram_relay.c
+++ b/src/lib/protocols/steam_datagram_relay.c
@@ -54,15 +54,13 @@ static void ndpi_search_valve_sdr(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_valve_sdr_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("SteamDatagramRelay", ndpi_struct,
-                                      NDPI_PROTOCOL_VALVE_SDR,
-                                      ndpi_search_valve_sdr,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("SteamDatagramRelay", ndpi_struct,
+                     ndpi_search_valve_sdr,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_VALVE_SDR);
 }

--- a/src/lib/protocols/stomp.c
+++ b/src/lib/protocols/stomp.c
@@ -62,15 +62,13 @@ static void ndpi_search_stomp(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_stomp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("STOMP", ndpi_struct,
-				      NDPI_PROTOCOL_STOMP,
-				      ndpi_search_stomp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("STOMP", ndpi_struct,
+                     ndpi_search_stomp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_STOMP);
 }

--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -1259,7 +1259,7 @@ static void ndpi_search_stun(struct ndpi_detection_module_struct *ndpi_struct, s
   if(packet->iph &&
      ((packet->iph->daddr == 0xFFFFFFFF /* 255.255.255.255 */) ||
       ((ntohl(packet->iph->daddr) & 0xF0000000) == 0xE0000000 /* A multicast address */))) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -1272,7 +1272,7 @@ static void ndpi_search_stun(struct ndpi_detection_module_struct *ndpi_struct, s
 
   /* TODO: can we stop earlier? */
   if(flow->packet_counter > 5)
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ************************************************************* */
@@ -1333,10 +1333,8 @@ void signal_add_to_cache(struct ndpi_detection_module_struct *ndpi_struct,
 /* ************************************************************ */
 
 void init_stun_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("STUN", ndpi_struct,
-				      NDPI_PROTOCOL_STUN,
-				      ndpi_search_stun,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("STUN", ndpi_struct,
+                     ndpi_search_stun,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_STUN);
 }

--- a/src/lib/protocols/syncthing.c
+++ b/src/lib/protocols/syncthing.c
@@ -45,7 +45,7 @@ static void ndpi_search_syncthing(struct ndpi_detection_module_struct *ndpi_stru
 
   if (packet->payload_packet_len <= 4)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -56,17 +56,14 @@ static void ndpi_search_syncthing(struct ndpi_detection_module_struct *ndpi_stru
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 }
 
 void init_syncthing_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Syncthing", ndpi_struct,
-    NDPI_PROTOCOL_SYNCTHING,
-    ndpi_search_syncthing,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("Syncthing", ndpi_struct,
+                     ndpi_search_syncthing,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_SYNCTHING);
 }

--- a/src/lib/protocols/syslog.c
+++ b/src/lib/protocols/syslog.c
@@ -56,7 +56,7 @@ static void ndpi_search_syslog(struct ndpi_detection_module_struct *ndpi_struct,
 
     if (packet->payload[i++] != '>') {
       NDPI_LOG_DBG(ndpi_struct, "excluded, there is no > following the number\n");
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     } else {
       NDPI_LOG_DBG2(ndpi_struct, "a > following the number\n");
@@ -79,7 +79,7 @@ static void ndpi_search_syslog(struct ndpi_detection_module_struct *ndpi_struct,
             {
                 break;
             }
-            NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+            NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
             return;
         }
 
@@ -91,7 +91,7 @@ static void ndpi_search_syslog(struct ndpi_detection_module_struct *ndpi_struct,
         if (++i >= packet->payload_packet_len ||
             packet->payload[i] != ' ')
         {
-            NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+            NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
             return;
         }
     }
@@ -100,16 +100,14 @@ static void ndpi_search_syslog(struct ndpi_detection_module_struct *ndpi_struct,
     ndpi_int_syslog_add_connection(ndpi_struct, flow);
     return;
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_syslog_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Syslog", ndpi_struct,
-				      NDPI_PROTOCOL_SYSLOG,
-				      ndpi_search_syslog,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Syslog", ndpi_struct,
+                     ndpi_search_syslog,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_SYSLOG);
 }

--- a/src/lib/protocols/tailscale.c
+++ b/src/lib/protocols/tailscale.c
@@ -45,14 +45,12 @@ static void ndpi_search_tailscale(struct ndpi_detection_module_struct *ndpi_stru
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_tailscale_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("Tailscale", ndpi_struct,
-				      NDPI_PROTOCOL_TAILSCALE,
-				      ndpi_search_tailscale,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Tailscale", ndpi_struct,
+                     ndpi_search_tailscale,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_TAILSCALE);
 }

--- a/src/lib/protocols/teamspeak.c
+++ b/src/lib/protocols/teamspeak.c
@@ -81,7 +81,7 @@ static void ndpi_search_teamspeak(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 
 ts3_license_weblist:
@@ -95,11 +95,9 @@ ts3_license_weblist:
 
 void init_teamspeak_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TeamSpeak", ndpi_struct,
-                                      NDPI_PROTOCOL_TEAMSPEAK,
-                                      ndpi_search_teamspeak,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("TeamSpeak", ndpi_struct,
+                     ndpi_search_teamspeak,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_TEAMSPEAK);
 }
 

--- a/src/lib/protocols/teamviewer.c
+++ b/src/lib/protocols/teamviewer.c
@@ -79,17 +79,15 @@ static void ndpi_search_teamview(struct ndpi_detection_module_struct *ndpi_struc
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_teamviewer_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TeamViewer", ndpi_struct,
-				      NDPI_PROTOCOL_TEAMVIEWER,
-				      ndpi_search_teamview,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("TeamViewer", ndpi_struct,
+                     ndpi_search_teamview,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_TEAMVIEWER);
 }
 

--- a/src/lib/protocols/telegram.c
+++ b/src/lib/protocols/telegram.c
@@ -107,16 +107,14 @@ static void ndpi_search_telegram(struct ndpi_detection_module_struct *ndpi_struc
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_telegram_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Telegram", ndpi_struct,
-				      NDPI_PROTOCOL_TELEGRAM,
-				      ndpi_search_telegram,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Telegram", ndpi_struct,
+                     ndpi_search_telegram,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_TELEGRAM);
 }

--- a/src/lib/protocols/telnet.c
+++ b/src/lib/protocols/telnet.c
@@ -209,7 +209,7 @@ static void ndpi_search_telnet_tcp(struct ndpi_detection_module_struct *ndpi_str
 #ifdef TELNET_DEBUG
     printf("==> [%s:%d] %s()\n", __FILE__, __LINE__, __FUNCTION__);
 #endif
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
   
   return;
@@ -218,10 +218,8 @@ static void ndpi_search_telnet_tcp(struct ndpi_detection_module_struct *ndpi_str
 
 void init_telnet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Telnet", ndpi_struct,
-				      NDPI_PROTOCOL_TELNET,
-				      ndpi_search_telnet_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Telnet", ndpi_struct,
+                     ndpi_search_telnet_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_TELNET);
 }

--- a/src/lib/protocols/tencent_games.c
+++ b/src/lib/protocols/tencent_games.c
@@ -82,15 +82,13 @@ static void ndpi_search_tencent_games(struct ndpi_detection_module_struct *ndpi_
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_tencent_games_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TencentGames", ndpi_struct,
-				      NDPI_PROTOCOL_TENCENTGAMES,
-				      ndpi_search_tencent_games,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("TencentGames", ndpi_struct,
+                     ndpi_search_tencent_games,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_TENCENTGAMES);
 }

--- a/src/lib/protocols/teredo.c
+++ b/src/lib/protocols/teredo.c
@@ -39,19 +39,16 @@ static void ndpi_search_teredo(struct ndpi_detection_module_struct *ndpi_struct,
     NDPI_LOG_INFO(ndpi_struct,"found teredo\n");
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_TEREDO, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
   }  else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 
 void init_teredo_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TEREDO", ndpi_struct,
-				      NDPI_PROTOCOL_TEREDO,
-				      ndpi_search_teredo,
-				      /* Teredo is inherently IPV4 only */
-				      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("TEREDO", ndpi_struct,
+                     ndpi_search_teredo,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* Teredo is inherently IPV4 only */
+                     1, NDPI_PROTOCOL_TEREDO);
 }
 

--- a/src/lib/protocols/teso.c
+++ b/src/lib/protocols/teso.c
@@ -49,7 +49,7 @@ static void ndpi_search_teso(struct ndpi_detection_module_struct *ndpi_struct,
   if (packet->payload_packet_len < 600 ||
       ntohl(get_u_int32_t(packet->payload, 0)) != (u_int32_t)(packet->payload_packet_len-4))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -75,15 +75,13 @@ static void ndpi_search_teso(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_teso_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TES_Online", ndpi_struct,
-              NDPI_PROTOCOL_TESO,
-              ndpi_search_teso,
-              NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-              ADD_TO_DETECTION_BITMASK);
+  register_dissector("TES_Online", ndpi_struct,
+                     ndpi_search_teso,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_TESO);
 }

--- a/src/lib/protocols/threema.c
+++ b/src/lib/protocols/threema.c
@@ -43,7 +43,7 @@ static void ndpi_search_threema(struct ndpi_detection_module_struct *ndpi_struct
   NDPI_LOG_DBG(ndpi_struct, "search Threema\n");
 
   if (ntohs(packet->tcp->source) != 5222 && ntohs(packet->tcp->dest) != 5222) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -52,19 +52,19 @@ static void ndpi_search_threema(struct ndpi_detection_module_struct *ndpi_struct
     case 1:
       if (packet->payload_packet_len != 48)
       {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       }
       return;
     case 2:
       if (packet->payload_packet_len != 80)
       {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       }
       return;
     case 3:
       if (packet->payload_packet_len != 191)
       {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       }
       return;
     case 4:
@@ -75,14 +75,14 @@ static void ndpi_search_threema(struct ndpi_detection_module_struct *ndpi_struct
 
   if (packet->payload_packet_len < 2)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   uint16_t len = le16toh(get_u_int16_t(packet->payload, 0));
   if (len + 2 != packet->payload_packet_len)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -91,11 +91,8 @@ static void ndpi_search_threema(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_threema_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Threema", ndpi_struct,
-    NDPI_PROTOCOL_THREEMA,
-    ndpi_search_threema,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("Threema", ndpi_struct,
+                     ndpi_search_threema,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_THREEMA);
 }

--- a/src/lib/protocols/thrift.c
+++ b/src/lib/protocols/thrift.c
@@ -144,22 +144,22 @@ static void ndpi_dissect_strict_hdr(struct ndpi_detection_module_struct *ndpi_st
   const size_t method_length = ntohl(strict_hdr->method_length);
 
   if (packet->tcp == NULL) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (packet->payload_packet_len < sizeof(*strict_hdr) + method_length) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (thrift_validate_version(strict_hdr->version) == 0) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (thrift_validate_type(strict_hdr->message_type) == 0) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -176,22 +176,22 @@ static void ndpi_dissect_compact_hdr(struct ndpi_detection_module_struct *ndpi_s
   struct ndpi_packet_struct const * const packet = &ndpi_struct->packet;
 
   if (packet->udp == NULL) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (packet->payload_packet_len < sizeof(*compact_hdr) + compact_hdr->method_length) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (thrift_validate_version(compact_hdr->version) == 0) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (thrift_validate_type(compact_hdr->message_type) == 0) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -235,7 +235,7 @@ static void ndpi_search_thrift_tcp_udp(struct ndpi_detection_module_struct *ndpi
       /* Strict Binary Protocol */
       if (packet->payload_packet_len < sizeof(*thrift_data.strict_hdr))
       {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
       }
 
@@ -247,20 +247,18 @@ static void ndpi_search_thrift_tcp_udp(struct ndpi_detection_module_struct *ndpi
       return;
     } else {
       /* Probably not Apache Thrift. */
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_apache_thrift_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Thrift", ndpi_struct,
-                                      NDPI_PROTOCOL_APACHE_THRIFT,
-                                      ndpi_search_thrift_tcp_udp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Thrift", ndpi_struct,
+                     ndpi_search_thrift_tcp_udp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_APACHE_THRIFT);
 }

--- a/src/lib/protocols/tinc.c
+++ b/src/lib/protocols/tinc.c
@@ -65,7 +65,7 @@ static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, st
       }
     }
     
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   } else if(packet->tcp != NULL) {
 
@@ -130,7 +130,7 @@ static void ndpi_check_tinc(struct ndpi_detection_module_struct *ndpi_struct, st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 static void ndpi_search_tinc(struct ndpi_detection_module_struct* ndpi_struct, struct ndpi_flow_struct* flow) {
@@ -143,11 +143,9 @@ static void ndpi_search_tinc(struct ndpi_detection_module_struct* ndpi_struct, s
 
 void init_tinc_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TINC", ndpi_struct,
-				      NDPI_PROTOCOL_TINC,
-				      ndpi_search_tinc,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION, /* TODO: IPv6? */
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("TINC", ndpi_struct,
+                     ndpi_search_tinc,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION, /* TODO: IPv6? */
+                     1, NDPI_PROTOCOL_TINC);
 }
 

--- a/src/lib/protocols/tivoconnect.c
+++ b/src/lib/protocols/tivoconnect.c
@@ -126,7 +126,7 @@ static void ndpi_search_tivoconnect(struct ndpi_detection_module_struct *ndpi_st
   {
     ndpi_int_tivoconnect_add_connection(ndpi_struct, flow);
   } else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -135,11 +135,8 @@ static void ndpi_search_tivoconnect(struct ndpi_detection_module_struct *ndpi_st
 
 void init_tivoconnect_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TiVoConnect", ndpi_struct,
-    NDPI_PROTOCOL_TIVOCONNECT,
-    ndpi_search_tivoconnect,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("TiVoConnect", ndpi_struct,
+                     ndpi_search_tivoconnect,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_TIVOCONNECT);
 }

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -492,8 +492,8 @@ static int tls_obfuscated_heur_search_again(struct ndpi_detection_module_struct*
     ndpi_protocol ret = { { __get_master(ndpi_struct, flow), NDPI_PROTOCOL_UNKNOWN }, NDPI_PROTOCOL_UNKNOWN /* unused */, NDPI_PROTOCOL_CATEGORY_UNSPECIFIED, NULL};
     flow->category = ndpi_get_proto_category(ndpi_struct, ret);
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow); /* Not necessary in extra-dissection data path,
-                                            but we need it with the plain heuristic */
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow); /* Not necessary in extra-dissection data path,
+                                                but we need it with the plain heuristic */
   return 0; /* Stop */
 }
 
@@ -3426,17 +3426,17 @@ static void ndpi_search_tls_wrapper(struct ndpi_detection_module_struct *ndpi_st
   if(flow->tls_quic.obfuscated_heur_state) {
     tls_obfuscated_heur_search_again(ndpi_struct, flow);
   } else if(rc == 0) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 /* **************************************** */
 
 void init_tls_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("TLS", ndpi_struct,
-				      NDPI_PROTOCOL_TLS,
-				      ndpi_search_tls_wrapper,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("(D)TLS", ndpi_struct,
+                     ndpi_search_tls_wrapper,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     2,
+                     NDPI_PROTOCOL_TLS,
+                     NDPI_PROTOCOL_DTLS);
 }

--- a/src/lib/protocols/tocaboca.c
+++ b/src/lib/protocols/tocaboca.c
@@ -73,16 +73,14 @@ static void ndpi_search_toca_boca(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_toca_boca_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TocaBoca", ndpi_struct,
-				      NDPI_PROTOCOL_TOCA_BOCA,
-				      ndpi_search_toca_boca,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("TocaBoca", ndpi_struct,
+                     ndpi_search_toca_boca,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_TOCA_BOCA);
 }
 

--- a/src/lib/protocols/tplink_shp.c
+++ b/src/lib/protocols/tplink_shp.c
@@ -57,7 +57,7 @@ static void ndpi_search_tplink_shp(struct ndpi_detection_module_struct *ndpi_str
 
   if (packet->payload_packet_len - offset < _TPLSHP_MIN_LEN)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -72,7 +72,7 @@ static void ndpi_search_tplink_shp(struct ndpi_detection_module_struct *ndpi_str
 
   if (b[0] != '{' || (b[1] != '}' && b[1] != '"'))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -83,11 +83,8 @@ static void ndpi_search_tplink_shp(struct ndpi_detection_module_struct *ndpi_str
   
 void init_tplink_shp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TPLINK SHP", ndpi_struct,
-                                      NDPI_PROTOCOL_TPLINK_SHP,
-                                      ndpi_search_tplink_shp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK
-                                     );
+  register_dissector("TPLINK SHP", ndpi_struct,
+                     ndpi_search_tplink_shp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_TPLINK_SHP);
 }

--- a/src/lib/protocols/trdp.c
+++ b/src/lib/protocols/trdp.c
@@ -80,15 +80,13 @@ static void ndpi_search_trdp(struct ndpi_detection_module_struct *ndpi_struct, s
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_trdp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TRDP", ndpi_struct,
-                                      NDPI_PROTOCOL_TRDP,
-                                      ndpi_search_trdp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("TRDP", ndpi_struct,
+                     ndpi_search_trdp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_TRDP);
 }

--- a/src/lib/protocols/tuya_lp.c
+++ b/src/lib/protocols/tuya_lp.c
@@ -48,21 +48,21 @@ static void ndpi_search_tuya_lp(struct ndpi_detection_module_struct *ndpi_struct
 
   if (packet->payload_packet_len < 16)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   /* https://github.com/tuya/tuya-iotos-embeded-sdk-wifi-ble-bk7231n/blob/0eff617610cc97e0d134bb8136cebb518a2a403b/sdk/include/lan_protocol.h#L73 */
   if (ntohl(get_u_int32_t(packet->payload, 0)) != 0x000055AA)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if (packet->payload_packet_len < 
     ntohl(get_u_int32_t(packet->payload, 4)))
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -71,7 +71,7 @@ static void ndpi_search_tuya_lp(struct ndpi_detection_module_struct *ndpi_struct
       packet->payload[packet->payload_packet_len - 2] != 0xAA ||
       packet->payload[packet->payload_packet_len - 1] != 0x55)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -82,11 +82,8 @@ static void ndpi_search_tuya_lp(struct ndpi_detection_module_struct *ndpi_struct
   
 void init_tuya_lp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("TUYA LP", ndpi_struct,
-                                      NDPI_PROTOCOL_TUYA_LP,
-                                      ndpi_search_tuya_lp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK
-                                     );
+  register_dissector("TUYA LP", ndpi_struct,
+                     ndpi_search_tuya_lp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_TUYA_LP);
 }

--- a/src/lib/protocols/ubntac2.c
+++ b/src/lib/protocols/ubntac2.c
@@ -68,16 +68,14 @@ static void ndpi_search_ubntac2(struct ndpi_detection_module_struct *ndpi_struct
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_ubntac2_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("UBNTAC2", ndpi_struct,
-				      NDPI_PROTOCOL_UBNTAC2,
-				      ndpi_search_ubntac2,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("UBNTAC2", ndpi_struct,
+                     ndpi_search_ubntac2,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_UBNTAC2);
 }

--- a/src/lib/protocols/uftp.c
+++ b/src/lib/protocols/uftp.c
@@ -54,15 +54,13 @@ static void ndpi_search_uftp(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_uftp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("UFTP", ndpi_struct,
-                                      NDPI_PROTOCOL_UFTP,
-                                      ndpi_search_uftp,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("UFTP", ndpi_struct,
+                     ndpi_search_uftp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_UFTP);
 }

--- a/src/lib/protocols/ultrasurf.c
+++ b/src/lib/protocols/ultrasurf.c
@@ -45,7 +45,7 @@ static void ndpi_search_ultrasurf(struct ndpi_detection_module_struct *ndpi_stru
 
   if (packet->payload_packet_len < 8)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -55,16 +55,13 @@ static void ndpi_search_ultrasurf(struct ndpi_detection_module_struct *ndpi_stru
     ndpi_int_ultrasurf_add_connection(ndpi_struct, flow);
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_ultrasurf_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("UltraSurf", ndpi_struct,
-    NDPI_PROTOCOL_ULTRASURF,
-    ndpi_search_ultrasurf,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-    SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-    ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("UltraSurf", ndpi_struct,
+                     ndpi_search_ultrasurf,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ULTRASURF);
 }

--- a/src/lib/protocols/usenet.c
+++ b/src/lib/protocols/usenet.c
@@ -92,16 +92,14 @@ static void ndpi_search_usenet_tcp(struct ndpi_detection_module_struct *ndpi_str
 		}
 	}
 
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_usenet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Usenet", ndpi_struct,
-				      NDPI_PROTOCOL_USENET,
-				      ndpi_search_usenet_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Usenet", ndpi_struct,
+                     ndpi_search_usenet_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_USENET);
 }

--- a/src/lib/protocols/viber.c
+++ b/src/lib/protocols/viber.c
@@ -45,7 +45,7 @@ static void ndpi_search_viber(struct ndpi_detection_module_struct *ndpi_struct, 
   if(packet->udp && packet->iph) {
     /* ignore broadcast as this isn't viber */
     if((packet->iph->saddr == 0xFFFFFFFF) || (packet->iph->daddr == 0xFFFFFFFF)) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
@@ -71,7 +71,7 @@ static void ndpi_search_viber(struct ndpi_detection_module_struct *ndpi_struct, 
       }
     }
 
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -89,22 +89,20 @@ static void ndpi_search_viber(struct ndpi_detection_module_struct *ndpi_struct, 
       return;
     }
 
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
   if(flow->packet_counter > 3)
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_viber_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Viber", ndpi_struct,
-				      NDPI_PROTOCOL_VIBER,
-				      ndpi_search_viber,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Viber", ndpi_struct,
+                     ndpi_search_viber,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_VIBER);
 }
 

--- a/src/lib/protocols/vmware.c
+++ b/src/lib/protocols/vmware.c
@@ -41,15 +41,13 @@ static void ndpi_search_vmware(struct ndpi_detection_module_struct *ndpi_struct,
       return;
     }
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_vmware_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("VMWARE", ndpi_struct,
-				      NDPI_PROTOCOL_VMWARE,
-				      ndpi_search_vmware,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("VMWARE", ndpi_struct,
+                     ndpi_search_vmware,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_VMWARE);
 }

--- a/src/lib/protocols/vnc.c
+++ b/src/lib/protocols/vnc.c
@@ -57,16 +57,14 @@ static void ndpi_search_vnc_tcp(struct ndpi_detection_module_struct *ndpi_struct
       }
     }
   }
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_vnc_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("VNC", ndpi_struct,
-				      NDPI_PROTOCOL_VNC,
-				      ndpi_search_vnc_tcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("VNC", ndpi_struct,
+                     ndpi_search_vnc_tcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_VNC);
 }

--- a/src/lib/protocols/vxlan.c
+++ b/src/lib/protocols/vxlan.c
@@ -53,7 +53,7 @@ static void ndpi_check_vxlan(struct ndpi_detection_module_struct *ndpi_struct, s
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   return;
 }
 
@@ -66,10 +66,8 @@ static void ndpi_search_vxlan(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_vxlan_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("VXLAN", ndpi_struct,
-              NDPI_PROTOCOL_VXLAN,
-              ndpi_search_vxlan,
-              NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-              SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-              ADD_TO_DETECTION_BITMASK);
+  register_dissector("VXLAN", ndpi_struct,
+                     ndpi_search_vxlan,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_VXLAN);
 }

--- a/src/lib/protocols/websocket.c
+++ b/src/lib/protocols/websocket.c
@@ -63,7 +63,7 @@ static void ndpi_check_websocket(struct ndpi_detection_module_struct *ndpi_struc
 
   if (packet->payload_packet_len < sizeof(u_int16_t))
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -75,7 +75,7 @@ static void ndpi_check_websocket(struct ndpi_detection_module_struct *ndpi_struc
   if (packet->payload_packet_len != hdr_size + websocket_payload_length)
     {
       NDPI_LOG_DBG(ndpi_struct, "Invalid WEBSOCKET payload");
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -89,7 +89,7 @@ static void ndpi_check_websocket(struct ndpi_detection_module_struct *ndpi_struc
 
   } else {
     NDPI_LOG_DBG(ndpi_struct, "Invalid WEBSOCKET payload");
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 }
@@ -99,7 +99,7 @@ static void ndpi_search_websocket(struct ndpi_detection_module_struct *ndpi_stru
   // Break after 6 packets.
   if (flow->packet_counter > 10)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -133,7 +133,7 @@ static void ndpi_search_websocket(struct ndpi_detection_module_struct *ndpi_stru
     }
     if (i == packet->parsed_lines)
     {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   }
@@ -145,7 +145,8 @@ static void ndpi_search_websocket(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_websocket_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("WEBSOCKET", ndpi_struct, NDPI_PROTOCOL_WEBSOCKET,
-                                     ndpi_search_websocket, NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                     SAVE_DETECTION_BITMASK_AS_UNKNOWN, ADD_TO_DETECTION_BITMASK);
+  register_dissector("WEBSOCKET", ndpi_struct,
+                     ndpi_search_websocket,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_WEBSOCKET);
 }

--- a/src/lib/protocols/whatsapp.c
+++ b/src/lib/protocols/whatsapp.c
@@ -93,7 +93,7 @@ static void ndpi_search_whatsapp(struct ndpi_detection_module_struct *ndpi_struc
 
   if (flow->packet_counter > 3)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -116,18 +116,14 @@ static void ndpi_search_whatsapp(struct ndpi_detection_module_struct *ndpi_struc
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_whatsapp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection(
-    "WhatsApp", ndpi_struct,
-    NDPI_PROTOCOL_WHATSAPP,
-    ndpi_search_whatsapp,
-    NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-	SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-	ADD_TO_DETECTION_BITMASK
-  );
+  register_dissector("WhatsApp", ndpi_struct,
+                     ndpi_search_whatsapp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_WHATSAPP);
 }

--- a/src/lib/protocols/whoisdas.c
+++ b/src/lib/protocols/whoisdas.c
@@ -49,16 +49,14 @@ static void ndpi_search_whois_das(struct ndpi_detection_module_struct *ndpi_stru
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_whois_das_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Whois-DAS", ndpi_struct,
-				      NDPI_PROTOCOL_WHOIS_DAS,
-				      ndpi_search_whois_das,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK); 
+  register_dissector("Whois-DA", ndpi_struct,
+                     ndpi_search_whois_das,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_WHOIS_DAS);
 }

--- a/src/lib/protocols/wireguard.c
+++ b/src/lib/protocols/wireguard.c
@@ -82,14 +82,14 @@ static void ndpi_search_wireguard(struct ndpi_detection_module_struct *ndpi_stru
    * Note that handshake packets have a slightly different structure, but they are larger.
    */
   if (packet->payload_packet_len < 32) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
   /*
    * The next three bytes after the message type are reserved and set to zero.
    */
   if (payload[1] != 0 || payload[2] != 0 || payload[3] != 0) {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -145,7 +145,7 @@ static void ndpi_search_wireguard(struct ndpi_detection_module_struct *ndpi_stru
         else
           ndpi_int_wireguard_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_UNKNOWN);
       } else {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       }
     }
     /* need more packets before deciding */
@@ -161,7 +161,7 @@ static void ndpi_search_wireguard(struct ndpi_detection_module_struct *ndpi_stru
       if (receiver_index == flow->l4.udp.wireguard_peer_index[1 - packet->packet_direction]) {
         ndpi_int_wireguard_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_UNKNOWN);
       } else {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       }
     }
     /* need more packets before deciding */
@@ -189,21 +189,19 @@ static void ndpi_search_wireguard(struct ndpi_detection_module_struct *ndpi_stru
       if (receiver_index == flow->l4.udp.wireguard_peer_index[packet->packet_direction]) {
         ndpi_int_wireguard_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_UNKNOWN);
       } else {
-        NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+        NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       }
     }
     /* need more packets before deciding */
   } else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 void init_wireguard_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("WireGuard", ndpi_struct,
-				      NDPI_PROTOCOL_WIREGUARD,
-				      ndpi_search_wireguard,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("WireGuard", ndpi_struct,
+                     ndpi_search_wireguard,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_WIREGUARD);
 }

--- a/src/lib/protocols/wsd.c
+++ b/src/lib/protocols/wsd.c
@@ -48,17 +48,15 @@ static void ndpi_search_wsd(struct ndpi_detection_module_struct *ndpi_struct,
     NDPI_LOG_INFO(ndpi_struct,"found wsd\n");
     ndpi_set_detected_protocol(ndpi_struct, flow, NDPI_PROTOCOL_WSD, NDPI_PROTOCOL_UNKNOWN, NDPI_CONFIDENCE_DPI);
   } else {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
   }
 }
 
 
 void init_wsd_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("WSD", ndpi_struct,
-				      NDPI_PROTOCOL_WSD,
-				      ndpi_search_wsd,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("WSD", ndpi_struct,
+                     ndpi_search_wsd,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_WSD);
 }
 

--- a/src/lib/protocols/xbox.c
+++ b/src/lib/protocols/xbox.c
@@ -94,17 +94,15 @@ static void ndpi_search_xbox(struct ndpi_detection_module_struct *ndpi_struct, s
   }
 
   if(flow->packet_counter >= 5)
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_xbox_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Xbox", ndpi_struct,
-				      NDPI_PROTOCOL_XBOX,
-				      ndpi_search_xbox,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Xbox", ndpi_struct,
+                     ndpi_search_xbox,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_XBOX);
 }
 

--- a/src/lib/protocols/xdmcp.c
+++ b/src/lib/protocols/xdmcp.c
@@ -61,16 +61,14 @@ static void ndpi_search_xdmcp(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_xdmcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("XDMCP", ndpi_struct,
-				      NDPI_PROTOCOL_XDMCP,
-				      ndpi_search_xdmcp,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("XDMCP", ndpi_struct,
+                     ndpi_search_xdmcp,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_XDMCP);
 }

--- a/src/lib/protocols/xiaomi.c
+++ b/src/lib/protocols/xiaomi.c
@@ -107,14 +107,12 @@ static void ndpi_search_xiaomi(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_xiaomi_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("Xiaomi", ndpi_struct,
-				      NDPI_PROTOCOL_XIAOMI,
-				      ndpi_search_xiaomi,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Xiaomi", ndpi_struct,
+                     ndpi_search_xiaomi,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_XIAOMI);
 }

--- a/src/lib/protocols/yojimbo.c
+++ b/src/lib/protocols/yojimbo.c
@@ -46,7 +46,7 @@ static void ndpi_search_yojimbo(struct ndpi_detection_module_struct *ndpi_struct
 
   if (packet->payload_packet_len < 9)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -57,16 +57,14 @@ static void ndpi_search_yojimbo(struct ndpi_detection_module_struct *ndpi_struct
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_yojimbo_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Yojimbo", ndpi_struct,
-                                      NDPI_PROTOCOL_YOJIMBO,
-                                      ndpi_search_yojimbo,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Yojimbo", ndpi_struct,
+                     ndpi_search_yojimbo,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_YOJIMBO);
 }
 

--- a/src/lib/protocols/z3950.c
+++ b/src/lib/protocols/z3950.c
@@ -94,7 +94,7 @@ static void ndpi_search_z3950(struct ndpi_detection_module_struct *ndpi_struct,
     int ret = z3950_parse_sequences(packet, minimum_expected_sequences);
 
     if(ret < 0) {
-      NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
 
@@ -107,24 +107,21 @@ static void ndpi_search_z3950(struct ndpi_detection_module_struct *ndpi_struct,
       if(flow->packet_direction_counter[0] && flow->packet_direction_counter[1])
 	ndpi_int_z3950_add_connection(ndpi_struct, flow);
       else
-	NDPI_EXCLUDE_PROTO(ndpi_struct, flow);  /* Skip if unidirectional traffic */
+	NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);  /* Skip if unidirectional traffic */
     } else
       flow->l4.tcp.z3950_stage++;
 
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* ***************************************************************** */
 
 void init_z3950_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("Z3950",
-                                      ndpi_struct,
-                                      NDPI_PROTOCOL_Z3950,
-                                      ndpi_search_z3950,
-                                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-                                      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-                                      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Z3950", ndpi_struct,
+                     ndpi_search_z3950,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_Z3950);
 }

--- a/src/lib/protocols/zabbix.c
+++ b/src/lib/protocols/zabbix.c
@@ -45,16 +45,14 @@ static void ndpi_search_zabbix(struct ndpi_detection_module_struct *ndpi_struct,
      && (memcmp(packet->payload, tomatch, 4) == 0))
     ndpi_int_zabbix_add_connection(ndpi_struct, flow);
   else
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* *************************************************** */
 
 void init_zabbix_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("Zabbix", ndpi_struct,
-				      NDPI_PROTOCOL_ZABBIX,
-				      ndpi_search_zabbix,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Zabbix", ndpi_struct,
+                     ndpi_search_zabbix,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ZABBIX);
 }

--- a/src/lib/protocols/zattoo.c
+++ b/src/lib/protocols/zattoo.c
@@ -204,16 +204,14 @@ static void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct,
 
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_zattoo_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("Zattoo", ndpi_struct,
-				      NDPI_PROTOCOL_ZATTOO,
-				      ndpi_search_zattoo,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Zattoo", ndpi_struct,
+                     ndpi_search_zattoo,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ZATTOO);
 }

--- a/src/lib/protocols/zeromq.c
+++ b/src/lib/protocols/zeromq.c
@@ -41,16 +41,14 @@ static void ndpi_search_zmq(struct ndpi_detection_module_struct *ndpi_struct, st
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 
 void init_zmq_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("ZeroMQ", ndpi_struct,
-				      NDPI_PROTOCOL_ZMQ,
-				      ndpi_search_zmq,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("ZeroMQ", ndpi_struct,
+                     ndpi_search_zmq,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
+                     1, NDPI_PROTOCOL_ZMQ);
 }

--- a/src/lib/protocols/zoom.c
+++ b/src/lib/protocols/zoom.c
@@ -242,16 +242,14 @@ static void ndpi_search_zoom(struct ndpi_detection_module_struct *ndpi_struct,
     }
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 /* *************************************************** */
 
 void init_zoom_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  ndpi_set_bitmask_protocol_detection("Zoom", ndpi_struct,
-				      NDPI_PROTOCOL_ZOOM,
-				      ndpi_search_zoom,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("Zoom", ndpi_struct,
+                     ndpi_search_zoom,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_ZOOM);
 }

--- a/src/lib/protocols/zug.c
+++ b/src/lib/protocols/zug.c
@@ -44,7 +44,7 @@ static void ndpi_search_zug(struct ndpi_detection_module_struct *ndpi_struct,
 
   if (packet->payload_packet_len < 5)
   {
-    NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+    NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
     return;
   }
 
@@ -55,16 +55,14 @@ static void ndpi_search_zug(struct ndpi_detection_module_struct *ndpi_struct,
     return;
   }
 
-  NDPI_EXCLUDE_PROTO(ndpi_struct, flow);
+  NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
 }
 
 void init_zug_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  ndpi_set_bitmask_protocol_detection("ZUG", ndpi_struct,
-				      NDPI_PROTOCOL_ZUG,
-				      ndpi_search_zug,
-				      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
-				      SAVE_DETECTION_BITMASK_AS_UNKNOWN,
-				      ADD_TO_DETECTION_BITMASK);
+  register_dissector("ZUG", ndpi_struct,
+                     ndpi_search_zug,
+                     NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
+                     1, NDPI_PROTOCOL_ZUG);
 }
 

--- a/tests/cfgs/disable_protocols/result/ospfv2_add_new_prefix.pcap.out
+++ b/tests/cfgs/disable_protocols/result/ospfv2_add_new_prefix.pcap.out
@@ -1,6 +1,6 @@
 DPI Packets (other):	2	(2.00 pkts/flow)
 Confidence Unknown          : 1 (flows)
-Num dissector calls: 2 (2.00 diss/flow)
+Num dissector calls: 1 (1.00 diss/flow)
 LRU cache ookla:      0/0/0 (insert/search/found)
 LRU cache bittorrent: 0/3/0 (insert/search/found)
 LRU cache stun:       0/0/0 (insert/search/found)

--- a/windows/src/ndpi_define.h
+++ b/windows/src/ndpi_define.h
@@ -85,18 +85,9 @@
 
 #define NDPI_SELECTION_BITMASK_PROTOCOL_SIZE			u_int32_t
 
-/**
- * convenience macro to check for excluded protocol
- * a protocol is excluded if the flow is known and either the protocol is not detected at all
- * or the excluded bitmask contains the protocol
- */
-#define NDPI_FLOW_PROTOCOL_EXCLUDED(ndpi_struct,flow,protocol) ((flow) != NULL && \
-								( NDPI_COMPARE_PROTOCOL_TO_BITMASK((ndpi_struct)->detection_bitmask, (protocol)) == 0 || \
-								  NDPI_COMPARE_PROTOCOL_TO_BITMASK((flow)->excluded_protocol_bitmask, (protocol)) != 0 ) )
-
 #define MAX_DEFAULT_PORTS                                        5
 
-#define NDPI_EXCLUDE_PROTO(mod,flow) ndpi_exclude_protocol(mod, flow, NDPI_CURRENT_PROTO, __FILE__, __FUNCTION__, __LINE__)
+#define NDPI_EXCLUDE_DISSECTOR(mod,flow) exclude_dissector(mod, flow, mod->current_dissector_idx, __FILE__, __FUNCTION__, __LINE__)
 
 /**
  * macro for getting the string len of a static string
@@ -138,9 +129,11 @@
 #define NDPI_ISSET_BIT(num, n)  (num & (1ULL << ( n )))
 #define NDPI_ZERO_BIT(num)      num = 0
 
+#define NDPI_MAX_NUM_DISSECTORS                 288      /* Multiple of 32, i.e. NDPI_BITS */
+#define NDPI_NUM_FDS_BITS_DISSECTORS            howmanybits(NDPI_MAX_NUM_DISSECTORS, NDPI_BITS)
 #define NDPI_DISSECTOR_BITMASK                  ndpi_dissector_bitmask_struct_t
 #define NDPI_DISSECTOR_BITMASK_IS_SET(p, n)     NDPI_ISSET(&(p), (n))
-#define NDPI_DISSECTOR_BITMASK_SET(p, n)        NDPI_SET(&(p), (n) & NDPI_NUM_BITS_MASK)
+#define NDPI_DISSECTOR_BITMASK_SET(p, n)        NDPI_SET(&(p), (n))
 
 /* this is a very very tricky macro *g*,
  * the compiler will remove all shifts here if the protocol is static...


### PR DESCRIPTION
We use `registr_dissector()` instead of `ndpi_set_bitmask_protocol_detection()`.

Every file in `src/lib/protocols/*.c` is a dissector.

Every dissector can handle multiple protocols.

The real goal is this small change:
```
 struct call_function_struct {
-  NDPI_PROTOCOL_BITMASK detection_bitmask;
```
i.e. getting rid of another protocol bitmask: this is mandatory to try to fix #2136 (see also e845e8205b68752c997d05224d8b2fd45acde714)

As a nice side effect, we remove a bitmask comparison in the hot function
`check_ndpi_detection_func()`

TODO: change logging configuration from per-protocol to per-dissector


