### PR TITLE
build tests in oss-fuzz

### DIFF
--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -42,9 +42,7 @@ fi
 
 # build project
 cd ndpi
-# Set LDFLAGS variable as workaround for the "missing
-# dependencies errors" in the introspector build. See #8939
-RANLIB=llvm-ranlib LDFLAGS="-L/usr/local/lib -lpcap" ./autogen.sh --enable-fuzztargets --enable-tls-sigs
+RANLIB=llvm-ranlib ./autogen.sh --enable-fuzztargets --enable-tls-sigs
 make -j$(nproc)
 # Copy fuzzers
 ls fuzz/fuzz* | grep -v "\." | while read -r i; do cp "$i" "$OUT"/; done

--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -42,9 +42,9 @@ fi
 
 # build project
 cd ndpi
-# Set LDFLAGS variable and `--with-only-libndpi` option as workaround for the
-# "missing dependencies errors" in the introspector build. See #8939
-RANLIB=llvm-ranlib LDFLAGS="-L/usr/local/lib -lpcap" ./autogen.sh --enable-fuzztargets --with-only-libndpi --enable-tls-sigs
+# Set LDFLAGS variable as workaround for the "missing
+# dependencies errors" in the introspector build. See #8939
+RANLIB=llvm-ranlib LDFLAGS="-L/usr/local/lib -lpcap" ./autogen.sh --enable-fuzztargets --enable-tls-sigs
 make -j$(nproc)
 # Copy fuzzers
 ls fuzz/fuzz* | grep -v "\." | while read -r i; do cp "$i" "$OUT"/; done


### PR DESCRIPTION
I changed the OSS-Fuzz build script in https://github.com/google/oss-fuzz/pull/13597 to add support for Chronos. Propagating the changes here to remove the .diff in OSS-Fuzz.

OSS-Fuzz's `run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests


Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):


Describe changes:


