### PR TITLE
Build system: Improve portability, parallelization, and VPATH builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,7 @@ doc-view:
 	python3 -m http.server --bind 127.0.0.1 --directory doc/_build/html 8080
 
 coverage: all
-	mkdir -vp coverage_report/ndpi_coverage_report
+	$(MKDIR_P) coverage_report/ndpi_coverage_report
 	lcov --directory . --capture --output-file lcov.info
 	genhtml -o coverage_report/ndpi_coverage_report lcov.info
 
@@ -60,3 +60,6 @@ changelog:
 	cd $(top_srcdir) && git log --since={`curl -s https://github.com/ntop/ndpi/releases | grep datetime | head -n1 | egrep -o "[0-9]+\-[0-9]+\-[0-9]+"`} --name-only --pretty=format:" - %s" | grep  "^ " > CHANGELOG.latest
 
 .PHONY: doc doc-view coverage clean-coverage changelog
+
+# Prevent parallel execution of clean/distclean to avoid potential race conditions
+.NOTPARALLEL: clean distclean

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_INIT([libndpi],[5.1.0])
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_MACRO_DIR([m4])
 
-AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_INIT_AUTOMAKE([foreign subdir-objects parallel-tests])
 
 AC_PREFIX_DEFAULT(/usr)
 
@@ -310,7 +310,7 @@ AS_IF([test "x$enable_global_context_support" != "xno"], [
 ])
 
 ADDITIONAL_INCS="${ADDITIONAL_INCS}"
-ADDITIONAL_LIBS="${ADDITIONAL_LIBS} $LIBM"
+ADDITIONAL_LIBS="${ADDITIONAL_LIBS}"
 PCAP_HOME=$HOME/PF_RING/userland
 
 DPDK_TARGET=
@@ -501,6 +501,10 @@ if test "${with_maxminddb+set}" = set; then :
   fi
 fi
 
+dnl> Add base system libraries last (lowest-level dependencies)
+dnl> This ensures proper linking order: high-level libs -> low-level libs
+ADDITIONAL_LIBS="${ADDITIONAL_LIBS} $LIBM"
+
 dnl> Use absolute source directory for NDPI_BASE_DIR
 NDPI_ABS_SRCDIR="`cd ${srcdir} && pwd`"
 AC_DEFINE_UNQUOTED(NDPI_BASE_DIR, "${NDPI_ABS_SRCDIR}", [nDPI base directory])
@@ -517,9 +521,10 @@ dnl> fi
 
 dnl> ndpiReader has some hard-coded unit tests: in the out-of-tree builds we need some configuration files in the expected path
 if test "${srcdir}" != . ; then :
-  mkdir -p example
+  $MKDIR_P example
+  $MKDIR_P lists
   cp ${srcdir}/example/categories.txt example/
