### PR TITLE
Better separation between "protocols" and "dissectors"

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1206,7 +1206,6 @@ typedef struct ndpi_proto_defaults {
   u_int16_t tcp_default_ports[MAX_DEFAULT_PORTS], udp_default_ports[MAX_DEFAULT_PORTS];
   ndpi_protocol_breed_t protoBreed;
   ndpi_protocol_qoe_category_t qoeCategory;
-  void (*func) (struct ndpi_detection_module_struct *, struct ndpi_flow_struct *flow);
 } ndpi_proto_defaults_t;
 
 

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -5767,7 +5767,6 @@ void register_dissector(char *dissector_name, struct ndpi_detection_module_struc
           first_protocol_id = ndpi_protocol_id;
 
         ndpi_str->proto_defaults[ndpi_protocol_id].dissector_idx = idx;
-        ndpi_str->proto_defaults[ndpi_protocol_id].func = func;
       }
       dissector_enabled = 1;
     }
@@ -7790,14 +7789,14 @@ static u_int32_t check_ndpi_detection_func(struct ndpi_detection_module_struct *
   u_int32_t a;
 
   if(fast_callback_protocol_id != NDPI_PROTOCOL_UNKNOWN &&
-     ndpi_str->proto_defaults[fast_callback_protocol_id].func &&
+     ndpi_str->callback_buffer[dissector_idx].func &&
      !NDPI_DISSECTOR_BITMASK_IS_SET(flow->excluded_dissectors_bitmask, dissector_idx) &&
      (ndpi_str->callback_buffer[dissector_idx].ndpi_selection_bitmask & ndpi_selection_packet) ==
      ndpi_str->callback_buffer[dissector_idx].ndpi_selection_bitmask) {
 
     ndpi_str->current_dissector_idx = dissector_idx;
-    ndpi_str->proto_defaults[fast_callback_protocol_id].func(ndpi_str, flow);
-    func = ndpi_str->proto_defaults[fast_callback_protocol_id].func;
+    ndpi_str->callback_buffer[dissector_idx].func(ndpi_str, flow);
+    func = ndpi_str->callback_buffer[dissector_idx].func;
     num_calls++;
   }
 


### PR DESCRIPTION
Callback functions are about dissectors, not protocols


