### PR TITLE
Build system: Standardize and improve clean/distclean targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,9 +48,14 @@ coverage: all
 	genhtml -o coverage_report/ndpi_coverage_report lcov.info
 
 clean-coverage:
-	rm -f lcov.info
+	$(RM) lcov.info
 	find . -type f -name "*.gcda" -exec rm "{}" +
 	find . -type f -name "*.gcno" -exec rm "{}" +
+
+distclean-local:
+	$(RM) -r autom4te.cache
+	$(RM) libtool config.status config.cache config.log
+	$(RM) src/include/stamp-h1
 
 pull:
 	cd $(top_srcdir) && git pull --rebase

--- a/configure.ac
+++ b/configure.ac
@@ -530,15 +530,6 @@ NDPI_ABS_SRCDIR="`cd ${srcdir} && pwd`"
 AC_DEFINE_UNQUOTED(NDPI_BASE_DIR, "${NDPI_ABS_SRCDIR}", [nDPI base directory])
 AC_SUBST(NDPI_BASE_DIR, "${NDPI_ABS_SRCDIR}")
 
-dnl> Curl
-dnl> AC_CHECK_LIB([curl], [curl_easy_perform])
-dnl> if test ${ac_cv_lib_curl_curl_easy_perform} = "no"; then
-dnl>    echo "Please install libcurl4-openssl-dev (http://curl.haxx.se/) in order to enable curl support"
-dnl> else
-dnl>   ADDITIONAL_LIBS="${ADDITIONAL_LIBS} -lcurl"
-dnl>   AC_DEFINE_UNQUOTED(HAVE_CURL, 1, [curl is present])
-dnl> fi
-
 dnl> ndpiReader has some hard-coded unit tests: in the out-of-tree builds we need some configuration files in the expected path
 if test "${srcdir}" != . ; then :
   $MKDIR_P example

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -50,7 +50,11 @@ help:
 
 .PHONY: clean
 clean:
