### PR TITLE
configure: improve roaring version detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') && !endsWith(matrix.os, 'arm') && !startsWith(matrix.msan, '--with-') && !startsWith(matrix.nBPF, 'nBPF') && !startsWith(matrix.global_context, '--without') # Only on a few "standard" builds
         run: |
           make distclean
-          ./autogen.sh --enable-option-checking=fatal --enable-debug-messages --enable-tls-sigs --host=x86_64-w64-mingw32 --enable-old-croaring
+          ./autogen.sh --enable-option-checking=fatal --enable-debug-messages --enable-tls-sigs --host=x86_64-w64-mingw32
           make -j $(nproc) all
         env:
           CC:

--- a/configure.ac
+++ b/configure.ac
@@ -131,19 +131,31 @@ AS_IF([test "x${enable_oldcroaring}" = "xyes"], [
   NDPI_CFLAGS="${NDPI_CFLAGS} -DUSE_OLD_ROARING"
   echo "Using old croaring (forced by user)"
 ], [
-  #TODO: try to autodetect if roaring v4 works.
-  #For the time being, check (only) compiler version
-  GCC_VERSION=`$CC --version | cut -d ' ' -f 3 | head -1|cut -d '.' -f 1`
-  if test "${GCC_VERSION}" == "version" ; then
-    GCC_VERSION=`$CC --version | cut -d ' ' -f 4 | head -1|cut -d '.' -f 1`
-  fi
-
-  if test "${GCC_VERSION}" -lt "7" ; then
+  # Test if the compiler supports C11 atomics (required by roaring v4)
+  # Roaring v4 requires __STDC_VERSION__ >= 201112L and working C11 atomics
+  AC_MSG_CHECKING([whether C compiler supports C11 atomics for roaring v4])
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdatomic.h>
+    #if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 201112L
+    #error "C11 not supported"
+    #endif
+    #if defined(__STDC_NO_ATOMICS__)
+    #error "C11 atomics not supported"
+    #endif
+    typedef _Atomic(unsigned int) test_atomic_t;
+    int main() {
+      test_atomic_t val = 0;
+      atomic_fetch_add_explicit(&val, 1, memory_order_relaxed);
+      return atomic_load_explicit(&val, memory_order_relaxed);
+    }
+  ]])], [
+    AC_MSG_RESULT(yes)
+    echo "Using croaring v4 (autodetect: C11 atomics available)"
+  ], [
+    AC_MSG_RESULT(no)
     NDPI_CFLAGS="${NDPI_CFLAGS} -DUSE_OLD_ROARING"
-    echo "Using old croaring (autodetect)"
-  else
-    echo "Using croaring v4 (autodetect)"
-  fi
+    echo "Using old croaring (autodetect: C11 atomics not available)"
+  ])
 ])
 
 

--- a/src/lib/third_party/src/roaring.c
+++ b/src/lib/third_party/src/roaring.c
@@ -25163,7 +25163,7 @@ void roaring64_bitmap_remove_bulk(roaring64_bitmap_t *r,
         }
         if (!container_nonzero_cardinality(container2, typecode2)) {
             container_free(container2, typecode2);
-            leaf_t leaf;
+            leaf_t leaf = 0;
             bool erased = art_erase(art, high48, (art_val_t *)&leaf);
             assert(erased);
             (void)erased;


### PR DESCRIPTION
Replace GCC version heuristic with proper C11 atomics feature detection.

Previously, the configure script used GCC version >= 7 as a proxy to determine whether to use roaring v4 or fall back to the old version. This approach had several limitations:
- Only worked reliably with GCC
- Didn't verify actual C11 support
- Could fail with other compilers (Clang, ICC, etc.)

Roaring v4 requires C11 atomics (stdatomic.h, _Atomic, etc.) as per roaring.h:547. This commit implements a proper feature test using AC_COMPILE_IFELSE that checks:
- C11 standard support (__STDC_VERSION__ >= 201112L)
- C11 atomics not disabled (__STDC_NO_ATOMICS__)
- Working <stdatomic.h> header
- Functional atomic operations (atomic_fetch_add_explicit, etc.)

Benefits:
- Works correctly with any C11-compliant compiler
- Tests actual requirements instead of compiler version
- More robust across different platforms

The --enable-old-croaring flag continues to work as before, allowing users to force the old roaring version when needed.

On CI, we can now autodetect roaring version even with mingw compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


