### PR TITLE
Build system: Remove libndpiReader.a intermediate archive

### DIFF
--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -59,11 +59,8 @@ all: ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) @DPDK_TARGET@
 EXECUTABLE_SOURCES := ndpiReader.c ndpiSimpleIntegration.c
 COMMON_SOURCES := $(filter-out $(EXECUTABLE_SOURCES),$(notdir $(wildcard $(srcdir)/*.c)))
 
-libndpiReader.a: $(COMMON_SOURCES:%.c=%.o) $(LIBNDPI)
-	$(AR) rsv libndpiReader.a $(COMMON_SOURCES:%.c=%.o)
-
-ndpiReader$(EXE_SUFFIX): libndpiReader.a $(LIBNDPI) ndpiReader.o
-	$(CC) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) ndpiReader.o libndpiReader.a $(LIBS) -o $@
+ndpiReader$(EXE_SUFFIX): $(COMMON_SOURCES:%.c=%.o) ndpiReader.o $(LIBNDPI)
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) ndpiReader.o $(COMMON_SOURCES:%.c=%.o) $(LIBS) -o $@
 
 ndpiSimpleIntegration$(EXE_SUFFIX): ndpiSimpleIntegration.o
 	$(CC) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) $< $(LIBS) -o $@
@@ -91,7 +88,7 @@ cppcheck:
 	 cppcheck --template='{file}:{line}:{severity}:{message}' --quiet --enable=all --force -I$(SRCHOME)/include $(srcdir)/*.c
 
 clean:
-	$(RM) *.o *.lo ndpiReader ndpiSimpleIntegration ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) ndpiReader.dpdk libndpiReader.a
+	$(RM) *.o *.lo ndpiReader ndpiSimpleIntegration ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) ndpiReader.dpdk
 	$(RM) .*.dpdk.cmd .*.o.cmd *.dpdk.map .*.o.d
 	$(RM) _install _postbuild _postinstall _preinstall
 	$(RM) -r build .libs .deps


### PR DESCRIPTION
Simplify the example/Makefile.in build process by removing the libndpiReader.a static archive target. Instead, compile and link all common object files directly into the ndpiReader executable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



