### PR TITLE
Extend values saved in hash data structure to `u_int64_t`

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -5831,14 +5831,14 @@ void rsiUnitTest() {
 void hashUnitTest() {
   ndpi_str_hash *h;
   char * const dict[] = { "hello", "world", NULL };
-  u_int32_t i;
+  u_int64_t i;
 
   assert(ndpi_hash_init(&h) == 0);
   assert(h->priv == NULL);
 
   for(i=0; dict[i] != NULL; i++) {
     u_int8_t l = strlen(dict[i]);
-    u_int32_t v;
+    u_int64_t v;
 
     assert(ndpi_hash_add_entry(&h, dict[i], l, i) == 0);
     assert(ndpi_hash_find_entry(h, dict[i], l, &v) == 0);
@@ -6853,7 +6853,7 @@ void encodeDomainsUnitTest() {
   struct stat st;
 
   if(stat(lists_path, &st) == 0) {
-    u_int32_t suffix_id;
+    u_int64_t suffix_id;
     char out[256];
     char *str;
     ndpi_protocol_category_t id;
@@ -6903,7 +6903,7 @@ void domainsUnitTest() {
   struct stat st;
 
   if(stat(lists_path, &st) == 0) {
-    u_int32_t suffix_id;
+    u_int64_t suffix_id;
 
     assert(ndpi_load_domain_suffixes(ndpi_str, (char*)lists_path) == 0);
 
@@ -6933,7 +6933,7 @@ void domainsUnitTest() {
 void domainSearchUnitTest() {
   ndpi_domain_classify *sc = ndpi_domain_classify_alloc();
   char *domain = "ntop.org";
-  u_int32_t class_id;
+  u_int64_t class_id;
   struct ndpi_detection_module_struct *ndpi_str = ndpi_init_detection_module(NULL);
   u_int8_t trace = 0;
 
@@ -6970,7 +6970,7 @@ void domainSearchUnitTest() {
 void domainSearchUnitTest2() {
   struct ndpi_detection_module_struct *ndpi_str = ndpi_init_detection_module(NULL);
   ndpi_domain_classify *c = ndpi_domain_classify_alloc();
-  u_int32_t class_id = 9;
+  u_int64_t class_id = 9;
 
   assert(ndpi_str);
   assert(c);

--- a/fuzz/fuzz_config.cpp
+++ b/fuzz/fuzz_config.cpp
@@ -750,7 +750,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   struct in_addr pin;
   struct in6_addr pin6;
-  u_int32_t suffix_id;
+  u_int64_t suffix_id;
   
   pin.s_addr = fuzzed_data.ConsumeIntegral<u_int32_t>();
   ndpi_network_port_ptree_match(ndpi_info_mod, &pin, fuzzed_data.ConsumeIntegral<u_int16_t>());

--- a/fuzz/fuzz_ds_domain_classify.cpp
+++ b/fuzz/fuzz_ds_domain_classify.cpp
@@ -21,7 +21,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   u_int16_t i, num_iteration, is_added = 0;
   bool rc;
   ndpi_domain_classify *d;
-  u_int32_t class_id;
+  u_int64_t class_id;
   std::string value, value_added;
 
   /* We don't need a complete (and costly to set up) context!
@@ -47,7 +47,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   
   for (i = 0; i < num_iteration; i++) {
     value = fuzzed_data.ConsumeBytesAsString(fuzzed_data.ConsumeIntegral<u_int8_t>());
-    class_id = fuzzed_data.ConsumeIntegral<u_int32_t>();
+    class_id = fuzzed_data.ConsumeIntegral<u_int64_t>();
     rc = ndpi_domain_classify_add(fuzzed_data.ConsumeBool() ? ndpi_struct : NULL,
                                   d, class_id, (char*)value.c_str());
     

--- a/fuzz/fuzz_ds_hash.cpp
+++ b/fuzz/fuzz_ds_hash.cpp
@@ -9,7 +9,7 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   FuzzedDataProvider fuzzed_data(data, size);
   u_int16_t i, rc, num_iteration, data_len, is_added = 0;
-  u_int32_t value32;
+  u_int64_t value64;
   std::vector<char>value_added;
   ndpi_str_hash *h = NULL;
 
@@ -45,11 +45,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     data_len = fuzzed_data.ConsumeIntegralInRange(0, 127);
     std::vector<char>data = fuzzed_data.ConsumeBytes<char>(data_len);
 
-    ndpi_hash_find_entry(h, data.data(), data.size(), &value32);
+    ndpi_hash_find_entry(h, data.data(), data.size(), &value64);
   }
   /* Search of an added entry */
   if (is_added) {
-    ndpi_hash_find_entry(h, value_added.data(), value_added.size(), &value32);
+    ndpi_hash_find_entry(h, value_added.data(), value_added.size(), &value64);
   }
 
   if (fuzzed_data.ConsumeBool())

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -2125,7 +2125,7 @@ extern "C" {
    * @return 0 if an entry with that key was found, 1 otherwise
    *
    */
-  int ndpi_hash_find_entry(ndpi_str_hash *h, char *key, u_int key_len, u_int32_t *value);
+  int ndpi_hash_find_entry(ndpi_str_hash *h, char *key, u_int key_len, u_int64_t *value);
 
   /**
    * Add an entry to the hashmap.
@@ -2138,7 +2138,7 @@ extern "C" {
    * @return 0 if the entry was added, 1 otherwise
    *
    */
-  int ndpi_hash_add_entry(ndpi_str_hash **h, char *key, u_int8_t key_len, u_int32_t value);
+  int ndpi_hash_add_entry(ndpi_str_hash **h, char *key, u_int8_t key_len, u_int64_t value);
 
   void ndpi_hash_get_stats(ndpi_str_hash *h, struct ndpi_str_hash_stats *stats);
   int ndpi_get_hash_stats(struct ndpi_detection_module_struct *ndpi_struct,
@@ -2275,7 +2275,7 @@ extern "C" {
 					     char *file_path);
   bool ndpi_domain_classify_hostname(struct ndpi_detection_module_struct *ndpi_mod,
 				     ndpi_domain_classify *s,
-				     u_int32_t *class_id /* out */,
+				     u_int64_t *class_id /* out */,
 				     char *hostname);
 
   /* ******************************* */
@@ -2352,7 +2352,7 @@ extern "C" {
    */
   const char* ndpi_get_host_domain_suffix(struct ndpi_detection_module_struct *ndpi_str,
 					  const char *hostname,
-					  u_int32_t *suffix_id /* out */);
+					  u_int64_t *suffix_id /* out */);
 
   /**
    * Returns the domain (including the TLS) suffix out of the specified hostname.

--- a/src/lib/ndpi_domain_classify.c
+++ b/src/lib/ndpi_domain_classify.c
@@ -148,7 +148,7 @@ u_int32_t ndpi_domain_classify_add_domains(struct ndpi_detection_module_struct *
 
 bool ndpi_domain_classify_hostname(struct ndpi_detection_module_struct *ndpi_mod,
 				   ndpi_domain_classify *s,
-				   u_int32_t *class_id /* out */,
+				   u_int64_t *class_id /* out */,
 				   char *hostname) {
   const char *dot;
   char *item;

--- a/src/lib/ndpi_domains.c
+++ b/src/lib/ndpi_domains.c
@@ -93,7 +93,7 @@ int ndpi_load_domain_suffixes(struct ndpi_detection_module_struct *ndpi_str,
 
 const char* ndpi_get_host_domain_suffix(struct ndpi_detection_module_struct *ndpi_str,
 					const char *hostname,
-					u_int32_t *domain_id /* out */) {
+					u_int64_t *domain_id /* out */) {
   char *dot, *prev_dot;
 
   if(!ndpi_str || !hostname || !domain_id)
@@ -135,7 +135,7 @@ const char* ndpi_get_host_domain(struct ndpi_detection_module_struct *ndpi_str,
 				 const char *hostname) {
   const char *ret;
   char *dot, *first_dc;
-  u_int32_t domain_id, len;
+  u_int64_t domain_id, len;
   
   if(!ndpi_str || !hostname)
     return NULL;

--- a/src/lib/ndpi_fingerprint.c
+++ b/src/lib/ndpi_fingerprint.c
@@ -49,7 +49,7 @@ void ndpi_load_tcp_fingerprints(struct ndpi_detection_module_struct *ndpi_str) {
 ndpi_os ndpi_get_os_from_tcp_fingerprint(struct ndpi_detection_module_struct *ndpi_str,
 					 char *tcp_fingerprint) {  
   if(tcp_fingerprint && (ndpi_str->tcp_fingerprint_hashmap != NULL)) {
-    u_int32_t ret;
+    u_int64_t ret;
     
     if(ndpi_hash_find_entry(ndpi_str->tcp_fingerprint_hashmap,
 			    tcp_fingerprint, strlen(tcp_fingerprint), &ret) == 0)
@@ -72,7 +72,7 @@ ndpi_os ndpi_get_os_from_tcp_fingerprint(struct ndpi_detection_module_struct *nd
 int ndpi_add_tcp_fingerprint(struct ndpi_detection_module_struct *ndpi_str,
 			     char *fingerprint, ndpi_os os) {
   u_int len;
-  u_int32_t ret;
+  u_int64_t ret;
 
   len = strlen(fingerprint);
 
@@ -82,7 +82,7 @@ int ndpi_add_tcp_fingerprint(struct ndpi_detection_module_struct *ndpi_str,
     return(-1);
   } else {
     if(ndpi_hash_add_entry(&ndpi_str->tcp_fingerprint_hashmap, fingerprint, len,
-			   (u_int32_t)os) == 0) {
+			   (u_int64_t)os) == 0) {
       return(0);
     } else
       return(-2);

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4983,7 +4983,7 @@ int ndpi_match_custom_category(struct ndpi_detection_module_struct *ndpi_str,
                                ndpi_protocol_category_t *category,
                                ndpi_protocol_breed_t *breed) {
   char buf[128];
-  u_int32_t class_id;
+  u_int64_t class_id;
   u_int max_len = sizeof(buf)-1;
 
   if(!ndpi_str->custom_categories.categories_loaded)

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -72,7 +72,7 @@ struct pcre2_struct {
 
 typedef struct {
   char *key;
-  u_int32_t value32;
+  u_int64_t value64;
   UT_hash_handle hh;
 } ndpi_str_hash_priv;
 
@@ -2881,7 +2881,7 @@ void ndpi_hash_free(ndpi_str_hash **h) {
 
 /* ******************************************************************** */
 
-int ndpi_hash_find_entry(ndpi_str_hash *h, char *key, u_int key_len, u_int32_t *value) {
+int ndpi_hash_find_entry(ndpi_str_hash *h, char *key, u_int key_len, u_int64_t *value) {
   ndpi_str_hash_priv *h_priv;
   ndpi_str_hash_priv *item;
 
@@ -2895,7 +2895,7 @@ int ndpi_hash_find_entry(ndpi_str_hash *h, char *key, u_int key_len, u_int32_t *
 
   if (item != NULL) {
     if(value != NULL)
-      *value = item->value32;
+      *value = item->value64;
 
     h->stats.n_found++;
     return 0;
@@ -2905,7 +2905,7 @@ int ndpi_hash_find_entry(ndpi_str_hash *h, char *key, u_int key_len, u_int32_t *
 
 /* ******************************************************************** */
 
-int ndpi_hash_add_entry(ndpi_str_hash **h, char *key, u_int8_t key_len, u_int32_t value) {
+int ndpi_hash_add_entry(ndpi_str_hash **h, char *key, u_int8_t key_len, u_int64_t value) {
   ndpi_str_hash_priv *h_priv;
   ndpi_str_hash_priv *item, *ret_found;
 
@@ -2917,7 +2917,7 @@ int ndpi_hash_add_entry(ndpi_str_hash **h, char *key, u_int8_t key_len, u_int32_
   HASH_FIND(hh, h_priv, key, key_len, item);
 
   if(item != NULL) {
-    item->value32 = value;
+    item->value64 = value;
     return(1); /* Entry already present */
   }
 
@@ -2935,7 +2935,7 @@ int ndpi_hash_add_entry(ndpi_str_hash **h, char *key, u_int8_t key_len, u_int32_
     item->key[key_len] = '\0';
   }
 
-  item->value32 = value;
+  item->value64 = value;
 
   HASH_ADD(hh, *(ndpi_str_hash_priv **)&((*h)->priv), key[0], key_len, item);
 
@@ -4092,7 +4092,7 @@ u_int ndpi_encode_domain(struct ndpi_detection_module_struct *ndpi_str,
   u_int out_idx = 0, i, buf_shift = 0, domain_buf_len, compressed_len, suffix_len, domain_len;
   u_int32_t value = 0;
   u_char domain_buf[256], compressed[128];
-  u_int32_t domain_id = 0;
+  u_int64_t domain_id = 0;
   const char *suffix;
 
   if(!ndpi_domain_mapper_initialized) {
@@ -4782,7 +4782,7 @@ char* ndpi_compute_ndpi_flow_fingerprint(struct ndpi_detection_module_struct *nd
 
       if(flow->ndpi.fingerprint != NULL &&
          ndpi_str->ndpifp_custom_protos != NULL) {
-	u_int32_t proto_id;
+	u_int64_t proto_id;
 
 	/* This protocol has been defined in protos.txt-like files */
 	if(ndpi_hash_find_entry(ndpi_str->ndpifp_custom_protos,

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -957,7 +957,7 @@ static void ndpi_check_http_url_subprotocol(struct ndpi_detection_module_struct 
 					    struct ndpi_flow_struct *flow) {
   if(flow->http.url) {
     if(ndpi_struct->http_url_hashmap) {
-      u_int32_t proto_id;
+      u_int64_t proto_id;
       
       /* This protocol has been defined in protos.txt-like files */
       if(ndpi_hash_find_entry(ndpi_struct->http_url_hashmap,

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -3377,7 +3377,7 @@ compute_ja4c:
 	        ndpi_compute_ja4(ndpi_struct, flow, quic_version, &ja);
 
 		if(ndpi_struct->ja4_custom_protos != NULL) {
-		  u_int32_t proto_id;
+		  u_int64_t proto_id;
 
 		  /* This protocol has been defined in protos.txt-like files */
 		  if(ndpi_hash_find_entry(ndpi_struct->ja4_custom_protos,


### PR DESCRIPTION
Move from `u_int32_t` to `u_int64_t`.
We want to be able to save protocol + category + breed in the same entry.


