### PR TITLE
Build system: Fix --disable-shared and --disable-static flags being ignored

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,17 @@ AS_IF([test "${enable_npcap+set}" = set],[DISABLE_NPCAP=1],[DISABLE_NPCAP=0])
 
 LT_INIT
 LT_LIB_M
+
+# Ensure at least one library type is enabled
+AS_IF([test "x${enable_shared}" = "xno" -a "x${enable_static}" = "xno"],[
+  AC_MSG_ERROR([Cannot disable both shared and static libraries. At least one must be enabled.])
+])
+
+# Fuzz targets require static library
+AS_IF([test "x${enable_fuzztargets}" = "xyes" -a "x${enable_static}" = "xno"],[
+  AC_MSG_ERROR([--enable-fuzztargets requires static library. Cannot use with --disable-static.])
+])
+
 PKG_PROG_PKG_CONFIG
 
 # Detect build and host system for cross-compilation support
@@ -577,6 +588,8 @@ AC_SUBST(EXE_SUFFIX)
 AC_SUBST(NDPI_CFLAGS)
 AC_SUBST(NDPI_LDFLAGS)
 AC_SUBST(NDPI_BASE_DIR)
+AC_SUBST(enable_shared)
+AC_SUBST(enable_static)
 AC_OUTPUT
 
 dnl> ========================================================================
