### PR TITLE
Fix string truncation warning

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -11863,9 +11863,10 @@ u_int16_t ndpi_match_host_subprotocol(struct ndpi_detection_module_struct *ndpi_
     if(rc1 > 0) {
       if(is_flowrisk_info_enabled(ndpi_str, NDPI_RISKY_DOMAIN)) {
         char str[64] = { '\0' };
+        const size_t len = ndpi_min(string_to_match_len, sizeof(str) - 1);
 
-        strncpy(str, string_to_match, ndpi_min(string_to_match_len, sizeof(str)));
-        str[sizeof(str) - 1] = '\0';
+        memcpy(str, string_to_match, len);
+        str[len] = '\0';
         ndpi_set_risk(ndpi_str, flow, NDPI_RISKY_DOMAIN, str);
       } else {
         ndpi_set_risk(ndpi_str, flow, NDPI_RISKY_DOMAIN, NULL);
@@ -11877,9 +11878,10 @@ u_int16_t ndpi_match_host_subprotocol(struct ndpi_detection_module_struct *ndpi_
   if(ndpi_check_punycode_string(string_to_match, string_to_match_len)) {
     if(is_flowrisk_info_enabled(ndpi_str, NDPI_PUNYCODE_IDN)) {
       char str[64] = { '\0' };
+      const size_t len = ndpi_min(string_to_match_len, sizeof(str) - 1);
 
-      strncpy(str, string_to_match, ndpi_min(string_to_match_len, sizeof(str)));
-      str[sizeof(str) - 1] = '\0';
+      memcpy(str, string_to_match, len);
+      str[len] = '\0';
       ndpi_set_risk(ndpi_str, flow, NDPI_PUNYCODE_IDN, str);
     } else {
       ndpi_set_risk(ndpi_str, flow, NDPI_PUNYCODE_IDN, NULL);


### PR DESCRIPTION
…length is always known.

```
 In file included from /usr/include/string.h:535,
                 from ../include/ndpi_includes.h:31,
                 from ../include/ndpi_main.h:27,
                 from ../include/ndpi_api.h:28,
                 from ndpi_main.c:32:
In function ‘strncpy’,
    inlined from ‘ndpi_match_host_subprotocol’ at ndpi_main.c:11867:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error: ‘__builtin___strncpy_chk’ output may be truncated copying between 0 and 64 bytes from a string of length 255 [-Werror=stringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |       __glibc_objsize (__dest));
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘ndpi_match_host_subprotocol’ at ndpi_main.c:11881:7:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error: ‘__builtin___strncpy_chk’ output may be truncated copying between 0 and 64 bytes from a string of length 255 [-Werror=stringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |       __glibc_objsize (__dest));
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)
