### PR TITLE
Build system: Add proper cross-compilation support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,24 +107,46 @@ LT_INIT
 LT_LIB_M
 PKG_PROG_PKG_CONFIG
 
+# Detect build and host system for cross-compilation support
+# Must be called early, before AC_PROG_CC
+AC_CANONICAL_HOST
+
 AC_PROG_CC
 AC_PROG_CPP_WERROR
 AC_C_INLINE
 
-SYSTEM=`uname -s`
-if test $SYSTEM = "Darwin"; then
-dnl>  AC_PROG_CC(clang gcc)
-  AM_PROG_CC_C_O(clang gcc)
-  AC_PROG_CXX(clang++ g++)
-else
-  AC_PROG_CC_C_O
-  AC_PROG_CXX
-fi
+# Prefer clang on Darwin if user didn't explicitly set CC
+case "$host_os" in
+  darwin*)
+    dnl>  AC_PROG_CC(clang gcc)
+    AM_PROG_CC_C_O(clang gcc)
+    AC_PROG_CXX(clang++ g++)
+    ;;
+  *)
+    AC_PROG_CC_C_O
+    AC_PROG_CXX
+    ;;
+esac
 
 dnl> Can't use AM_PROG_AR because not all of our Makefiles are automake (yet?)
 AC_CHECK_TOOL(AR, ar, [false])
+AC_CHECK_TOOL([RANLIB], [ranlib], [:])
 
 AC_LANG_WERROR
+
+# Set OS_TYPE for Makefiles based on host system
+case "$host_os" in
+  darwin*)
+    OS_TYPE="Darwin"
+    ;;
+  mingw*|msys*)
+    OS_TYPE="Windows_NT"
+    ;;
+  *)
+    OS_TYPE="Unix"
+    ;;
+esac
+AC_SUBST(OS_TYPE)
 
 #We should use latest croaring version, but with old compilers we need to
 #fallback to old/legacy code
@@ -328,17 +350,15 @@ fi
 if ! test -d $PCAP_HOME; then :
      PCAP_HOME=${srcdir}/../../PF_RING/userland
 fi
-SHORT_MACHINE=`uname -m | cut -b1-3`
-if test $SHORT_MACHINE = "arm"; then
-     LIBNUMA=""
-else
-     AC_CHECK_LIB([numa], [numa_available], [LIBNUMA="-lnuma"], [
-        AC_MSG_WARN([libnuma not found. NUMA optimizations will be disabled.])
-        AC_MSG_WARN([Install libnuma-dev or numactl-devel for better performance on NUMA systems.])
-     ])
-fi
 
-MACHINE=`uname -m`
+AC_CHECK_LIB([numa], [numa_available], [LIBNUMA="-lnuma"], [
+    AC_MSG_WARN([libnuma not found. NUMA optimizations will be disabled.])
+    AC_MSG_WARN([Install libnuma-dev or numactl-devel for better performance on NUMA systems.])
+])
+
+# Set MACHINE from host_cpu for compatibility with existing code
+MACHINE="$host_cpu"
+AC_SUBST(MACHINE)
 
 NBPF_ENABLED=0
 AC_MSG_CHECKING([PF_RING nBPF ($NBPF_HOME)])

--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -9,18 +9,13 @@ CC=@CC@
 CXX=@CXX@
 CFLAGS=@CFLAGS@
 LDFLAGS=@LDFLAGS@
-ifneq ($(OS),Windows_NT)
-OS := $(shell uname)
-endif
-ifeq ($(OS),Darwin)
-CC=clang -fno-color-diagnostics
-endif
+OS_TYPE=@OS_TYPE@
 BUILD_MINGW=@BUILD_MINGW@
 BUILD_MINGW_X64=@BUILD_MINGW_X64@
 DISABLE_NPCAP=@DISABLE_NPCAP@
 EXE_SUFFIX=@EXE_SUFFIX@
 SRCHOME=$(top_srcdir)/src
-ifneq ($(OS),Windows_NT)
+ifneq ($(OS_TYPE),Windows_NT)
 AM_CFLAGS=-fPIC -DPIC
 else
 AM_CFLAGS=

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -26,10 +26,8 @@ libdir     = @libdir@
 includedir = @includedir@/ndpi
 # For backwards compatibility
 PREFIX = $(prefix)
-ifneq ($(OS),Windows_NT)
-OS := $(shell uname)
-endif
-ifneq ($(OS),Windows_NT)
+OS_TYPE = @OS_TYPE@
+ifneq ($(OS_TYPE),Windows_NT)
 AM_CFLAGS  = -fPIC -DPIC
 else
 AM_CFLAGS  =
@@ -61,8 +59,8 @@ endif
 
 BUILD_MINGW    		 = @BUILD_MINGW@
 
-ifeq ($(OS),Darwin)
-CC=clang -fno-color-diagnostics
+# Platform-specific settings
+ifeq ($(OS_TYPE),Darwin)
 SONAME_FLAG=
 else
 ifneq ($(BUILD_MINGW),)


### PR DESCRIPTION
This commit improves cross-compilation support by replacing runtime uname calls with autotools host detection. Changes include:

- Add AC_CANONICAL_HOST to detect build/host/target systems
- Replace uname-based OS detection with $host_os checks
- Use AC_CHECK_TOOL for AR and RANLIB (cross-compilation aware)
- Set MACHINE from $host_cpu instead of uname -m
- Remove ARM-specific libnuma exclusion (let configure detect)
- Export OS_TYPE to Makefiles for consistent platform checks
- Stop overriding CC in Makefiles (respects configure settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



