### PR TITLE
TLS: fix infinite loop

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -3322,7 +3322,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		}
 	      } else if(extension_id == 51 &&  /* key_share */
 	                offset + extension_offset < total_len) {
-		u_int16_t extn_offset        = extn_off + 4;
+		u_int32_t extn_offset        = extn_off + 4;
 		u_int16_t extn_end           = extn_offset + extension_len;
 
 		if(extn_offset + extension_len <= total_len) {


### PR DESCRIPTION
```
==76196== ERROR: libFuzzer: timeout after 11 seconds
    #0 0x638deac5c8c8 in __sanitizer_print_stack_trace (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet+0x15c8c8) (BuildId: c5a1de964ceb88124c6a028092ae3e9c5bc0b1d4)
    #1 0x638deac2e4fc in fuzzer::PrintStackTrace() (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet+0x12e4fc) (BuildId: c5a1de964ceb88124c6a028092ae3e9c5bc0b1d4)
    #2 0x638deac134cb in fuzzer::Fuzzer::AlarmCallback() (/home/ivan/svnrepos/nDPI/fuzz/fuzz_process_packet+0x1134cb) (BuildId: c5a1de964ceb88124c6a028092ae3e9c5bc0b1d4)
    #3 0x7afcaf84532f  (/lib/x86_64-linux-gnu/libc.so.6+0x4532f) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #4 0x638deacd951b in processClientServerHello /home/ivan/svnrepos/nDPI/src/lib/protocols/tls.c:3358:33
    #5 0x638deacd74e8 in processTLSBlock /home/ivan/svnrepos/nDPI/src/lib/protocols/tls.c:1277:5

```
Found by oss-fuzz
See: https://issues.oss-fuzz.com/issues/444567412


