### PR TITLE
CI: update macOS runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # macos-14 and 15 are on **ARM64**
-        os: ["ubuntu-22.04", "ubuntu-24.04", "macOS-13", "macOS-14", "macOS-15", "ubuntu-22.04-arm", "ubuntu-24.04-arm"]
+        # macos-14,15 and 26 are on **ARM64**
+        os: ["ubuntu-22.04", "ubuntu-24.04", "macOS-14", "macOS-15", "macOS-26", "ubuntu-22.04-arm", "ubuntu-24.04-arm"]
         compiler: ["cc"]
         pcre: [""]
         maxminddb: [""]


### PR DESCRIPTION
macOS-13 is deprecated: https://github.com/actions/runner-images/issues/13046
macOS-26 is available: https://github.com/actions/runner-images/issues/13008



