### PR TITLE
Enhanced TLS blocks computation and included in nDPI Fingerprint

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -2796,23 +2796,6 @@ static void printFlowSerialized(struct ndpi_flow_info *flow)
   }
   
   /* Bins */
-  if(flow->ssh_tls.num_blocks > 0) {
-    u_int i;
-    
-    ndpi_serialize_start_of_list(serializer, "tls_blocks");
-
-    for(i=0; i<flow->ssh_tls.num_blocks; i++) {
-      char str[64];
-
-      snprintf(str, sizeof(str), "%s:%d",
-	       ndpi_print_encoded_tls_block_type(flow->ssh_tls.blocks[i].block_type, true),
-	       flow->ssh_tls.blocks[i].len);
-      ndpi_serialize_string_string(serializer, "", str);
-    }
-    
-    ndpi_serialize_end_of_list(serializer);
-  }
-  
   ndpi_serialize_start_of_block(serializer, "plen_bins");
   ndpi_serialize_string_string(serializer, "raw",
 			       sprint_bin(buf, sizeof(buf), &flow->payload_len_bin, ",", false));

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -2655,8 +2655,8 @@ static void printFlow(u_int32_t id, struct ndpi_flow_info *flow, u_int16_t threa
       fprintf(out, "[TLS blocks: ");
 
       for(i=0; i<flow->ssh_tls.num_blocks; i++)
-	fprintf(out, "%s%s/%d", (i > 0) ? "," : "",
-		ndpi_print_encoded_tls_block_type(flow->ssh_tls.blocks[i].block_type),
+	fprintf(out, "%s%s=%d", (i > 0) ? "," : "",
+		ndpi_print_encoded_tls_block_type(flow->ssh_tls.blocks[i].block_type, true),
 		flow->ssh_tls.blocks[i].len);
 
       fprintf(out, "]");
@@ -2805,7 +2805,7 @@ static void printFlowSerialized(struct ndpi_flow_info *flow)
       char str[64];
 
       snprintf(str, sizeof(str), "%s:%d",
-	       ndpi_print_encoded_tls_block_type(flow->ssh_tls.blocks[i].block_type),
+	       ndpi_print_encoded_tls_block_type(flow->ssh_tls.blocks[i].block_type, true),
 	       flow->ssh_tls.blocks[i].len);
       ndpi_serialize_string_string(serializer, "", str);
     }

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -1131,7 +1131,7 @@ extern "C" {
   char *ndpi_stack2str(struct ndpi_detection_module_struct *ndpi_str,
                        struct ndpi_proto_stack *stack, char *buf, u_int buf_len);
   ndpi_tls_block_type ndpi_encode_tls_block_type(u_int8_t block_type, u_int8_t handshake_type);
-  const char* ndpi_print_encoded_tls_block_type(ndpi_tls_block_type block_type);
+  const char* ndpi_print_encoded_tls_block_type(ndpi_tls_block_type block_type, bool numeric_mode);
   
   ndpi_proto_defaults_t* ndpi_get_proto_defaults(struct ndpi_detection_module_struct *ndpi_mod);
   u_int ndpi_get_ndpi_detection_module_size(void);

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -853,7 +853,8 @@ typedef enum {
 } ndpi_tls_block_type;
 
 struct ndpi_tls_block {
-  ndpi_tls_block_type block_type;
+  u_int8_t block_type /* ndpi_tls_block_type */;
+  u_int8_t same_pkt:1, _unused:7;
   int16_t len; /* + = src->dst, - = dst->src */
 };
 
@@ -1548,7 +1549,7 @@ typedef struct {
   u_int16_t num_supported_versions, supported_version[MAX_NUM_JA];
   u_int16_t num_key_share_groups, key_share_group[MAX_NUM_JA];
   char signature_algorithms_str[MAX_JA_STRLEN], alpn[MAX_JA_STRLEN];
-  char alpn_original_last;  /* Store original last character before null terminator */  
+  char alpn_original_last;  /* Store original last character before null terminator */
 } ndpi_tls_client_info;
 
 typedef struct {
@@ -1557,7 +1558,7 @@ typedef struct {
   u_int16_t num_tls_extensions, tls_extension[MAX_NUM_JA];
   u_int16_t tls_supported_version;
   u_int16_t num_elliptic_curve_point_format, elliptic_curve_point_format[MAX_NUM_JA];
-  char alpn[MAX_JA_STRLEN];  
+  char alpn[MAX_JA_STRLEN];
 } ndpi_tls_server_info;
 
 struct ndpi_flow_struct {
@@ -1910,7 +1911,7 @@ struct ndpi_flow_struct {
     NDPIProtocolPluginEntryPoint *plugin;
     void *plugin_data;
   } custom;
-  
+
   /* **Packet** metadata for flows where monitoring is enabled. It is reset after each packet! */
   struct ndpi_metadata_monitoring *monit;
 

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -1206,8 +1206,8 @@ void ndpi_serialize_proto(struct ndpi_detection_module_struct *ndpi_struct,
 
 /* ********************************** */
 
-static void ndpi_tls2json(ndpi_serializer *serializer, struct ndpi_flow_struct *flow, bool is_tls_proto)
-{
+static void ndpi_tls2json(struct ndpi_detection_module_struct *ndpi_struct, ndpi_serializer *serializer,
+			  struct ndpi_flow_struct *flow, bool is_tls_proto) {
   if(flow->protos.tls_quic.ssl_version) {
     char buf[64];
     char notBefore[32], notAfter[32];
@@ -1267,7 +1267,7 @@ static void ndpi_tls2json(ndpi_serializer *serializer, struct ndpi_flow_struct *
       if(flow->protos.tls_quic.sha1_certificate_fingerprint[0] != '\0') {
         for(i=0, off=0; i<20; i++) {
           int rc = ndpi_snprintf(&buf[off], sizeof(buf)-off,"%s%02X", (i > 0) ? ":" : "",
-                               flow->protos.tls_quic.sha1_certificate_fingerprint[i] & 0xFF);
+				 flow->protos.tls_quic.sha1_certificate_fingerprint[i] & 0xFF);
 
           if(rc <= 0) break; else off += rc;
         }
@@ -1275,126 +1275,160 @@ static void ndpi_tls2json(ndpi_serializer *serializer, struct ndpi_flow_struct *
         ndpi_serialize_string_string(serializer, "fingerprint", buf);
       }
 
-      if (is_tls_proto == true)
-        ndpi_serialize_string_uint32(serializer, "blocks", flow->l4.tcp.tls.num_tls_blocks);
+      if (is_tls_proto == true) {
+	if(ndpi_struct->cfg.tls_blocks_analysis_enabled) {
+	  u_int16_t i, idx = 0;
+	  int ret;
+	  char buf[256];
+
+	  ndpi_serialize_start_of_block(serializer, "tls_blocks");
+	  ndpi_serialize_string_uint32(serializer, "num_blocks", flow->l4.tcp.tls.num_tls_blocks);
+
+	  ndpi_serialize_start_of_list(serializer, "blocks");
+
+	  for(i=0; i< flow->l4.tcp.tls.num_tls_blocks; i++) {
+	    if(!flow->l4.tcp.tls.tls_blocks[i].same_pkt) {
+	      if(idx > 0) {
+		ndpi_serialize_string_string(serializer, "", buf);
+		idx = 0;
+	      }
+	    }
+
+	    ret = snprintf(&buf[idx], sizeof(buf)-1, "%s%s=%d",
+			   (idx > 0) ? "," : "",
+			   ndpi_print_encoded_tls_block_type(flow->l4.tcp.tls.tls_blocks[i].block_type),
+			   flow->l4.tcp.tls.tls_blocks[i].len);
+
+	    if(ret > 0) idx += ret; else break;	    
+	  } /* for */
+
+	  if(idx > 0) {
+	    ndpi_serialize_string_string(serializer, "", buf);
+	    
+	    ndpi_serialize_end_of_list(serializer);
+
+	    ndpi_serialize_end_of_block(serializer);
+	  }
+	}
 
 #ifdef TLS_HANDLE_SIGNATURE_ALGORITMS
-      ndpi_serialize_string_uint32(serializer, "sig_algs", flow->protos.tls_quic.num_tls_signature_algorithms);
+	ndpi_serialize_string_uint32(serializer, "sig_algs", flow->protos.tls_quic.num_tls_signature_algorithms);
 #endif
 
-      if(flow->protos.tls_quic.ja_client != NULL) {
-	ndpi_tls_client_info *c = flow->protos.tls_quic.ja_client;
-	u_int16_t i;
-	
-	ndpi_serialize_start_of_block(serializer, "client_data");
+	if(flow->protos.tls_quic.ja_client != NULL) {
+	  ndpi_tls_client_info *c = flow->protos.tls_quic.ja_client;
+	  u_int16_t i;
 
-	if(c->num_ciphers > 0) {
-	  ndpi_serialize_start_of_list(serializer, "ciphers");
-	  
-	  for(i=0; i<c->num_ciphers; i++)
-	    ndpi_serialize_string_uint32(serializer, "", c->cipher[i]);
+	  ndpi_serialize_start_of_block(serializer, "client_data");
 
-	  ndpi_serialize_end_of_list(serializer);
+	  if(c->num_ciphers > 0) {
+	    ndpi_serialize_start_of_list(serializer, "ciphers");
+
+	    for(i=0; i<c->num_ciphers; i++)
+	      ndpi_serialize_string_uint32(serializer, "", c->cipher[i]);
+
+	    ndpi_serialize_end_of_list(serializer);
+	  }
+
+	  if(c->num_tls_extensions > 0) {
+	    ndpi_serialize_start_of_list(serializer, "tls_extensions");
+
+	    for(i=0; i<c->num_tls_extensions; i++)
+	      ndpi_serialize_string_uint32(serializer, "", c->tls_extension[i]);
+
+	    ndpi_serialize_end_of_list(serializer);
+	  }
+
+	  if(c->num_elliptic_curve_groups > 0) {
+	    ndpi_serialize_start_of_list(serializer, "elliptic_curve_groups");
+
+	    for(i=0; i<c->num_elliptic_curve_groups; i++)
+	      ndpi_serialize_string_uint32(serializer, "", c->elliptic_curve_group[i]);
+
+	    ndpi_serialize_end_of_list(serializer);
+	  }
+
+	  if(c->num_elliptic_curve_point_format > 0) {
+	    ndpi_serialize_start_of_list(serializer, "elliptic_curve_point_format");
+
+	    for(i=0; i<c->num_elliptic_curve_point_format; i++)
+	      ndpi_serialize_string_uint32(serializer, "", c->elliptic_curve_point_format[i]);
+
+	    ndpi_serialize_end_of_list(serializer);
+	  }
+
+	  if(c->num_signature_algorithms > 0) {
+	    ndpi_serialize_start_of_list(serializer, "signature_algorithms");
+
+	    for(i=0; i<c->num_signature_algorithms; i++)
+	      ndpi_serialize_string_uint32(serializer, "", c->signature_algorithm[i]);
+
+	    ndpi_serialize_end_of_list(serializer);
+	  }
+
+	  if(c->num_key_share_groups > 0) {
+	    ndpi_serialize_start_of_list(serializer, "key_share_groups");
+
+	    for(i=0; i<c->num_key_share_groups; i++)
+	      ndpi_serialize_string_uint32(serializer, "", c->key_share_group[i]);
+
+	    ndpi_serialize_end_of_list(serializer);
+	  }
+
+	  if(c->num_supported_versions > 0) {
+	    ndpi_serialize_start_of_list(serializer, "supported_versions");
+
+	    for(i=0; i<c->num_supported_versions; i++)
+	      ndpi_serialize_string_uint32(serializer, "", c->supported_version[i]);
+
+	    ndpi_serialize_end_of_list(serializer);
+	  }
+
+	  ndpi_serialize_end_of_block(serializer);
 	}
 
-	if(c->num_tls_extensions > 0) {
-	  ndpi_serialize_start_of_list(serializer, "tls_extensions");
-	  
-	  for(i=0; i<c->num_tls_extensions; i++)
-	    ndpi_serialize_string_uint32(serializer, "", c->tls_extension[i]);
+	if(flow->protos.tls_quic.ja_server != NULL) {
+	  ndpi_tls_server_info *s = flow->protos.tls_quic.ja_server;
+	  u_int16_t i;
 
-	  ndpi_serialize_end_of_list(serializer);
-	}
+	  ndpi_serialize_start_of_block(serializer, "server_data");
 
-	if(c->num_elliptic_curve_groups > 0) {
-	  ndpi_serialize_start_of_list(serializer, "elliptic_curve_groups");
-	  
-	  for(i=0; i<c->num_elliptic_curve_groups; i++)
-	    ndpi_serialize_string_uint32(serializer, "", c->elliptic_curve_group[i]);
+	  if(s->num_ciphers > 0) {
+	    ndpi_serialize_start_of_list(serializer, "ciphers");
 
-	  ndpi_serialize_end_of_list(serializer);
-	}
+	    for(i=0; i<s->num_ciphers; i++)
+	      ndpi_serialize_string_uint32(serializer, "", s->cipher[i]);
 
-	if(c->num_elliptic_curve_point_format > 0) {
-	  ndpi_serialize_start_of_list(serializer, "elliptic_curve_point_format");
-	  
-	  for(i=0; i<c->num_elliptic_curve_point_format; i++)
-	    ndpi_serialize_string_uint32(serializer, "", c->elliptic_curve_point_format[i]);
+	    ndpi_serialize_end_of_list(serializer);
+	  }
 
-	  ndpi_serialize_end_of_list(serializer);
-	}
-	
-	if(c->num_signature_algorithms > 0) {
-	  ndpi_serialize_start_of_list(serializer, "signature_algorithms");
-	  
-	  for(i=0; i<c->num_signature_algorithms; i++)
-	    ndpi_serialize_string_uint32(serializer, "", c->signature_algorithm[i]);
+	  if(s->num_tls_extensions > 0) {
+	    ndpi_serialize_start_of_list(serializer, "tls_extensions");
 
-	  ndpi_serialize_end_of_list(serializer);
-	}
+	    for(i=0; i<s->num_tls_extensions; i++)
+	      ndpi_serialize_string_uint32(serializer, "", s->tls_extension[i]);
 
-	if(c->num_key_share_groups > 0) {
-	  ndpi_serialize_start_of_list(serializer, "key_share_groups");
-	  
-	  for(i=0; i<c->num_key_share_groups; i++)
-	    ndpi_serialize_string_uint32(serializer, "", c->key_share_group[i]);
+	    ndpi_serialize_end_of_list(serializer);
+	  }
 
-	  ndpi_serialize_end_of_list(serializer);
-	}
+	  if(s->num_elliptic_curve_point_format > 0) {
+	    ndpi_serialize_start_of_list(serializer, "elliptic_curve_point_format");
 
-	if(c->num_supported_versions > 0) {
-	  ndpi_serialize_start_of_list(serializer, "supported_versions");
-	  
-	  for(i=0; i<c->num_supported_versions; i++)
-	    ndpi_serialize_string_uint32(serializer, "", c->supported_version[i]);
+	    for(i=0; i<s->num_elliptic_curve_point_format; i++)
+	      ndpi_serialize_string_uint32(serializer, "", s->elliptic_curve_point_format[i]);
 
-	  ndpi_serialize_end_of_list(serializer);
+	    ndpi_serialize_end_of_list(serializer);
+	  }
+
+	  ndpi_serialize_end_of_block(serializer);
 	}
 
 	ndpi_serialize_end_of_block(serializer);
       }
-      
-      if(flow->protos.tls_quic.ja_server != NULL) {
-	ndpi_tls_server_info *s = flow->protos.tls_quic.ja_server;
-	u_int16_t i;
-	
-	ndpi_serialize_start_of_block(serializer, "server_data");
-
-	if(s->num_ciphers > 0) {
-	  ndpi_serialize_start_of_list(serializer, "ciphers");
-	  
-	  for(i=0; i<s->num_ciphers; i++)
-	    ndpi_serialize_string_uint32(serializer, "", s->cipher[i]);
-
-	  ndpi_serialize_end_of_list(serializer);
-	}
-
-	if(s->num_tls_extensions > 0) {
-	  ndpi_serialize_start_of_list(serializer, "tls_extensions");
-	  
-	  for(i=0; i<s->num_tls_extensions; i++)
-	    ndpi_serialize_string_uint32(serializer, "", s->tls_extension[i]);
-
-	  ndpi_serialize_end_of_list(serializer);
-	}
-
-	if(s->num_elliptic_curve_point_format > 0) {
-	  ndpi_serialize_start_of_list(serializer, "elliptic_curve_point_format");
-	  
-	  for(i=0; i<s->num_elliptic_curve_point_format; i++)
-	    ndpi_serialize_string_uint32(serializer, "", s->elliptic_curve_point_format[i]);
-
-	  ndpi_serialize_end_of_list(serializer);
-	}
-	
-	ndpi_serialize_end_of_block(serializer);
-      }
-      
-      ndpi_serialize_end_of_block(serializer);
     }
   }
 }
-
+ 
 /* ********************************** */
 
 char* print_ndpi_address_port(ndpi_address_port *ap, char *buf, u_int buf_len) {
@@ -1417,9 +1451,9 @@ void ndpi_ssh_serialize_csv(ndpi_serializer *serializer,
 			    const char *csv_string,
 			    const char* label) {
   u_int offset=0;
-  
+
   if(!csv_string) return;
-  
+
   ndpi_serialize_start_of_list(serializer, label);
 
   while(csv_string[offset] != '\0') {
@@ -1433,7 +1467,7 @@ void ndpi_ssh_serialize_csv(ndpi_serializer *serializer,
       messages after the KEX starts.
     */
     const char *toskip = "ext-info-";
-      
+
     while((csv_string[new_offset] != ',')
 	  && (csv_string[new_offset] != '\0'))
       new_offset++, len++;
@@ -1441,15 +1475,15 @@ void ndpi_ssh_serialize_csv(ndpi_serializer *serializer,
     if(ndpi_strnstr(&csv_string[offset], toskip, len) == NULL)
       ndpi_serialize_string_string_len(serializer, "",
 				       &csv_string[offset], len);
-    
+
     offset += len;
-    
+
     if(csv_string[offset] == ',')
       offset++;
     else
       break;
   }
-  
+
   ndpi_serialize_end_of_list(serializer);
 }
 
@@ -1671,7 +1705,7 @@ int ndpi_dpi2json(struct ndpi_detection_module_struct *ndpi_struct,
                           flow->protos.tls_quic.quic_version);
     ndpi_serialize_string_string(serializer, "quic_version", quic_version);
 
-    ndpi_tls2json(serializer, flow, false);
+    ndpi_tls2json(ndpi_struct, serializer, flow, false);
 
     ndpi_serialize_end_of_block(serializer);
     break;
@@ -1863,7 +1897,7 @@ int ndpi_dpi2json(struct ndpi_detection_module_struct *ndpi_struct,
 
     if(ndpi_struct->cfg.ssh_hassh_data_enabled) {
       ndpi_serialize_start_of_block(serializer, "key_exchange_algorithms");
-      
+
       if(flow->protos.ssh.client_key_exchange_algorithms)
 	ndpi_ssh_serialize_csv(serializer, flow->protos.ssh.client_key_exchange_algorithms, "client");
 
@@ -1876,7 +1910,7 @@ int ndpi_dpi2json(struct ndpi_detection_module_struct *ndpi_struct,
 				     flow->protos.ssh.key_exchange_method);
       ndpi_serialize_end_of_block(serializer);
     }
-    
+
     ndpi_serialize_end_of_block(serializer);
     break;
 
@@ -1922,11 +1956,11 @@ int ndpi_dpi2json(struct ndpi_detection_module_struct *ndpi_struct,
     break;
 
   case NDPI_PROTOCOL_TLS:
-    ndpi_tls2json(serializer, flow, true);
+    ndpi_tls2json(ndpi_struct, serializer, flow, true);
     break;
 
   case NDPI_PROTOCOL_DTLS:
-    ndpi_tls2json(serializer, flow, false);
+    ndpi_tls2json(ndpi_struct, serializer, flow, false);
 #ifdef CUSTOM_NDPI_PROTOCOLS
 #include "../../../nDPI-custom/ndpi_utils_dpi2json_dtls.c"
 #endif
@@ -1939,8 +1973,8 @@ int ndpi_dpi2json(struct ndpi_detection_module_struct *ndpi_struct,
 
   if((flow->custom.plugin != NULL)
      && (flow->custom.plugin->jsonExportFctn != NULL))
-    flow->custom.plugin->jsonExportFctn(ndpi_struct, flow, serializer); 
-  
+    flow->custom.plugin->jsonExportFctn(ndpi_struct, flow, serializer);
+
   ndpi_serialize_end_of_block(serializer); // "ndpi"
 
   return(0);
@@ -5106,7 +5140,7 @@ char *ndpi_stack2str(struct ndpi_detection_module_struct *ndpi_str,
 
 ndpi_tls_block_type ndpi_encode_tls_block_type(u_int8_t block_type, u_int8_t handshake_type) {
   switch(block_type) {
-  case 20: /* Change Cipher */    
+  case 20: /* Change Cipher */
     return(tls_change_cipher);
   case 21: /* Alert */
     return(tls_alert);
@@ -5151,23 +5185,22 @@ ndpi_tls_block_type ndpi_encode_tls_block_type(u_int8_t block_type, u_int8_t han
 
 const char* ndpi_print_encoded_tls_block_type(ndpi_tls_block_type block_type) {
   switch(block_type) {
-  case tls_change_cipher: return("ChangeCipher"); 
-  case tls_alert: return("Alert");
-  case tls_handshake_hello_request: return("Handshake:HelloRequest");
-  case tls_handshake_client_hello: return("Handshake:ClientHello");
-  case tls_handshake_server_hello: return("Handshake:ServerHello");
-  case tls_handshake_new_session_ticket: return("Handshake:NewSessTicket");
-  case tls_handshake_encrypted_extn: return("Handshake:EncryptedExtn");
-  case tls_handshake_certificate: return("Handshake:Certificate");
+  case tls_change_cipher:                 return("ChangeCipher");
+  case tls_alert:                         return("Alert");
+  case tls_handshake_hello_request:       return("Handshake:HelloRequest");
+  case tls_handshake_client_hello:        return("Handshake:ClientHello");
+  case tls_handshake_server_hello:        return("Handshake:ServerHello");
+  case tls_handshake_new_session_ticket:  return("Handshake:NewSessTicket");
+  case tls_handshake_encrypted_extn:      return("Handshake:EncryptedExtn");
+  case tls_handshake_certificate:         return("Handshake:Certificate");
   case tls_handshake_server_key_exchange: return("Handshake:ServerKeyExch");
   case tls_handshake_certificate_request: return("Handshake:CertRequest");
-  case tls_handshake_server_hello_done: return("Handshake:ServerHelloDone");
-  case tls_handshake_certificate_verify: return("Handshake:CertVerify");
+  case tls_handshake_server_hello_done:   return("Handshake:ServerHelloDone");
+  case tls_handshake_certificate_verify:  return("Handshake:CertVerify");
   case tls_handshake_client_key_exchange: return("Handshake:ClientKeyExch");
-  case tls_handshake_finished: return("Handshake:Finished");
-  case tls_application_data: return("AppData");
-  case tls_heartbeat: return("Heartbeat");
-  default: return("Unknown");
+  case tls_handshake_finished:            return("Handshake:Finished");
+  case tls_application_data:              return("AppData");
+  case tls_heartbeat:                     return("Heartbeat");
+  default:                                return("Unknown");
   }
 }
-

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -4954,14 +4954,14 @@ static char* ndpi_compute_tls_blocks_flow_fingerprint(struct ndpi_flow_struct *f
   for(i=0; i< flow->l4.tcp.tls.num_tls_blocks; i++) {
     if(!flow->l4.tcp.tls.tls_blocks[i].same_pkt) {
       if(idx > 0) {
-	ret = snprintf(&fp_buf[idx], fp_buf_len-1, ";");
+	ret = snprintf(&fp_buf[idx], fp_buf_len-idx-1, ";");
 	if(ret > 0) idx += ret; else break;
 	first = true;
       }
     } else
       first = false;
 
-    ret = snprintf(&fp_buf[idx], fp_buf_len-1, "%s%s=%d",
+    ret = snprintf(&fp_buf[idx], fp_buf_len-idx-1, "%s%s=%d",
 		   (!first) ? "," : "",
 		   ndpi_print_encoded_tls_block_type(flow->l4.tcp.tls.tls_blocks[i].block_type, true),
 		   flow->l4.tcp.tls.tls_blocks[i].len);
@@ -5008,7 +5008,7 @@ char* ndpi_compute_ndpi_flow_fingerprint(struct ndpi_detection_module_struct *nd
     u_int8_t sha_hash[NDPI_SHA256_BLOCK_SIZE];
     size_t s;
     u_int8_t fp_buf[128];
-    char l7_pf_tls_blocks_buf[64];
+    char l7_pf_tls_blocks_buf[256];
 
     if(flow->protos.tls_quic.ja4_client[0] != '\0')
       l7_pf = flow->protos.tls_quic.ja4_client;

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -1296,15 +1296,15 @@ static void ndpi_tls2json(struct ndpi_detection_module_struct *ndpi_struct, ndpi
 
 	    ret = snprintf(&buf[idx], sizeof(buf)-1, "%s%s=%d",
 			   (idx > 0) ? "," : "",
-			   ndpi_print_encoded_tls_block_type(flow->l4.tcp.tls.tls_blocks[i].block_type),
+			   ndpi_print_encoded_tls_block_type(flow->l4.tcp.tls.tls_blocks[i].block_type, true),
 			   flow->l4.tcp.tls.tls_blocks[i].len);
 
-	    if(ret > 0) idx += ret; else break;	    
+	    if(ret > 0) idx += ret; else break;
 	  } /* for */
 
 	  if(idx > 0) {
 	    ndpi_serialize_string_string(serializer, "", buf);
-	    
+
 	    ndpi_serialize_end_of_list(serializer);
 
 	    ndpi_serialize_end_of_block(serializer);
@@ -1428,7 +1428,7 @@ static void ndpi_tls2json(struct ndpi_detection_module_struct *ndpi_struct, ndpi
     }
   }
 }
- 
+
 /* ********************************** */
 
 char* print_ndpi_address_port(ndpi_address_port *ap, char *buf, u_int buf_len) {
@@ -4939,6 +4939,56 @@ u_int16_t ndpi_get_master_proto(struct ndpi_detection_module_struct *ndpi_struct
 
 /* **************************************** */
 
+static char* ndpi_compute_tls_blocks_flow_fingerprint(struct ndpi_flow_struct *flow,
+						      char *fp_buf, u_int fp_buf_len) {
+  u_int16_t i, idx = 0;
+  int ret;
+  bool first = true;
+  u_int8_t sha_hash[NDPI_SHA256_BLOCK_SIZE];
+
+  if((flow->l4_proto != IPPROTO_TCP) || (flow->l4.tcp.tls.num_tls_blocks == 0))
+    return("");
+
+  fp_buf[0] = '\0'; /* Not really necessary, but just to be sure */
+
+  for(i=0; i< flow->l4.tcp.tls.num_tls_blocks; i++) {
+    if(!flow->l4.tcp.tls.tls_blocks[i].same_pkt) {
+      if(idx > 0) {
+	ret = snprintf(&fp_buf[idx], fp_buf_len-1, ";");
+	if(ret > 0) idx += ret; else break;
+	first = true;
+      }
+    } else
+      first = false;
+
+    ret = snprintf(&fp_buf[idx], fp_buf_len-1, "%s%s=%d",
+		   (!first) ? "," : "",
+		   ndpi_print_encoded_tls_block_type(flow->l4.tcp.tls.tls_blocks[i].block_type, true),
+		   flow->l4.tcp.tls.tls_blocks[i].len);
+
+    if(ret > 0) idx += ret; else break;
+  } /* for */
+
+#if 0
+  fprintf(stderr, "#### [sport=%u] %s\n", ntohs(flow->c_port), fp_buf);
+#endif
+
+  ndpi_sha256((u_char*)fp_buf, idx, sha_hash);
+
+  ndpi_snprintf((char*)fp_buf, fp_buf_len-1,
+		"%02x%02x%02x%02x%02x%02x%02x%02x"
+		"%02x%02x%02x%02x%02x%02x%02x%02x",
+		sha_hash[0], sha_hash[1], sha_hash[2],    sha_hash[3],
+		sha_hash[4], sha_hash[5], sha_hash[6],    sha_hash[7],
+		sha_hash[8], sha_hash[9], sha_hash[10],   sha_hash[11],
+		sha_hash[12], sha_hash[13], sha_hash[14], sha_hash[15]
+		);
+
+  return(fp_buf);
+}
+
+/* **************************************** */
+
 char* ndpi_compute_ndpi_flow_fingerprint(struct ndpi_detection_module_struct *ndpi_str,
 					 struct ndpi_flow_struct *flow) {
   if(ndpi_str->cfg.ndpi_fingerprint_enabled &&
@@ -4953,13 +5003,19 @@ char* ndpi_compute_ndpi_flow_fingerprint(struct ndpi_detection_module_struct *nd
      (flow->tcp.fingerprint || flow->protos.tls_quic.ja4_client[0] != '\0')) {
     char *l4_fp = flow->tcp.fingerprint ? flow->tcp.fingerprint : "no_l4_fp";
     char *l7_pf = "no_app_fp_cli";
+    char *l7_pf_tls_blocks = "";
     char *l7_pf_server = "no_app_fp_srv";
     u_int8_t sha_hash[NDPI_SHA256_BLOCK_SIZE];
     size_t s;
     u_int8_t fp_buf[128];
+    char l7_pf_tls_blocks_buf[64];
 
     if(flow->protos.tls_quic.ja4_client[0] != '\0')
       l7_pf = flow->protos.tls_quic.ja4_client;
+
+    if(ndpi_str->cfg.tls_blocks_analysis_enabled)
+      l7_pf_tls_blocks = ndpi_compute_tls_blocks_flow_fingerprint(flow,
+								  l7_pf_tls_blocks_buf, sizeof(l7_pf_tls_blocks_buf));
 
     if(ndpi_str->cfg.ndpi_fingerprint_format == NDPI_CLIENT_SERVER_NDPI_FINGERPRINT) {
       if(flow->protos.tls_quic.sha1_certificate_fingerprint[0] != '\0')
@@ -4970,7 +5026,7 @@ char* ndpi_compute_ndpi_flow_fingerprint(struct ndpi_detection_module_struct *nd
       }
     }
 
-    s = snprintf((char*)fp_buf, sizeof(fp_buf)-1, "%s-%s-%s", l4_fp, l7_pf, l7_pf_server);
+    s = snprintf((char*)fp_buf, sizeof(fp_buf)-1, "%s-%s%s-%s", l4_fp, l7_pf, l7_pf_tls_blocks, l7_pf_server);
     if(s > 0) {
       s = ndpi_min(s, sizeof(fp_buf)-1);
       ndpi_sha256(fp_buf, s, sha_hash);
@@ -5183,24 +5239,24 @@ ndpi_tls_block_type ndpi_encode_tls_block_type(u_int8_t block_type, u_int8_t han
 
 /* ****************************************** */
 
-const char* ndpi_print_encoded_tls_block_type(ndpi_tls_block_type block_type) {
+const char* ndpi_print_encoded_tls_block_type(ndpi_tls_block_type block_type, bool numeric_mode) {
   switch(block_type) {
-  case tls_change_cipher:                 return("ChangeCipher");
-  case tls_alert:                         return("Alert");
-  case tls_handshake_hello_request:       return("Handshake:HelloRequest");
-  case tls_handshake_client_hello:        return("Handshake:ClientHello");
-  case tls_handshake_server_hello:        return("Handshake:ServerHello");
-  case tls_handshake_new_session_ticket:  return("Handshake:NewSessTicket");
-  case tls_handshake_encrypted_extn:      return("Handshake:EncryptedExtn");
-  case tls_handshake_certificate:         return("Handshake:Certificate");
-  case tls_handshake_server_key_exchange: return("Handshake:ServerKeyExch");
-  case tls_handshake_certificate_request: return("Handshake:CertRequest");
-  case tls_handshake_server_hello_done:   return("Handshake:ServerHelloDone");
-  case tls_handshake_certificate_verify:  return("Handshake:CertVerify");
-  case tls_handshake_client_key_exchange: return("Handshake:ClientKeyExch");
-  case tls_handshake_finished:            return("Handshake:Finished");
-  case tls_application_data:              return("AppData");
-  case tls_heartbeat:                     return("Heartbeat");
-  default:                                return("Unknown");
+  case tls_change_cipher:                 return(numeric_mode ? "20"    : "ChangeCipher");
+  case tls_alert:                         return(numeric_mode ? "21"    : "Alert");
+  case tls_handshake_hello_request:       return(numeric_mode ? "22:0"  : "Handshake:HelloRequest");
+  case tls_handshake_client_hello:        return(numeric_mode ? "22:1"  : "Handshake:ClientHello");
+  case tls_handshake_server_hello:        return(numeric_mode ? "22:2"  : "Handshake:ServerHello");
+  case tls_handshake_new_session_ticket:  return(numeric_mode ? "22:4"  : "Handshake:NewSessTicket");
+  case tls_handshake_encrypted_extn:      return(numeric_mode ? "22:8"  : "Handshake:EncryptedExtn");
+  case tls_handshake_certificate:         return(numeric_mode ? "22:11" : "Handshake:Certificate");
+  case tls_handshake_server_key_exchange: return(numeric_mode ? "22:12" : "Handshake:ServerKeyExch");
+  case tls_handshake_certificate_request: return(numeric_mode ? "22:13" : "Handshake:CertRequest");
+  case tls_handshake_server_hello_done:   return(numeric_mode ? "22:14" : "Handshake:ServerHelloDone");
+  case tls_handshake_certificate_verify:  return(numeric_mode ? "22:15" : "Handshake:CertVerify");
+  case tls_handshake_client_key_exchange: return(numeric_mode ? "22:16" : "Handshake:ClientKeyExch");
+  case tls_handshake_finished:            return(numeric_mode ? "22:20" : "Handshake:Finished");
+  case tls_application_data:              return(numeric_mode ? "21"    : "AppData");
+  case tls_heartbeat:                     return(numeric_mode ? "24"    : "Heartbeat");
+  default:                                return(numeric_mode ? "0"     : "Unknown");
   }
 }

--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -1276,15 +1276,13 @@ static void ndpi_tls2json(struct ndpi_detection_module_struct *ndpi_struct, ndpi
       }
 
       if (is_tls_proto == true) {
-	if(ndpi_struct->cfg.tls_blocks_analysis_enabled) {
+	if(ndpi_struct->cfg.tls_blocks_analysis_enabled
+	   && (flow->l4.tcp.tls.num_tls_blocks > 0)) {
 	  u_int16_t i, idx = 0;
 	  int ret;
 	  char buf[256];
 
-	  ndpi_serialize_start_of_block(serializer, "tls_blocks");
-	  ndpi_serialize_string_uint32(serializer, "num_blocks", flow->l4.tcp.tls.num_tls_blocks);
-
-	  ndpi_serialize_start_of_list(serializer, "blocks");
+	  ndpi_serialize_start_of_list(serializer, "tls_blocks");
 
 	  for(i=0; i< flow->l4.tcp.tls.num_tls_blocks; i++) {
 	    if(!flow->l4.tcp.tls.tls_blocks[i].same_pkt) {
@@ -1306,8 +1304,6 @@ static void ndpi_tls2json(struct ndpi_detection_module_struct *ndpi_struct, ndpi
 	    ndpi_serialize_string_string(serializer, "", buf);
 
 	    ndpi_serialize_end_of_list(serializer);
-
-	    ndpi_serialize_end_of_block(serializer);
 	  }
 	}
 

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1241,20 +1241,20 @@ int processCertificate(struct ndpi_detection_module_struct *ndpi_struct,
 
 static void handleTLSBlockStat(struct ndpi_detection_module_struct *ndpi_struct,
 			       struct ndpi_flow_struct *flow, bool same_packet) {
-  if((flow->l4.tcp.tls.num_tls_blocks < NDPI_MAX_NUM_TLS_APPL_BLOCKS)
-     && (flow->l4_proto == IPPROTO_TCP)
-     && ndpi_struct->cfg.tls_blocks_analysis_enabled
-     ) {
+  if(flow->l4.tcp.tls.num_tls_blocks < NDPI_MAX_NUM_TLS_APPL_BLOCKS) {
     struct ndpi_packet_struct *packet = &ndpi_struct->packet;
     message_t *message = &flow->tls_quic.message[packet->packet_direction];
-    u_int32_t len = (message->buffer[3] << 8) + message->buffer[4] + 5;
-    int16_t blen = len-5;
-    u_int8_t content_type = message->buffer[0];
 
-    flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].len = blen,
-      flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].same_pkt = same_packet ? 1 : 0;
-    flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks++].block_type =
-      ndpi_encode_tls_block_type(content_type, (len > 5) ? message->buffer[5] : 0);
+    if(message->buffer != NULL) {
+      u_int32_t len = (message->buffer[3] << 8) + message->buffer[4] + 5;
+      int16_t blen = len-5;
+      u_int8_t content_type = message->buffer[0];
+
+      flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].len = blen,
+	flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].same_pkt = same_packet ? 1 : 0;
+      flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks++].block_type =
+	ndpi_encode_tls_block_type(content_type, (len > 5) ? message->buffer[5] : 0);
+    }
   }
 }
 
@@ -1307,7 +1307,8 @@ static int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
     break;
 
   case 0x0b: /* Certificate */
-    if(ndpi_struct->cfg.tls_blocks_analysis_enabled)
+    if(ndpi_struct->cfg.tls_blocks_analysis_enabled
+       && (flow->l4_proto == IPPROTO_TCP))
       handleTLSBlockStat(ndpi_struct, flow, true);
 
     /* Important: populate the tls union fields only after
@@ -1332,7 +1333,8 @@ static int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
     break;
 
   default:
-    if(ndpi_struct->cfg.tls_blocks_analysis_enabled)
+    if(ndpi_struct->cfg.tls_blocks_analysis_enabled
+       && (flow->l4_proto == IPPROTO_TCP))
       handleTLSBlockStat(ndpi_struct, flow, true);
     else
       return(-1);
@@ -1424,29 +1426,10 @@ int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
     content_type = message->buffer[0];
 
     if(ndpi_struct->cfg.tls_blocks_analysis_enabled) {
-#if 1
-      handleTLSBlockStat(ndpi_struct, flow, same_packet);
+      if(flow->l4_proto == IPPROTO_TCP)
+	handleTLSBlockStat(ndpi_struct, flow, same_packet);
+
       same_packet = true;
-#else
-      if(flow->l4.tcp.tls.num_tls_blocks < NDPI_MAX_NUM_TLS_APPL_BLOCKS) {
-	int16_t blen = len-5;
-
-	/* Use positive values for c->s and negative for s->c */
-	if(packet->packet_direction != 0) blen = -blen;
-
-	flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].len = blen,
-	  flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].same_pkt = same_packet ? 1 : 0;
-	flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks++].block_type =
-	  ndpi_encode_tls_block_type(content_type, (len > 5) ? message->buffer[5] : 0);
-
-	same_packet = true;
-
-#ifdef DEBUG_TLS_BLOCKS
-	printf("*** [TLS Block] [len: %u][num_tls_blocks: %u/%u]\n",
-	       len-5, flow->l4.tcp.tls.num_tls_blocks, ndpi_struct->num_tls_blocks_to_follow);
-#endif
-      }
-#endif
     }
 
     /* Overwriting packet payload */

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -106,7 +106,7 @@ static int keep_extra_dissection_tcp(struct ndpi_detection_module_struct *ndpi_s
                                      struct ndpi_flow_struct *flow) {
   if(ndpi_struct->cfg.tls_blocks_analysis_enabled)
     return(1); /* Process as much TLS blocks as the max packet number */
-  
+
   /* Common path: found handshake on both directions */
   if(
      (flow->tls_quic.certificate_processed == 1 && flow->protos.tls_quic.client_hello_processed)
@@ -1239,6 +1239,27 @@ int processCertificate(struct ndpi_detection_module_struct *ndpi_struct,
 
 /* **************************************** */
 
+static void handleTLSBlockStat(struct ndpi_detection_module_struct *ndpi_struct,
+			       struct ndpi_flow_struct *flow, bool same_packet) {
+  if((flow->l4.tcp.tls.num_tls_blocks < NDPI_MAX_NUM_TLS_APPL_BLOCKS)
+     && (flow->l4_proto == IPPROTO_TCP)
+     && ndpi_struct->cfg.tls_blocks_analysis_enabled
+     ) {
+    struct ndpi_packet_struct *packet = &ndpi_struct->packet;
+    message_t *message = &flow->tls_quic.message[packet->packet_direction];
+    u_int32_t len = (message->buffer[3] << 8) + message->buffer[4] + 5;
+    int16_t blen = len-5;
+    u_int8_t content_type = message->buffer[0];
+
+    flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].len = blen,
+      flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].same_pkt = same_packet ? 1 : 0;
+    flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks++].block_type =
+      ndpi_encode_tls_block_type(content_type, (len > 5) ? message->buffer[5] : 0);
+  }
+}
+
+/* **************************************** */
+
 static int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
                            struct ndpi_flow_struct *flow) {
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
@@ -1286,6 +1307,9 @@ static int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
     break;
 
   case 0x0b: /* Certificate */
+    if(ndpi_struct->cfg.tls_blocks_analysis_enabled)
+      handleTLSBlockStat(ndpi_struct, flow, true);
+
     /* Important: populate the tls union fields only after
      * ndpi_int_tls_add_connection has been called */
     if(flow->protos.tls_quic.client_hello_processed ||
@@ -1308,7 +1332,10 @@ static int processTLSBlock(struct ndpi_detection_module_struct *ndpi_struct,
     break;
 
   default:
-    return(-1);
+    if(ndpi_struct->cfg.tls_blocks_analysis_enabled)
+      handleTLSBlockStat(ndpi_struct, flow, true);
+    else
+      return(-1);
   }
 
   return(0);
@@ -1330,7 +1357,7 @@ int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
   u_int8_t something_went_wrong = 0;
   message_t *message;
   bool same_packet = false;
-  
+
   if(packet->tcp == NULL)
     return 0; /* Error -> stop (this doesn't seem to be TCP) */
 
@@ -1397,24 +1424,29 @@ int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
     content_type = message->buffer[0];
 
     if(ndpi_struct->cfg.tls_blocks_analysis_enabled) {
+#if 1
+      handleTLSBlockStat(ndpi_struct, flow, same_packet);
+      same_packet = true;
+#else
       if(flow->l4.tcp.tls.num_tls_blocks < NDPI_MAX_NUM_TLS_APPL_BLOCKS) {
 	int16_t blen = len-5;
-	
+
 	/* Use positive values for c->s and negative for s->c */
 	if(packet->packet_direction != 0) blen = -blen;
-	
+
 	flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].len = blen,
 	  flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].same_pkt = same_packet ? 1 : 0;
 	flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks++].block_type =
 	  ndpi_encode_tls_block_type(content_type, (len > 5) ? message->buffer[5] : 0);
 
 	same_packet = true;
-	
+
 #ifdef DEBUG_TLS_BLOCKS
 	printf("*** [TLS Block] [len: %u][num_tls_blocks: %u/%u]\n",
 	       len-5, flow->l4.tcp.tls.num_tls_blocks, ndpi_struct->num_tls_blocks_to_follow);
 #endif
       }
+#endif
     }
 
     /* Overwriting packet payload */
@@ -2285,8 +2317,9 @@ bool skipTLSextension(struct ndpi_detection_module_struct *ndpi_struct,
 		      u_int16_t extension_id)  {
   if(ndpi_struct->cfg.tls_ja_ignore_ephemeral_extensions) {
     switch(extension_id) {
-    case 0x23: /* session ticket - RFC 8447 */
+    case 0x23: /* session ticket - RFC 9149 */
     case 0x29: /* pre-shared key - RFC 8446 */
+    case 0x15: /* padding        - RFC 7685 */
       return(true);
     }
   }
@@ -2344,7 +2377,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
       int rc;
 
       memset(&ja.server, 0, sizeof(ja.server));
-      
+
       ja.server.tls_handshake_version = tls_version;
 
 #ifdef DEBUG_TLS
@@ -2601,7 +2634,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 
       memset(&ja.client, 0, sizeof(ja.client));
       ja.client.alpn_original_last = '0'; /* Initialize to '0' if no ALPN */
-      
+
       flow->protos.tls_quic.ssl_version = ja.client.tls_handshake_version = tls_version;
       if(flow->protos.tls_quic.ssl_version < 0x0303) /* < TLSv1.2 */ {
         if(is_flowrisk_info_enabled(ndpi_struct, NDPI_TLS_OBSOLETE_VERSION)) {
@@ -2799,7 +2832,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		/* Skip GREASE */
 
 		if(ja.client.num_tls_extensions < MAX_NUM_JA) {
-		  if((extension_id == 0xFE0D /* ECHO */)
+		  if(((extension_id == 0xFE0D /* ECHO */) || skipTLSextension(ndpi_struct, extension_id))
 		     && (flow->l4_proto == IPPROTO_TCP)
 		     && ndpi_struct->cfg.tls_blocks_analysis_enabled
 		     && (flow->l4.tcp.tls.num_tls_blocks > 0) /* It should always be like that */) {
@@ -2848,7 +2881,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		      */
 		      flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks-1].len -= sni_len;
 		    }
-		    
+
 		    if(ndpi_is_valid_hostname((char *)&packet->payload[offset+extension_offset+5], len) == 0) {
 		      ndpi_set_risk(ndpi_struct, flow, NDPI_INVALID_CHARACTERS, sni);
 
@@ -2942,7 +2975,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 #ifdef DEBUG_TLS
 		    printf("Client TLS [EllipticCurve: %u/0x%04X]\n", s_group, s_group);
 #endif
-		    
+
 		    if((s_group == 0) || (packet->payload[s_offset+i] != packet->payload[s_offset+i+1])
 		       || ((packet->payload[s_offset+i] & 0xF) != 0xA)) {
 		      /* Skip GREASE */
@@ -3015,7 +3048,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 
 		for(i=0, id=0; i<tot_signature_algorithms_len && s_offset+i+1<total_len; i += 2)
 		  ja.client.signature_algorithm[id++] = ntohs(*(u_int16_t*)&packet->payload[s_offset+i]);
-		
+
 		ja.client.num_signature_algorithms = id;
 
 		for(i=0, id=0; i<tot_signature_algorithms_len && s_offset+i+1<total_len; i++) {
@@ -3380,7 +3413,7 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		      if(ja.client.num_key_share_groups < MAX_NUM_JA)
 			ja.client.key_share_group[ja.client.num_key_share_groups++] = group_id;
 		    }
-		    
+
                     extn_offset += key_extn_len + 4;
                   }
 		}
@@ -3403,10 +3436,10 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 compute_ja4c:
 	      if(ndpi_struct->cfg.tls_ja4c_fingerprint_enabled) {
 	        ndpi_compute_ja4(ndpi_struct, flow, quic_version, &ja);
-		
+
 		if(ndpi_struct->ja4_custom_protos != NULL) {
 		  u_int64_t proto_id;
-		  
+
 		  /* This protocol has been defined in protos.txt-like files */
 		  if(ndpi_hash_find_entry(ndpi_struct->ja4_custom_protos,
 					  flow->protos.tls_quic.ja4_client,
@@ -3432,12 +3465,12 @@ compute_ja4c:
 	      if(ndpi_struct->cfg.tls_ja_data_enabled) {
 		if(flow->protos.tls_quic.ja_client == NULL) {
 		  flow->protos.tls_quic.ja_client = ndpi_malloc(sizeof(ndpi_tls_client_info));
-		  
+
 		  if(flow->protos.tls_quic.ja_client != NULL)
 		    memcpy(flow->protos.tls_quic.ja_client, &ja.client, sizeof(ndpi_tls_client_info));
 		}
 	      }
-	      
+
 	      /* End JA4 */
 	    }
 

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1329,7 +1329,8 @@ int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
   struct ndpi_packet_struct *packet = &ndpi_struct->packet;
   u_int8_t something_went_wrong = 0;
   message_t *message;
-
+  bool same_packet = false;
+  
   if(packet->tcp == NULL)
     return 0; /* Error -> stop (this doesn't seem to be TCP) */
 
@@ -1402,9 +1403,12 @@ int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	/* Use positive values for c->s and negative for s->c */
 	if(packet->packet_direction != 0) blen = -blen;
 	
-	flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].len = blen;
+	flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].len = blen,
+	  flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].same_pkt = same_packet ? 1 : 0;
 	flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks++].block_type =
 	  ndpi_encode_tls_block_type(content_type, (len > 5) ? message->buffer[5] : 0);
+
+	same_packet = true;
 	
 #ifdef DEBUG_TLS_BLOCKS
 	printf("*** [TLS Block] [len: %u][num_tls_blocks: %u/%u]\n",

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1250,6 +1250,8 @@ static void handleTLSBlockStat(struct ndpi_detection_module_struct *ndpi_struct,
       int16_t blen = len-5;
       u_int8_t content_type = message->buffer[0];
 
+      if(packet->packet_direction == 1 /* srv -> cli */) blen *= -1;
+
       flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].len = blen,
 	flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks].same_pkt = same_packet ? 1 : 0;
       flow->l4.tcp.tls.tls_blocks[flow->l4.tcp.tls.num_tls_blocks++].block_type =


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [ X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X ] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [ X] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Describe changes:
- TLS blocks now include all blocks and not just client/server hello
- The nDPI fingerprint includes TLS blocks when --cfg "tls,blocks_analysis,1"  is set (i.e. TLS blocks are computed)