-  cp -R ${srcdir}/lists lists/
+  cp -R ${srcdir}/lists/* lists/
 fi
 
 AC_CONFIG_FILES([Makefile example/Makefile example/Makefile.dpdk tests/Makefile tests/unit/Makefile tests/performance/Makefile tests/dga/Makefile rrdtool/Makefile influxdb/Makefile libndpi.pc src/include/ndpi_define.h src/lib/Makefile fuzz/Makefile doc/Doxyfile.cfg utils/Makefile])

--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -24,9 +24,10 @@ endif
 CFLAGS+=-I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@ @PCAP_INC@ @GPROF_CFLAGS@ @CUSTOM_NDPI@
 LDFLAGS+=@NDPI_LDFLAGS@
 LIBNDPI=$(top_builddir)/src/lib/libndpi.a
-LIBS=$(LIBNDPI) @PCAP_LIB@ @ADDITIONAL_LIBS@ @LIBS@ @GPROF_LIBS@
+LIBS=$(LIBNDPI) @PCAP_LIB@ @ADDITIONAL_LIBS@ @GPROF_LIBS@ @LIBS@
 HEADERS=reader_util.h $(SRCHOME)/include/ndpi_api.h \
         $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
+HEADERS+=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 PREFIX?=@prefix@
 
 ifneq ($(BUILD_MINGW),)
@@ -72,8 +73,8 @@ ndpiSimpleIntegration$(EXE_SUFFIX): ndpiSimpleIntegration.o
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 install: ndpiReader$(EXE_SUFFIX)
-	mkdir -p $(DESTDIR)$(PREFIX)/bin/
-	mkdir -p $(DESTDIR)$(PREFIX)/share/ndpi
+	@MKDIR_P@ $(DESTDIR)$(PREFIX)/bin/
+	@MKDIR_P@ $(DESTDIR)$(PREFIX)/share/ndpi
 	cp ndpiReader$(EXE_SUFFIX) $(DESTDIR)$(PREFIX)/bin/
 	cp $(srcdir)/protos.txt $(DESTDIR)$(PREFIX)/share/ndpi/ndpiProtos.txt
 	cp $(srcdir)/mining_hosts.txt $(DESTDIR)$(PREFIX)/share/ndpi/ndpiCustomCategory.txt

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = -I $(top_srcdir)/src/include -I $(top_srcdir)/src/lib/third_party/
 AM_LDFLAGS = $(LIBS)
 AM_CFLAGS = @NDPI_CFLAGS@ $(CFLAGS)
 AM_CXXFLAGS = @NDPI_CFLAGS@ $(CXXFLAGS)
-LDADD = $(PCAP_LIB) $(top_builddir)/src/lib/libndpi.a $(ADDITIONAL_LIBS)
+LDADD = $(top_builddir)/src/lib/libndpi.a $(PCAP_LIB) $(ADDITIONAL_LIBS)
 if HAS_FUZZLDFLAGS
 CFLAGS += $(LIB_FUZZING_ENGINE)
 LDFLAGS += $(LIB_FUZZING_ENGINE)

--- a/influxdb/Makefile.in
+++ b/influxdb/Makefile.in
@@ -9,13 +9,14 @@ INC=-I $(top_srcdir)/src/include -I $(top_builddir)/src/include -I/usr/local/inc
 LIBDPI=$(top_builddir)/src/lib/libndpi.a
 CFLAGS+=@NDPI_CFLAGS@
 LDFLAGS+=@NDPI_LDFLAGS@
-LIB=$(LIBDPI) -lm @ADDITIONAL_LIBS@ @LIBS@
+LIB=$(LIBDPI) @ADDITIONAL_LIBS@ @LIBS@ -lm
+GEN_HEADERS=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 
 TOOLS=metric_anomaly
 
 all: $(TOOLS)
 
-metric_anomaly: $(srcdir)/metric_anomaly.c Makefile $(LIBDPI)
+metric_anomaly: $(srcdir)/metric_anomaly.c Makefile $(LIBDPI) $(GEN_HEADERS)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -g $(INC) $(LDFLAGS) $(srcdir)/metric_anomaly.c -o metric_anomaly $(LIB)
 
 clean:

--- a/rrdtool/Makefile.in
+++ b/rrdtool/Makefile.in
@@ -9,16 +9,17 @@ INC=-I $(top_srcdir)/src/include -I $(top_builddir)/src/include -I/usr/local/inc
 LIBDPI=$(top_builddir)/src/lib/libndpi.a
 CFLAGS+=@NDPI_CFLAGS@
 LDFLAGS+=@NDPI_LDFLAGS@
-LIB=$(LIBDPI) -lm @ADDITIONAL_LIBS@ @LIBRRD@ @LIBS@ -lpthread
+LIB=$(LIBDPI) @ADDITIONAL_LIBS@ @LIBRRD@ @LIBS@ -lm -lpthread
+GEN_HEADERS=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 
 TOOLS=rrd_anomaly rrd_similarity
 
 all: $(TOOLS)
 
-rrd_anomaly: $(srcdir)/rrd_anomaly.c Makefile $(LIBDPI)
+rrd_anomaly: $(srcdir)/rrd_anomaly.c Makefile $(LIBDPI) $(GEN_HEADERS)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -g $(INC) $(LDFLAGS) $(srcdir)/rrd_anomaly.c -o rrd_anomaly $(LIB)
 
-rrd_similarity: $(srcdir)/rrd_similarity.c Makefile $(LIBDPI)
+rrd_similarity: $(srcdir)/rrd_similarity.c Makefile $(LIBDPI) $(GEN_HEADERS)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -g $(INC) $(LDFLAGS) $(srcdir)/rrd_similarity.c -o rrd_similarity $(LIB)
 
 clean:

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -39,7 +39,8 @@ LDFLAGS    += @NDPI_LDFLAGS@
 LIBS       = @ADDITIONAL_LIBS@ @LIBS@ @GPROF_LIBS@
 
 OBJECTS   = $(patsubst $(srcdir)/protocols/%.c, %.o, $(wildcard $(srcdir)/protocols/*.c)) $(patsubst $(srcdir)/third_party/src/%.c, %.o, $(wildcard $(srcdir)/third_party/src/*.c)) $(patsubst $(srcdir)/third_party/src/hll/%.c, %.o, $(wildcard $(srcdir)/third_party/src/hll/*.c)) $(patsubst $(srcdir)/%.c, %.o, $(wildcard $(srcdir)/*.c))
-HEADERS   = $(wildcard $(top_srcdir)/src/include/*.h) $(wildcard $(top_builddir)/src/include/*.h) $(wildcard $(srcdir)/*.h)
+HEADERS   = $(wildcard $(top_srcdir)/src/include/*.h) $(wildcard $(srcdir)/*.h)
+HEADERS  += $(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 NDPI_VERSION_MAJOR   = @NDPI_MAJOR@
 NDPI_LIB_STATIC      = libndpi.a
 NDPI_LIB_SHARED_BASE = libndpi.so
@@ -70,6 +71,8 @@ all: $(NDPI_LIBS)
 
 ndpi_main.o: $(srcdir)/ndpi_content_match.c.inc
 
+$(OBJECTS): $(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
+
 $(NDPI_LIB_STATIC): $(OBJECTS)
 	   $(AR) rc $@ $(OBJECTS)
 	   $(RANLIB) $@      
@@ -83,7 +86,8 @@ $(NDPI_LIB_SHARED): $(OBJECTS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_$(notdir $<)) -c $< -o $@
 
 clean:
-	/bin/rm -f $(NDPI_LIB_STATIC) $(OBJECTS) *.o *.so *.lo libndpi.so*
+	/bin/rm -f $(NDPI_LIB_STATIC) $(NDPI_LIB_SHARED) $(OBJECTS) *.o *.so *.so.* *.lo *.dll
+	/bin/rm -f $(NDPI_LIB_SHARED_BASE) $(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR)
 
 distdir:
 	find $(srcdir) -type d | xargs -I'{}' mkdir -p '$(distdir)/{}'
@@ -105,11 +109,11 @@ cppcheck:
 	cppcheck --template='{file}:{line}:{severity}:{message}' --quiet --enable=all --force -I $(top_srcdir)/src/include $(srcdir)/*.c $(srcdir)/protocols/*.c
 
 install: $(NDPI_LIBS)
-	mkdir -p $(DESTDIR)@libdir@
+	@MKDIR_P@ $(DESTDIR)@libdir@
 	cp $(NDPI_LIBS) $(DESTDIR)@libdir@/
 	cp -P $(NDPI_LIB_SHARED_BASE) $(DESTDIR)@libdir@/
 	cp -P $(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR) $(DESTDIR)@libdir@/
-	mkdir -p $(DESTDIR)@includedir@/ndpi
+	@MKDIR_P@ $(DESTDIR)@includedir@/ndpi
 	#Avoid installing private header
 	# Installing header files to $(DESTDIR)@includedir@/ndpi
 	find $(top_srcdir)/src/include/*.h ! -name ndpi_private.h -exec cp "{}" $(DESTDIR)@includedir@/ndpi \;

--- a/tests/dga/Makefile.in
+++ b/tests/dga/Makefile.in
@@ -15,9 +15,10 @@ CFLAGS+=-fPIC -DPIC
 endif
 CFLAGS+=-g -I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@
 LIBNDPI=$(top_builddir)/src/lib/libndpi.a
-LIBS=$(LIBNDPI) @ADDITIONAL_LIBS@ -lpthread @LIBS@
+LIBS=$(LIBNDPI) @ADDITIONAL_LIBS@ @LIBS@ -lpthread
 LDFLAGS+=@NDPI_LDFLAGS@
 HEADERS=$(SRCHOME)/include/ndpi_api.h $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
+HEADERS+=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 OBJS=dga_evaluate
 PREFIX?=@prefix@
 

--- a/tests/performance/Makefile.in
+++ b/tests/performance/Makefile.in
@@ -17,19 +17,19 @@ all: $(TESTS)
 tools: $(TOOLS)
 
 gcrypt-int: $(srcdir)/gcrypt.c Makefile $(GEN_HEADERS)
-	$(CC) $(INC) @CFLAGS@ $(srcdir)/gcrypt.c -o $@
+	$(CC) $(INC) @NDPI_CFLAGS@ @CFLAGS@ $(srcdir)/gcrypt.c -o $@
 
 gcrypt-gnu: $(srcdir)/gcrypt.c Makefile $(GEN_HEADERS)
-	$(CC) $(INC) @CFLAGS@ -DHAVE_LIBGCRYPT $(srcdir)/gcrypt.c -o $@ -lgcrypt
+	$(CC) $(INC) @NDPI_CFLAGS@ @CFLAGS@ -DHAVE_LIBGCRYPT $(srcdir)/gcrypt.c -o $@ -lgcrypt
 
 substringsearch: $(srcdir)/substringsearch.c Makefile $(GEN_HEADERS)
-	$(CC) $(INC) @CFLAGS@ $(srcdir)/substringsearch.c -o substringsearch $(LIB)
+	$(CC) $(INC) @NDPI_CFLAGS@ @CFLAGS@ $(srcdir)/substringsearch.c -o substringsearch $(LIB)
 
 strnstr: $(srcdir)/strnstr.cpp Makefile $(GEN_HEADERS)
-	$(CXX) $(INC) @CFLAGS@ $(srcdir)/strnstr.cpp -o strnstr
+	$(CXX) $(INC) @NDPI_CFLAGS@ @CFLAGS@ $(srcdir)/strnstr.cpp -o strnstr
 
 geo: $(srcdir)/geo.c Makefile $(GEN_HEADERS)
-	$(CC) $(INC) @CFLAGS@ $(srcdir)/geo.c -o geo $(LIB)
+	$(CC) $(INC) @NDPI_CFLAGS@ @CFLAGS@ $(srcdir)/geo.c -o geo $(LIB)
 
 substring_test: substringsearch top-1m.csv
 	./substringsearch
@@ -43,7 +43,7 @@ geo_test: geo
 #
 
 patriciasearch: $(srcdir)/patriciasearch.c Makefile $(GEN_HEADERS)
-	$(CC) $(INC) @CFLAGS@ $(srcdir)/patriciasearch.c -o patriciasearch $(LIB)
+	$(CC) $(INC) @NDPI_CFLAGS@ @CFLAGS@ $(srcdir)/patriciasearch.c -o patriciasearch $(LIB)
 
 patricia_test: patriciasearch blacklist-ip.txt
 	./patriciasearch

--- a/tests/performance/Makefile.in
+++ b/tests/performance/Makefile.in
@@ -6,6 +6,7 @@ VPATH = @srcdir@
 
 INC=-I $(top_srcdir)/src/include/ -I $(top_builddir)/src/include/ -I $(top_srcdir)/src/lib/third_party/include/
 LIB=$(top_builddir)/src/lib/libndpi.a @ADDITIONAL_LIBS@ @LIBS@
+GEN_HEADERS=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 
 TOOLS=substringsearch patriciasearch gcrypt-int gcrypt-gnu strnstr
 TESTS=substring_test patricia_test strnstr_test geo_test
@@ -15,19 +16,19 @@ all: $(TESTS)
 
 tools: $(TOOLS)
 
-gcrypt-int: $(srcdir)/gcrypt.c Makefile
+gcrypt-int: $(srcdir)/gcrypt.c Makefile $(GEN_HEADERS)
 	$(CC) $(INC) @CFLAGS@ $(srcdir)/gcrypt.c -o $@
 
-gcrypt-gnu: $(srcdir)/gcrypt.c Makefile
+gcrypt-gnu: $(srcdir)/gcrypt.c Makefile $(GEN_HEADERS)
 	$(CC) $(INC) @CFLAGS@ -DHAVE_LIBGCRYPT $(srcdir)/gcrypt.c -o $@ -lgcrypt
 
-substringsearch: $(srcdir)/substringsearch.c Makefile
+substringsearch: $(srcdir)/substringsearch.c Makefile $(GEN_HEADERS)
 	$(CC) $(INC) @CFLAGS@ $(srcdir)/substringsearch.c -o substringsearch $(LIB)
 
-strnstr: $(srcdir)/strnstr.cpp Makefile
+strnstr: $(srcdir)/strnstr.cpp Makefile $(GEN_HEADERS)
 	$(CXX) $(INC) @CFLAGS@ $(srcdir)/strnstr.cpp -o strnstr
 
-geo: $(srcdir)/geo.c Makefile
+geo: $(srcdir)/geo.c Makefile $(GEN_HEADERS)
 	$(CC) $(INC) @CFLAGS@ $(srcdir)/geo.c -o geo $(LIB)
 
 substring_test: substringsearch top-1m.csv
@@ -41,7 +42,7 @@ geo_test: geo
 
 #
 
-patriciasearch: $(srcdir)/patriciasearch.c Makefile
+patriciasearch: $(srcdir)/patriciasearch.c Makefile $(GEN_HEADERS)
 	$(CC) $(INC) @CFLAGS@ $(srcdir)/patriciasearch.c -o patriciasearch $(LIB)
 
 patricia_test: patriciasearch blacklist-ip.txt

--- a/tests/unit/Makefile.in
+++ b/tests/unit/Makefile.in
@@ -19,6 +19,7 @@ LIBNDPI=$(top_builddir)/src/lib/libndpi.a
 LIBS=$(LIBNDPI) @PCAP_LIB@ @ADDITIONAL_LIBS@ @JSONC_LIBS@ @LIBS@
 LDFLAGS+=@NDPI_LDFLAGS@
 HEADERS=$(SRCHOME)/include/ndpi_api.h $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
+HEADERS+=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 OBJS=unit
 PREFIX?=@prefix@
 


### PR DESCRIPTION
This commit implements comprehensive improvements to the nDPI build system to enhance portability, enable parallel testing, and ensure reliable out-of-tree (VPATH) builds across all platforms.

Changes:

1. Optimize library linking order (configure.ac, all Makefiles)
   - Reorder ADDITIONAL_LIBS to follow proper dependency hierarchy
   - Move low-level libraries (libm) to end of link line
   - Ensures compatibility with --as-needed linker flag
   - Improves LTO and static linking support

2. Fix VPATH build dependencies (all Makefiles)
   - Add explicit dependencies on generated headers (ndpi_config.h, ndpi_define.h)
   - Prevents race conditions in parallel builds (make -j)
   - Ensures headers exist before compilation starts

3. Replace mkdir -p with portable $(MKDIR_P) macro

4. Enable parallel test execution (configure.ac)
   - Add 'parallel-tests' option to AM_INIT_AUTOMAKE
   - Allows test suites to run concurrently during 'make check'

5. Add defensive .NOTPARALLEL directive (Makefile.am)
   - Prevents race conditions if 'make -j clean distclean' is run

6. Fix clean target completeness (src/lib/Makefile.in)
   - Remove all .so symlinks (libndpi.so, libndpi.so.N)
   - Add cleanup for Windows DLL files (*.dll)
   - Explicitly remove versioned shared libraries

🤖 Generated with [Claude Code](https://claude.com/claude-code)


