### PR TITLE
TCP fingerprint: fix an heap-buffer-overflow

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -7826,6 +7826,9 @@ static int ndpi_init_packet(struct ndpi_detection_module_struct *ndpi_str,
 
 	      ndpi_set_risk(ndpi_str, flow, NDPI_MALICIOUS_FINGERPRINT, (char*)msg);
 	    } else {
+#ifdef DEBUG_TCP_OPTIONS
+              printf("Options len: %u\n", options_len);
+#endif
 	      for(i=0; i<options_len; /* don't increase here */) {
 		u_int8_t kind = options[i];
 
@@ -7880,7 +7883,8 @@ static int ndpi_init_packet(struct ndpi_detection_module_struct *ndpi_str,
 		    int j = i+2;
 		    u_int8_t opt_len = len - 2;
 
-		    if((kind == 2 /* Maximum segment size */) || (kind == 3 /* TCP window scale */)) {
+		    if(((kind == 2 /* Maximum segment size */) || (kind == 3 /* TCP window scale */)) &&
+		       j + opt_len - 1 < options_len){
 		      u_int32_t val = 0;
 
 		      if(opt_len == 1)


### PR DESCRIPTION
```
=================================================================
==17655==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x71053b8a702a at pc 0x5e6f1ed825a2 bp 0x7095389f1d10 sp 0x7095389f1d08
READ of size 1 at 0x71053b8a702a thread T1
    #0 0x5e6f1ed825a1 in ndpi_init_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:7890:10
    #1 0x5e6f1ed94bb2 in ndpi_internal_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:9768:6
    #2 0x5e6f1ed92f9f in ndpi_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:10065:22
    #3 0x5e6f1ebe7a2e in packet_processing /home/ivan/svnrepos/nDPI/example/reader_util.c:1985:31
    #4 0x5e6f1ebdffd2 in ndpi_workflow_process_packet /home/ivan/svnrepos/nDPI/example/reader_util.c:2730:10
    #5 0x5e6f1ea5da49 in ndpi_process_packet /home/ivan/svnrepos/nDPI/example/ndpiReader.c:4751:7
    #6 0x74953c48763e  (/lib/x86_64-linux-gnu/libpcap.so.0.8+0x2d63e) (BuildId: d0c6c787d35246d7107d600c893454c1fcbaf262)
    #7 0x74953c4688e7 in pcap_loop (/lib/x86_64-linux-gnu/libpcap.so.0.8+0xe8e7) (BuildId: d0c6c787d35246d7107d600c893454c1fcbaf262)
```

Found by oss-fuzz


