### PR TITLE
Fix roaring_v2 build issue if compiling with `-Werrror -Wall -Wextra -fno-inline`

### DIFF
--- a/src/lib/third_party/src/roaring_v2.c
+++ b/src/lib/third_party/src/roaring_v2.c
@@ -4437,9 +4437,11 @@ static inline container_t *get_writable_copy_if_shared(
  * End of shared container code
  */
 
+#ifdef NDPI_ENABLE_DEBUG_MESSAGES
 static const char *container_names[] = {"bitset", "array", "run", "shared"};
 static const char *shared_container_names[] = {
     "bitset (shared)", "array (shared)", "run (shared)"};
+#endif
 
 // no matter what the initial container was, convert it to a bitset
 // if a new container is produced, caller responsible for freeing the previous
@@ -4487,6 +4489,7 @@ static inline bitset_container_t *container_to_bitset(
     }
 }*/
 
+#ifdef NDPI_ENABLE_DEBUG_MESSAGES
 static inline const char *get_full_container_name(
     const container_t *c, uint8_t typecode
 ){
@@ -4519,6 +4522,7 @@ static inline const char *get_full_container_name(
     __builtin_unreachable();
     return NULL;
 }
+#endif
 
 /**
  * Get the container cardinality (number of elements), requires a  typecode


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)