-	rm -rf $(BUILDDIR)/* api doxygen
+	$(RM) -r $(BUILDDIR)/* api doxygen
+
+.PHONY: distclean
+distclean: clean
+	$(RM) Doxyfile.cfg
 
 .PHONY: html
 html:

--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -91,10 +91,10 @@ cppcheck:
 	 cppcheck --template='{file}:{line}:{severity}:{message}' --quiet --enable=all --force -I$(SRCHOME)/include $(srcdir)/*.c
 
 clean:
-	/bin/rm -f *.o ndpiReader ndpiSimpleIntegration ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) ndpiReader.dpdk libndpiReader.a
-	/bin/rm -f .*.dpdk.cmd .*.o.cmd *.dpdk.map .*.o.d
-	/bin/rm -f _install _postbuild _postinstall _preinstall
-	/bin/rm -rf build
+	$(RM) *.o *.lo ndpiReader ndpiSimpleIntegration ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) ndpiReader.dpdk libndpiReader.a
+	$(RM) .*.dpdk.cmd .*.o.cmd *.dpdk.map .*.o.d
+	$(RM) _install _postbuild _postinstall _preinstall
+	$(RM) -r build .libs .deps
 
 distdir:
 	cp $(srcdir)/README.DPDK '$(distdir)/'
@@ -106,5 +106,5 @@ distdir:
 		-o -name '*.csv' | xargs -I'{}' cp '{}' '$(distdir)/{}'
 
 distclean: clean
-	/bin/rm -f Makefile.dpdk
-	/bin/rm -f Makefile
+	$(RM) Makefile.dpdk
+	$(RM) Makefile

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -405,11 +405,18 @@ fuzz_process_packet.dict: $(srcdir)/dictionary.dict
 fuzz_tls_certificate.dict: $(srcdir)/dictionary_tls_certificate.dict
 	@cp $(srcdir)/dictionary_tls_certificate.dict $@
 
-clean:
-	rm -f *.o $(bin_PROGRAMS) ../example/fuzz_*.o ../src/lib/third_party/src/fuzz_*.o ../src/lib/third_party/src/fuzz/fuzz_*.o
-	rm -f testpcaps.zip
-	rm -f *_seed_corpus.zip
-	rm -f fuzz*.dict
+clean-local:
+	$(RM) *.o $(bin_PROGRAMS)
+	$(RM) $(top_builddir)/example/fuzz_*.o
+	$(RM) $(top_builddir)/src/lib/third_party/src/fuzz_*.o
+	$(RM) $(top_builddir)/src/lib/third_party/src/fuzz/fuzz_*.o
+	$(RM) testpcaps.zip
+	$(RM) *_seed_corpus.zip
+	$(RM) fuzz*.dict
+	$(RM) -r .libs .deps
+
+distclean-local:
+	$(RM) Makefile
 
 distdir:
 	find $(srcdir) -type d | xargs -I'{}' mkdir -p '$(distdir)/{}'

--- a/influxdb/Makefile.in
+++ b/influxdb/Makefile.in
@@ -22,10 +22,11 @@ metric_anomaly: $(srcdir)/metric_anomaly.c Makefile $(LIBDPI) $(GEN_HEADERS)
 	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(INC) $(AM_LDFLAGS) $(LDFLAGS) $(srcdir)/metric_anomaly.c -o metric_anomaly $(LIB)
 
 clean:
-	/bin/rm -f *.o $(TOOLS) *~
+	$(RM) *.o *.lo $(TOOLS) *~
+	$(RM) -r .libs .deps
 
 distclean: clean
-	/bin/rm -f Makefile
+	$(RM) Makefile
 
 distdir:
 	find $(srcdir) -type f -name '*.c' \

--- a/packages/rpm/Makefile.in
+++ b/packages/rpm/Makefile.in
@@ -15,19 +15,19 @@ build-src:
 	cd ../..; ./autogen.sh; ./configure; make clean; make
 
 cleanup-rpm:
-	rm -rf $(HOME)/rpmbuild/BUILD/ndpi* $(HOME)/rpmbuild/SOURCES/ndpi*
+	$(RM) -r $(HOME)/rpmbuild/BUILD/ndpi* $(HOME)/rpmbuild/SOURCES/ndpi*
 
 build-rpm: build-src cleanup-rpm
-	-rm -rf ndpi-@PACKAGE_VERSION@
+	-$(RM) -r ndpi-@PACKAGE_VERSION@
 	mkdir -p ndpi-@PACKAGE_VERSION@/packages
 	cp ndpi.spec.in ndpi-@PACKAGE_VERSION@/packages
 	cp ../../Makefile.* ../../libtool ../../configure* ../../config.* ../../install-sh ../../autogen.sh ndpi-@PACKAGE_VERSION@
-	cp -rf ../../src ndpi-@PACKAGE_VERSION@ 
-	cp ../../CHANGELOG.md ../../COPYING ndpi-@PACKAGE_VERSION@ 
-	\rm -f ndpi-@PACKAGE_VERSION@/config.status
+	cp -rf ../../src ndpi-@PACKAGE_VERSION@
+	cp ../../CHANGELOG.md ../../COPYING ndpi-@PACKAGE_VERSION@
+	$(RM) ndpi-@PACKAGE_VERSION@/config.status
 	mkdir -p $(HOME)/rpmbuild/SOURCES
 	tar cvfz $(HOME)/rpmbuild/SOURCES/ndpi-@PACKAGE_VERSION@.tgz ndpi-@PACKAGE_VERSION@
-	@rm -f $(HOME)/rpmbuild/RPMS/$(PLATFORM)/$(PACKAGE)
+	@$(RM) $(HOME)/rpmbuild/RPMS/$(PLATFORM)/$(PACKAGE)
 	@rpmbuild -bb ./$(APPL).spec --define "buildnumber $(GIT_REVISION)"
 	@if [[ $EUID -ne 0 ]]; then @RPM_SIGN_CMD@ $(HOME)/rpmbuild/RPMS/$(PLATFORM)/$(PACKAGE); fi
 	@if [[ $EUID -ne 0 ]]; then @RPM_SIGN_CMD@ $(HOME)/rpmbuild/RPMS/$(PLATFORM)/$(DEV_PACKAGE); fi

--- a/packages/rpm/ndpi.spec.in
+++ b/packages/rpm/ndpi.spec.in
@@ -73,8 +73,8 @@ rm -rf $RPM_BUILD_ROOT/usr/sbin/ndpi
 rm -f $RPM_BUILD_ROOT/usr/bin/ndpiSimpleIntegration
 strip $RPM_BUILD_ROOT%{bindir}/*
 rm -fr %{buildroot}%{includedir}/ndpi_win32.h
-if test -f $RPM_BUILD_ROOT/usr/lib/pkgconfig/libndpi.pc; then /bin/rm -f $RPM_BUILD_ROOT/usr/lib/pkgconfig/libndpi.pc; fi
-if test -f $RPM_BUILD_ROOT/usr/lib64/pkgconfig/libndpi.pc; then /bin/rm -f $RPM_BUILD_ROOT/usr/lib64/pkgconfig/libndpi.pc; fi
+if test -f $RPM_BUILD_ROOT/usr/lib/pkgconfig/libndpi.pc; then rm -f $RPM_BUILD_ROOT/usr/lib/pkgconfig/libndpi.pc; fi
+if test -f $RPM_BUILD_ROOT/usr/lib64/pkgconfig/libndpi.pc; then rm -f $RPM_BUILD_ROOT/usr/lib64/pkgconfig/libndpi.pc; fi
 
 %clean
 rm -fr $RPM_BUILD_ROOT

--- a/packages/ubuntu/Makefile.in
+++ b/packages/ubuntu/Makefile.in
@@ -2,7 +2,7 @@ NDPI_HOME=$(PWD)/../..
 NDPI_BUILD="$(realpath ${NDPI_HOME}/packages/ubuntu)"
 
 ndpi:
-	\rm -rf ./debian/ndpi-tmp ./debian/ndpi-dev-tmp ./debian/ndpi ./debian/ndpi-dev
+	$(RM) -r ./debian/ndpi-tmp ./debian/ndpi-dev-tmp ./debian/ndpi ./debian/ndpi-dev
 	mkdir -p ./debian/ndpi-tmp ./debian/ndpi-dev-tmp
 	mkdir -p  ./debian/ndpi-tmp/usr/lib ./debian/ndpi-tmp/usr/bin ./debian/ndpi-tmp/usr/share/ndpi
 	mkdir -p ./debian/ndpi-dev-tmp/usr/lib ./debian/ndpi-dev-tmp/usr/include/ndpi ./debian/ndpi-dev-tmp/usr/lib/pkgconfig
@@ -15,13 +15,13 @@ ndpi:
 	cp $(NDPI_HOME)/example/ndpiReader ./debian/ndpi-tmp/usr/bin/
 	cp $(NDPI_HOME)/src/include/*.h ./debian/ndpi-dev-tmp/usr/include/ndpi/
 	cp $(NDPI_HOME)/libndpi.pc ./debian/ndpi-dev-tmp/usr/lib/pkgconfig/
-	-rm -fr ./debian/ndpi-dev-tmp/usr/include/ndpi/ndpi_win32.h*
+	-$(RM) -r ./debian/ndpi-dev-tmp/usr/include/ndpi/ndpi_win32.h*
 	@echo
-	@find ./debian/ndpi-tmp -name "*~" -exec /bin/rm {} ';'
-	@find ./debian/ndpi-dev-tmp -name "*~" -exec /bin/rm {} ';'
+	@find ./debian/ndpi-tmp -name "*~" -exec rm {} ';'
+	@find ./debian/ndpi-dev-tmp -name "*~" -exec rm {} ';'
 	dpkg-buildpackage -rfakeroot -d -us -uc
 	@SIGN_CMD@ --sign builder -k D1EB60BE ../ndpi*deb
-	@\rm -f ../ndpi*dsc ../ndpi*.gz ../ndpi*changes
+	@$(RM) ../ndpi*dsc ../ndpi*.gz ../ndpi*changes
 	@/bin/mv ../ndpi*deb .
 	@echo
 	@echo "Package built."
@@ -41,4 +41,4 @@ install:
 
 clean:
 	-cd ${NDPI_HOME} && $(MAKE) clean
-	-rm -rf *~ *deb ./usr ./debian/ndpi ./debian/ndpi-dev ./debian/ndpi ./debian/ndpi-dev
+	-$(RM) -r *~ *deb ./usr ./debian/ndpi ./debian/ndpi-dev ./debian/ndpi ./debian/ndpi-dev

--- a/rrdtool/Makefile.in
+++ b/rrdtool/Makefile.in
@@ -25,10 +25,11 @@ rrd_similarity: $(srcdir)/rrd_similarity.c Makefile $(LIBDPI) $(GEN_HEADERS)
 	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(INC) $(AM_LDFLAGS) $(LDFLAGS) $(srcdir)/rrd_similarity.c -o rrd_similarity $(LIB)
 
 clean:
-	/bin/rm -f *.o $(TOOLS) *~
+	$(RM) *.o *.lo $(TOOLS) *~
+	$(RM) -r .libs .deps
 
 distclean: clean
-	/bin/rm -f Makefile
+	$(RM) Makefile
 
 distdir:
 	find $(srcdir) -type f -name '*.c' \

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -94,8 +94,9 @@ $(NDPI_LIB_SHARED): $(OBJECTS)
 	$(CC) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CFLAGS_$(notdir $<)) -c $< -o $@
 
 clean:
-	/bin/rm -f $(NDPI_LIB_STATIC) $(NDPI_LIB_SHARED) $(OBJECTS) *.o *.so *.so.* *.lo *.dll
-	/bin/rm -f $(NDPI_LIB_SHARED_BASE) $(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR)
+	$(RM) $(NDPI_LIB_STATIC) $(NDPI_LIB_SHARED) $(OBJECTS) *.o *.so *.so.* *.lo *.dll *.la
+	$(RM) $(NDPI_LIB_SHARED_BASE) $(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR)
+	$(RM) -r .libs .deps
 
 distdir:
 	find $(srcdir) -type d | xargs -I'{}' mkdir -p '$(distdir)/{}'
@@ -108,7 +109,7 @@ distdir:
 		-o -name '*.h' | xargs -I'{}' cp '{}' '$(distdir)/{}'
 
 distclean: clean
-	/bin/rm -f Makefile
+	$(RM) Makefile
 
 check:
 	true # nothing to do here

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,3 +11,6 @@ EXTRA_DIST = cfgs/*/pcap cfgs/*/result cfgs/*/*.txt performance \
 
 all:
 	@echo -n ""
