### PR TITLE
Build system: minor fixes about flag compilation and example dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Python Bindings (ubuntu-latest)
     runs-on: ubuntu-latest
     env:
-      CFLAGS: -Wextra -Werror
+      CFLAGS: -Werror
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,11 +68,11 @@ jobs:
           git diff-index --quiet HEAD -- || true
 
   test:
-    name: ${{ matrix.os }} ${{ matrix.compiler }} ${{ matrix.pcre }} ${{ matrix.maxminddb }} ${{ matrix.msan }} ${{ matrix.nBPF }} ${{matrix.global_context}}
+    name: ${{ matrix.os }} ${{ matrix.compiler }} ${{ matrix.cflags }} ${{ matrix.pcre }} ${{ matrix.maxminddb }} ${{ matrix.msan }} ${{ matrix.nBPF }} ${{matrix.global_context}}
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.compiler }}
-      CFLAGS: -Wextra -Werror -DNDPI_EXTENDED_SANITY_CHECKS
+      CFLAGS: -Werror -DNDPI_EXTENDED_SANITY_CHECKS ${{ matrix.cflags }}
     strategy:
       fail-fast: true
       matrix:
@@ -84,6 +84,7 @@ jobs:
         msan: [""]
         nBPF: [""]
         global_context: [""] # Enable by default
+        cflags: ["-g -O2"] # Default value if you do not specify CFLAGS variable
         include:
           - compiler: "gcc-4.9" # "Oldest" gcc easily available. To simulate RHEL7
             os: ubuntu-22.04
@@ -91,24 +92,28 @@ jobs:
             maxminddb: "--with-maxminddb"
             msan: "--with-sanitizer"
             nBPF: ""
+            cflags: "-O0"
           - compiler: "gcc-14" # "Newest" gcc easily available
             os: ubuntu-24.04
             pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-sanitizer"
             nBPF: ""
+            cflags: "-O1"
           - compiler: "clang-12" # "Oldest" clang easily available
             os: ubuntu-22.04
             pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-sanitizer"
             nBPF: ""
+            cflags: "-Os"
           - compiler: "clang-18" # "Newest" clang easily available. See also below...
             os: ubuntu-24.04
             pcre: "--with-pcre2"
             maxminddb: "--with-maxminddb"
             msan: "--with-sanitizer"
             nBPF: ""
+            cflags: "-O3"
           - compiler: "cc"
             os: ubuntu-latest
             pcre: "--with-pcre2"
@@ -241,7 +246,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       CC: ${{ matrix.compiler }}
-      CFLAGS: -Wextra -Werror -DNDPI_EXTENDED_SANITY_CHECKS
+      CFLAGS: -Werror -DNDPI_EXTENDED_SANITY_CHECKS
     strategy:
       fail-fast: true
       matrix:
@@ -277,7 +282,7 @@ jobs:
     name: ${{ matrix.os }} (msys2)
     runs-on: ${{ matrix.os }}
     env:
-      CFLAGS: -Wextra -Werror -DNDPI_EXTENDED_SANITY_CHECKS
+      CFLAGS: -Werror -DNDPI_EXTENDED_SANITY_CHECKS -g -O2
     strategy:
       fail-fast: true
       matrix:
@@ -311,7 +316,7 @@ jobs:
     name: Out-of-tree builds
     runs-on: ubuntu-latest
     env:
-      CFLAGS: -Wextra -Werror -DNDPI_EXTENDED_SANITY_CHECKS
+      CFLAGS: -Werror -DNDPI_EXTENDED_SANITY_CHECKS -g -O2
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -18,7 +18,7 @@ jobs:
     name: Ubuntu ${{ matrix.arch }}
     runs-on: ubuntu-latest
     env:
-      CFLAGS: -Wextra -Werror -DNDPI_EXTENDED_SANITY_CHECKS
+      CFLAGS: -Werror -DNDPI_EXTENDED_SANITY_CHECKS
       # Idea to have significant faster tests while pushing/merging: test all pcaps only on schedule runs; otherwise tests only the pcaps updated/added recently
       NDPI_TEST_ONLY_RECENTLY_UPDATED_PCAPS: ${{ (github.event_name == 'schedule') && '0' || '1' }}
     strategy:

--- a/.github/workflows/build_masan.yml
+++ b/.github/workflows/build_masan.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04 # TODO: some issues with masan/clang/ubuntu-24.04
     env:
       CC: clang
