### PR TITLE
Build system: Respect user CFLAGS and LDFLAGS, remove hardcoded -g

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,10 @@ AC_ARG_ENABLE(global-context-support, AS_HELP_STRING([--disable-global-context-s
 AC_ARG_ENABLE(memory-track-origins, AS_HELP_STRING([--disable-memory-track-origins], [Don't add -fsanitize-memory-track-origins flag when compiling with MASAN support. Useful for faster CI]))
 AC_ARG_ENABLE(old-croaring, AS_HELP_STRING([--enable-old-croaring], [Always use old croaring version, instead of try to auto-detect if v4 works. Useful with old compilers]),[enable_oldcroaring=$enableval],[enable_oldcroaring=no])
 
-NDPI_CFLAGS="${NDPI_CFLAGS} -D_DEFAULT_SOURCE=1 -D_GNU_SOURCE=1"
+#These two variables are not supposed to be set/changed by the user:
+#he should use standard CFLAGS/LDFLAGS, instead
+NDPI_CFLAGS="-D_DEFAULT_SOURCE=1 -D_GNU_SOURCE=1"
+NDPI_LDFLAGS=""
 
 AS_IF([test "x$enable_fuzztargets" = "xyes"], [
   BUILD_FUZZTARGETS=1

--- a/example/Makefile.dpdk.in
+++ b/example/Makefile.dpdk.in
@@ -19,8 +19,9 @@ LIBNDPI = $(PWD)/../src/lib/libndpi.a
 
 SRCS-y := reader_util.c ndpiReader.c
 
-CFLAGS += -g
-CFLAGS += -Wno-strict-prototypes -Wno-missing-prototypes -Wno-missing-declarations -Wno-unused-parameter -I $(PWD)/../src/include @CFLAGS@ -DUSE_DPDK
+# Preserve user's CFLAGS from configure and add package flags
+USER_CFLAGS = @CFLAGS@
+CFLAGS += -Wno-strict-prototypes -Wno-missing-prototypes -Wno-missing-declarations -Wno-unused-parameter -I $(PWD)/../src/include -DUSE_DPDK $(USER_CFLAGS)
 LDLIBS = $(LIBNDPI) @PCAP_LIB@ @LIBS@ @ADDITIONAL_LIBS@ -lpthread @LDFLAGS@
 
 include $(RTE_SDK)/mk/rte.extapp.mk

--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -7,6 +7,8 @@ VPATH = @srcdir@
 AR=@AR@
 CC=@CC@
 CXX=@CXX@
+CFLAGS=@CFLAGS@
+LDFLAGS=@LDFLAGS@
 ifneq ($(OS),Windows_NT)
 OS := $(shell uname)
 endif
@@ -19,10 +21,12 @@ DISABLE_NPCAP=@DISABLE_NPCAP@
 EXE_SUFFIX=@EXE_SUFFIX@
 SRCHOME=$(top_srcdir)/src
 ifneq ($(OS),Windows_NT)
-CFLAGS+=-fPIC -DPIC
+AM_CFLAGS=-fPIC -DPIC
+else
+AM_CFLAGS=
 endif
-CFLAGS+=-I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@ @PCAP_INC@ @GPROF_CFLAGS@ @CUSTOM_NDPI@
-LDFLAGS+=@NDPI_LDFLAGS@
+AM_CFLAGS+=-I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@ @PCAP_INC@ @GPROF_CFLAGS@ @CUSTOM_NDPI@
+AM_LDFLAGS=@NDPI_LDFLAGS@
 LIBNDPI=$(top_builddir)/src/lib/libndpi.a
 LIBS=$(LIBNDPI) @PCAP_LIB@ @ADDITIONAL_LIBS@ @GPROF_LIBS@ @LIBS@
 HEADERS=reader_util.h $(SRCHOME)/include/ndpi_api.h \
@@ -33,9 +37,9 @@ PREFIX?=@prefix@
 ifneq ($(BUILD_MINGW),)
 
 ifeq ($(DISABLE_NPCAP),0)
-CFLAGS+=-I@srcdir@/../windows/WpdPack/Include -I@srcdir@/../windows/WpdPack/Include/pcap
+AM_CFLAGS+=-I@srcdir@/../windows/WpdPack/Include -I@srcdir@/../windows/WpdPack/Include/pcap
 else
-CFLAGS+=-DDISABLE_NPCAP
+AM_CFLAGS+=-DDISABLE_NPCAP
 endif
 
 ifeq ($(DISABLE_NPCAP),0)
@@ -53,7 +57,7 @@ else
 LIBS+=-pthread
 endif
 
-CFLAGS+=-pthread
+AM_CFLAGS+=-pthread
 
 all: ndpiReader$(EXE_SUFFIX) @DPDK_TARGET@
 
@@ -64,13 +68,13 @@ libndpiReader.a: $(COMMON_SOURCES:%.c=%.o) $(LIBNDPI)
 	$(AR) rsv libndpiReader.a $(COMMON_SOURCES:%.c=%.o)
 
 ndpiReader$(EXE_SUFFIX): libndpiReader.a $(LIBNDPI) ndpiReader.o
-	$(CC) $(CFLAGS) $(LDFLAGS) ndpiReader.o libndpiReader.a $(LIBS) -o $@
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) ndpiReader.o libndpiReader.a $(LIBS) -o $@
 
 ndpiSimpleIntegration$(EXE_SUFFIX): ndpiSimpleIntegration.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $< $(LIBS) -o $@
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) $< $(LIBS) -o $@
 
 %.o: %.c $(HEADERS) Makefile
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c $< -o $@
 
 install: ndpiReader$(EXE_SUFFIX)
 	@MKDIR_P@ $(DESTDIR)$(PREFIX)/bin/

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -17,19 +17,20 @@ bin_PROGRAMS += fuzz_ndpi_reader_pl7m fuzz_ndpi_reader_pl7m_64k fuzz_ndpi_reader
 #Common flags
 AM_CPPFLAGS = -I $(top_srcdir)/src/include -I $(top_srcdir)/src/lib/third_party/include/ @NDPI_CFLAGS@
 AM_LDFLAGS = $(LIBS)
-AM_CFLAGS = @NDPI_CFLAGS@ $(CFLAGS)
-AM_CXXFLAGS = @NDPI_CFLAGS@ $(CXXFLAGS)
+# Use AM_CFLAGS for package flags, never modify or embed user's CFLAGS
+AM_CFLAGS = @NDPI_CFLAGS@
+AM_CXXFLAGS = @NDPI_CFLAGS@
 LDADD = $(top_builddir)/src/lib/libndpi.a $(PCAP_LIB) $(ADDITIONAL_LIBS)
 if HAS_FUZZLDFLAGS
-CFLAGS += $(LIB_FUZZING_ENGINE)
-LDFLAGS += $(LIB_FUZZING_ENGINE)
-CXXFLAGS += $(LIB_FUZZING_ENGINE)
+AM_CFLAGS += $(LIB_FUZZING_ENGINE)
+AM_LDFLAGS += $(LIB_FUZZING_ENGINE)
+AM_CXXFLAGS += $(LIB_FUZZING_ENGINE)
 endif
 
 # Common linker command template for all fuzz targets
 # All fuzz targets need to use CXX as linker (required by libFuzzer)
 FUZZ_LINK_COMMAND = $(AM_V_CCLD)$(LIBTOOL) $(AM_V_lt) --silent --tag=CC $(AM_LIBTOOLFLAGS) \
-    $(LIBTOOLFLAGS) --mode=link $(CXX) @NDPI_CFLAGS@ $(AM_CXXFLAGS) $(CXXFLAGS) \
+    $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
     $($@_LDFLAGS) @NDPI_LDFLAGS@ $(LDFLAGS) -o $@
 
 # Define sources and flags for each fuzz target

--- a/influxdb/Makefile.in
+++ b/influxdb/Makefile.in
@@ -5,10 +5,12 @@ top_builddir = @top_builddir@
 VPATH = @srcdir@
 
 CC=@CC@
+LDFLAGS=@LDFLAGS@
+CFLAGS=@CFLAGS@
+AM_CFLAGS=@NDPI_CFLAGS@
 INC=-I $(top_srcdir)/src/include -I $(top_builddir)/src/include -I/usr/local/include
 LIBDPI=$(top_builddir)/src/lib/libndpi.a
-CFLAGS+=@NDPI_CFLAGS@
-LDFLAGS+=@NDPI_LDFLAGS@
+AM_LDFLAGS=@NDPI_LDFLAGS@
 LIB=$(LIBDPI) @ADDITIONAL_LIBS@ @LIBS@ -lm
 GEN_HEADERS=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 
@@ -17,7 +19,7 @@ TOOLS=metric_anomaly
 all: $(TOOLS)
 
 metric_anomaly: $(srcdir)/metric_anomaly.c Makefile $(LIBDPI) $(GEN_HEADERS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -g $(INC) $(LDFLAGS) $(srcdir)/metric_anomaly.c -o metric_anomaly $(LIB)
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(INC) $(AM_LDFLAGS) $(LDFLAGS) $(srcdir)/metric_anomaly.c -o metric_anomaly $(LIB)
 
 clean:
 	/bin/rm -f *.o $(TOOLS) *~

--- a/rrdtool/Makefile.in
+++ b/rrdtool/Makefile.in
@@ -5,10 +5,12 @@ top_builddir = @top_builddir@
 VPATH = @srcdir@
 
 CC=@CC@
+LDFLAGS=@LDFLAGS@
+CFLAGS=@CFLAGS@
+AM_CFLAGS=@NDPI_CFLAGS@
 INC=-I $(top_srcdir)/src/include -I $(top_builddir)/src/include -I/usr/local/include
 LIBDPI=$(top_builddir)/src/lib/libndpi.a
-CFLAGS+=@NDPI_CFLAGS@
-LDFLAGS+=@NDPI_LDFLAGS@
+AM_LDFLAGS=@NDPI_LDFLAGS@
 LIB=$(LIBDPI) @ADDITIONAL_LIBS@ @LIBRRD@ @LIBS@ -lm -lpthread
 GEN_HEADERS=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 
@@ -17,10 +19,10 @@ TOOLS=rrd_anomaly rrd_similarity
 all: $(TOOLS)
 
 rrd_anomaly: $(srcdir)/rrd_anomaly.c Makefile $(LIBDPI) $(GEN_HEADERS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -g $(INC) $(LDFLAGS) $(srcdir)/rrd_anomaly.c -o rrd_anomaly $(LIB)
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(INC) $(AM_LDFLAGS) $(LDFLAGS) $(srcdir)/rrd_anomaly.c -o rrd_anomaly $(LIB)
 
 rrd_similarity: $(srcdir)/rrd_similarity.c Makefile $(LIBDPI) $(GEN_HEADERS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -g $(INC) $(LDFLAGS) $(srcdir)/rrd_similarity.c -o rrd_similarity $(LIB)
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(INC) $(AM_LDFLAGS) $(LDFLAGS) $(srcdir)/rrd_similarity.c -o rrd_similarity $(LIB)
 
 clean:
 	/bin/rm -f *.o $(TOOLS) *~

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -14,6 +14,9 @@ VPATH = @srcdir@:@srcdir@/protocols:@srcdir@/third_party/src:@srcdir@/third_part
 AR = @AR@
 CC = @CC@
 RANLIB = @RANLIB@
+# Preserve user's CFLAGS and LDFLAGS from configure
+CFLAGS = @CFLAGS@
+LDFLAGS = @LDFLAGS@
 #
 # Installation directories
 #
@@ -27,15 +30,18 @@ ifneq ($(OS),Windows_NT)
 OS := $(shell uname)
 endif
 ifneq ($(OS),Windows_NT)
-CFLAGS     += -fPIC -DPIC
+AM_CFLAGS  = -fPIC -DPIC
+else
+AM_CFLAGS  =
 endif
-CFLAGS     += -I$(srcdir) -I$(top_srcdir)/src/include -I$(top_builddir)/src/include -I$(srcdir)/third_party/include -DNDPI_LIB_COMPILATION @NDPI_CFLAGS@ @GPROF_CFLAGS@ @CUSTOM_NDPI@ @ADDITIONAL_INCS@
+AM_CFLAGS += -I$(srcdir) -I$(top_srcdir)/src/include -I$(top_builddir)/src/include -I$(srcdir)/third_party/include -DNDPI_LIB_COMPILATION @NDPI_CFLAGS@ @GPROF_CFLAGS@ @CUSTOM_NDPI@ @ADDITIONAL_INCS@
 CFLAGS_ndpi_bitmap.c := -Wno-unused-function
 CFLAGS_ndpi_bitmap64_fuse.c := -Wno-unused-function
 CFLAGS_gcrypt_light.c := -Wno-unused-function -Wno-unused-parameter
 CFLAGS_ahocorasick.c := -Wno-unused-function -Wno-unused-parameter
 CFLAGS_roaring.c := -Wno-unused-function -Wno-attributes
-LDFLAGS    += @NDPI_LDFLAGS@
+# Use AM_LDFLAGS for package flags, never modify user's LDFLAGS
+AM_LDFLAGS = @NDPI_LDFLAGS@
 LIBS       = @ADDITIONAL_LIBS@ @LIBS@ @GPROF_LIBS@
 
 OBJECTS   = $(patsubst $(srcdir)/protocols/%.c, %.o, $(wildcard $(srcdir)/protocols/*.c)) $(patsubst $(srcdir)/third_party/src/%.c, %.o, $(wildcard $(srcdir)/third_party/src/*.c)) $(patsubst $(srcdir)/third_party/src/hll/%.c, %.o, $(wildcard $(srcdir)/third_party/src/hll/*.c)) $(patsubst $(srcdir)/%.c, %.o, $(wildcard $(srcdir)/*.c))
@@ -78,12 +84,12 @@ $(NDPI_LIB_STATIC): $(OBJECTS)
 	   $(RANLIB) $@      
 
 $(NDPI_LIB_SHARED): $(OBJECTS)
-	$(CC) -shared -fPIC $(CFLAGS) $(SONAME_FLAG) -o $@ $(LDFLAGS) $(OBJECTS) $(LIBS)
+	$(CC) -shared -fPIC $(AM_CFLAGS) $(CFLAGS) $(SONAME_FLAG) -o $@ $(AM_LDFLAGS) $(LDFLAGS) $(OBJECTS) $(LIBS)
 	ln -fs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE)
 	ln -fs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR)
 
 %.o: %.c $(HEADERS) Makefile
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_$(notdir $<)) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CFLAGS_$(notdir $<)) -c $< -o $@
 
 clean:
 	/bin/rm -f $(NDPI_LIB_STATIC) $(NDPI_LIB_SHARED) $(OBJECTS) *.o *.so *.so.* *.lo *.dll

--- a/tests/dga/Makefile.in
+++ b/tests/dga/Makefile.in
@@ -5,18 +5,22 @@ top_builddir = @top_builddir@
 VPATH = @srcdir@
 
 CC=@CC@
+LDFLAGS=@LDFLAGS@
 CXX=@CXX@
+CFLAGS=@CFLAGS@
 EXE_SUFFIX=@EXE_SUFFIX@
 
 SRCHOME=$(top_srcdir)/src
 
 ifneq ($(OS),Windows_NT)
-CFLAGS+=-fPIC -DPIC
+AM_CFLAGS=-fPIC -DPIC
+else
+AM_CFLAGS=
 endif
-CFLAGS+=-g -I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@
+AM_CFLAGS+=-I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@
 LIBNDPI=$(top_builddir)/src/lib/libndpi.a
 LIBS=$(LIBNDPI) @ADDITIONAL_LIBS@ @LIBS@ -lpthread
-LDFLAGS+=@NDPI_LDFLAGS@
+AM_LDFLAGS=@NDPI_LDFLAGS@
 HEADERS=$(SRCHOME)/include/ndpi_api.h $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
 HEADERS+=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 OBJS=dga_evaluate
@@ -28,10 +32,10 @@ EXECUTABLE_SOURCES := dga_evaluate.c
 COMMON_SOURCES := $(filter-out $(EXECUTABLE_SOURCES),$(wildcard *.c ))
 
 dga_evaluate$(EXE_SUFFIX): $(LIBNDPI) dga_evaluate.o
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) dga_evaluate.o $(LIBS) -o $@
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(AM_LDFLAGS) $(LDFLAGS) dga_evaluate.o $(LIBS) -o $@
 
 %.o: %.c $(HEADERS) Makefile
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
 	/bin/rm -f *.o dga_evaluate$(EXE_SUFFIX)

--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -45,7 +45,7 @@ cd ndpi
 #There are two workarounds:
 # * pcap stuff + --with-only-libndpi: for introspector builds. As reported in #8939, configure is not able to detect external libraries in introspector builds
 # * ADDITIONAL_* stuff: to be able run tests/unit/unit (via chronos/check_tests.sh) even with the previous workaround
-./autogen.sh && AR=llvm-ar RANLIB=llvm-ranlib NDPI_LDFLAGS="-L/usr/local/lib -lpcap" ADDITIONAL_INCS="-I/usr/local/include/json-c/" ADDITIONAL_LIBS="-L/usr/local/lib -ljson-c" ./configure --enable-fuzztargets --enable-tls-sigs --with-only-libndpi
+./autogen.sh && AR=llvm-ar RANLIB=llvm-ranlib LDFLAGS="-L/usr/local/lib -lpcap" ADDITIONAL_INCS="-I/usr/local/include/json-c/" ADDITIONAL_LIBS="-L/usr/local/lib -ljson-c" ./configure --enable-fuzztargets --enable-tls-sigs --with-only-libndpi
 make -j$(nproc)
 # Copy fuzzers
 ls fuzz/fuzz* | grep -v "\." | while read -r i; do cp "$i" "$OUT"/; done

--- a/tests/performance/Makefile.in
+++ b/tests/performance/Makefile.in
@@ -4,6 +4,9 @@ top_srcdir = @top_srcdir@
 top_builddir = @top_builddir@
 VPATH = @srcdir@
 
+CFLAGS=@CFLAGS@
+AM_CFLAGS=@NDPI_CFLAGS@
+
 INC=-I $(top_srcdir)/src/include/ -I $(top_builddir)/src/include/ -I $(top_srcdir)/src/lib/third_party/include/
 LIB=$(top_builddir)/src/lib/libndpi.a @ADDITIONAL_LIBS@ @LIBS@
 GEN_HEADERS=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
@@ -17,19 +20,19 @@ all: $(TESTS)
 tools: $(TOOLS)
 
 gcrypt-int: $(srcdir)/gcrypt.c Makefile $(GEN_HEADERS)
-	$(CC) $(INC) @NDPI_CFLAGS@ @CFLAGS@ $(srcdir)/gcrypt.c -o $@
+	$(CC) $(INC) $(AM_CFLAGS) $(CFLAGS) $(srcdir)/gcrypt.c -o $@
 
 gcrypt-gnu: $(srcdir)/gcrypt.c Makefile $(GEN_HEADERS)
-	$(CC) $(INC) @NDPI_CFLAGS@ @CFLAGS@ -DHAVE_LIBGCRYPT $(srcdir)/gcrypt.c -o $@ -lgcrypt
+	$(CC) $(INC) $(AM_CFLAGS) $(CFLAGS) -DHAVE_LIBGCRYPT $(srcdir)/gcrypt.c -o $@ -lgcrypt
 
 substringsearch: $(srcdir)/substringsearch.c Makefile $(GEN_HEADERS)
-	$(CC) $(INC) @NDPI_CFLAGS@ @CFLAGS@ $(srcdir)/substringsearch.c -o substringsearch $(LIB)
+	$(CC) $(INC) $(AM_CFLAGS) $(CFLAGS) $(srcdir)/substringsearch.c -o substringsearch $(LIB)
 
 strnstr: $(srcdir)/strnstr.cpp Makefile $(GEN_HEADERS)
-	$(CXX) $(INC) @NDPI_CFLAGS@ @CFLAGS@ $(srcdir)/strnstr.cpp -o strnstr
+	$(CXX) $(INC) $(AM_CFLAGS) $(CFLAGS) $(srcdir)/strnstr.cpp -o strnstr
 
 geo: $(srcdir)/geo.c Makefile $(GEN_HEADERS)
-	$(CC) $(INC) @NDPI_CFLAGS@ @CFLAGS@ $(srcdir)/geo.c -o geo $(LIB)
+	$(CC) $(INC) $(AM_CFLAGS) $(CFLAGS) $(srcdir)/geo.c -o geo $(LIB)
 
 substring_test: substringsearch top-1m.csv
 	./substringsearch
@@ -43,7 +46,7 @@ geo_test: geo
 #
 
 patriciasearch: $(srcdir)/patriciasearch.c Makefile $(GEN_HEADERS)
-	$(CC) $(INC) @NDPI_CFLAGS@ @CFLAGS@ $(srcdir)/patriciasearch.c -o patriciasearch $(LIB)
+	$(CC) $(INC) $(AM_CFLAGS) $(CFLAGS) $(srcdir)/patriciasearch.c -o patriciasearch $(LIB)
 
 patricia_test: patriciasearch blacklist-ip.txt
 	./patriciasearch

--- a/tests/unit/Makefile.in
+++ b/tests/unit/Makefile.in
@@ -5,19 +5,23 @@ top_builddir = @top_builddir@
 VPATH = @srcdir@
 
 CC=@CC@
+LDFLAGS=@LDFLAGS@
 CXX=@CXX@
+CFLAGS=@CFLAGS@
 BUILD_MINGW=@BUILD_MINGW@
 EXE_SUFFIX=@EXE_SUFFIX@
 
 SRCHOME=$(top_srcdir)/src
 
 ifneq ($(OS),Windows_NT)
-CFLAGS+=-fPIC -DPIC
+AM_CFLAGS=-fPIC -DPIC
+else
+AM_CFLAGS=
 endif
-CFLAGS+=-g -I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@ @JSONC_CFLAGS@ @PCAP_INC@ @ADDITIONAL_INCS@
+AM_CFLAGS+=-I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@ @JSONC_CFLAGS@ @PCAP_INC@ @ADDITIONAL_INCS@
 LIBNDPI=$(top_builddir)/src/lib/libndpi.a
 LIBS=$(LIBNDPI) @PCAP_LIB@ @ADDITIONAL_LIBS@ @JSONC_LIBS@ @LIBS@
-LDFLAGS+=@NDPI_LDFLAGS@
+AM_LDFLAGS=@NDPI_LDFLAGS@
 HEADERS=$(SRCHOME)/include/ndpi_api.h $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
 HEADERS+=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 OBJS=unit
@@ -26,9 +30,9 @@ PREFIX?=@prefix@
 ifneq ($(BUILD_MINGW),)
 
 ifeq ($(DISABLE_NPCAP),0)
-CFLAGS+=-I@srcdir@/../windows/WpdPack/Include -I@srcdir@/../windows/WpdPack/Include/pcap
+AM_CFLAGS+=-I@srcdir@/../windows/WpdPack/Include -I@srcdir@/../windows/WpdPack/Include/pcap
 else
-CFLAGS+=-DDISABLE_NPCAP
+AM_CFLAGS+=-DDISABLE_NPCAP
 endif
 
 ifeq ($(DISABLE_NPCAP),0)
@@ -52,10 +56,10 @@ EXECUTABLE_SOURCES := unit.c
 COMMON_SOURCES := $(filter-out $(EXECUTABLE_SOURCES),$(wildcard *.c ))
 
 unit$(EXE_SUFFIX): $(LIBNDPI) unit.o
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) unit.o $(LIBS) -o $@
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(AM_LDFLAGS) $(LDFLAGS) unit.o $(LIBS) -o $@
 
 %.o: %.c $(HEADERS) Makefile
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
 	/bin/rm -f *.o unit$(EXE_SUFFIX)


### PR DESCRIPTION
Fix improper handling of CFLAGS and LDFLAGS throughout the build system. Also remove hardcoded debug flags that prevented production builds without symbols.

Problems:
---------
1. CFLAGS/LDFLAGS handling: The build system was using `CFLAGS +=` and `LDFLAGS +=` to append package-specific flags, which modifies the user's environment variables instead of keeping package and user flags separate. This caused:
   - User-specified optimization levels being overridden by package defaults
   - Inability to properly override flags at configure or make time
   - Problems with cross-compilation and embedded toolchains

2. Hardcoded -g flags: Debug symbols (-g) were hardcoded in several Makefiles, forcing debug symbols in all builds including production. This caused:
   - Larger binary sizes (library and tools)
   - No way to build without debug symbols
   - Conflicts with user's debug level preferences (-g1, -g2, -g3)
   - Redundancy with configure options (--enable-debug-build)

Solutions:
----------
1. Implement proper CFLAGS/LDFLAGS separation using AM_CFLAGS/AM_LDFLAGS:
   - Added `CFLAGS = @CFLAGS@` to preserve configure-time flags
   - Added `LDFLAGS = @LDFLAGS@` to preserve configure-time flags
   - Changed `CFLAGS +=` to `AM_CFLAGS =` and `AM_CFLAGS +=`
   - Changed `LDFLAGS +=` to `AM_LDFLAGS =` and `AM_LDFLAGS +=`
   - Updated compilation rules: $(CC) $(AM_CFLAGS) $(CFLAGS) ...
   - Updated linking rules: $(CC) ... $(AM_LDFLAGS) $(LDFLAGS) ...

2. Remove all hardcoded -g flags from Makefiles:
   - Debug symbols now controlled via configure (--enable-debug-build) or user CFLAGS (e.g., CFLAGS="-g3")

Flag ordering ensures:
- Package flags come first (e.g., -O2, -fPIC)
- User flags come after and can override (e.g., -O3)
- Last flag wins for conflicting options

🤖 Generated with [Claude Code](https://claude.com/claude-code)



