### PR TITLE
Add ndpi_get_breed_by_name

### DIFF
--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -669,6 +669,15 @@ extern "C" {
 					     u_int16_t proto);
 
   /**
+   * Get the protocol breed ID associated to the breed name
+   *
+   * @par     name          = the string name of the breed
+   * @return  the breed ID associated to the name, or NDPI_PROTOCOL_UNRATED if not found
+   *
+   */
+  ndpi_protocol_breed_t ndpi_get_breed_by_name(const char *name);
+
+  /**
    * Return the string name of the protocol breed
    *
    * @par     ndpi_struct   = the detection module

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -10958,6 +10958,27 @@ char *ndpi_get_proto_breed_name(ndpi_protocol_breed_t breed_id) {
   }
 }
 
+ndpi_protocol_breed_t ndpi_get_breed_by_name(const char *name) {
+  if(!name)
+    return(NDPI_PROTOCOL_UNRATED);
+
+  if (*name == '\0')
+    return(NDPI_PROTOCOL_UNRATED);
+
+  /* Cache the lowercased first character of 'name' */
+  const unsigned char fc = tolower((unsigned char)*name);
+
+  for(int i = NDPI_PROTOCOL_SAFE; i <= NDPI_PROTOCOL_UNRATED; i++) {
+    char *breed_name = ndpi_get_proto_breed_name((ndpi_protocol_breed_t)i);
+    if(breed_name && tolower((unsigned char)*breed_name) == fc) {
+      if(strcasecmp(breed_name + 1, name + 1) == 0)
+        return((ndpi_protocol_breed_t)i);
+    }
+  }
+
+  return(NDPI_PROTOCOL_UNRATED);
+}
+
 /* ****************************************************** */
 
 #ifdef OBSOLETE


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Describe changes:

Prep for category/breed support (https://github.com/ntop/nDPI/issues/2594) - add `ndpi_get_breed_by_name()`


- Implements protocol breed name to `ndpi_protocol_breed_t` lookup
- Follows same pattern as `ndpi_get_proto_by_name()` and `ndpi_get_category_id`

