### PR TITLE
Remove `NDPI_PROTOCOL_BITMASK`; add a new generic bitmask data structure

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -302,7 +302,7 @@ static int dpdk_port_id = 0, dpdk_run_capture = 1;
 void test_lib(); /* Forward */
 
 extern void ndpi_report_payload_stats(FILE *out);
-extern int parse_proto_name_list(char *str, NDPI_INTERNAL_PROTOCOL_BITMASK *bitmask,
+extern int parse_proto_name_list(char *str, struct ndpi_bitmask *bitmask,
 				 int inverted_logic);
 extern u_int8_t is_ndpi_proto(struct ndpi_flow_info *flow, u_int16_t id);
 
@@ -2994,7 +2994,7 @@ static void on_protocol_discovered(struct ndpi_workflow * workflow,
  */
 static void setupDetection(u_int16_t thread_id, pcap_t * pcap_handle,
                            struct ndpi_global_context *g_ctx) {
-  NDPI_INTERNAL_PROTOCOL_BITMASK enabled_bitmask;
+  struct ndpi_bitmask enabled_bitmask, *enabled_bitmask_ptr = NULL;
   struct ndpi_workflow_prefs prefs;
   int i, ret;
   ndpi_cfg_error rc;
@@ -3007,15 +3007,19 @@ static void setupDetection(u_int16_t thread_id, pcap_t * pcap_handle,
   prefs.ignore_vlanid = ignore_vlanid;
 
   /* Protocols to enable/disable. Default: everything is enabled */
-  NDPI_INTERNAL_PROTOCOL_SET_ALL(enabled_bitmask);
   if(_disabled_protocols != NULL) {
+    if(ndpi_bitmask_alloc(&enabled_bitmask, ndpi_get_num_internal_protocols()) != 0)
+      exit(-1);
+    ndpi_bitmask_set_all(&enabled_bitmask);
     if(parse_proto_name_list(_disabled_protocols, &enabled_bitmask, 1))
       exit(-1);
+    enabled_bitmask_ptr = &enabled_bitmask;
   }
 
   memset(&ndpi_thread_info[thread_id], 0, sizeof(ndpi_thread_info[thread_id]));
   ndpi_thread_info[thread_id].workflow = ndpi_workflow_init(&prefs, pcap_handle, 1,
-                                                            serialization_format, g_ctx, &enabled_bitmask);
+                                                            serialization_format, g_ctx, enabled_bitmask_ptr);
+  ndpi_bitmask_dealloc(enabled_bitmask_ptr);
 
   if(_categoriesDirPath) {
     int failed_files = ndpi_load_categories_dir(ndpi_thread_info[thread_id].workflow->ndpi_struct, _categoriesDirPath);
@@ -6265,6 +6269,36 @@ void mahalanobisUnitTest()
 
 /* *********************************************** */
 
+void bitmaskUnitTest()
+{
+  struct ndpi_bitmask b;
+  int i;
+
+  assert(ndpi_bitmask_alloc(&b, 512) == 0);
+  for(i = 0; i < b.max_bits; i++) {
+    ndpi_bitmask_set(&b, i);
+    assert(ndpi_bitmask_is_set(&b, i));
+  }
+  for(i = 0; i < b.max_bits; i++) {
+    ndpi_bitmask_clear(&b, i);
+    assert(!ndpi_bitmask_is_set(&b, i));
+  }
+  ndpi_bitmask_set_all(&b);
+  for(i = 0; i < b.max_bits; i++)
+    assert(ndpi_bitmask_is_set(&b, i));
+  ndpi_bitmask_reset(&b);
+  for(i = 0; i < b.max_bits; i++)
+    assert(!ndpi_bitmask_is_set(&b, i));
+  for(i = 0; i < b.max_bits; i++) {
+    ndpi_bitmask_set(&b, i);
+    assert(ndpi_bitmask_is_set(&b, i));
+  }
+
+  ndpi_bitmask_dealloc(&b);
+}
+
+/* *********************************************** */
+
 void filterUnitTest() {
   ndpi_filter* f = ndpi_filter_alloc();
   u_int32_t v, i;
@@ -6798,6 +6832,7 @@ int main(int argc, char **argv) {
     memmemUnitTest();
     memcasecmpUnitTest();
     mahalanobisUnitTest();
+    bitmaskUnitTest();
 #endif
   }
 

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -337,7 +337,7 @@ void ndpi_free_flow_info_half(struct ndpi_flow_info *flow) {
 /* ***************************************************** */
 
 static char _proto_delim[] = " \t,:;";
-int parse_proto_name_list(char *str, NDPI_INTERNAL_PROTOCOL_BITMASK *bitmask, int inverted_logic) {
+int parse_proto_name_list(char *str, struct ndpi_bitmask *bitmask, int inverted_logic) {
   char *n;
   uint16_t proto;
   char op;
@@ -366,9 +366,9 @@ int parse_proto_name_list(char *str, NDPI_INTERNAL_PROTOCOL_BITMASK *bitmask, in
     }
     if(!strcmp(n,"all")) {
       if(op)
-        NDPI_INTERNAL_PROTOCOL_SET_ALL(*bitmask);
+        ndpi_bitmask_set_all(bitmask);
       else
-        NDPI_INTERNAL_PROTOCOL_RESET(*bitmask);
+        ndpi_bitmask_reset(bitmask);
       continue;
     }
     proto = ndpi_get_proto_by_name(module, n);
@@ -378,9 +378,9 @@ int parse_proto_name_list(char *str, NDPI_INTERNAL_PROTOCOL_BITMASK *bitmask, in
       return 1;
     }
     if(op)
-      NDPI_INTERNAL_PROTOCOL_ADD(*bitmask,proto);
+      ndpi_bitmask_set(bitmask, proto);
     else
-      NDPI_INTERNAL_PROTOCOL_DEL(*bitmask,proto);
+      ndpi_bitmask_clear(bitmask, proto);
   }
 
   ndpi_exit_detection_module(module);
@@ -410,7 +410,7 @@ struct ndpi_workflow* ndpi_workflow_init(const struct ndpi_workflow_prefs * pref
 					 pcap_t * pcap_handle, int do_init_flows_root,
 					 ndpi_serialization_format serialization_format,
 					 struct ndpi_global_context *g_ctx,
-					 NDPI_INTERNAL_PROTOCOL_BITMASK *enabled_bitmask) {
+					 struct ndpi_bitmask *enabled_bitmask) {
   struct ndpi_detection_module_struct * module;
   struct ndpi_workflow * workflow;
 

--- a/example/reader_util.h
+++ b/example/reader_util.h
@@ -435,7 +435,7 @@ typedef struct ndpi_workflow {
 
 
 /* TODO: remove wrappers parameters and use ndpi global, when their initialization will be fixed... */
-struct ndpi_workflow * ndpi_workflow_init(const struct ndpi_workflow_prefs * prefs, pcap_t * pcap_handle, int do_init_flows_root, ndpi_serialization_format serialization_format, struct ndpi_global_context *g_ctx, NDPI_INTERNAL_PROTOCOL_BITMASK *enabled_bitmask);
+struct ndpi_workflow * ndpi_workflow_init(const struct ndpi_workflow_prefs * prefs, pcap_t * pcap_handle, int do_init_flows_root, ndpi_serialization_format serialization_format, struct ndpi_global_context *g_ctx, struct ndpi_bitmask *enabled_bitmask);
 
 
 /* workflow main free function */
@@ -471,7 +471,7 @@ void process_ndpi_collected_info(struct ndpi_workflow * workflow, struct ndpi_fl
 void ndpi_flow_info_free_data(struct ndpi_flow_info *flow);
 void ndpi_flow_info_freer(void *node);
 const char* print_cipher_id(u_int32_t cipher);
-int parse_proto_name_list(char *str, NDPI_INTERNAL_PROTOCOL_BITMASK *bitmask, int inverted_logic);
+int parse_proto_name_list(char *str, struct ndpi_bitmask *bitmask, int inverted_logic);
 
 extern int reader_log_level;
 

--- a/fuzz/fuzz_config.cpp
+++ b/fuzz/fuzz_config.cpp
@@ -15,7 +15,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   u_int8_t protocol_was_guessed, unused;
   u_int32_t i, ret;
   u_int16_t bool_value;
-  NDPI_INTERNAL_PROTOCOL_BITMASK enabled_bitmask;
+  struct ndpi_bitmask enabled_bitmask;
   struct ndpi_lru_cache_stats lru_stats;
   struct ndpi_patricia_tree_stats patricia_stats;
   struct ndpi_automa_stats automa_stats;
@@ -46,16 +46,20 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   else
     g_ctx = NULL;
 
-  NDPI_INTERNAL_PROTOCOL_SET_ALL(enabled_bitmask);
-  if(fuzzed_data.ConsumeBool()) {
-    NDPI_INTERNAL_PROTOCOL_RESET(enabled_bitmask);
-    for(i = 0; i < ndpi_get_num_internal_protocols(); i++) {
-      if(fuzzed_data.ConsumeBool())
-        NDPI_INTERNAL_PROTOCOL_ADD(enabled_bitmask, i);
+  if(ndpi_bitmask_alloc(&enabled_bitmask, ndpi_get_num_internal_protocols()) == 0) {
+    ndpi_bitmask_set_all(&enabled_bitmask);
+    if(fuzzed_data.ConsumeBool()) {
+      ndpi_bitmask_reset(&enabled_bitmask);
+      for(i = 0; i < ndpi_get_num_internal_protocols(); i++) {
+        if(fuzzed_data.ConsumeBool())
+          ndpi_bitmask_set(&enabled_bitmask, i);
+      }
     }
+    ndpi_info_mod = ndpi_init_detection_module_ext(g_ctx, &enabled_bitmask);
+    ndpi_bitmask_dealloc(&enabled_bitmask);
+  } else {
+    ndpi_info_mod = ndpi_init_detection_module_ext(g_ctx, NULL);
   }
-
-  ndpi_info_mod = ndpi_init_detection_module_ext(g_ctx, &enabled_bitmask);
 
   set_ndpi_debug_function(ndpi_info_mod, NULL);
 

--- a/fuzz/fuzz_readerutils_parseprotolist.cpp
+++ b/fuzz/fuzz_readerutils_parseprotolist.cpp
@@ -19,17 +19,19 @@ int monitoring_enabled = 0;
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   FuzzedDataProvider fuzzed_data(data, size);
   int inverted_logic;
-  NDPI_INTERNAL_PROTOCOL_BITMASK bitmask;
+  struct ndpi_bitmask bitmask;
   char *str;
+
+  ndpi_bitmask_alloc(&bitmask, ndpi_get_num_internal_protocols()); /* Don't make this call to fail...*/
 
   /* To allow memory allocation failures */
   fuzz_set_alloc_callbacks_and_seed(size);
 
   inverted_logic = size % 2; /* pseudo-random */
   if(inverted_logic) {
-    NDPI_INTERNAL_PROTOCOL_SET_ALL(bitmask);
+    ndpi_bitmask_set_all(&bitmask);
   } else {
-    NDPI_INTERNAL_PROTOCOL_RESET(bitmask);
+    ndpi_bitmask_reset(&bitmask);
   }
 
   str = (char *)ndpi_malloc(size + 1); /* We need a null-terminated string */
@@ -41,5 +43,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     ndpi_free(str);
   }
+
+  ndpi_bitmask_dealloc(&bitmask);
+
   return 0;
 }

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -212,7 +212,7 @@ extern "C" {
    *
    */
   struct ndpi_detection_module_struct *ndpi_init_detection_module_ext(struct ndpi_global_context *g_ctx,
-                                                                      const NDPI_INTERNAL_PROTOCOL_BITMASK *detection_bitmask);
+                                                                      const struct ndpi_bitmask *detection_bitmask);
 
   /**
    * Completes the initialization (2nd step)
@@ -878,6 +878,14 @@ extern "C" {
    *
    */
   u_int ndpi_get_num_protocols(struct ndpi_detection_module_struct *ndpi_mod);
+
+  /**
+   * Get the number of the internal protocols.
+   *
+   * @return  the number of protocols
+   *
+   */
+  u_int ndpi_get_num_internal_protocols(void);
 
   /**
    * Get the nDPI version release
@@ -2432,6 +2440,16 @@ extern "C" {
    * comparison.
    */
   int ndpi_memcasecmp(const void *s1, const void *s2, size_t n);
+
+
+  int ndpi_bitmask_alloc(struct ndpi_bitmask *b, u_int16_t max_bits);
+  void ndpi_bitmask_dealloc(struct ndpi_bitmask *b);
+  void ndpi_bitmask_set(struct ndpi_bitmask *b, u_int16_t bit);
+  void ndpi_bitmask_clear(struct ndpi_bitmask *b, u_int16_t bit);
+  int ndpi_bitmask_is_set(const struct ndpi_bitmask *b, u_int16_t bit);
+  void ndpi_bitmask_set_all(struct ndpi_bitmask *b);
+  void ndpi_bitmask_reset(struct ndpi_bitmask *b);
+  struct ndpi_bitmask *ndpi_bitmask_clone(const struct ndpi_bitmask *b);
 
 #ifdef __cplusplus
 }

--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -102,57 +102,15 @@
   ((x.u6_addr.u6_addr64[0] < y.u6_addr.u6_addr64[0]) || ((x.u6_addr.u6_addr64[0] == y.u6_addr.u6_addr64[0]) && (x.u6_addr.u6_addr64[1] < y.u6_addr.u6_addr64[1])))
 
 #define NDPI_NUM_BITS              512
-#define NDPI_NUM_BITS_MASK         (512-1)
 
-#define NDPI_BITS /* 32 */ (sizeof(ndpi_ndpi_mask) * 8 /* number of bits in a byte */)        /* bits per mask */
 #define howmanybits(x, y)   (((x)+((y)-1))/(y))
-
-
-#define NDPI_SET(p, n)    ((p)->fds_bits[(n)/NDPI_BITS] |=  (1ul << (((u_int32_t)n) % NDPI_BITS)))
-#define NDPI_CLR(p, n)    ((p)->fds_bits[(n)/NDPI_BITS] &= ~(1ul << (((u_int32_t)n) % NDPI_BITS)))
-#define NDPI_ISSET(p, n)  ((p)->fds_bits[(n)/NDPI_BITS] &   (1ul << (((u_int32_t)n) % NDPI_BITS)))
-#define NDPI_ZERO(p)      memset((char *)(p), 0, sizeof(*(p)))
-#define NDPI_ONE(p)       memset((char *)(p), 0xFF, sizeof(*(p)))
-
-#define NDPI_NUM_FDS_BITS     howmanybits(NDPI_NUM_BITS, NDPI_BITS)
-
-#define NDPI_PROTOCOL_BITMASK ndpi_protocol_bitmask_struct_t
-
-#define NDPI_BITMASK_ADD(a,b)     NDPI_SET(&a,b)
-#define NDPI_BITMASK_DEL(a,b)     NDPI_CLR(&a,b)
-#define NDPI_BITMASK_RESET(a)     NDPI_ZERO(&a)
-#define NDPI_BITMASK_SET_ALL(a)   NDPI_ONE(&a)
-#define NDPI_BITMASK_SET(a, b)    { memcpy(&a, &b, sizeof(NDPI_PROTOCOL_BITMASK)); }
 
 #define NDPI_SET_BIT(num, n)    num |= 1ULL << ( n )
 #define NDPI_CLR_BIT(num, n)    num &= ~(1ULL << ( n ))
 #define NDPI_CLR_BIT(num, n)    num &= ~(1ULL << ( n ))
 #define NDPI_ISSET_BIT(num, n)  (num & (1ULL << ( n )))
 #define NDPI_ZERO_BIT(num)      num = 0
-
-#define NDPI_MAX_NUM_DISSECTORS                 288      /* Multiple of 32, i.e. NDPI_BITS */
-#define NDPI_NUM_FDS_BITS_DISSECTORS            howmanybits(NDPI_MAX_NUM_DISSECTORS, NDPI_BITS)
-#define NDPI_DISSECTOR_BITMASK                  ndpi_dissector_bitmask_struct_t
-#define NDPI_DISSECTOR_BITMASK_IS_SET(p, n)     NDPI_ISSET(&(p), (n))
-#define NDPI_DISSECTOR_BITMASK_SET(p, n)        NDPI_SET(&(p), (n))
-
-#define NDPI_NUM_FDS_BITS_INTERNAL              howmanybits(NDPI_MAX_INTERNAL_PROTOCOLS, NDPI_BITS)
-#define NDPI_INTERNAL_PROTOCOL_BITMASK          ndpi_internal_protocol_bitmask_struct_t
-#define NDPI_INTERNAL_PROTOCOL_SET_ALL(a)        NDPI_ONE(&a)
-#define NDPI_INTERNAL_PROTOCOL_RESET(a)          NDPI_ZERO(&a)
-#define NDPI_INTERNAL_PROTOCOL_ADD(p, n)         NDPI_SET(&(p), (n))
-#define NDPI_INTERNAL_PROTOCOL_DEL(a,b)          NDPI_CLR(&a,b)
-#define NDPI_INTERNAL_PROTOCOL_IS_SET(p, n)      NDPI_ISSET(&(p), (n))
-
-/* this is a very very tricky macro *g*,
- * the compiler will remove all shifts here if the protocol is static...
- */
-#define NDPI_ADD_PROTOCOL_TO_BITMASK(bmask,value)     NDPI_SET(&bmask,   value & NDPI_NUM_BITS_MASK)
-#define NDPI_DEL_PROTOCOL_FROM_BITMASK(bmask,value)   NDPI_CLR(&bmask,   value & NDPI_NUM_BITS_MASK)
-#define NDPI_COMPARE_PROTOCOL_TO_BITMASK(bmask,value) NDPI_ISSET(&bmask, value & NDPI_NUM_BITS_MASK)
-
-#define NDPI_SAVE_AS_BITMASK(bmask,value)  { NDPI_ZERO(&bmask) ; NDPI_ADD_PROTOCOL_TO_BITMASK(bmask, value); }
-
+#define NDPI_ONES_BIT(num)      num = -1;
 
 #define ndpi_min(a,b)   ((a < b) ? a : b)
 #define ndpi_max(a,b)   ((a > b) ? a : b)

--- a/src/include/ndpi_main.h
+++ b/src/include/ndpi_main.h
@@ -46,8 +46,6 @@ extern "C" {
   void ndpi_twalk(const void *, void (*)(const void *, ndpi_VISIT, int, void*), void *user_data);
   void ndpi_tdestroy(void *vrootp, void (*freefct)(void *));
 
-  int NDPI_BITMASK_COMPARE(NDPI_PROTOCOL_BITMASK a, NDPI_PROTOCOL_BITMASK b);
-
   u_int16_t ntohs_ndpi_bytestream_to_number(const u_int8_t * str,
 					    u_int16_t max_chars_to_read,
 					    u_int16_t * bytes_read);

--- a/src/include/ndpi_private.h
+++ b/src/include/ndpi_private.h
@@ -331,12 +331,12 @@ struct ndpi_detection_module_config_struct {
 
   int wireguard_subclassification_by_ip;
 
-  NDPI_INTERNAL_PROTOCOL_BITMASK debug_bitmask;
-  NDPI_INTERNAL_PROTOCOL_BITMASK ip_list_bitmask;
-  NDPI_INTERNAL_PROTOCOL_BITMASK monitoring;
+  struct ndpi_bitmask debug_bitmask;
+  struct ndpi_bitmask ip_list_bitmask;
+  struct ndpi_bitmask monitoring;
 
-  NDPI_INTERNAL_PROTOCOL_BITMASK flowrisk_bitmask;
-  NDPI_INTERNAL_PROTOCOL_BITMASK flowrisk_info_bitmask;
+  struct ndpi_bitmask flowrisk_bitmask;
+  struct ndpi_bitmask flowrisk_info_bitmask;
 
   int flow_risk_lists_enabled;
   int risk_anonymous_subscriber_list_icloudprivaterelay_enabled;
@@ -345,7 +345,7 @@ struct ndpi_detection_module_config_struct {
 };
 
 struct ndpi_detection_module_struct {
-  NDPI_INTERNAL_PROTOCOL_BITMASK detection_bitmask;
+  struct ndpi_bitmask *detection_bitmask;
 
   u_int64_t current_ts;
   u_int16_t num_tls_blocks_to_follow;

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -262,34 +262,25 @@ typedef u_int32_t ndpi_ndpi_mask;
 
 #define MAX_NUM_RISK_INFOS    8
 
-/* NDPI_PROTO_BITMASK_STRUCT */
-#ifdef NDPI_CFFI_PREPROCESSING
-#undef NDPI_NUM_FDS_BITS
-#define NDPI_NUM_FDS_BITS     16
+struct ndpi_bitmask {
+  u_int16_t max_bits;
+  u_int16_t num_fds;
+  ndpi_ndpi_mask *fds;
+};
+
+#define NDPI_MAX_NUM_DISSECTORS                 288      /* Multiple of 32 */
+#ifndef NDPI_CFFI_PREPROCESSING
+#define NDPI_NUM_FDS_DISSECTORS                 howmanybits(NDPI_MAX_NUM_DISSECTORS, 32)
+#else
+#define NDPI_NUM_FDS_DISSECTORS    9
 #endif
 
-typedef struct ndpi_protocol_bitmask_struct {
-  ndpi_ndpi_mask fds_bits[NDPI_NUM_FDS_BITS];
-} ndpi_protocol_bitmask_struct_t;
-
-
-#ifdef NDPI_CFFI_PREPROCESSING
-#undef NDPI_NUM_FDS_BITS_DISSECTORS
-#define NDPI_NUM_FDS_BITS_DISSECTORS    9
-#endif
-
-typedef struct ndpi_dissector_bitmask_struct {
-  ndpi_ndpi_mask fds_bits[NDPI_NUM_FDS_BITS_DISSECTORS];
-} ndpi_dissector_bitmask_struct_t;
-
-#ifdef NDPI_CFFI_PREPROCESSING
-#undef NDPI_NUM_FDS_BITS_INTERNAL
-#define NDPI_NUM_FDS_BITS_INTERNAL     15
-#endif
-
-typedef struct ndpi_internal_protocol_bitmask_struct {
-  ndpi_ndpi_mask fds_bits[NDPI_NUM_FDS_BITS_INTERNAL];
-} ndpi_internal_protocol_bitmask_struct_t;
+/* Similar to `struct ndpi_bitmask` but with pre-allocated memory, i.e. fixed size.
+   Used only internally in `ndpi_flow_struct`
+ */
+struct ndpi_dissector_bitmask {
+  ndpi_ndpi_mask fds[NDPI_NUM_FDS_DISSECTORS];
+};
 
 struct ndpi_detection_module_struct;
 
@@ -1664,7 +1655,7 @@ struct ndpi_flow_struct {
   /* **Packet** metadata for flows where monitoring is enabled. It is reset after each packet! */
   struct ndpi_metadata_monitoring *monit;
 
-  NDPI_DISSECTOR_BITMASK excluded_dissectors_bitmask;
+  struct ndpi_dissector_bitmask excluded_dissectors_bitmask;
 
   /* NDPI_PROTOCOL_BITTORRENT */
   u_int8_t bittorrent_stage;		      // can be 0 - 255

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -232,7 +232,8 @@ static int ndpi_callback_init(struct ndpi_detection_module_struct *ndpi_str);
 static void ndpi_enabled_callbacks_init(struct ndpi_detection_module_struct *ndpi_str,
 					int count_only);
 
-static void set_default_config(struct ndpi_detection_module_config_struct *cfg);
+static int set_default_config(struct ndpi_detection_module_config_struct *cfg,
+                              u_int16_t max_internal_proto);
 
 static void internal_giveup(struct ndpi_detection_module_struct *ndpi_str,
                             struct ndpi_flow_struct *flow,
@@ -295,6 +296,20 @@ u_int32_t ndpi_detection_get_sizeof_ndpi_flow_udp_struct(void) {
 
 char *ndpi_get_proto_by_id(struct ndpi_detection_module_struct *ndpi_str, u_int id) {
   return(!ndpi_is_valid_protoId(ndpi_str, id) ? NULL : ndpi_str->proto_defaults[id].protoName);
+}
+
+/* *********************************************************************************** */
+
+static void dissector_bitmask_set(struct ndpi_dissector_bitmask *b, u_int16_t bit)
+{
+  b->fds[bit / 32] |= (1ul << (bit % 32));
+}
+
+/* *********************************************************************************** */
+
+static int dissector_bitmask_is_set(const struct ndpi_dissector_bitmask *b, u_int16_t bit)
+{
+  return b->fds[bit / 32] & (1ul << (bit % 32));
 }
 
 /* *********************************************************************************** */
@@ -587,7 +602,7 @@ void exclude_dissector(struct ndpi_detection_module_struct *ndpi_str, struct ndp
   (void)_func;
   (void)_line;
 #endif
-  NDPI_DISSECTOR_BITMASK_SET(flow->excluded_dissectors_bitmask, dissector_idx);
+  dissector_bitmask_set(&flow->excluded_dissectors_bitmask, dissector_idx);
 }
 
 /* ********************************************************************************** */
@@ -599,9 +614,12 @@ int is_proto_enabled(struct ndpi_detection_module_struct *ndpi_str, int protoId)
   /* Custom protocols are always enabled */
   if(ndpi_is_custom_protocol(ndpi_str, protoId))
     return 1;
-  if(NDPI_INTERNAL_PROTOCOL_IS_SET(ndpi_str->detection_bitmask, protoId) == 0)
-    return 0;
-  return 1;
+  /* By default, all protocols are enabled */
+  if(ndpi_str->detection_bitmask == NULL)
+    return 1;
+  if(ndpi_bitmask_is_set(ndpi_str->detection_bitmask, protoId))
+    return 1;
+  return 0;
 }
 
 /* ********************************************************************************** */
@@ -3678,7 +3696,7 @@ void ndpi_debug_printf(u_int16_t proto, struct ndpi_detection_module_struct *ndp
 #define MAX_STR_LEN 250
   char str[MAX_STR_LEN];
   if(ndpi_str != NULL && log_level > NDPI_LOG_ERROR && proto > 0 && proto < ndpi_get_num_internal_protocols() &&
-     !NDPI_INTERNAL_PROTOCOL_IS_SET(ndpi_str->cfg.debug_bitmask, proto))
+     !ndpi_bitmask_is_set(&ndpi_str->cfg.debug_bitmask, proto))
     return;
   va_start(args, format);
   ndpi_vsnprintf(str, sizeof(str) - 1, format, args);
@@ -3917,16 +3935,13 @@ void ndpi_global_deinit(struct ndpi_global_context *g_ctx) {
 /* ******************************************************************** */
 
 struct ndpi_detection_module_struct *ndpi_init_detection_module(struct ndpi_global_context *g_ctx) {
-  NDPI_INTERNAL_PROTOCOL_BITMASK detection_bitmask;
-
   /* By default, all protocols are enabled */
-  NDPI_INTERNAL_PROTOCOL_SET_ALL(detection_bitmask);
-  return ndpi_init_detection_module_ext(g_ctx, &detection_bitmask);
+  return ndpi_init_detection_module_ext(g_ctx, NULL);
 }
 /* ******************************************************************** */
 
 struct ndpi_detection_module_struct *ndpi_init_detection_module_ext(struct ndpi_global_context *g_ctx,
-                                                                    const NDPI_INTERNAL_PROTOCOL_BITMASK *detection_bitmask) {
+                                                                    const struct ndpi_bitmask *detection_bitmask) {
   struct ndpi_detection_module_struct *ndpi_str = ndpi_calloc(1, sizeof(struct ndpi_detection_module_struct));
   int i;
 
@@ -3960,12 +3975,9 @@ struct ndpi_detection_module_struct *ndpi_init_detection_module_ext(struct ndpi_
   ndpi_str->ip_risk_mask = ndpi_ptree_create();
 
   ndpi_str->g_ctx = g_ctx;
-  set_default_config(&ndpi_str->cfg);
 
   if(detection_bitmask)
-    ndpi_str->detection_bitmask = *detection_bitmask;
-  else
-    NDPI_INTERNAL_PROTOCOL_SET_ALL(ndpi_str->detection_bitmask);
+    ndpi_str->detection_bitmask = ndpi_bitmask_clone(detection_bitmask);
 
   ndpi_str->user_data = NULL;
 
@@ -4081,6 +4093,15 @@ struct ndpi_detection_module_struct *ndpi_init_detection_module_ext(struct ndpi_
     return(NULL);
   }
 
+  /* When we know the number of internal protocols, we can set the default configuration
+     (we need the number to proper initialize the bitmasks)*/
+  if(set_default_config(&ndpi_str->cfg,
+                        ndpi_str->num_supported_protocols) != 0) {
+    NDPI_LOG_ERR(ndpi_str, "[NDPI] Error allocating set_default_config\n");
+    ndpi_exit_detection_module(ndpi_str);
+    return(NULL);
+  }
+
   /* TODO: should we move that into ndpi_finalize_initialization()? */
   if(ndpi_callback_init(ndpi_str)) {
     NDPI_LOG_ERR(ndpi_str, "[NDPI] Error allocating callbacks\n");
@@ -4141,7 +4162,7 @@ static void ndpi_add_domain_risk_exceptions(struct ndpi_detection_module_struct 
 
 static int is_ip_list_enabled(struct ndpi_detection_module_struct *ndpi_str, int protoId)
 {
-  if(NDPI_INTERNAL_PROTOCOL_IS_SET(ndpi_str->cfg.ip_list_bitmask, protoId) == 0)
+  if(ndpi_bitmask_is_set(&ndpi_str->cfg.ip_list_bitmask, protoId) == 0)
     return 0;
   return 1;
 }
@@ -4150,7 +4171,7 @@ static int is_ip_list_enabled(struct ndpi_detection_module_struct *ndpi_str, int
 
 int is_monitoring_enabled(struct ndpi_detection_module_struct *ndpi_str, int protoId)
 {
-  if(NDPI_INTERNAL_PROTOCOL_IS_SET(ndpi_str->cfg.monitoring, protoId) == 0)
+  if(ndpi_bitmask_is_set(&ndpi_str->cfg.monitoring, protoId) == 0)
     return 0;
   return 1;
 }
@@ -4846,6 +4867,15 @@ int ndpi_get_custom_category_match(struct ndpi_detection_module_struct *ndpi_str
 void ndpi_exit_detection_module(struct ndpi_detection_module_struct *ndpi_str) {
   if(ndpi_str != NULL) {
     unsigned int i;
+
+    ndpi_bitmask_dealloc(ndpi_str->detection_bitmask);
+    ndpi_free(ndpi_str->detection_bitmask);
+
+    ndpi_bitmask_dealloc(&ndpi_str->cfg.debug_bitmask);
+    ndpi_bitmask_dealloc(&ndpi_str->cfg.ip_list_bitmask);
+    ndpi_bitmask_dealloc(&ndpi_str->cfg.monitoring);
+    ndpi_bitmask_dealloc(&ndpi_str->cfg.flowrisk_bitmask);
+    ndpi_bitmask_dealloc(&ndpi_str->cfg.flowrisk_info_bitmask);
 
     for (i = 0; i < ndpi_str->proto_defaults_num_allocated; i++) {
       if(ndpi_str->proto_defaults[i].protoName)
@@ -8348,7 +8378,7 @@ static u_int32_t check_ndpi_subprotocols(struct ndpi_detection_module_struct * c
 
     if((ndpi_str->callback_buffer[subproto_index].ndpi_selection_bitmask & ndpi_selection_packet) ==
        ndpi_str->callback_buffer[subproto_index].ndpi_selection_bitmask &&
-       !NDPI_DISSECTOR_BITMASK_IS_SET(flow->excluded_dissectors_bitmask, subproto_index)) {
+       !dissector_bitmask_is_set(&flow->excluded_dissectors_bitmask, subproto_index)) {
       ndpi_str->current_dissector_idx = subproto_index;
       ndpi_str->callback_buffer[subproto_index].func(ndpi_str, flow);
       num_calls++;
@@ -8375,7 +8405,7 @@ static u_int32_t check_ndpi_detection_func(struct ndpi_detection_module_struct *
 
   if(fast_callback_protocol_id != NDPI_PROTOCOL_UNKNOWN &&
      ndpi_str->callback_buffer[dissector_idx].func &&
-     !NDPI_DISSECTOR_BITMASK_IS_SET(flow->excluded_dissectors_bitmask, dissector_idx) &&
+     !dissector_bitmask_is_set(&flow->excluded_dissectors_bitmask, dissector_idx) &&
      (ndpi_str->callback_buffer[dissector_idx].ndpi_selection_bitmask & ndpi_selection_packet) ==
      ndpi_str->callback_buffer[dissector_idx].ndpi_selection_bitmask) {
 
@@ -8395,7 +8425,7 @@ static u_int32_t check_ndpi_detection_func(struct ndpi_detection_module_struct *
         if((func != callback_buffer[a].func) &&
 	   (callback_buffer[a].ndpi_selection_bitmask & ndpi_selection_packet) ==
 	   callback_buffer[a].ndpi_selection_bitmask &&
-	   !NDPI_DISSECTOR_BITMASK_IS_SET(flow->excluded_dissectors_bitmask, dissector_idx))
+	   !dissector_bitmask_is_set(&flow->excluded_dissectors_bitmask, dissector_idx))
 	  {
             ndpi_str->current_dissector_idx = dissector_idx;
 	    callback_buffer[a].func(ndpi_str, flow);
@@ -11548,17 +11578,6 @@ char *ndpi_revision() {
 
 /* ****************************************************** */
 
-int NDPI_BITMASK_COMPARE(NDPI_PROTOCOL_BITMASK a, NDPI_PROTOCOL_BITMASK b) {
-  unsigned int i;
-
-  for(i = 0; i < NDPI_NUM_FDS_BITS; i++) {
-    if(a.fds_bits[i] & b.fds_bits[i])
-      return(1);
-  }
-
-  return(0);
-}
-
 u_int16_t ndpi_get_api_version() {
   return(NDPI_API_VERSION);
 }
@@ -12456,14 +12475,14 @@ static ndpi_cfg_error _set_param_filename_config(struct ndpi_detection_module_st
 static char *_get_param_protocol_enable_disable(void *_variable, const char *proto,
 						char *buf, int buf_len)
 {
-  NDPI_INTERNAL_PROTOCOL_BITMASK *bitmask = (NDPI_INTERNAL_PROTOCOL_BITMASK *)_variable;
+  struct ndpi_bitmask *bitmask = (struct ndpi_bitmask *)_variable;
   u_int16_t proto_id;
 
   proto_id = __get_proto_id(proto);
   if(proto_id == NDPI_PROTOCOL_UNKNOWN)
     return NULL;
 
-  snprintf(buf, buf_len, "%d", !!NDPI_INTERNAL_PROTOCOL_IS_SET(*bitmask, proto_id));
+  snprintf(buf, buf_len, "%d", !!ndpi_bitmask_is_set(bitmask, proto_id));
   buf[buf_len - 1] = '\0';
   return buf;
 }
@@ -12473,7 +12492,7 @@ static ndpi_cfg_error _set_param_protocol_enable_disable(struct ndpi_detection_m
                                                          const char *min_value, const char *max_value,
                                                          const char *proto, const char *param)
 {
-  NDPI_INTERNAL_PROTOCOL_BITMASK *bitmask = (NDPI_INTERNAL_PROTOCOL_BITMASK *)_variable;
+  struct ndpi_bitmask *bitmask = (struct ndpi_bitmask *)_variable;
   u_int16_t proto_id;
 
   (void)ndpi_str;
@@ -12486,12 +12505,12 @@ static ndpi_cfg_error _set_param_protocol_enable_disable(struct ndpi_detection_m
      strcmp(proto, "$PROTO_NAME_OR_ID") == 0) {
     if(strcmp(value, "1") == 0 ||
        strcmp(value, "enable") == 0) {
-      NDPI_INTERNAL_PROTOCOL_SET_ALL(*bitmask);
+      ndpi_bitmask_set_all(bitmask);
       return NDPI_CFG_OK;
     }
     if(strcmp(value, "0") == 0 ||
        strcmp(value, "disable") == 0) {
-      NDPI_INTERNAL_PROTOCOL_RESET(*bitmask);
+      ndpi_bitmask_reset(bitmask);
       return NDPI_CFG_OK;
     }
   }
@@ -12502,12 +12521,12 @@ static ndpi_cfg_error _set_param_protocol_enable_disable(struct ndpi_detection_m
 
   if(strcmp(value, "1") == 0 ||
      strcmp(value, "enable") == 0) {
-    NDPI_INTERNAL_PROTOCOL_ADD(*bitmask, proto_id);
+    ndpi_bitmask_set(bitmask, proto_id);
     return NDPI_CFG_OK;
   }
   if(strcmp(value, "0") == 0 ||
      strcmp(value, "disable") == 0) {
-    NDPI_INTERNAL_PROTOCOL_DEL(*bitmask, proto_id);
+    ndpi_bitmask_clear(bitmask, proto_id);
     return NDPI_CFG_OK;
   }
   return NDPI_CFG_INVALID_PARAM;
@@ -12516,14 +12535,14 @@ static ndpi_cfg_error _set_param_protocol_enable_disable(struct ndpi_detection_m
 static char *_get_param_flowrisk_enable_disable(void *_variable, const char *proto,
                                                 char *buf, int buf_len)
 {
-  NDPI_INTERNAL_PROTOCOL_BITMASK *bitmask = (NDPI_INTERNAL_PROTOCOL_BITMASK *)_variable;
+  struct ndpi_bitmask *bitmask = (struct ndpi_bitmask *)_variable;
   ndpi_risk_enum flowrisk_id;
 
   flowrisk_id = __get_flowrisk_id(proto);
   if(flowrisk_id == NDPI_NO_RISK)
     return NULL;
 
-  snprintf(buf, buf_len, "%d", !!NDPI_INTERNAL_PROTOCOL_IS_SET(*bitmask, flowrisk_id));
+  snprintf(buf, buf_len, "%d", !!ndpi_bitmask_is_set(bitmask, flowrisk_id));
   buf[buf_len - 1] = '\0';
   return buf;
 }
@@ -12533,7 +12552,7 @@ static ndpi_cfg_error _set_param_flowrisk_enable_disable(struct ndpi_detection_m
                                                          const char *min_value, const char *max_value,
                                                          const char *proto, const char *_param)
 {
-  NDPI_INTERNAL_PROTOCOL_BITMASK *bitmask = (NDPI_INTERNAL_PROTOCOL_BITMASK *)_variable;
+  struct ndpi_bitmask *bitmask = (struct ndpi_bitmask *)_variable;
   ndpi_risk_enum flowrisk_id;
   char param[128] = {0};
 
@@ -12558,12 +12577,12 @@ static ndpi_cfg_error _set_param_flowrisk_enable_disable(struct ndpi_detection_m
      strcmp(param, "$FLOWRISK_NAME_OR_ID") == 0) {
     if(strcmp(value, "1") == 0 ||
        strcmp(value, "enable") == 0) {
-      NDPI_INTERNAL_PROTOCOL_SET_ALL(*bitmask);
+      ndpi_bitmask_set_all(bitmask);
       return NDPI_CFG_OK;
     }
     if(strcmp(value, "0") == 0 ||
        strcmp(value, "disable") == 0) {
-      NDPI_INTERNAL_PROTOCOL_RESET(*bitmask);
+      ndpi_bitmask_reset(bitmask);
       return NDPI_CFG_OK;
     }
   }
@@ -12574,12 +12593,12 @@ static ndpi_cfg_error _set_param_flowrisk_enable_disable(struct ndpi_detection_m
 
   if(strcmp(value, "1") == 0 ||
      strcmp(value, "enable") == 0) {
-    NDPI_INTERNAL_PROTOCOL_ADD(*bitmask, flowrisk_id);
+    ndpi_bitmask_set(bitmask, flowrisk_id);
     return NDPI_CFG_OK;
   }
   if(strcmp(value, "0") == 0 ||
      strcmp(value, "disable") == 0) {
-    NDPI_INTERNAL_PROTOCOL_DEL(*bitmask, flowrisk_id);
+    ndpi_bitmask_clear(bitmask, flowrisk_id);
     return NDPI_CFG_OK;
   }
   return NDPI_CFG_INVALID_PARAM;
@@ -12791,14 +12810,23 @@ static const struct cfg_param {
 
 #undef __OFF
 
-static void set_default_config(struct ndpi_detection_module_config_struct *cfg)
+static int set_default_config(struct ndpi_detection_module_config_struct *cfg,
+                              u_int16_t max_internal_proto)
 {
   const struct cfg_param *c;
+
+  if(ndpi_bitmask_alloc(&cfg->debug_bitmask, max_internal_proto) != 0 ||
+     ndpi_bitmask_alloc(&cfg->ip_list_bitmask, max_internal_proto) != 0 ||
+     ndpi_bitmask_alloc(&cfg->monitoring, max_internal_proto) != 0 ||
+     ndpi_bitmask_alloc(&cfg->flowrisk_bitmask, NDPI_MAX_RISK) != 0 ||
+     ndpi_bitmask_alloc(&cfg->flowrisk_info_bitmask, NDPI_MAX_RISK) != 0)
+    return -1;
 
   for(c = &cfg_params[0]; c && c->param; c++) {
     cfg_ops[c->type].fn_set(NULL, (void *)((char *)cfg + c->offset),
                             c->default_value, c->min_value, c->max_value, c->proto, c->param);
   }
+  return 0;
 }
 
 ndpi_cfg_error ndpi_set_config(struct ndpi_detection_module_struct *ndpi_str,

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -3022,7 +3022,7 @@ static u_int8_t ndpi_check_ipv6_exception(struct ndpi_detection_module_struct *n
 
 static int is_flowrisk_enabled(struct ndpi_detection_module_struct *ndpi_str, ndpi_risk_enum flowrisk_id)
 {
-  if(NDPI_INTERNAL_PROTOCOL_IS_SET(ndpi_str->cfg.flowrisk_bitmask, flowrisk_id) == 0)
+  if(ndpi_bitmask_is_set(&ndpi_str->cfg.flowrisk_bitmask, flowrisk_id) == 0)
     return 0;
   return 1;
 }
@@ -3031,7 +3031,7 @@ static int is_flowrisk_enabled(struct ndpi_detection_module_struct *ndpi_str, nd
 
 int is_flowrisk_info_enabled(struct ndpi_detection_module_struct *ndpi_str, ndpi_risk_enum flowrisk_id)
 {
-  if(NDPI_INTERNAL_PROTOCOL_IS_SET(ndpi_str->cfg.flowrisk_info_bitmask, flowrisk_id) == 0)
+  if(ndpi_bitmask_is_set(&ndpi_str->cfg.flowrisk_info_bitmask, flowrisk_id) == 0)
     return 0;
   return 1;
 }
@@ -4444,4 +4444,74 @@ bool ndpi_normalize_protocol(struct ndpi_detection_module_struct *ndpi_str,
   }
 
   return(false);
+}
+
+
+
+int ndpi_bitmask_alloc(struct ndpi_bitmask *b, u_int16_t max_bits)
+{
+  if(!b)
+    return -1;
+  b->fds = ndpi_calloc(howmanybits(max_bits, sizeof(ndpi_ndpi_mask)), sizeof(ndpi_ndpi_mask));
+  if(!b->fds)
+    return -1;
+  b->max_bits = max_bits;
+  b->num_fds = howmanybits(max_bits, sizeof(ndpi_ndpi_mask));
+  return 0;
+}
+
+void ndpi_bitmask_dealloc(struct ndpi_bitmask *b)
+{
+  if(b) {
+    ndpi_free(b->fds);
+    b->num_fds = 0;
+  }
+}
+
+void ndpi_bitmask_set(struct ndpi_bitmask *b, u_int16_t bit)
+{
+  if(b && b->fds && bit < b->max_bits)
+    b->fds[bit / 32] |= (1ul << (bit % 32));
+}
+
+void ndpi_bitmask_clear(struct ndpi_bitmask *b, u_int16_t bit)
+{
+  if(b && b->fds && bit < b->max_bits)
+    b->fds[bit / 32] &= ~(1ul << (bit % 32));
+}
+
+int ndpi_bitmask_is_set(const struct ndpi_bitmask *b, u_int16_t bit)
+{
+  if(b && b->fds && bit < b->max_bits)
+    return b->fds[bit / 32] & (1ul << (bit % 32));
+  return -1;
+}
+
+void ndpi_bitmask_set_all(struct ndpi_bitmask *b)
+{
+  if(b && b->fds)
+    memset(b->fds, 0xFF, b->num_fds * sizeof(ndpi_ndpi_mask));
+}
+
+void ndpi_bitmask_reset(struct ndpi_bitmask *b)
+{
+  if(b && b->fds)
+    memset(b->fds, 0x00, b->num_fds * sizeof(ndpi_ndpi_mask));
+}
+
+struct ndpi_bitmask *ndpi_bitmask_clone(const struct ndpi_bitmask *b)
+{
+  struct ndpi_bitmask *a;
+
+  if(!b)
+    return NULL;
+  a = ndpi_calloc(1, sizeof(*a));
+  if(!a)
+    return NULL;
+  if(ndpi_bitmask_alloc(a, b->max_bits) != 0) {
+    ndpi_free(a);
+    return NULL;
+  }
+  memcpy(a->fds, b->fds, b->num_fds * sizeof(ndpi_ndpi_mask));
+  return a;
 }

--- a/windows/src/ndpi_define.h
+++ b/windows/src/ndpi_define.h
@@ -101,57 +101,15 @@
   ((x.u6_addr.u6_addr64[0] < y.u6_addr.u6_addr64[0]) || ((x.u6_addr.u6_addr64[0] == y.u6_addr.u6_addr64[0]) && (x.u6_addr.u6_addr64[1] < y.u6_addr.u6_addr64[1])))
 
 #define NDPI_NUM_BITS              512
-#define NDPI_NUM_BITS_MASK         (512-1)
 
-#define NDPI_BITS /* 32 */ (sizeof(ndpi_ndpi_mask) * 8 /* number of bits in a byte */)        /* bits per mask */
 #define howmanybits(x, y)   (((x)+((y)-1))/(y))
-
-
-#define NDPI_SET(p, n)    ((p)->fds_bits[(n)/NDPI_BITS] |=  (1ul << (((u_int32_t)n) % NDPI_BITS)))
-#define NDPI_CLR(p, n)    ((p)->fds_bits[(n)/NDPI_BITS] &= ~(1ul << (((u_int32_t)n) % NDPI_BITS)))
-#define NDPI_ISSET(p, n)  ((p)->fds_bits[(n)/NDPI_BITS] &   (1ul << (((u_int32_t)n) % NDPI_BITS)))
-#define NDPI_ZERO(p)      memset((char *)(p), 0, sizeof(*(p)))
-#define NDPI_ONE(p)       memset((char *)(p), 0xFF, sizeof(*(p)))
-
-#define NDPI_NUM_FDS_BITS     howmanybits(NDPI_NUM_BITS, NDPI_BITS)
-
-#define NDPI_PROTOCOL_BITMASK ndpi_protocol_bitmask_struct_t
-
-#define NDPI_BITMASK_ADD(a,b)     NDPI_SET(&a,b)
-#define NDPI_BITMASK_DEL(a,b)     NDPI_CLR(&a,b)
-#define NDPI_BITMASK_RESET(a)     NDPI_ZERO(&a)
-#define NDPI_BITMASK_SET_ALL(a)   NDPI_ONE(&a)
-#define NDPI_BITMASK_SET(a, b)    { memcpy(&a, &b, sizeof(NDPI_PROTOCOL_BITMASK)); }
 
 #define NDPI_SET_BIT(num, n)    num |= 1ULL << ( n )
 #define NDPI_CLR_BIT(num, n)    num &= ~(1ULL << ( n ))
 #define NDPI_CLR_BIT(num, n)    num &= ~(1ULL << ( n ))
 #define NDPI_ISSET_BIT(num, n)  (num & (1ULL << ( n )))
 #define NDPI_ZERO_BIT(num)      num = 0
-
-#define NDPI_MAX_NUM_DISSECTORS                 288      /* Multiple of 32, i.e. NDPI_BITS */
-#define NDPI_NUM_FDS_BITS_DISSECTORS            howmanybits(NDPI_MAX_NUM_DISSECTORS, NDPI_BITS)
-#define NDPI_DISSECTOR_BITMASK                  ndpi_dissector_bitmask_struct_t
-#define NDPI_DISSECTOR_BITMASK_IS_SET(p, n)     NDPI_ISSET(&(p), (n))
-#define NDPI_DISSECTOR_BITMASK_SET(p, n)        NDPI_SET(&(p), (n))
-
-#define NDPI_NUM_FDS_BITS_INTERNAL              howmanybits(NDPI_MAX_INTERNAL_PROTOCOLS, NDPI_BITS)
-#define NDPI_INTERNAL_PROTOCOL_BITMASK          ndpi_internal_protocol_bitmask_struct_t
-#define NDPI_INTERNAL_PROTOCOL_SET_ALL(a)       NDPI_ONE(&a)
-#define NDPI_INTERNAL_PROTOCOL_RESET(a)         NDPI_ZERO(&a)
-#define NDPI_INTERNAL_PROTOCOL_ADD(p, n)        NDPI_SET(&(p), (n))
-#define NDPI_INTERNAL_PROTOCOL_DEL(a,b)         NDPI_CLR(&a,b)
-#define NDPI_INTERNAL_PROTOCOL_IS_SET(p, n)      NDPI_ISSET(&(p), (n))
-
-/* this is a very very tricky macro *g*,
- * the compiler will remove all shifts here if the protocol is static...
- */
-#define NDPI_ADD_PROTOCOL_TO_BITMASK(bmask,value)     NDPI_SET(&bmask,   value & NDPI_NUM_BITS_MASK)
-#define NDPI_DEL_PROTOCOL_FROM_BITMASK(bmask,value)   NDPI_CLR(&bmask,   value & NDPI_NUM_BITS_MASK)
-#define NDPI_COMPARE_PROTOCOL_TO_BITMASK(bmask,value) NDPI_ISSET(&bmask, value & NDPI_NUM_BITS_MASK)
-
-#define NDPI_SAVE_AS_BITMASK(bmask,value)  { NDPI_ZERO(&bmask) ; NDPI_ADD_PROTOCOL_TO_BITMASK(bmask, value); }
-
+#define NDPI_ONES_BIT(num)      num = -1;
 
 #define ndpi_min(a,b)   ((a < b) ? a : b)
 #define ndpi_max(a,b)   ((a > b) ? a : b)


### PR DESCRIPTION
The main difference is that the memory is allocated at runtime

Typical usercase:
```
struct ndpi_bitmask b;

ndpi_bitmask_alloc(&b, ndpi_get_num_internal_protocols());

ndpi_bitmask_set(&b, $BIT);
ndpi_bitmask_is_set(&b, $BIT);
[...]

ndpi_bitmask_dealloc(&b);

```

See #2136


