### PR TITLE
HTTP: fix memory leak

### DIFF
--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -370,7 +370,8 @@ static ndpi_protocol_category_t ndpi_http_check_content(struct ndpi_detection_mo
     }
 
     /* check for attachment */
-    if(packet->content_disposition_line.len > 0) {
+    if(packet->content_disposition_line.len > 0 &&
+       flow->http.filename == NULL) {
       u_int8_t attachment_len = sizeof("attachment; filename");
 
       if(packet->content_disposition_line.len > attachment_len &&


### PR DESCRIPTION
```
Direct leak of 3 byte(s) in 1 object(s) allocated from:
    #0 0x5673d8986b28 in malloc (/home/ivan/svnrepos/nDPI/build-fuzz/fuzz/fuzz_ndpi_reader_pl7m_only_subclassification+0x95eb28)
    #1 0x5673d8b946d5 in ndpi_malloc /home/ivan/svnrepos/nDPI/build-fuzz/src/lib/../../../src/lib/ndpi_memory.c:83:46
    #2 0x5673d8cc6d9c in ndpi_http_check_content /home/ivan/svnrepos/nDPI/build-fuzz/src/lib/../../../src/lib/protocols/http.c:404:26
    #3 0x5673d8cb9dda in check_content_type_and_change_protocol /home/ivan/svnrepos/nDPI/build-fuzz/src/lib/../../../src/lib/protocols/http.c:1279:19
    #4 0x5673d8caf0ce in process_response /home/ivan/svnrepos/nDPI/build-fuzz/src/lib/../../../src/lib/protocols/http.c:1734:3
```
Found by oss-fuzz