@@ -638,6 +651,18 @@ AS_IF([test "${with_lto_and_gold_linker+set}" = set],
   LTO + Gold linker:       enabled"],
   [SUMMARY="${SUMMARY}
   LTO + Gold linker:       disabled"])
+
+AS_IF([test "x${enable_shared}" = "xyes"],
+  [SUMMARY="${SUMMARY}
+  Shared library:          enabled"],
+  [SUMMARY="${SUMMARY}
+  Shared library:          disabled"])
+
+AS_IF([test "x${enable_static}" = "xyes"],
+  [SUMMARY="${SUMMARY}
+  Static library:          enabled"],
+  [SUMMARY="${SUMMARY}
+  Static library:          disabled"])
 
 AS_IF([test "x${DPDK_TARGET}" = "xdpdk"],
   [SUMMARY="${SUMMARY}

--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -22,7 +22,15 @@ AM_CFLAGS=
 endif
 AM_CFLAGS+=-I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@ @PCAP_INC@ @GPROF_CFLAGS@ @CUSTOM_NDPI@
 AM_LDFLAGS=@NDPI_LDFLAGS@
+ENABLE_STATIC        = @enable_static@
+ifeq ($(ENABLE_STATIC),yes)
 LIBNDPI=$(top_builddir)/src/lib/libndpi.a
+LIBNDPI_DEP=$(LIBNDPI)
+else
+LIBNDPI=-lndpi
+LIBNDPI_DEP=$(top_builddir)/src/lib/libndpi.so
+AM_LDFLAGS+=-L$(top_builddir)/src/lib
+endif
 LIBS=$(LIBNDPI) @PCAP_LIB@ @ADDITIONAL_LIBS@ @GPROF_LIBS@ @LIBS@
 HEADERS=reader_util.h $(SRCHOME)/include/ndpi_api.h \
         $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
@@ -59,7 +67,7 @@ all: ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) @DPDK_TARGET@
 EXECUTABLE_SOURCES := ndpiReader.c ndpiSimpleIntegration.c
 COMMON_SOURCES := $(filter-out $(EXECUTABLE_SOURCES),$(notdir $(wildcard $(srcdir)/*.c)))
 
-ndpiReader$(EXE_SUFFIX): $(COMMON_SOURCES:%.c=%.o) ndpiReader.o $(LIBNDPI)
+ndpiReader$(EXE_SUFFIX): $(COMMON_SOURCES:%.c=%.o) ndpiReader.o $(LIBNDPI_DEP)
 	$(CC) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) ndpiReader.o $(COMMON_SOURCES:%.c=%.o) $(LIBS) -o $@
 
 ndpiSimpleIntegration$(EXE_SUFFIX): ndpiSimpleIntegration.o

--- a/rrdtool/Makefile.in
+++ b/rrdtool/Makefile.in
@@ -9,8 +9,16 @@ LDFLAGS=@LDFLAGS@
 CFLAGS=@CFLAGS@
 AM_CFLAGS=@NDPI_CFLAGS@
 INC=-I $(top_srcdir)/src/include -I $(top_builddir)/src/include -I/usr/local/include
-LIBDPI=$(top_builddir)/src/lib/libndpi.a
 AM_LDFLAGS=@NDPI_LDFLAGS@
+ENABLE_STATIC        = @enable_static@
+ifeq ($(ENABLE_STATIC),yes)
+LIBDPI=$(top_builddir)/src/lib/libndpi.a
+LIBDPI_DEP=$(LIBDPI)
+else
+LIBDPI=-lndpi
+LIBDPI_DEP=$(top_builddir)/src/lib/libndpi.so
+AM_LDFLAGS+=-L$(top_builddir)/src/lib
+endif
 LIB=$(LIBDPI) @ADDITIONAL_LIBS@ @LIBRRD@ @LIBS@ -lm -lpthread
 GEN_HEADERS=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 
@@ -18,10 +26,10 @@ TOOLS=rrd_anomaly rrd_similarity
 
 all: $(TOOLS)
 
-rrd_anomaly: $(srcdir)/rrd_anomaly.c Makefile $(LIBDPI) $(GEN_HEADERS)
+rrd_anomaly: $(srcdir)/rrd_anomaly.c Makefile $(LIBDPI_DEP) $(GEN_HEADERS)
 	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(INC) $(AM_LDFLAGS) $(LDFLAGS) $(srcdir)/rrd_anomaly.c -o rrd_anomaly $(LIB)
 
-rrd_similarity: $(srcdir)/rrd_similarity.c Makefile $(LIBDPI) $(GEN_HEADERS)
+rrd_similarity: $(srcdir)/rrd_similarity.c Makefile $(LIBDPI_DEP) $(GEN_HEADERS)
 	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(INC) $(AM_LDFLAGS) $(LDFLAGS) $(srcdir)/rrd_similarity.c -o rrd_similarity $(LIB)
 
 clean:

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -49,7 +49,8 @@ NDPI_VERSION_MAJOR   = @NDPI_MAJOR@
 NDPI_LIB_STATIC      = libndpi.a
 NDPI_LIB_SHARED_BASE = libndpi.so
 NDPI_LIB_SHARED      = $(NDPI_LIB_SHARED_BASE).@NDPI_VERSION_SHORT@
-NDPI_LIBS            = $(NDPI_LIB_STATIC) $(NDPI_LIB_SHARED)
+ENABLE_SHARED        = @enable_shared@
+ENABLE_STATIC        = @enable_static@
 USE_HOST_LIBGCRYPT   = @USE_HOST_LIBGCRYPT@
 
 ifneq ($(USE_HOST_LIBGCRYPT),0)
@@ -69,6 +70,20 @@ NDPI_LIB_SHARED      = $(NDPI_LIB_SHARED_BASE)-@NDPI_VERSION_SHORT@.dll
 else
 SONAME_FLAG=-Wl,-soname,$(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR)
 endif
+endif
+
+# Conditionally build libraries based on configure flags
+NDPI_LIBS =
+ifeq ($(ENABLE_STATIC),yes)
+NDPI_LIBS += $(NDPI_LIB_STATIC)
+endif
+ifeq ($(ENABLE_SHARED),yes)
+NDPI_LIBS += $(NDPI_LIB_SHARED)
+endif
+
+# Sanity check: at least one library type must be enabled
+ifeq ($(NDPI_LIBS),)
+$(error Cannot build with both --disable-shared and --disable-static)
 endif
 
 all: $(NDPI_LIBS)
@@ -120,8 +135,10 @@ cppcheck:
 install: $(NDPI_LIBS)
 	@MKDIR_P@ $(DESTDIR)@libdir@
 	cp $(NDPI_LIBS) $(DESTDIR)@libdir@/
+ifeq ($(ENABLE_SHARED),yes)
 	cp -P $(NDPI_LIB_SHARED_BASE) $(DESTDIR)@libdir@/
 	cp -P $(NDPI_LIB_SHARED_BASE).$(NDPI_VERSION_MAJOR) $(DESTDIR)@libdir@/
+endif
 	@MKDIR_P@ $(DESTDIR)@includedir@/ndpi
 	#Avoid installing private header
 	# Installing header files to $(DESTDIR)@includedir@/ndpi

--- a/tests/dga/Makefile.in
+++ b/tests/dga/Makefile.in
@@ -18,9 +18,17 @@ else
 AM_CFLAGS=
 endif
 AM_CFLAGS+=-I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@
-LIBNDPI=$(top_builddir)/src/lib/libndpi.a
-LIBS=$(LIBNDPI) @ADDITIONAL_LIBS@ @LIBS@ -lpthread
 AM_LDFLAGS=@NDPI_LDFLAGS@
+ENABLE_STATIC        = @enable_static@
+ifeq ($(ENABLE_STATIC),yes)
+LIBNDPI=$(top_builddir)/src/lib/libndpi.a
+LIBNDPI_DEP=$(LIBNDPI)
+else
+LIBNDPI=-lndpi
+LIBNDPI_DEP=$(top_builddir)/src/lib/libndpi.so
+AM_LDFLAGS+=-L$(top_builddir)/src/lib
+endif
+LIBS=$(LIBNDPI) @ADDITIONAL_LIBS@ @LIBS@ -lpthread
 HEADERS=$(SRCHOME)/include/ndpi_api.h $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
 HEADERS+=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 OBJS=dga_evaluate
@@ -31,7 +39,7 @@ all: dga_evaluate$(EXE_SUFFIX)
 EXECUTABLE_SOURCES := dga_evaluate.c
 COMMON_SOURCES := $(filter-out $(EXECUTABLE_SOURCES),$(wildcard *.c ))
 
-dga_evaluate$(EXE_SUFFIX): $(LIBNDPI) dga_evaluate.o
+dga_evaluate$(EXE_SUFFIX): $(LIBNDPI_DEP) dga_evaluate.o
 	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(AM_LDFLAGS) $(LDFLAGS) dga_evaluate.o $(LIBS) -o $@
 
 %.o: %.c $(HEADERS) Makefile

--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -45,7 +45,7 @@ cd ndpi
 #There are two workarounds:
 # * pcap stuff + --with-only-libndpi: for introspector builds. As reported in #8939, configure is not able to detect external libraries in introspector builds
 # * ADDITIONAL_* stuff: to be able run tests/unit/unit (via chronos/check_tests.sh) even with the previous workaround
-./autogen.sh && AR=llvm-ar RANLIB=llvm-ranlib LDFLAGS="-L/usr/local/lib -lpcap" ADDITIONAL_INCS="-I/usr/local/include/json-c/" ADDITIONAL_LIBS="-L/usr/local/lib -ljson-c" ./configure --enable-fuzztargets --enable-tls-sigs --with-only-libndpi
+./autogen.sh && AR=llvm-ar RANLIB=llvm-ranlib LDFLAGS="-L/usr/local/lib -lpcap" ADDITIONAL_INCS="-I/usr/local/include/json-c/" ADDITIONAL_LIBS="-L/usr/local/lib -ljson-c" ./configure --disable-shared --enable-fuzztargets --enable-tls-sigs --with-only-libndpi
 make -j$(nproc)
 # Copy fuzzers
 # TEMPORARY HACK for #14297: let's check if introspector job failed because

--- a/tests/unit/Makefile.in
+++ b/tests/unit/Makefile.in
@@ -19,9 +19,17 @@ else
 AM_CFLAGS=
 endif
 AM_CFLAGS+=-I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@ @JSONC_CFLAGS@ @PCAP_INC@ @ADDITIONAL_INCS@
-LIBNDPI=$(top_builddir)/src/lib/libndpi.a
-LIBS=$(LIBNDPI) @PCAP_LIB@ @ADDITIONAL_LIBS@ @JSONC_LIBS@ @LIBS@
 AM_LDFLAGS=@NDPI_LDFLAGS@
+ENABLE_STATIC        = @enable_static@
+ifeq ($(ENABLE_STATIC),yes)
+LIBNDPI=$(top_builddir)/src/lib/libndpi.a
+LIBNDPI_DEP=$(LIBNDPI)
+else
+LIBNDPI=-lndpi
+LIBNDPI_DEP=$(top_builddir)/src/lib/libndpi.so
+AM_LDFLAGS+=-L$(top_builddir)/src/lib
+endif
+LIBS=$(LIBNDPI) @PCAP_LIB@ @ADDITIONAL_LIBS@ @JSONC_LIBS@ @LIBS@
 HEADERS=$(SRCHOME)/include/ndpi_api.h $(SRCHOME)/include/ndpi_typedefs.h $(SRCHOME)/include/ndpi_protocol_ids.h
 HEADERS+=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 OBJS=unit
@@ -55,7 +63,7 @@ all: unit$(EXE_SUFFIX)
 EXECUTABLE_SOURCES := unit.c
 COMMON_SOURCES := $(filter-out $(EXECUTABLE_SOURCES),$(wildcard *.c ))
 
-unit$(EXE_SUFFIX): $(LIBNDPI) unit.o
+unit$(EXE_SUFFIX): $(LIBNDPI_DEP) unit.o
 	$(CC) $(AM_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(AM_LDFLAGS) $(LDFLAGS) unit.o $(LIBS) -o $@
 
 %.o: %.c $(HEADERS) Makefile


### PR DESCRIPTION
The configure flags --disable-shared and --disable-static were properly recognized by libtool but ignored by nDPI's custom src/lib/Makefile.in, which always built both static and shared libraries regardless of the flags specified.

This commit fixes the issue by:

1. Exporting enable_shared and enable_static variables from configure.ac via AC_SUBST so they're available in Makefiles

2. Adding configure-time error checks:
   - Prevent both --disable-shared and --disable-static simultaneously
   - Require static library for --enable-fuzztargets (fuzz targets need static linking for proper instrumentation)

3. Modifying src/lib/Makefile.in to conditionally build libraries

4. Updating all build targets to support dynamic linking when static library is disabled. These targets now:
   - Use static library when available (preferred, default behavior)
   - Fall back to dynamic linking with -lndpi when --disable-static

5. Adding configuration summary output showing which libraries will be built (enabled/disabled status for both shared and static)

fuzz: disable creation of (unused) shared library

🤖 Generated with [Claude Code](https://claude.com/claude-code)


