### PR TITLE
Refactor: make src_name/dst_name dynamically allocated to reduce RAM usage in struct ndpi_flow_info

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -1754,8 +1754,10 @@ static void printFlow(u_int32_t id, struct ndpi_flow_info *flow, u_int16_t threa
             flow->protocol,
             f/1000.0, l/1000.0,
             (l-f)/1000.0,
-            flow->src_name, ntohs(flow->src_port),
-            flow->dst_name, ntohs(flow->dst_port)
+            flow->src_name ? flow->src_name : "",
+            ntohs(flow->src_port),
+            flow->dst_name ? flow->dst_name : "",
+            ntohs(flow->dst_port)
             );
 
     fprintf(csv_fp, "%s|",
@@ -1862,10 +1864,12 @@ static void printFlow(u_int32_t id, struct ndpi_flow_info *flow, u_int16_t threa
 
     fprintf(out, "%s%s%s:%u %s %s%s%s:%u ",
 	    (flow->ip_version == 6) ? "[" : "",
-	    flow->src_name, (flow->ip_version == 6) ? "]" : "", ntohs(flow->src_port),
+      flow->src_name ? flow->src_name : "",
+      (flow->ip_version == 6) ? "]" : "", ntohs(flow->src_port),
 	    flow->bidirectional ? "<->" : "->",
 	    (flow->ip_version == 6) ? "[" : "",
-	    flow->dst_name, (flow->ip_version == 6) ? "]" : "", ntohs(flow->dst_port)
+      flow->dst_name ? flow->dst_name : "",
+      (flow->ip_version == 6) ? "]" : "", ntohs(flow->dst_port)
 	    );
 
     if(flow->vlan_id > 0) fprintf(out, "[VLAN: %u]", flow->vlan_id);
@@ -3006,8 +3010,8 @@ static void dump_realtime_protocol(struct ndpi_workflow * workflow, struct ndpi_
     inet_ntop(AF_INET, &flow->src_ip, srcip, sizeof(srcip));
     inet_ntop(AF_INET, &flow->dst_ip, dstip, sizeof(dstip));
   } else {
-    snprintf(srcip, sizeof(srcip), "[%s]", flow->src_name);
-    snprintf(dstip, sizeof(dstip), "[%s]", flow->dst_name);
+    snprintf(srcip, sizeof(srcip), "[%s]", flow->src_name ? flow->src_name : "");
+    snprintf(dstip, sizeof(dstip), "[%s]", flow->dst_name ? flow->dst_name : "");
   }
 
   ndpi_protocol2name(workflow->ndpi_struct, flow->detected_protocol, app_name, sizeof(app_name));
@@ -3420,7 +3424,7 @@ static void printFlowsStats() {
             ndpi_host_ja_fingerprints *newHost = ndpi_malloc(sizeof(ndpi_host_ja_fingerprints));
             newHost->host_client_info_hasht = NULL;
             newHost->host_server_info_hasht = NULL;
-            newHost->ip_string = all_flows[i].flow->src_name;
+            newHost->ip_string = all_flows[i].flow->src_name ? all_flows[i].flow->src_name : NULL;
             newHost->ip = all_flows[i].flow->src_ip;
             newHost->dns_name = all_flows[i].flow->host_server_name;
 
@@ -3454,7 +3458,7 @@ static void printFlowsStats() {
             ndpi_ip_dns *newHost = ndpi_malloc(sizeof(ndpi_ip_dns));
 
             newHost->ip = all_flows[i].flow->src_ip;
-            newHost->ip_string = all_flows[i].flow->src_name;
+            newHost->ip_string = all_flows[i].flow->src_name ? all_flows[i].flow->src_name : NULL;
             newHost->dns_name = all_flows[i].flow->host_server_name;
 
             ndpi_ja_fingerprints_host *newElement = ndpi_malloc(sizeof(ndpi_ja_fingerprints_host));
@@ -3471,7 +3475,7 @@ static void printFlowsStats() {
             if(innerElement == NULL) {
               ndpi_ip_dns *newInnerElement = ndpi_malloc(sizeof(ndpi_ip_dns));
               newInnerElement->ip = all_flows[i].flow->src_ip;
-              newInnerElement->ip_string = all_flows[i].flow->src_name;
+              newInnerElement->ip_string = all_flows[i].flow->src_name ? all_flows[i].flow->src_name : NULL;
               newInnerElement->dns_name = all_flows[i].flow->host_server_name;
               HASH_ADD_INT(hostByJAFound->ipToDNS_ht, ip, newInnerElement);
             }
@@ -3486,7 +3490,7 @@ static void printFlowsStats() {
             ndpi_host_ja_fingerprints *newHost = ndpi_malloc(sizeof(ndpi_host_ja_fingerprints));
             newHost->host_client_info_hasht = NULL;
             newHost->host_server_info_hasht = NULL;
-            newHost->ip_string = all_flows[i].flow->dst_name;
+            newHost->ip_string = all_flows[i].flow->dst_name ? all_flows[i].flow->dst_name : NULL;
             newHost->ip = all_flows[i].flow->dst_ip;
             newHost->dns_name = all_flows[i].flow->ssh_tls.server_info;
 
@@ -3517,7 +3521,7 @@ static void printFlowsStats() {
             ndpi_ip_dns *newHost = ndpi_malloc(sizeof(ndpi_ip_dns));
 
             newHost->ip = all_flows[i].flow->dst_ip;
-            newHost->ip_string = all_flows[i].flow->dst_name;
+            newHost->ip_string = all_flows[i].flow->dst_name ? all_flows[i].flow->dst_name : NULL;
             newHost->dns_name = all_flows[i].flow->ssh_tls.server_info;;
 
             ndpi_ja_fingerprints_host *newElement = ndpi_malloc(sizeof(ndpi_ja_fingerprints_host));
@@ -3535,7 +3539,7 @@ static void printFlowsStats() {
             if(innerElement == NULL) {
               ndpi_ip_dns *newInnerElement = ndpi_malloc(sizeof(ndpi_ip_dns));
               newInnerElement->ip = all_flows[i].flow->dst_ip;
-              newInnerElement->ip_string = all_flows[i].flow->dst_name;
+              newInnerElement->ip_string = all_flows[i].flow->dst_name ? all_flows[i].flow->dst_name : NULL;
               newInnerElement->dns_name = all_flows[i].flow->ssh_tls.server_info;
               HASH_ADD_INT(hostByJAFound->ipToDNS_ht, ip, newInnerElement);
             }
@@ -3921,9 +3925,9 @@ static void printFlowsStats() {
                       i,
                       ndpi_protocol2name(ndpi_thread_info[0].workflow->ndpi_struct,
                                          all_flows[i].flow->detected_protocol, buf, sizeof(buf)),
-                      all_flows[i].flow->src_name,
+                      all_flows[i].flow->src_name ? all_flows[i].flow->src_name : "",
                       ntohs(all_flows[i].flow->src_port),
-                      all_flows[i].flow->dst_name,
+                      all_flows[i].flow->dst_name ? all_flows[i].flow->dst_name : "",
                       ntohs(all_flows[i].flow->dst_port));
 
               print_bin(out, NULL, &bins[i]);

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -207,8 +207,10 @@ void ndpi_payload_analyzer(struct ndpi_flow_info *flow,
 #ifdef DEBUG_PAYLOAD
     printf("[hashval: %u][proto: %u][vlan: %u][%s:%u <-> %s:%u][direction: %s][payload_len: %u]\n",
 	   flow->hashval, flow->protocol, flow->vlan_id,
-	   flow->src_name, flow->src_port,
-	   flow->dst_name, flow->dst_port,
+     flow->src_name ? flow->src_name : "",
+     flow->src_port,
+     flow->dst_name ? flow->dst_name : "",
+     flow->dst_port,
 	   src_to_dst_direction ? "s2d" : "d2s",
 	   payload_len);
 #endif
@@ -602,6 +604,8 @@ void ndpi_flow_info_free_data(struct ndpi_flow_info *flow) {
   ndpi_free_bin(&flow->payload_len_bin);
 #endif
 
+  if(flow->src_name)        ndpi_free(flow->src_name);
+  if(flow->dst_name)        ndpi_free(flow->dst_name);
   if(flow->tcp_fingerprint) ndpi_free(flow->tcp_fingerprint);
   if(flow->risk_str)        ndpi_free(flow->risk_str);
   if(flow->flow_payload)    ndpi_free(flow->flow_payload);
@@ -913,18 +917,29 @@ static struct ndpi_flow_info *get_ndpi_flow_info(struct ndpi_workflow * workflow
       ndpi_init_bin(&newflow->payload_len_bin, ndpi_bin_family8, PLEN_NUM_BINS);
 #endif
 
-      if(version == IPVERSION) {
-	inet_ntop(AF_INET, &newflow->src_ip, newflow->src_name, sizeof(newflow->src_name));
-	inet_ntop(AF_INET, &newflow->dst_ip, newflow->dst_name, sizeof(newflow->dst_name));
-      } else {
-        newflow->src_ip6 = *(struct ndpi_in6_addr *)&iph6->ip6_src;
-        inet_ntop(AF_INET6, &newflow->src_ip6,
-                  newflow->src_name, sizeof(newflow->src_name));
-        newflow->dst_ip6 = *(struct ndpi_in6_addr *)&iph6->ip6_dst;
-        inet_ntop(AF_INET6, &newflow->dst_ip6,
-                  newflow->dst_name, sizeof(newflow->dst_name));
-        /* For consistency across platforms replace :0: with :: */
-        ndpi_patchIPv6Address(newflow->src_name), ndpi_patchIPv6Address(newflow->dst_name);
+      if (version == 4 || version == 6) {
+        uint16_t inet_addrlen = (version == 4) ? INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
+        newflow->src_name = ndpi_malloc(inet_addrlen);
+        newflow->dst_name = ndpi_malloc(inet_addrlen);
+
+        if(version == 4) {
+          if (newflow->src_name)
+            inet_ntop(AF_INET, &newflow->src_ip, newflow->src_name, inet_addrlen);
+          if (newflow->dst_name)
+            inet_ntop(AF_INET, &newflow->dst_ip, newflow->dst_name, inet_addrlen);
+        } else if (version == 6) {
+          newflow->src_ip6 = *(struct ndpi_in6_addr *)&iph6->ip6_src;
+          newflow->dst_ip6 = *(struct ndpi_in6_addr *)&iph6->ip6_dst;
+
+          if (newflow->src_name)
+            inet_ntop(AF_INET6, &newflow->src_ip6, newflow->src_name, inet_addrlen);
+          if (newflow->dst_name)
+            inet_ntop(AF_INET6, &newflow->dst_ip6, newflow->dst_name, inet_addrlen);
+
+          /* For consistency across platforms replace :0: with :: */
+          if (newflow->src_name) ndpi_patchIPv6Address(newflow->src_name);
+          if (newflow->dst_name) ndpi_patchIPv6Address(newflow->dst_name);
+        }
       }
 
       if((newflow->ndpi_flow = ndpi_flow_malloc(SIZEOF_FLOW_STRUCT)) == NULL) {
@@ -1117,9 +1132,9 @@ static void dump_flow_fingerprint(struct ndpi_workflow * workflow,
     u_int32_t buffer_len;
 
     ndpi_serialize_string_uint32(&serializer, "proto", flow->protocol);
-    ndpi_serialize_string_string(&serializer, "cli_ip", flow->src_name);
+    ndpi_serialize_string_string(&serializer, "cli_ip", flow->src_name ? flow->src_name : "");
     ndpi_serialize_string_uint32(&serializer, "cli_port", ntohs(flow->src_port));
-    ndpi_serialize_string_string(&serializer, "srv_ip", flow->dst_name);
+    ndpi_serialize_string_string(&serializer, "srv_ip", flow->dst_name ? flow->dst_name : "");
     ndpi_serialize_string_uint32(&serializer, "srv_port", ntohs(flow->dst_port));
     ndpi_serialize_string_string(&serializer, "proto",
 				 ndpi_protocol2name(workflow->ndpi_struct,

--- a/example/reader_util.h
+++ b/example/reader_util.h
@@ -195,7 +195,7 @@ typedef struct ndpi_flow_info {
   u_int16_t vlan_id;
   ndpi_packet_tunnel tunnel_type;
   struct ndpi_flow_struct *ndpi_flow;
-  char src_name[INET6_ADDRSTRLEN], dst_name[INET6_ADDRSTRLEN];
+  char *src_name, *dst_name;
   u_int8_t ip_version;
   u_int32_t cwr_count, src2dst_cwr_count, dst2src_cwr_count;
   u_int32_t ece_count, src2dst_ece_count, dst2src_ece_count;


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [ X ] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ X ] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues): -


Describe changes:
- Changed ndpi_flow_info: replaced fixed-size char arrays (always INET6_ADDRSTRLEN) for src_name and dst_name with char* pointers.
- Now IPv4 flows use only INET_ADDRSTRLEN when needed, instead of always reserving IPv6 size.
- Updated ndpi_patchIPv6Address to handle pointer safely.

Impact:
- Saves up to ~92 bytes per flow when reverse lookup is not used.
- In pure IPv4 scenarios this avoids overallocating IPv6 buffer unnecessarily.