+
+distclean-local:
+	$(RM) do.sh do-dga.sh do-unit.sh

--- a/tests/dga/Makefile.in
+++ b/tests/dga/Makefile.in
@@ -38,9 +38,9 @@ dga_evaluate$(EXE_SUFFIX): $(LIBNDPI) dga_evaluate.o
 	$(CC) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
-	/bin/rm -f *.o dga_evaluate$(EXE_SUFFIX)
-	/bin/rm -f .*.o.cmd .*.o.d
-	/bin/rm -rf build
+	$(RM) *.o *.lo dga_evaluate$(EXE_SUFFIX)
+	$(RM) .*.o.cmd .*.o.d
+	$(RM) -r build .libs .deps
 
 install:
 	echo ""
@@ -48,7 +48,7 @@ install:
 distdir:
 
 distclean: clean
-	/bin/rm -f Makefile
+	$(RM) Makefile
 
 check:
 	true # nothing to do here, done by invoking tests/do-dga.sh

--- a/tests/do.sh.in
+++ b/tests/do.sh.in
@@ -211,7 +211,7 @@ run_single_pcap()
         if [ $FORCE_PARALLEL_UTESTS -eq 0 ]; then
             printf "%-48s\tOK\n" "$f"
         fi
-        /bin/rm -f /tmp/reader.$$.out
+        rm -f /tmp/reader.$$.out
         return 0
     else
         if [ $FORCE_PARALLEL_UTESTS -eq 1 ]; then
