### PR TITLE
TLS: blocks: fix use-of-uninitialized-value error

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1253,7 +1253,7 @@ static void handleTLSBlockStat(struct ndpi_detection_module_struct *ndpi_struct,
       struct ndpi_packet_struct *packet = &ndpi_struct->packet;
       message_t *message = &flow->tls_quic.message[packet->packet_direction];
 
-      if(message->buffer != NULL) {
+      if(message->buffer != NULL && message->buffer_used >= 5) {
 	u_int32_t len = (message->buffer[3] << 8) + message->buffer[4] + 5;
 	int16_t blen = len-5;
 	u_int8_t content_type = message->buffer[0];


### PR DESCRIPTION
```
==13164==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x555555eb41a4 in handleTLSBlockStat /home/ivan/svnrepos/nDPI/src/lib/protocols/tls.c:1274:45
    #1 0x555555eb7698 in processTLSBlock /home/ivan/svnrepos/nDPI/src/lib/protocols/tls.c:1359:7
    #2 0x555555ef2bb2 in ndpi_search_dtls /home/ivan/svnrepos/nDPI/src/lib/protocols/tls.c:1715:11
    #3 0x555555ebb842 in ndpi_search_tls_wrapper /home/ivan/svnrepos/nDPI/src/lib/protocols/tls.c:3580:12
    #4 0x555555ebb31d in switch_to_tls /home/ivan/svnrepos/nDPI/src/lib/protocols/tls.c:1888:3
    #5 0x555555e49895 in stun_search_again /home/ivan/svnrepos/nDPI/src/lib/protocols/stun.c:904:9
```
Found by oss-fuzz.
See: https://issues.oss-fuzz.com/issues/474015854