-      CFLAGS: -Wextra -Werror -DNDPI_EXTENDED_SANITY_CHECKS
+      CFLAGS: -Werror -DNDPI_EXTENDED_SANITY_CHECKS
       # Idea to have significant faster tests while pushing/merging: test all pcaps only on schedule runs; otherwise tests only the pcaps updated/added recently
       NDPI_TEST_ONLY_RECENTLY_UPDATED_PCAPS: ${{ (github.event_name == 'schedule') && '0' || '1' }}
     steps:

--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -112,7 +112,7 @@ jobs:
     name: Thread Sanitizer (ubuntu-latest)
     runs-on: ubuntu-latest
     env:
-      CFLAGS: -Wextra -Werror
+      CFLAGS: -Werror
     steps:
       - uses: actions/checkout@v4
         with:
@@ -137,7 +137,7 @@ jobs:
     name: Local gcrypt on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      CFLAGS: -Wextra -Werror -DNDPI_EXTENDED_SANITY_CHECKS
+      CFLAGS: -Werror -DNDPI_EXTENDED_SANITY_CHECKS
     strategy:
       fail-fast: true
       matrix:
@@ -175,7 +175,7 @@ jobs:
     name: Local gcrypt on ${{ matrix.os }} (msys2)
     runs-on: ${{ matrix.os }}
     env:
-      CFLAGS: -Wextra -Werror -DNDPI_EXTENDED_SANITY_CHECKS
+      CFLAGS: -Werror -DNDPI_EXTENDED_SANITY_CHECKS
     strategy:
       fail-fast: true
       matrix:

--- a/configure.ac
+++ b/configure.ac
@@ -57,9 +57,6 @@ AS_IF([test "${with_thread_sanitizer+set}" = set -a "${with_memory_sanitizer+set
 ])
 AS_IF([test "${with_sanitizer+set}" = set -o "${with_thread_sanitizer+set}" = set -o "${with_memory_sanitizer+set}" = set],[
   NDPI_CFLAGS="${NDPI_CFLAGS} -O0 -g3"
-],[
-  dnl>  Oss-fuzz doesn't really like any optimizaton flags don't set by itself
-  AS_IF([test "x$enable_fuzztargets" != "xyes"], [NDPI_CFLAGS="${NDPI_CFLAGS} -O2"])
 ])
 AS_IF([test "${with_sanitizer+set}" = set -o "${with_thread_sanitizer+set}" = set -o "${with_memory_sanitizer+set}" = set],[
   AS_IF([test "x$enable_gprof" = "xyes"], [
@@ -254,7 +251,7 @@ echo "Setting API version to ${NDPI_API_VERSION}"
 AC_DEFINE_UNQUOTED(NDPI_GIT_RELEASE, "${GIT_RELEASE}", [GIT Release])
 AC_DEFINE_UNQUOTED(NDPI_GIT_DATE, "${GIT_DATE}", [Last GIT change])
 
-NDPI_CFLAGS="-W -Wall -Wno-address-of-packed-member ${NDPI_CFLAGS}"
+NDPI_CFLAGS="-W -Wall -Wextra -Wno-address-of-packed-member ${NDPI_CFLAGS}"
 
 dnl> MacOS brew.sh
 HOMEBREW_DIR=/opt/homebrew

--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -54,7 +54,7 @@ endif
 
 AM_CFLAGS+=-pthread
 
-all: ndpiReader$(EXE_SUFFIX) @DPDK_TARGET@
+all: ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) @DPDK_TARGET@
 
 EXECUTABLE_SOURCES := ndpiReader.c ndpiSimpleIntegration.c
 COMMON_SOURCES := $(filter-out $(EXECUTABLE_SOURCES),$(notdir $(wildcard $(srcdir)/*.c)))

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -5188,9 +5188,9 @@ static void ndpi_process_packet(u_char *args,
     trailer->flow_score = htons(ndpi_risk2score(flow_risk, &cli_score, &srv_score));
     trailer->flow_risk_info_len = ntohs(WIRESHARK_FLOW_RISK_INFO_SIZE);
     if(flow && flow->risk_str) {
-      strncpy(trailer->flow_risk_info, flow->risk_str, sizeof(trailer->flow_risk_info));
+      strncpy(trailer->flow_risk_info, flow->risk_str, sizeof(trailer->flow_risk_info) - 1);
+      trailer->flow_risk_info[sizeof(trailer->flow_risk_info) - 1] = '\0';
     }
-    trailer->flow_risk_info[sizeof(trailer->flow_risk_info) - 1] = '\0';
     trailer->proto.master_protocol = htons(p.proto.master_protocol), trailer->proto.app_protocol = htons(p.proto.app_protocol);
     ndpi_protocol2name(ndpi_thread_info[thread_id].workflow->ndpi_struct, p.proto, trailer->name, sizeof(trailer->name));
 

--- a/example/reader_util.c
+++ b/example/reader_util.c
@@ -1838,7 +1838,7 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
       }
     }
 
-    memcpy(&flow->flow_last_pkt_time, &when, sizeof(when));
+    flow->flow_last_pkt_time = when;
 
     if(src_to_dst_direction) {
       if(flow->src2dst_last_pkt_time.tv_sec) {
@@ -1855,7 +1855,7 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
 
       ndpi_data_add_value(flow->pktlen_c_to_s, rawsize);
       flow->src2dst_packets++, flow->src2dst_bytes += rawsize, flow->src2dst_goodput_bytes += payload_len;
-      memcpy(&flow->src2dst_last_pkt_time, &when, sizeof(when));
+      flow->src2dst_last_pkt_time = when;
 
 #ifdef DIRECTION_BINS
       if(payload_len && (flow->src2dst_packets < MAX_NUM_BIN_PKTS))
@@ -1874,7 +1874,7 @@ static struct ndpi_proto packet_processing(struct ndpi_workflow * workflow,
       ndpi_data_add_value(flow->pktlen_s_to_c, rawsize);
       flow->dst2src_packets++, flow->dst2src_bytes += rawsize, flow->dst2src_goodput_bytes += payload_len;
       flow->risk &= ~(1ULL << NDPI_UNIDIRECTIONAL_TRAFFIC); /* Clear bit */
-      memcpy(&flow->dst2src_last_pkt_time, &when, sizeof(when));
+      flow->dst2src_last_pkt_time = when;
 
 #ifdef DIRECTION_BINS
       if(payload_len && (flow->dst2src_packets < MAX_NUM_BIN_PKTS))

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -37,7 +37,7 @@ CFLAGS_ndpi_bitmap.c := -Wno-unused-function
 CFLAGS_ndpi_bitmap64_fuse.c := -Wno-unused-function
 CFLAGS_gcrypt_light.c := -Wno-unused-function -Wno-unused-parameter
 CFLAGS_ahocorasick.c := -Wno-unused-function -Wno-unused-parameter
-CFLAGS_roaring.c := -Wno-unused-function -Wno-attributes
+CFLAGS_roaring.c := -Wno-unused-function -Wno-attributes -Wno-missing-braces -Wno-missing-field-initializers
 # Use AM_LDFLAGS for package flags, never modify user's LDFLAGS
 AM_LDFLAGS = @NDPI_LDFLAGS@
 LIBS       = @ADDITIONAL_LIBS@ @LIBS@ @GPROF_LIBS@

--- a/src/lib/protocols/softether.c
+++ b/src/lib/protocols/softether.c
@@ -178,7 +178,7 @@ static int dissect_softether_host_fqdn(struct ndpi_flow_struct *flow,
   u_int8_t const *payload = packet->payload;
   u_int16_t payload_len = packet->payload_packet_len;
   u_int32_t tuple_count;
-  size_t value_siz, hostname_len, fqdn_len;
+  size_t value_siz, hostname_len = 0, fqdn_len;
   struct softether_value val1, val2;
   uint8_t got_hostname = 0, got_fqdn = 0;
   const char *hostname_ptr = NULL, *fqdn_ptr = NULL;

--- a/utils/check_symbols.sh
+++ b/utils/check_symbols.sh
@@ -28,6 +28,11 @@ for line in $(nm -P -u "${NDPI_LIB}"); do
                     'printf'|'fprintf') SKIP=1 ;;
                 esac
             ;;
+            '[ndpi_analyze.o]'|'[ndpi_cache.o]'|'[ndpi_config.o]')
+                case "${FOUND_SYMBOL}" in
+                    'fprintf') SKIP=1 ;;
+                esac
+            ;;
             '[ahocorasick.o]')
                 case "${FOUND_SYMBOL}" in
                     'fprintf') SKIP=1 ;;


### PR DESCRIPTION
- always use `-Wextra` compilation flag; it was already used in CI
- always compile `ndpiSimpleIntegration` when building examples
- don't mess with optimization flags: `CFLAGS` default value is "-g -O2" and the user can change it

Try to test -O1,2,3,s flags in CI.

Fix some warnings.