@@ -229,7 +229,7 @@ run_single_pcap()
         fi
     fi
 
-    /bin/rm -f /tmp/reader.$$.out
+    rm -f /tmp/reader.$$.out
 
     return 1
 }

--- a/tests/performance/Makefile.in
+++ b/tests/performance/Makefile.in
@@ -61,6 +61,13 @@ blacklist-ip.txt:
 	wget http://blacklists.ntop.org/blacklist-ip.txt
 
 clean:
-	/bin/rm -f *zip top-1m.csv blacklist-ip.txt
+	$(RM) $(TOOLS) $(TESTS) *.o *.lo
+	$(RM) *zip top-1m.csv blacklist-ip.txt
+	$(RM) -r .libs .deps
 
+distclean: clean
+	$(RM) Makefile
+
+check:
+	true # nothing to do here, tests run via make all
 

--- a/tests/unit/Makefile.in
+++ b/tests/unit/Makefile.in
@@ -62,9 +62,9 @@ unit$(EXE_SUFFIX): $(LIBNDPI) unit.o
 	$(CC) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c $< -o $@
 
 clean:
-	/bin/rm -f *.o unit$(EXE_SUFFIX)
-	/bin/rm -f .*.o.cmd .*.o.d
-	/bin/rm -rf build
+	$(RM) *.o *.lo unit$(EXE_SUFFIX)
+	$(RM) .*.o.cmd .*.o.d
+	$(RM) -r build .libs .deps
 
 install:
 	echo ""
@@ -72,7 +72,7 @@ install:
 distdir:
 
 distclean: clean
-	/bin/rm -f Makefile
+	$(RM) Makefile
 
 check:
 	true # nothing to do here, done by invoking tests/do-unit.sh

--- a/utils/Makefile.in
+++ b/utils/Makefile.in
@@ -15,3 +15,9 @@ hosts2domains: $(srcdir)/hosts2domains.c Makefile
 
 print_rank: $(srcdir)/print_rank.c Makefile
 	$(CC) $(INC) -g $(srcdir)/print_rank.c -o print_rank $(LIBS)
+
+clean:
+	$(RM) hosts2domains print_rank *.o
+
+distclean: clean
+	$(RM) Makefile


### PR DESCRIPTION
This commit improves the nDPI build system by standardizing cleanup targets, improving portability, and ensuring complete removal of generated files during `make distclean`.

Changes:

1. Standardize clean targets (replace /bin/rm with portable $(RM))

2. Add distclean-local targets for complete cleanup

3. Add missing clean/distclean targets

4. Remove obsolete commented-out curl detection code

5. fuzz/Makefile.am: Fix out-of-tree build compatibility by replacing hardcoded relative paths (../example/fuzz_*.o) with proper $(top_builddir) variables. Add distclean-local target.


