### PR TITLE
Fix segfault on -m option: safely reuse/reset stats between iterations (#2903)

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -132,6 +132,7 @@ u_int8_t max_num_udp_dissected_pkts = 24 /* 8 is enough for most protocols, Sign
 static u_int32_t pcap_analysis_duration = (u_int32_t)-1;
 static u_int32_t risk_stats[NDPI_MAX_RISK] = { 0 }, risks_found = 0, flows_with_risks = 0;
 static struct ndpi_stats cumulative_stats;
+static int cumulative_stats_initialized = 0;
 static u_int16_t decode_tunnels = 0;
 static u_int16_t num_loops = 1;
 static u_int8_t shutdown_app = 0, quiet_mode = 0;
@@ -3133,18 +3134,7 @@ static void setupDetection(u_int16_t thread_id, pcap_t * pcap_handle,
   }
 
   unsigned int num_protocols = ndpi_get_num_protocols(ndpi_thread_info[thread_id].workflow->ndpi_struct);
-  ndpi_thread_info[thread_id].workflow->stats.protocol_counter = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  ndpi_thread_info[thread_id].workflow->stats.protocol_counter_bytes = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  ndpi_thread_info[thread_id].workflow->stats.protocol_flows = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  ndpi_thread_info[thread_id].workflow->stats.fpc_protocol_counter = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  ndpi_thread_info[thread_id].workflow->stats.fpc_protocol_counter_bytes = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  ndpi_thread_info[thread_id].workflow->stats.fpc_protocol_flows = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  if(!ndpi_thread_info[thread_id].workflow->stats.protocol_counter ||
-     !ndpi_thread_info[thread_id].workflow->stats.protocol_counter_bytes ||
-     !ndpi_thread_info[thread_id].workflow->stats.protocol_flows ||
-     !ndpi_thread_info[thread_id].workflow->stats.fpc_protocol_counter ||
-     !ndpi_thread_info[thread_id].workflow->stats.fpc_protocol_counter_bytes ||
-     !ndpi_thread_info[thread_id].workflow->stats.fpc_protocol_flows) {
+  if (!ndpi_stats_init(&ndpi_thread_info[thread_id].workflow->stats, num_protocols)) {
     exit(-1);
   }
 
@@ -4055,25 +4045,14 @@ static void printResults(u_int64_t processing_time_usec, u_int64_t setup_time_us
   long long unsigned int breed_stats_pkts[NUM_BREEDS] = { 0 };
   long long unsigned int breed_stats_bytes[NUM_BREEDS] = { 0 };
   long long unsigned int breed_stats_flows[NUM_BREEDS] = { 0 };
-  unsigned int num_protocols;
-
-  memset(&cumulative_stats, 0, sizeof(cumulative_stats));
 
   /* In ndpiReader all the contexts have the same configuration */
-  num_protocols = ndpi_get_num_protocols(ndpi_thread_info[0].workflow->ndpi_struct);
-  cumulative_stats.protocol_counter = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  cumulative_stats.protocol_counter_bytes = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  cumulative_stats.protocol_flows = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  cumulative_stats.fpc_protocol_counter = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  cumulative_stats.fpc_protocol_counter_bytes = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  cumulative_stats.fpc_protocol_flows = ndpi_calloc(sizeof(u_int64_t), num_protocols);
-  if(!cumulative_stats.protocol_counter ||
-     !cumulative_stats.protocol_counter_bytes ||
-     !cumulative_stats.protocol_flows ||
-     !cumulative_stats.fpc_protocol_counter ||
-     !cumulative_stats.fpc_protocol_counter_bytes ||
-     !cumulative_stats.fpc_protocol_flows) {
-    goto free_stats;
+  if (!cumulative_stats_initialized) {
+    unsigned int num_protocols = ndpi_get_num_protocols(ndpi_thread_info[0].workflow->ndpi_struct);
+    if (!ndpi_stats_init(&cumulative_stats, num_protocols)) {
+      return;
+    }
+    cumulative_stats_initialized = 1;
   }
 
   for(thread_id = 0; thread_id < num_threads; thread_id++) {
@@ -4096,7 +4075,7 @@ static void printResults(u_int64_t processing_time_usec, u_int64_t setup_time_us
     cumulative_stats.total_ip_bytes += ndpi_thread_info[thread_id].workflow->stats.total_ip_bytes;
     cumulative_stats.total_discarded_bytes += ndpi_thread_info[thread_id].workflow->stats.total_discarded_bytes;
 
-    for(i = 0; i < ndpi_get_num_protocols(ndpi_thread_info[0].workflow->ndpi_struct); i++) {
+    for (i = 0; i < cumulative_stats.num_protocols; i++) {
       cumulative_stats.protocol_counter[i] += ndpi_thread_info[thread_id].workflow->stats.protocol_counter[i];
       cumulative_stats.protocol_counter_bytes[i] += ndpi_thread_info[thread_id].workflow->stats.protocol_counter_bytes[i];
       cumulative_stats.protocol_flows[i] += ndpi_thread_info[thread_id].workflow->stats.protocol_flows[i];
@@ -4479,7 +4458,7 @@ static void printResults(u_int64_t processing_time_usec, u_int64_t setup_time_us
   }
 
   if(!quiet_mode) printf("\n\nDetected protocols:\n");
-  for(i = 0; i < ndpi_get_num_protocols(ndpi_thread_info[0].workflow->ndpi_struct); i++) {
+  for(i = 0; i < cumulative_stats.num_protocols; i++) {
     ndpi_protocol_breed_t breed = ndpi_get_proto_breed(ndpi_thread_info[0].workflow->ndpi_struct,
                                                        ndpi_map_ndpi_id_to_user_proto_id(ndpi_thread_info[0].workflow->ndpi_struct, i));
 
@@ -4628,12 +4607,7 @@ static void printResults(u_int64_t processing_time_usec, u_int64_t setup_time_us
     dstStats = NULL;
   }
 
-  ndpi_free(cumulative_stats.protocol_counter);
-  ndpi_free(cumulative_stats.protocol_counter_bytes);
-  ndpi_free(cumulative_stats.protocol_flows);
-  ndpi_free(cumulative_stats.fpc_protocol_counter);
-  ndpi_free(cumulative_stats.fpc_protocol_counter_bytes);
-  ndpi_free(cumulative_stats.fpc_protocol_flows);
+  ndpi_stats_reset(&cumulative_stats);
 }
 
 /**
@@ -4962,7 +4936,7 @@ static void ndpi_process_packet(u_char *args,
       ndpi_tdestroy(ndpi_thread_info[thread_id].workflow->ndpi_flows_root[i], ndpi_flow_info_freer);
       ndpi_thread_info[thread_id].workflow->ndpi_flows_root[i] = NULL;
 
-      memset(&ndpi_thread_info[thread_id].workflow->stats, 0, sizeof(struct ndpi_stats));
+      ndpi_stats_reset(&ndpi_thread_info[thread_id].workflow->stats);
     }
 
     if(!quiet_mode)

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -352,6 +352,78 @@ bool load_public_lists(struct ndpi_detection_module_struct *ndpi_str) {
 
 /* ***************************************************** */
 
+void ndpi_stats_free(ndpi_stats_t *s) {
+  if (s->protocol_counter)           ndpi_free(s->protocol_counter);
+  if (s->protocol_counter_bytes)     ndpi_free(s->protocol_counter_bytes);
+  if (s->protocol_flows)             ndpi_free(s->protocol_flows);
+  if (s->fpc_protocol_counter)       ndpi_free(s->fpc_protocol_counter);
+  if (s->fpc_protocol_counter_bytes) ndpi_free(s->fpc_protocol_counter_bytes);
+  if (s->fpc_protocol_flows)         ndpi_free(s->fpc_protocol_flows);
+
+  s->num_protocols = 0;
+}
+
+int ndpi_stats_init(ndpi_stats_t *s, uint32_t num_protocols) {
+  memset(s, 0, sizeof(*s));
+  s->num_protocols = num_protocols;
+
+  s->protocol_counter           = ndpi_calloc(num_protocols, sizeof(u_int64_t));
+  s->protocol_counter_bytes     = ndpi_calloc(num_protocols, sizeof(u_int64_t));
+  s->protocol_flows             = ndpi_calloc(num_protocols, sizeof(u_int32_t));
+  s->fpc_protocol_counter       = ndpi_calloc(num_protocols, sizeof(u_int64_t));
+  s->fpc_protocol_counter_bytes = ndpi_calloc(num_protocols, sizeof(u_int64_t));
+  s->fpc_protocol_flows         = ndpi_calloc(num_protocols, sizeof(u_int32_t));
+
+  if(!s->protocol_counter || !s->protocol_counter_bytes || !s->protocol_flows ||
+     !s->fpc_protocol_counter || !s->fpc_protocol_counter_bytes || !s->fpc_protocol_flows) {
+
+    ndpi_stats_free(s);
+
+    LOG(NDPI_LOG_ERROR, "[NDPI] %s: error allocating memory for ndpi_stats\n", __FUNCTION__);
+    return 0;
+  }
+  return 1;
+}
+
+void ndpi_stats_reset(ndpi_stats_t *s) {
+  memset(s->flow_count, 0, sizeof(s->flow_count));
+  s->guessed_flow_protocols = 0;
+  s->raw_packet_count = 0;
+  s->ip_packet_count = 0;
+  s->total_wire_bytes = 0;
+  s->total_ip_bytes = 0;
+  s->total_discarded_bytes = 0;
+  s->ndpi_flow_count = 0;
+  s->tcp_count = 0;
+  s->udp_count = 0;
+  s->mpls_count = 0;
+  s->pppoe_count = 0;
+  s->vlan_count = 0;
+  s->fragmented_count = 0;
+  s->max_packet_len = 0;
+  s->num_dissector_calls = 0;
+
+  memset(s->packet_len, 0, sizeof(s->packet_len));
+  memset(s->dpi_packet_count, 0, sizeof(s->dpi_packet_count));
+  memset(s->flow_confidence, 0, sizeof(s->flow_confidence));
+  memset(s->fpc_flow_confidence, 0, sizeof(s->fpc_flow_confidence));
+  memset(s->category_counter, 0, sizeof(s->category_counter));
+  memset(s->category_counter_bytes, 0, sizeof(s->category_counter_bytes));
+  memset(s->category_flows, 0, sizeof(s->category_flows));
+  memset(s->lru_stats, 0, sizeof(s->lru_stats));
+  memset(s->automa_stats, 0, sizeof(s->automa_stats));
+  memset(s->patricia_stats, 0, sizeof(s->patricia_stats));
+
+  if (s->protocol_counter)           memset(s->protocol_counter,           0, sizeof(u_int64_t) * s->num_protocols);
+  if (s->protocol_counter_bytes)     memset(s->protocol_counter_bytes,     0, sizeof(u_int64_t) * s->num_protocols);
+  if (s->protocol_flows)             memset(s->protocol_flows,             0, sizeof(u_int32_t) * s->num_protocols);
+  if (s->fpc_protocol_counter)       memset(s->fpc_protocol_counter,       0, sizeof(u_int64_t) * s->num_protocols);
+  if (s->fpc_protocol_counter_bytes) memset(s->fpc_protocol_counter_bytes, 0, sizeof(u_int64_t) * s->num_protocols);
+  if (s->fpc_protocol_flows)         memset(s->fpc_protocol_flows,         0, sizeof(u_int32_t) * s->num_protocols);
+}
+
+/* ***************************************************** */
+
 struct ndpi_workflow* ndpi_workflow_init(const struct ndpi_workflow_prefs * prefs,
 					 pcap_t * pcap_handle, int do_init_flows_root,
 					 ndpi_serialization_format serialization_format,
@@ -549,12 +621,7 @@ void ndpi_workflow_free(struct ndpi_workflow * workflow) {
   ndpi_exit_detection_module(workflow->ndpi_struct);
   ndpi_free(workflow->ndpi_flows_root);
 
-  ndpi_free(workflow->stats.protocol_counter);
-  ndpi_free(workflow->stats.protocol_counter_bytes);
-  ndpi_free(workflow->stats.protocol_flows);
-  ndpi_free(workflow->stats.fpc_protocol_counter);
-  ndpi_free(workflow->stats.fpc_protocol_counter_bytes);
-  ndpi_free(workflow->stats.fpc_protocol_flows);
+  ndpi_stats_free(&workflow->stats);
 
   ndpi_free(workflow);
 }

--- a/example/reader_util.h
+++ b/example/reader_util.h
@@ -372,6 +372,7 @@ typedef struct ndpi_stats {
   u_int64_t raw_packet_count;
   u_int64_t ip_packet_count;
   u_int64_t total_wire_bytes, total_ip_bytes, total_discarded_bytes;
+  u_int32_t num_protocols;
   u_int64_t *protocol_counter;
   u_int64_t *protocol_counter_bytes;
   u_int32_t *protocol_flows;
@@ -436,6 +437,9 @@ typedef struct ndpi_workflow {
   ndpi_serialization_format ndpi_serialization_format;
 } ndpi_workflow_t;
 
+void ndpi_stats_free(ndpi_stats_t *s);
+int ndpi_stats_init(ndpi_stats_t *s, uint32_t num_protocols);
+void ndpi_stats_reset(ndpi_stats_t *s);
 
 /* TODO: remove wrappers parameters and use ndpi global, when their initialization will be fixed... */
 struct ndpi_workflow * ndpi_workflow_init(const struct ndpi_workflow_prefs * prefs, pcap_t * pcap_handle, int do_init_flows_root, ndpi_serialization_format serialization_format, struct ndpi_global_context *g_ctx);


### PR DESCRIPTION

Please sign (check) the below before submitting the Pull Request:

- [ X ] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ X ] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [2903](https://github.com/ntop/nDPI/issues/2903):


Describe changes:
Refactored stats allocation and reset logic to avoid segmentation faults when running ndpiReader in live_capture mode with the -m (duration) option.

- Introduced ndpi_stats_init(), ndpi_stats_reset(), and ndpi_stats_free() to encapsulate lifecycle management of stats.
- Applied these functions in ndpiReader.c and reader_util.{c,h}.
- Prevented multiple allocations and ensured safe reuse of cumulative_stats and per-thread stats structures between capture iterations.

