### PR TITLE
CI: fix armhf tests failing due to QEMU readdir bug

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,5 +1,6 @@
 name: ARM builds with docker
 on:
+  workflow_dispatch:
   push:
     branches:
       - dev
@@ -43,18 +44,29 @@ jobs:
             "
       - name: Configure, compile and test using qemu for the specified architecture (armhf - little endian)
         if: startsWith(matrix.arch, 'armhf')
-        uses: docker://multiarch/ubuntu-core:armhf-focal
-        with:
-          args: >
-            bash -c
-            "apt-get -y update &&
-            DEBIAN_FRONTEND=noninteractive apt-get -y install make git wdiff colordiff autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev rrdtool librrd-dev &&
-            git config --global --add safe.directory $(realpath .) &&
-            env CC=gcc ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages &&
-            make -j $(nproc) all &&
-            make -C example ndpiSimpleIntegration &&
-            make -C rrdtool &&
-            make check VERBOSE=1
+        # Use docker run with --privileged to allow tmpfs mount.
+        # This works around QEMU bug #1805913 where readdir() returns EOVERFLOW
+        # for 32-bit ARM emulation on 64-bit hosts due to large inode numbers.
+        # Since we need to load files from two directories (lists and plugins) the simpler
+        # solution is to make an out-of-tree build in a tmpfs and run the tests directly from there
+        # See: https://bugs.launchpad.net/qemu/+bug/1805913
+        run: |
+          docker run --rm --privileged -v $(pwd):/src:ro \
+            -e NDPI_TEST_ONLY_RECENTLY_UPDATED_PCAPS=$NDPI_TEST_ONLY_RECENTLY_UPDATED_PCAPS \
+            -e CFLAGS="$CFLAGS" \
+            multiarch/ubuntu-core:armhf-focal bash -c "
+              apt-get -y update &&
+              DEBIAN_FRONTEND=noninteractive apt-get -y install make git wdiff colordiff autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev rrdtool librrd-dev &&
+              mkdir -p /build &&
+              mount -t tmpfs tmpfs /build &&
+              cp -a /src/. /build/ &&
+              cd /build &&
+              git config --global --add safe.directory /build &&
+              env CC=gcc ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages &&
+              make -j \$(nproc) all &&
+              make -C example ndpiSimpleIntegration &&
+              make -C rrdtool &&
+              make check VERBOSE=1
             "
       - name: Display qemu specified architecture (s390x - big endian)
         if: startsWith(matrix.arch, 's390x')


### PR DESCRIPTION
Problem:
--------
The armhf CI tests were failing because readdir() returns NULL with errno=EOVERFLOW when running 32-bit ARM emulation via QEMU user-mode on a 64-bit host. This is a known QEMU bug (#1805913).

Root cause: The host kernel's getdents64 syscall returns 64-bit inode numbers. When QEMU passes these to 32-bit ARM glibc, they overflow the 32-bit range, causing glibc to return EOVERFLOW. This affects any code that lists directory contents (e.g., ndpi_load_categories_dir).

See: https://bugs.launchpad.net/qemu/+bug/1805913
     https://gitlab.com/qemu-project/qemu/-/issues/263

Possible fixes:
---------------
1. Use tmpfs filesystem - inode numbers start small (1, 2, 3...) and fit in 32-bit range
2. Use real ARM hardware or full system emulation instead of user-mode emulation
3. Skip directory-loading tests on armhf emulation
4. Wait for QEMU to fix the bug (open since 2018)

Implemented fix:
----------------
Use tmpfs for the build and test environment:
- Switch from 'uses: docker://' to 'run: docker run --privileged' to allow mounting tmpfs inside the container
- Create tmpfs at /build and copy entire source tree there
- Build and run tests from tmpfs where inode numbers are small

This approach was validated locally - all tests pass with tmpfs while they fail on the host-mounted filesystem.


