### PR TITLE
Rework API to set custom memory allocator functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - Remove `NDPI_PROTOCOL_BITMASK` (because its size is hardcoded to 512). Create a new structure, `ndpi_bitmask`, where the max number of bits is specified at runtime
  - Change the return parameter of `ndpi_detection_process_packet()`; get rid of `ndpi_extra_dissection_possible()`. See: https://github.com/ntop/nDPI/pull/2942
  - Remove `NDPI_PROTOCOL_ADULT_CONTENT`, `NDPI_PROTOCOL_LLM` and `NDPI_PROTOCOL_ADS_ANALYTICS_TRACK` because they are not real protocol: keep only the categories with a similar name
+ - Modify the API to set a custom memory allocator
 
 Further information are available at https://github.com/ntop/nDPI/issues/2862
 

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -332,7 +332,7 @@ static u_int32_t reader_slot_malloc_bins(u_int64_t v)
 /**
  * @brief ndpi_malloc wrapper function
  */
-static void *ndpi_malloc_wrapper(size_t size) {
+static void *malloc_wrapper(size_t size) {
   tot_ndpi_memory += size;
 
   if(enable_malloc_bins && malloc_size_stats)
@@ -347,6 +347,73 @@ static void *ndpi_malloc_wrapper(size_t size) {
  * @brief free wrapper function
  */
 static void free_wrapper(void *freeable) {
+  free(freeable); /* Don't change to ndpi_free !!!!! */
+}
+
+/* ***************************************************** */
+
+static void *calloc_wrapper(size_t nmemb, size_t size) {
+  tot_ndpi_memory += (nmemb * size);
+
+  if(enable_malloc_bins && malloc_size_stats)
+    ndpi_inc_bin(&malloc_bins, reader_slot_malloc_bins(nmemb * size), 1);
+
+  return(calloc(nmemb, size)); /* Don't change to ndpi_calloc !!!!! */
+}
+
+/* ***************************************************** */
+
+static void *realloc_wrapper(void *ptr, size_t size) {
+  tot_ndpi_memory += size;
+
+  if(enable_malloc_bins && malloc_size_stats)
+    ndpi_inc_bin(&malloc_bins, reader_slot_malloc_bins(size), 1);
+
+  return(realloc(ptr, size)); /* Don't change to ndpi_realloc !!!!! */
+}
+
+/* ***************************************************** */
+
+static void *aligned_malloc_wrapper(size_t alignment, size_t size) {
+  tot_ndpi_memory += size;
+
+  if(enable_malloc_bins && malloc_size_stats)
+    ndpi_inc_bin(&malloc_bins, reader_slot_malloc_bins(size), 1);
+
+  void* p;
+#ifdef _MSC_VER
+  p = _aligned_malloc(size, alignment);
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+  p = __mingw_aligned_malloc(size, alignment);
+#else
+  if (posix_memalign(&p, alignment, size) != 0)
+    return NULL;
+#endif
+  return p;
+}
+
+/* ***************************************************** */
+
+static void aligned_free_wrapper(void *ptr) {
+#ifdef _MSC_VER
+  _aligned_free(ptr);
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+  __mingw_aligned_free(ptr);
+#else
+  free(ptr); /* Don't change to ndpi_free !!!!! */
+#endif
+}
+
+/* ***************************************************** */
+
+static void *flow_malloc_wrapper(size_t size) {
+  /* No stats; this memory is allocated by application, not from the library */
+  return(malloc(size)); /* Don't change to ndpi_malloc !!!!! */
+}
+
+/* ***************************************************** */
+
+static void flow_free_wrapper(void *freeable) {
   free(freeable); /* Don't change to ndpi_free !!!!! */
 }
 
@@ -648,7 +715,7 @@ void ndpiCheckHostsFileStringMatch(const char *domains_file) {
       printf("Domain [%s] NOT Found!!\n", line);
 
       /* Not very efficient but it should be ok */
-      not_matches = ndpi_realloc(not_matches, not_maches_num * sizeof(char *),
+      not_matches = ndpi_realloc(not_matches,
                                  (not_maches_num + 1) * sizeof(char *));
       not_matches[not_maches_num] = ndpi_strdup(line);
       not_maches_num += 1;
@@ -5332,8 +5399,14 @@ void test_lib() {
 #endif
   struct ndpi_global_context *g_ctx;
 
-  set_ndpi_malloc(ndpi_malloc_wrapper), set_ndpi_free(free_wrapper);
-  set_ndpi_flow_malloc(NULL), set_ndpi_flow_free(NULL);
+  ndpi_set_memory_alloction_functions(malloc_wrapper,
+                                      free_wrapper,
+                                      calloc_wrapper,
+                                      realloc_wrapper,
+                                      aligned_malloc_wrapper,
+                                      aligned_free_wrapper,
+                                      flow_malloc_wrapper,
+                                      flow_free_wrapper);
 
 #ifndef USE_GLOBAL_CONTEXT
   /* ndpiReader works even if libnDPI has been compiled without global context support,

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1148,7 +1148,7 @@ static void add_to_address_port_list(ndpi_address_port_list *list, ndpi_address_
 
   if(list->num_aps == list->num_aps_allocated) {
     new_num = 1 + list->num_aps_allocated * 2;
-    new_buf = ndpi_realloc(list->aps, list->num_aps_allocated * sizeof(ndpi_address_port),
+    new_buf = ndpi_realloc(list->aps,
 	                   new_num * sizeof(ndpi_address_port));
     if(!new_buf)
       return;

--- a/fuzz/fuzz_common_code.c
+++ b/fuzz/fuzz_common_code.c
@@ -18,11 +18,26 @@ static void *malloc_wrapper(size_t size) {
 static void free_wrapper(void *freeable) {
   free(freeable);
 }
+static void *calloc_wrapper(size_t nmemb, size_t size) {
+  return (fastrand () % 16) ? calloc (nmemb, size) : NULL;
+}
+static void *realloc_wrapper(void *ptr, size_t size) {
+  return (fastrand () % 16) ? realloc (ptr, size) : NULL;
+}
 
 void fuzz_set_alloc_callbacks(void)
 {
-  set_ndpi_malloc(malloc_wrapper);
-  set_ndpi_free(free_wrapper);
+  ndpi_set_memory_alloction_functions(malloc_wrapper,
+                                      free_wrapper,
+                                      calloc_wrapper,
+                                      realloc_wrapper,
+                                      /* Aligned allocations are used only by croaring,
+                                         but no during fuzzing. So no point to set
+                                         these two wrappers here */
+                                      NULL, NULL,
+                                      /* No interested in flow allocator, because it
+                                         is used only by the application */
+                                      NULL, NULL);
 }
 void fuzz_set_alloc_seed(int seed)
 {

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -88,7 +88,7 @@ extern "C" {
 
   /**
    * Allocate memory using nDPI's memory allocator.
-   * This function can be customized via ndpi_set_malloc() to use a custom allocator.
+   * This function can be customized via ndpi_set_memory_alloction_functions() to use a custom allocator.
    *
    * @param size Number of bytes to allocate
    * @return Pointer to allocated memory, or NULL on failure
@@ -97,24 +97,34 @@ extern "C" {
 
   /**
    * Allocate and zero-initialize memory using nDPI's memory allocator.
-   * This function can be customized via ndpi_set_calloc() to use a custom allocator.
+   * This function can be customized via ndpi_set_memory_alloction_functions() to use a custom allocator.
    *
    * @param count Number of elements to allocate
    * @param size Size of each element in bytes
    * @return Pointer to zero-initialized memory, or NULL on failure
    */
-  void * ndpi_calloc(unsigned long count, size_t size);
+  void * ndpi_calloc(size_t nmemb, size_t size);
 
   /**
    * Reallocate memory using nDPI's memory allocator.
-   * This function can be customized via ndpi_set_realloc() to use a custom allocator.
+   * This function can be customized via ndpi_set_memory_alloction_functions() to use a custom allocator.
    *
    * @param ptr Pointer to previously allocated memory (or NULL for new allocation)
    * @param old_size Current size of the allocated block in bytes
    * @param new_size Desired new size in bytes
    * @return Pointer to reallocated memory, or NULL on failure
    */
-  void * ndpi_realloc(void *ptr, size_t old_size, size_t new_size);
+  void * ndpi_realloc(void *ptr, size_t size);
+
+  /**
+   * Allocate aligned memory using nDPI's memory allocator.
+   * This function can be customized via ndpi_set_memory_alloction_functions() to use a custom allocator.
+   *
+   * @param the address of the allocated memory will be a multiple of `alignment`
+   * @param size Number of bytes to allocate
+   * @return Pointer to allocated memory, or NULL on failure
+   */
+  void * ndpi_aligned_malloc(size_t alignment, size_t size);
 
   /**
    * Duplicate a string using nDPI's memory allocator.
@@ -137,16 +147,25 @@ extern "C" {
 
   /**
    * Free memory allocated by nDPI's memory allocator.
-   * This function can be customized via ndpi_set_free() to use a custom deallocator.
+   * This function can be customized via ndpi_set_memory_alloction_functions() to use a custom deallocator.
    *
    * @param ptr Pointer to memory to free (NULL is safe to pass)
    */
   void   ndpi_free(void *ptr);
 
   /**
+   * Free aligned memory allocated by nDPI's memory allocator.
+   * This function can be customized via ndpi_set_memory_alloction_functions() to use a custom deallocator.
+   *
+   * @param ptr Pointer to memory to free (NULL is safe to pass)
+   */
+  void   ndpi_aligned_free(void *ptr);
+
+  /**
    * Allocate memory for flow-specific data using nDPI's flow allocator.
    * Flow memory can use a separate allocator from general memory for better
    * memory management in high-throughput scenarios.
+   * This function can be customized via ndpi_set_memory_alloction_functions() to use a custom allocator.
    *
    * @param size Number of bytes to allocate
    * @return Pointer to allocated memory, or NULL on failure
@@ -155,6 +174,7 @@ extern "C" {
 
   /**
    * Free memory allocated by ndpi_flow_malloc().
+   * This function can be customized via ndpi_set_memory_alloction_functions() to use a custom deallocator.
    *
    * @param ptr Pointer to flow memory to free (NULL is safe to pass)
    */
@@ -1116,32 +1136,37 @@ extern "C" {
 				   struct ndpi_flow_struct *flow);
 
   /**
-   * Set a custom malloc function for nDPI's general memory allocator.
+   * Set custom memory allocation functions for nDPI's general memory allocator.
    *
-   * @param __ndpi_malloc Function pointer to the custom malloc implementation
+   * @param __ndpi_malloc         Function pointer to the custom malloc implementation
+   * @param __ndpi_free           Function pointer to the custom free implementation
+   * @param __ndpi_calloc         Function pointer to the custom calloc implementation
+   * @param __ndpi_realloc        Function pointer to the custom realloc implementation
+   * @param __ndpi_aligned_malloc Function pointer to the custom aligned allocation implementation
+   * @param __ndpi_aligned_free   Function pointer to the custom aligned free implementation
+   * @param __ndpi_flow_malloc    Function pointer to the custom allocation of flows
+   * @param __ndpi_flow_free      Function pointer to the custom free of flows
+   *
+   * This function is optional, but if used, it MUST be called before ANY other nDPI functions!!
+   *
+   * The first 4 parameters are mandatory.
+   * If you want to set a custom allocator for aligned memory, you must specify `__ndpi_aligned_malloc`
+   * and `__ndpi_aligned_free`, both
+   * If you want to set a custom allocator for flow memory, you must specify `__ndpi_flow_malloc`
+   * and `__ndpi_flow_free`, both
+   *
+   * Flow memory can use a separate allocator from general memory for better
+   * memory management in high-throughput scenarios.
    */
-  void set_ndpi_malloc(void* (*__ndpi_malloc)(size_t size));
 
-  /**
-   * Set a custom free function for nDPI's general memory allocator.
-   *
-   * @param __ndpi_free Function pointer to the custom free implementation
-   */
-  void set_ndpi_free(void  (*__ndpi_free)(void *ptr));
-
-  /**
-   * Set a custom malloc function for nDPI's flow-specific memory allocator.
-   *
-   * @param __ndpi_flow_malloc Function pointer to the custom flow malloc implementation
-   */
-  void set_ndpi_flow_malloc(void* (*__ndpi_flow_malloc)(size_t size));
-
-  /**
-   * Set a custom free function for nDPI's flow-specific memory allocator.
-   *
-   * @param __ndpi_flow_free Function pointer to the custom flow free implementation
-   */
-  void set_ndpi_flow_free(void  (*__ndpi_flow_free)(void *ptr));
+  void ndpi_set_memory_alloction_functions(void *(*__ndpi_malloc)(size_t size),
+                                           void (*__ndpi_free)(void *ptr),
+                                           void *(*__ndpi_calloc)(size_t nmemb, size_t size),
+                                           void *(*__ndpi_realloc)(void *ptr, size_t size),
+                                           void *(*__ndpi_aligned_malloc)(size_t alignment, size_t size),
+                                           void (*__ndpi_aligned_free)(void *ptr),
+                                           void *(*__ndpi_flow_malloc)(size_t size),
+                                           void (*__ndpi_flow_free)(void *ptr));
 
   /**
    * Set a custom debug/logging function for nDPI.

--- a/src/lib/ndpi_binary_bitmap.c
+++ b/src/lib/ndpi_binary_bitmap.c
@@ -60,7 +60,6 @@ bool ndpi_binary_bitmap_set(ndpi_binary_bitmap *b, u_int64_t value, u_int8_t cat
     u_int32_t new_len = b->num_allocated_entries + NDPI_BINARY_BITMAP_REALLOC_SIZE;
 
     rc = (struct ndpi_binary_bitmap_entry*)ndpi_realloc(b->entries,
-							sizeof(struct ndpi_binary_bitmap_entry)*b->num_allocated_entries,
 							sizeof(struct ndpi_binary_bitmap_entry)*new_len);
     if(rc == NULL) return(false);
 
@@ -126,7 +125,6 @@ bool ndpi_binary_bitmap_compress(ndpi_binary_bitmap *b) {
     
     b->entries = (struct ndpi_binary_bitmap_entry*)
       ndpi_realloc(b->entries,
-		   sizeof(struct ndpi_binary_bitmap_entry)*b->num_allocated_entries,
 		   sizeof(struct ndpi_binary_bitmap_entry)*new_len);
 
     b->num_used_entries = b->num_allocated_entries = new_len;

--- a/src/lib/ndpi_bitmap64_fuse.c
+++ b/src/lib/ndpi_bitmap64_fuse.c
@@ -149,7 +149,6 @@ bool ndpi_bitmap64_fuse_set(ndpi_bitmap64_fuse *_b, u_int64_t value) {
     u_int32_t new_len = b->num_allocated_entries + NDPI_BITMAP64_FUSE_REALLOC_SIZE;
 
     rc = (u_int64_t*)ndpi_realloc(b->entries,
-				  sizeof(u_int64_t)*b->num_allocated_entries,
 				  sizeof(u_int64_t)*new_len);
     if(rc == NULL) {
       b->is_compressed = false;

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -156,11 +156,6 @@
 
 /* ****************************************** */
 
-static void *(*_ndpi_flow_malloc)(size_t size);
-static void (*_ndpi_flow_free)(void *ptr);
-
-/* ****************************************** */
-
 
 static ndpi_risk_info ndpi_known_risks[] = {
   { NDPI_NO_RISK,                               NDPI_RISK_LOW,    CLIENT_FAIR_RISK_PERCENTAGE, NDPI_NO_ACCOUNTABILITY  },
@@ -268,21 +263,6 @@ ndpi_custom_dga_predict_fctn ndpi_dga_function = NULL;
 
 static inline u_int8_t flow_is_proto(struct ndpi_flow_struct *flow, u_int16_t p) {
   return((flow->detected_protocol_stack[0] == p) || (flow->detected_protocol_stack[1] == p));
-}
-
-/* ****************************************** */
-
-void *ndpi_flow_malloc(size_t size) {
-  return(_ndpi_flow_malloc ? _ndpi_flow_malloc(size) : ndpi_malloc(size));
-}
-
-/* ****************************************** */
-
-void ndpi_flow_free(void *ptr) {
-  if(_ndpi_flow_free)
-    _ndpi_flow_free(ptr);
-  else
-    ndpi_free_flow((struct ndpi_flow_struct *) ptr);
 }
 
 /* *********************************************************************************** */
@@ -397,7 +377,6 @@ static void ndpi_add_user_proto_id_mapping(struct ndpi_detection_module_struct *
     new_num = ndpi_max(64, ndpi_str->ndpi_to_user_proto_id_num_allocated * 2);
     new_num = ndpi_min(new_num, 65535); /* ndpi_str->ndpi_to_user_proto_id_num_allocated is uint16_t */
     new_ptr = ndpi_realloc(ndpi_str->ndpi_to_user_proto_id,
-                           ndpi_str->ndpi_to_user_proto_id_num_allocated * sizeof(u_int16_t),
                            new_num * sizeof(u_int16_t));
     if(!new_ptr) {
       NDPI_LOG_DBG(ndpi_str, "Realloc error\n");
@@ -714,7 +693,6 @@ static int ndpi_set_proto_defaults(struct ndpi_detection_module_struct *ndpi_str
     new_num = ndpi_max(512, ndpi_nearest_power_of_two(protoId + 1));
     new_num = ndpi_min(new_num, 65535); /* ndpi_str->proto_defaults_num_allocated is uint16_t */
     new_ptr = ndpi_realloc(ndpi_str->proto_defaults,
-                           ndpi_str->proto_defaults_num_allocated * sizeof(ndpi_proto_defaults_t),
                            new_num * sizeof(ndpi_proto_defaults_t));
     if(!new_ptr) {
       NDPI_LOG_DBG(ndpi_str, "Realloc error\n");
@@ -3816,14 +3794,6 @@ static int ndpi_add_host_ip_subprotocol(struct ndpi_detection_module_struct *ndp
   return(0);
 }
 
-void set_ndpi_flow_malloc(void *(*__ndpi_flow_malloc)(size_t size)) {
-  _ndpi_flow_malloc = __ndpi_flow_malloc;
-}
-
-void set_ndpi_flow_free(void (*__ndpi_flow_free)(void *ptr)) {
-  _ndpi_flow_free = __ndpi_flow_free;
-}
-
 #ifdef NDPI_ENABLE_DEBUG_MESSAGES
 void ndpi_debug_printf(u_int16_t proto, struct ndpi_detection_module_struct *ndpi_str, ndpi_log_level_t log_level,
                        const char *file_name, const char *func_name, unsigned int line_number, const char *format, ...) {
@@ -6568,7 +6538,7 @@ int ndpi_load_protocols_file(struct ndpi_detection_module_struct *ndpi_str, cons
 
 int load_protocols_file_fd(struct ndpi_detection_module_struct *ndpi_str, FILE *fd) {
   char *buffer, *old_buffer;
-  int chunk_len = 1024, buffer_len = chunk_len, old_buffer_len;
+  int chunk_len = 1024, buffer_len = chunk_len;
   int i;
 
   if(!ndpi_str || !fd)
@@ -6589,10 +6559,9 @@ int load_protocols_file_fd(struct ndpi_detection_module_struct *ndpi_str, FILE *
 	  && (line[strlen(line) - 1] != '\n')) {
       i = strlen(line);
       old_buffer = buffer;
-      old_buffer_len = buffer_len;
       buffer_len += chunk_len;
 
-      buffer = ndpi_realloc(old_buffer, old_buffer_len, buffer_len);
+      buffer = ndpi_realloc(old_buffer, buffer_len);
       if(buffer == NULL) {
 	NDPI_LOG_ERR(ndpi_str, "Memory allocation failure\n");
 	ndpi_free(old_buffer);

--- a/src/lib/ndpi_memory.c
+++ b/src/lib/ndpi_memory.c
@@ -31,17 +31,43 @@
 
 static void *(*_ndpi_malloc)(size_t size);
 static void (*_ndpi_free)(void *ptr);
+static void *(*_ndpi_calloc)(size_t nmemb, size_t size);
+static void *(*_ndpi_realloc)(void *ptr, size_t size);
+static void *(*_ndpi_aligned_malloc)(size_t alignment, size_t size);
+static void (*_ndpi_aligned_free)(void *ptr);
+static void *(*_ndpi_flow_malloc)(size_t size);
+static void (*_ndpi_flow_free)(void *ptr);
 
 static volatile long int ndpi_tot_allocated_memory;
 
 /* ****************************************** */
 
-void set_ndpi_malloc(void *(*__ndpi_malloc)(size_t size)) {
-  _ndpi_malloc = __ndpi_malloc;
-}
+void ndpi_set_memory_alloction_functions(void *(*__ndpi_malloc)(size_t size),
+                                         void (*__ndpi_free)(void *ptr),
+                                         void *(*__ndpi_calloc)(size_t nmemb, size_t size),
+                                         void *(*__ndpi_realloc)(void *ptr, size_t size),
+                                         void *(*__ndpi_aligned_malloc)(size_t alignment, size_t size),
+                                         void (*__ndpi_aligned_free)(void *ptr),
+                                         void *(*__ndpi_flow_malloc)(size_t size),
+                                         void (*__ndpi_flow_free)(void *ptr)) {
 
-void set_ndpi_free(void (*__ndpi_free)(void *ptr)) {
-  _ndpi_free = __ndpi_free;
+  /* We can't log here */
+
+  if(__ndpi_malloc && __ndpi_free &&
+     __ndpi_calloc && __ndpi_realloc) {
+    _ndpi_malloc = __ndpi_malloc;
+    _ndpi_free = __ndpi_free;
+    _ndpi_calloc = __ndpi_calloc;
+    _ndpi_realloc = __ndpi_realloc;
+  }
+  if(__ndpi_aligned_malloc && __ndpi_aligned_free) {
+    _ndpi_aligned_malloc = __ndpi_aligned_malloc;
+    _ndpi_aligned_free = __ndpi_aligned_free;
+  }
+  if(__ndpi_flow_malloc && __ndpi_flow_free) {
+    _ndpi_flow_malloc = __ndpi_flow_malloc;
+    _ndpi_flow_free = __ndpi_flow_free;
+  }
 }
 
 /* ****************************************** */
@@ -59,43 +85,71 @@ void *ndpi_malloc(size_t size) {
 
 /* ****************************************** */
 
-void *ndpi_calloc(unsigned long count, size_t size) {
-  size_t len = count * size;
-  void *p = _ndpi_malloc ? _ndpi_malloc(len) : malloc(len);
-
-  if(p) {
-    memset(p, 0, len);
-    __sync_fetch_and_add(&ndpi_tot_allocated_memory, len);
-  }
-
-  return(p);
+void *ndpi_calloc(size_t nmemb, size_t size) {
+  __sync_fetch_and_add(&ndpi_tot_allocated_memory, nmemb * size);
+  return(_ndpi_calloc ? _ndpi_calloc(nmemb, size) : calloc(nmemb, size));
 }
 
 /* ****************************************** */
 
 void ndpi_free(void *ptr) {
-  if(_ndpi_free) {
-    if(ptr)
-      _ndpi_free(ptr);
-  } else {
-    if(ptr)
-      free(ptr);
-  }
+  _ndpi_free ? _ndpi_free(ptr) : free(ptr);
 }
 
 /* ****************************************** */
 
-void *ndpi_realloc(void *ptr, size_t old_size, size_t new_size) {
-  void *ret = ndpi_malloc(new_size);
+void *ndpi_realloc(void *ptr, size_t size) {
+  __sync_fetch_and_add(&ndpi_tot_allocated_memory, size);
+  return(_ndpi_realloc ? _ndpi_realloc(ptr, size) : realloc(ptr, size));
+}
 
-  if(!ret)
-    return(ret);
-  else {
-    if(ptr != NULL) {
-      memcpy(ret, ptr, (old_size < new_size ? old_size : new_size));
-      ndpi_free(ptr);
-    }
-    return(ret);
+/* ****************************************** */
+
+void *ndpi_aligned_malloc(size_t alignment, size_t size) {
+  __sync_fetch_and_add(&ndpi_tot_allocated_memory, size);
+  if(_ndpi_aligned_malloc) {
+    return _ndpi_aligned_malloc(alignment, size);
+  }
+  void* p;
+#ifdef _MSC_VER
+  p = _aligned_malloc(size, alignment);
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+  p = __mingw_aligned_malloc(size, alignment);
+#else
+  if (posix_memalign(&p, alignment, size) != 0)
+    return NULL;
+#endif
+  return p;
+}
+
+/* ****************************************** */
+
+void ndpi_aligned_free(void *ptr) {
+  if(_ndpi_aligned_free) {
+    _ndpi_aligned_free(ptr);
+    return;
+  }
+#ifdef _MSC_VER
+  _aligned_free(ptr);
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+  __mingw_aligned_free(ptr);
+#else
+  free(ptr); /* No ndpi_free!! */
+#endif
+}
+
+/* ****************************************** */
+
+void *ndpi_flow_malloc(size_t size) {
+  return(_ndpi_flow_malloc ? _ndpi_flow_malloc(size) : ndpi_malloc(size));
+}
+
+/* ****************************************** */
+
+void ndpi_flow_free(void *ptr) {
+  if(ptr) {
+    ndpi_free_flow_data((struct ndpi_flow_struct *)ptr);
+    _ndpi_flow_free ? _ndpi_flow_free(ptr) : ndpi_free(ptr);
   }
 }
 

--- a/src/lib/ndpi_serializer.c
+++ b/src/lib/ndpi_serializer.c
@@ -280,7 +280,7 @@ static inline int ndpi_extend_serializer_buffer(ndpi_private_serializer_buffer *
   new_size = buffer->size + min_len;
   new_size = ((new_size / 4) + 1) * 4; /* required by zmq encryption */
 
-  r = ndpi_realloc((void *) buffer->data, buffer->size, new_size);
+  r = ndpi_realloc((void *) buffer->data, new_size);
 
   if(r == NULL)
     return(-1);

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -510,8 +510,7 @@ static int ndpi_search_tls_memory(const u_int8_t *payload,
 
   if(avail_bytes < payload_len) {
     u_int new_len = message->buffer_len + payload_len - avail_bytes + 1;
-    void *newbuf  = ndpi_realloc(message->buffer,
-				 message->buffer_len, new_len);
+    void *newbuf  = ndpi_realloc(message->buffer, new_len);
     if(!newbuf) return -1;
 
 #ifdef DEBUG_TLS_MEMORY
@@ -1027,7 +1026,7 @@ void processCertificateElements(struct ndpi_detection_module_struct *ndpi_struct
                       } else if((u_int16_t)(flow->protos.tls_quic.server_names_len + dNSName_len + 1) > flow->protos.tls_quic.server_names_len) {
                         u_int16_t newstr_len = flow->protos.tls_quic.server_names_len + dNSName_len + 1;
                         char *newstr = (char*)ndpi_realloc(flow->protos.tls_quic.server_names,
-                                                           flow->protos.tls_quic.server_names_len+1, newstr_len+1);
+                                                           newstr_len + 1);
 
                         if(newstr) {
                           flow->protos.tls_quic.server_names = newstr;

--- a/src/lib/third_party/src/roaring.c
+++ b/src/lib/third_party/src/roaring.c
@@ -19824,6 +19824,8 @@ int croaring_hardware_support(void) {
 extern int posix_memalign(void** __memptr, size_t __alignment, size_t __size);
 #endif  //__cplusplus // C++ does not have a well defined signature
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
 // portable version of  posix_memalign
 static void* roaring_bitmap_aligned_malloc(size_t alignment, size_t size) {
     void* p;
@@ -19849,6 +19851,24 @@ static void roaring_bitmap_aligned_free(void* memblock) {
 #endif
 }
 
+#endif
+
+#include <ndpi_api.h> /* For memory allocations */
+
+/* croaring doesn't handle memory allocation failure, so avoid
+   custom allocator while fuzzing.
+   See: https://github.com/RoaringBitmap/CRoaring/issues/638
+ */
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+static roaring_memory_t global_memory_hook = {
+    .malloc = ndpi_malloc,
+    .realloc = ndpi_realloc,
+    .calloc = ndpi_calloc,
+    .free = ndpi_free,
+    .aligned_malloc = ndpi_aligned_malloc,
+    .aligned_free = ndpi_aligned_free,
+};
+#else
 static roaring_memory_t global_memory_hook = {
     .malloc = malloc,
     .realloc = realloc,
@@ -19857,6 +19877,7 @@ static roaring_memory_t global_memory_hook = {
     .aligned_malloc = roaring_bitmap_aligned_malloc,
     .aligned_free = roaring_bitmap_aligned_free,
 };
+#endif
 
 void roaring_init_memory_hook(roaring_memory_t memory_hook) {
     global_memory_hook = memory_hook;

--- a/utils/check_symbols.sh
+++ b/utils/check_symbols.sh
@@ -40,7 +40,7 @@ for line in $(nm -P -u "${NDPI_LIB}"); do
             ;;
             '[ndpi_utils.o]'|'[ndpi_memory.o]')
                 case "${FOUND_SYMBOL}" in
-                    'malloc'|'calloc'|'free') SKIP=1 ;;
+                    'malloc'|'calloc'|'free'|'realloc') SKIP=1 ;;
                 esac
             ;;
             '[gcrypt_light.o]')


### PR DESCRIPTION
Full accounting of memory used by the library.

Change `ndpi_realloc()` prototype to be compatible with standard
`realloc()`.
Be compatible with croaring allocation logic.

Note that aligned allocations are used only by croaring code.
Note that flow allocations are used only by the application, not by the
library.

API changes:
* remove `set_ndpi_malloc()` and `set_ndpi_free()`; use `ndpi_set_memory_alloction_functions()` instead


