### PR TITLE
Speed up protocol lookup in ndpi_get_proto_by_name

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -301,12 +301,20 @@ u_int16_t ndpi_get_proto_by_name(struct ndpi_detection_module_struct *ndpi_str, 
   if(!ndpi_str || !name)
     return(NDPI_PROTOCOL_UNKNOWN);
 
+  if (*name == '\0')
+    return(NDPI_PROTOCOL_UNKNOWN);
+
   num = ndpi_str->num_supported_protocols;
+
+  /* Cache the lowercased first character of 'name' */
+  const unsigned char fc = tolower((unsigned char)*name);
 
   for(i = 0; i < num; i++) {
     p = ndpi_get_proto_by_id(ndpi_str, i);
-    if(p && strcasecmp(p, name) == 0)
-      return(i);
+    if (p && tolower((unsigned char)*p) == fc) {
+      if(strcasecmp(p + 1, name + 1) == 0)
+        return(i);
+    }
   }
 
   return(NDPI_PROTOCOL_UNKNOWN);


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Describe changes:

Prep for category/breed support (#2594) — optimized `ndpi_get_proto_by_name()`

- Skips full `strcasecmp` if first chars don’t match
- No behavior changes, just faster lookup