### PR TITLE
Fix broken header install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,6 +195,10 @@ jobs:
         run: |
           DESTDIR=/tmp/ndpi make install
           ls -alhHR /tmp/ndpi
+          file /tmp/ndpi/usr/include/ndpi/ndpi_api.h
+          test ! -r /tmp/ndpi/usr/include/ndpi/ndpi_private.h
+          file /tmp/ndpi/usr/lib/libndpi.a
+          file /tmp/ndpi/usr/lib/libndpi.so*
       - name: Test nDPI [SYMBOLS]
         if: startsWith(matrix.os, 'ubuntu') && !endsWith(matrix.os, 'arm') && !startsWith(matrix.msan, '--with-') && !startsWith(matrix.nBPF, 'nBPF') && !startsWith(matrix.global_context, '--without') # Only on a few "standard" builds
         run: |

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -103,6 +103,7 @@ install: $(NDPI_LIBS)
 	cp $(NDPI_LIBS) $(DESTDIR)@libdir@/
 	cp -P $(NDPI_LIB_SHARED_BASE) $(DESTDIR)@libdir@/
 	cp -P $(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR) $(DESTDIR)@libdir@/
-	mkdir -p $(DESTDIR)@includedir@
-	#Avoid installing private header
-	find ../include/*.h ! -name ndpi_private.h -exec cp "{}" $(DESTDIR)@includedir@/ \;
+	mkdir -p $(DESTDIR)@includedir@/ndpi
+	# Avoid installing private header
+	# Installing header files to $(DESTDIR)@includedir@/ndpi
+	find ../include/*.h ! -name ndpi_private.h -exec cp "{}" $(DESTDIR)@includedir@/ndpi \;


### PR DESCRIPTION
 * header files are expected to reside in prefix/includedir/ndpi/ instead of prefix/includedir/

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Describe changes:
broken since 9aeb80f902