### PR TITLE
Rename `register_dissector()` into `ndpi_register_dissector()`

### DIFF
--- a/src/include/ndpi_private.h
+++ b/src/include/ndpi_private.h
@@ -654,7 +654,7 @@ struct ndpi_detection_module_struct {
 int is_proto_enabled(struct ndpi_detection_module_struct *ndpi_str, int protoId);
 int is_flowrisk_enabled(struct ndpi_detection_module_struct *ndpi_str, ndpi_risk_enum flowrisk_id);
 
-void register_dissector(char *dissector_name, struct ndpi_detection_module_struct *ndpi_str,
+void ndpi_register_dissector(char *dissector_name, struct ndpi_detection_module_struct *ndpi_str,
                         void (*func)(struct ndpi_detection_module_struct *,
                                      struct ndpi_flow_struct *flow),
                         const NDPI_SELECTION_BITMASK_PROTOCOL_SIZE ndpi_selection_bitmask,

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -6613,7 +6613,7 @@ int load_protocols_file_fd(struct ndpi_detection_module_struct *ndpi_str, FILE *
 
 /* ******************************************************************** */
 
-void register_dissector(char *dissector_name, struct ndpi_detection_module_struct *ndpi_str,
+void ndpi_register_dissector(char *dissector_name, struct ndpi_detection_module_struct *ndpi_str,
                         void (*func)(struct ndpi_detection_module_struct *,
                                      struct ndpi_flow_struct *flow),
                         const NDPI_SELECTION_BITMASK_PROTOCOL_SIZE ndpi_selection_bitmask,

--- a/src/lib/plugins/myproto_plugin.c
+++ b/src/lib/plugins/myproto_plugin.c
@@ -83,7 +83,7 @@ static void myprotoInitFctn(struct ndpi_detection_module_struct *ndpi_struct) {
                           ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */,
                           1);
 
-  register_dissector(NDPI_PROTOCOL_MYPROTO_NAME, ndpi_struct,
+  ndpi_register_dissector(NDPI_PROTOCOL_MYPROTO_NAME, ndpi_struct,
                      ndpi_search_myproto,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, myproto_id);

--- a/src/lib/protocols/activision.c
+++ b/src/lib/protocols/activision.c
@@ -100,7 +100,7 @@ static void ndpi_search_activision(struct ndpi_detection_module_struct *ndpi_str
 
 void init_activision_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Activision", ndpi_struct,
+  ndpi_register_dissector("Activision", ndpi_struct,
                      ndpi_search_activision,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_ACTIVISION);

--- a/src/lib/protocols/afp.c
+++ b/src/lib/protocols/afp.c
@@ -78,7 +78,7 @@ static void ndpi_search_afp(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_afp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("AFP", ndpi_struct,
+  ndpi_register_dissector("AFP", ndpi_struct,
                      ndpi_search_afp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_AFP);

--- a/src/lib/protocols/ajp.c
+++ b/src/lib/protocols/ajp.c
@@ -122,7 +122,7 @@ static void ndpi_search_ajp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_ajp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("AJP", ndpi_struct,
+  ndpi_register_dissector("AJP", ndpi_struct,
                      ndpi_search_ajp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_AJP);

--- a/src/lib/protocols/alicloud.c
+++ b/src/lib/protocols/alicloud.c
@@ -70,7 +70,7 @@ static void ndpi_search_alicloud(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_alicloud_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("AliCloud", ndpi_struct,
+  ndpi_register_dissector("AliCloud", ndpi_struct,
                      ndpi_search_alicloud,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ALICLOUD);

--- a/src/lib/protocols/amazon_video.c
+++ b/src/lib/protocols/amazon_video.c
@@ -66,7 +66,7 @@ static void ndpi_search_amazon_video(struct ndpi_detection_module_struct *ndpi_s
 
 
 void init_amazon_video_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("AMAZON_VIDEO", ndpi_struct,
+  ndpi_register_dissector("AMAZON_VIDEO", ndpi_struct,
                      ndpi_search_amazon_video,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_AMAZON_VIDEO);

--- a/src/lib/protocols/among_us.c
+++ b/src/lib/protocols/among_us.c
@@ -49,7 +49,7 @@ static void ndpi_search_among_us(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_among_us_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("AmongUs", ndpi_struct,
+  ndpi_register_dissector("AmongUs", ndpi_struct,
                      ndpi_search_among_us,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_AMONG_US);

--- a/src/lib/protocols/amqp.c
+++ b/src/lib/protocols/amqp.c
@@ -74,7 +74,7 @@ static void ndpi_search_amqp(struct ndpi_detection_module_struct *ndpi_struct, s
 
 
 void init_amqp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("AMQP", ndpi_struct,
+  ndpi_register_dissector("AMQP", ndpi_struct,
                      ndpi_search_amqp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_AMQP);

--- a/src/lib/protocols/apple_push.c
+++ b/src/lib/protocols/apple_push.c
@@ -96,7 +96,7 @@ static void ndpi_search_apple_push(struct ndpi_detection_module_struct *ndpi_str
 
 void init_apple_push_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("APPLE_PUSH", ndpi_struct,
+  ndpi_register_dissector("APPLE_PUSH", ndpi_struct,
                      ndpi_search_apple_push,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_APPLE_PUSH);

--- a/src/lib/protocols/armagetron.c
+++ b/src/lib/protocols/armagetron.c
@@ -73,7 +73,7 @@ static void ndpi_search_armagetron_udp(struct ndpi_detection_module_struct *ndpi
 
 void init_armagetron_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Armagetron", ndpi_struct,
+  ndpi_register_dissector("Armagetron", ndpi_struct,
                      ndpi_search_armagetron_udp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_ARMAGETRON);

--- a/src/lib/protocols/atg.c
+++ b/src/lib/protocols/atg.c
@@ -56,7 +56,7 @@ static void ndpi_search_atg(struct ndpi_detection_module_struct *ndpi_struct,
 }
 
 void init_atg_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("ATG", ndpi_struct,
+  ndpi_register_dissector("ATG", ndpi_struct,
                      ndpi_search_atg,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ATG);

--- a/src/lib/protocols/avast.c
+++ b/src/lib/protocols/avast.c
@@ -55,7 +55,7 @@ static void ndpi_search_avast(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_avast_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("AVAST", ndpi_struct,
+  ndpi_register_dissector("AVAST", ndpi_struct,
                      ndpi_search_avast,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_AVAST);

--- a/src/lib/protocols/avast_securedns.c
+++ b/src/lib/protocols/avast_securedns.c
@@ -56,7 +56,7 @@ static void ndpi_search_avast_securedns(struct ndpi_detection_module_struct *ndp
 
 void init_avast_securedns_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("AVAST SecureDNS", ndpi_struct,
+  ndpi_register_dissector("AVAST SecureDNS", ndpi_struct,
                      ndpi_search_avast_securedns,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_AVAST_SECUREDNS);

--- a/src/lib/protocols/bacnet.c
+++ b/src/lib/protocols/bacnet.c
@@ -89,7 +89,7 @@ static void ndpi_search_bacnet(struct ndpi_detection_module_struct *ndpi_struct,
   
 void init_bacnet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("BACnet", ndpi_struct,
+  ndpi_register_dissector("BACnet", ndpi_struct,
                      ndpi_search_bacnet,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_BACNET);

--- a/src/lib/protocols/beckhoff_ads.c
+++ b/src/lib/protocols/beckhoff_ads.c
@@ -114,7 +114,7 @@ not_beckhoff_ads:
 
 void init_beckhoff_ads_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("BeckhoffADS", ndpi_struct,
+  ndpi_register_dissector("BeckhoffADS", ndpi_struct,
                      ndpi_search_beckhoff_ads,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_BECKHOFF_ADS);

--- a/src/lib/protocols/bfcp.c
+++ b/src/lib/protocols/bfcp.c
@@ -79,7 +79,7 @@ not_bfcp:
 
 void init_bfcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("BFCP", ndpi_struct,
+  ndpi_register_dissector("BFCP", ndpi_struct,
                      ndpi_search_bfcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_BFCP);

--- a/src/lib/protocols/bfd.c
+++ b/src/lib/protocols/bfd.c
@@ -70,7 +70,7 @@ static void ndpi_search_bfd(struct ndpi_detection_module_struct *ndpi_struct,
 }
 void init_bfd_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("BFD", ndpi_struct,
+  ndpi_register_dissector("BFD", ndpi_struct,
                      ndpi_search_bfd,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_BFD);

--- a/src/lib/protocols/bgp.c
+++ b/src/lib/protocols/bgp.c
@@ -57,7 +57,7 @@ static void ndpi_search_bgp(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_bgp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("BGP", ndpi_struct,
+  ndpi_register_dissector("BGP", ndpi_struct,
                      ndpi_search_bgp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_BGP);

--- a/src/lib/protocols/bitcoin.c
+++ b/src/lib/protocols/bitcoin.c
@@ -59,7 +59,7 @@ static void ndpi_search_bitcoin(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_bitcoin_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Bitcoin", ndpi_struct,
+  ndpi_register_dissector("Bitcoin", ndpi_struct,
                      ndpi_search_bitcoin,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_BITCOIN);

--- a/src/lib/protocols/bittorrent.c
+++ b/src/lib/protocols/bittorrent.c
@@ -655,7 +655,7 @@ static void ndpi_search_bittorrent(struct ndpi_detection_module_struct *ndpi_str
 
 void init_bittorrent_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("BitTorrent", ndpi_struct,
+  ndpi_register_dissector("BitTorrent", ndpi_struct,
                      ndpi_search_bittorrent,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_BITTORRENT);

--- a/src/lib/protocols/bjnp.c
+++ b/src/lib/protocols/bjnp.c
@@ -42,7 +42,7 @@ static void ndpi_search_bjnp(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_bjnp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("BJNP", ndpi_struct,
+  ndpi_register_dissector("BJNP", ndpi_struct,
                      ndpi_search_bjnp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_BJNP);

--- a/src/lib/protocols/blizzard.c
+++ b/src/lib/protocols/blizzard.c
@@ -144,7 +144,7 @@ static void ndpi_search_blizzard(struct ndpi_detection_module_struct* ndpi_struc
 
 void init_blizzard_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Blizzard", ndpi_struct,
+  ndpi_register_dissector("Blizzard", ndpi_struct,
                      ndpi_search_blizzard,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_BLIZZARD);

--- a/src/lib/protocols/c1222.c
+++ b/src/lib/protocols/c1222.c
@@ -64,7 +64,7 @@ static void ndpi_search_c1222(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_c1222_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("ANSI_C1222", ndpi_struct,
+  ndpi_register_dissector("ANSI_C1222", ndpi_struct,
                      ndpi_search_c1222,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_C1222);

--- a/src/lib/protocols/can.c
+++ b/src/lib/protocols/can.c
@@ -73,7 +73,7 @@ static void ndpi_search_can(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_can_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Controller_Area_Network", ndpi_struct,
+  ndpi_register_dissector("Controller_Area_Network", ndpi_struct,
                      ndpi_search_can,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_CAN);

--- a/src/lib/protocols/capwap.c
+++ b/src/lib/protocols/capwap.c
@@ -133,7 +133,7 @@ static void ndpi_search_capwap(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_capwap_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("CAPWAP", ndpi_struct,
+  ndpi_register_dissector("CAPWAP", ndpi_struct,
                      ndpi_search_capwap,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_CAPWAP);

--- a/src/lib/protocols/cassandra.c
+++ b/src/lib/protocols/cassandra.c
@@ -93,7 +93,7 @@ static void ndpi_search_cassandra(struct ndpi_detection_module_struct *ndpi_stru
 }
 
 void init_cassandra_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Cassandra", ndpi_struct,
+  ndpi_register_dissector("Cassandra", ndpi_struct,
                      ndpi_search_cassandra,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_CASSANDRA);

--- a/src/lib/protocols/ceph.c
+++ b/src/lib/protocols/ceph.c
@@ -53,7 +53,7 @@ static void ndpi_search_ceph(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_ceph_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Ceph", ndpi_struct,
+  ndpi_register_dissector("Ceph", ndpi_struct,
                      ndpi_search_ceph,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_CEPH);

--- a/src/lib/protocols/checkmk.c
+++ b/src/lib/protocols/checkmk.c
@@ -75,7 +75,7 @@ static void ndpi_search_checkmk(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_checkmk_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("CHECKMK", ndpi_struct,
+  ndpi_register_dissector("CHECKMK", ndpi_struct,
                      ndpi_search_checkmk,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_CHECKMK);

--- a/src/lib/protocols/cip.c
+++ b/src/lib/protocols/cip.c
@@ -64,7 +64,7 @@ static void ndpi_search_cip(struct ndpi_detection_module_struct *ndpi_struct,
 
 
 void init_cip_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("CIP", ndpi_struct,
+  ndpi_register_dissector("CIP", ndpi_struct,
                      ndpi_search_cip,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_CIP);

--- a/src/lib/protocols/ciscovpn.c
+++ b/src/lib/protocols/ciscovpn.c
@@ -67,7 +67,7 @@ static void ndpi_search_ciscovpn(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_ciscovpn_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("CiscoVPN", ndpi_struct,
+  ndpi_register_dissector("CiscoVPN", ndpi_struct,
                      ndpi_search_ciscovpn,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_CISCOVPN);

--- a/src/lib/protocols/citrix.c
+++ b/src/lib/protocols/citrix.c
@@ -68,7 +68,7 @@ static void ndpi_search_citrix(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_citrix_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Citrix", ndpi_struct,
+  ndpi_register_dissector("Citrix", ndpi_struct,
                      ndpi_search_citrix,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_CITRIX);

--- a/src/lib/protocols/cloudflare_warp.c
+++ b/src/lib/protocols/cloudflare_warp.c
@@ -85,7 +85,7 @@ static void ndpi_search_cloudflare_warp(struct ndpi_detection_module_struct *ndp
 
 void init_cloudflare_warp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("CloudflareWarp", ndpi_struct,
+  ndpi_register_dissector("CloudflareWarp", ndpi_struct,
                      ndpi_search_cloudflare_warp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_CLOUDFLARE_WARP);

--- a/src/lib/protocols/cnp-ip.c
+++ b/src/lib/protocols/cnp-ip.c
@@ -56,7 +56,7 @@ static void ndpi_search_cnp_ip(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_cnp_ip_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("CNP-IP", ndpi_struct,
+  ndpi_register_dissector("CNP-IP", ndpi_struct,
                      ndpi_search_cnp_ip,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_CNP_IP);

--- a/src/lib/protocols/coap.c
+++ b/src/lib/protocols/coap.c
@@ -151,7 +151,7 @@ static void ndpi_search_coap(struct ndpi_detection_module_struct *ndpi_struct,
  */
 void init_coap_dissector (struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("COAP", ndpi_struct,
+  ndpi_register_dissector("COAP", ndpi_struct,
                      ndpi_search_coap,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_COAP);

--- a/src/lib/protocols/cod_mobile.c
+++ b/src/lib/protocols/cod_mobile.c
@@ -72,7 +72,7 @@ static void ndpi_search_cod_mobile(struct ndpi_detection_module_struct *ndpi_str
 
 void init_cod_mobile_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("CoD_Mobile", ndpi_struct,
+  ndpi_register_dissector("CoD_Mobile", ndpi_struct,
                      ndpi_search_cod_mobile,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_COD_MOBILE);

--- a/src/lib/protocols/collectd.c
+++ b/src/lib/protocols/collectd.c
@@ -192,7 +192,7 @@ static void ndpi_search_collectd(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_collectd_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("collectd", ndpi_struct,
+  ndpi_register_dissector("collectd", ndpi_struct,
                      ndpi_search_collectd,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_COLLECTD);

--- a/src/lib/protocols/corba.c
+++ b/src/lib/protocols/corba.c
@@ -61,7 +61,7 @@ static void ndpi_search_corba(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_corba_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Corba", ndpi_struct,
+  ndpi_register_dissector("Corba", ndpi_struct,
                      ndpi_search_corba,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_CORBA);

--- a/src/lib/protocols/cpha.c
+++ b/src/lib/protocols/cpha.c
@@ -53,7 +53,7 @@ static void ndpi_search_cpha(struct ndpi_detection_module_struct *ndpi_struct, s
 
 
 void init_cpha_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("CPHA", ndpi_struct,
+  ndpi_register_dissector("CPHA", ndpi_struct,
                      ndpi_search_cpha,
                      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* TODO: ipv6 support? */
                      1, NDPI_PROTOCOL_CPHA);

--- a/src/lib/protocols/crossfire.c
+++ b/src/lib/protocols/crossfire.c
@@ -70,7 +70,7 @@ static void ndpi_search_crossfire_tcp_udp(struct ndpi_detection_module_struct *n
 
 void init_crossfire_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Crossfire", ndpi_struct,
+  ndpi_register_dissector("Crossfire", ndpi_struct,
                      ndpi_search_crossfire_tcp_udp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_CROSSFIRE);

--- a/src/lib/protocols/crynet.c
+++ b/src/lib/protocols/crynet.c
@@ -103,7 +103,7 @@ static void ndpi_search_crynet(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_crynet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("CryNetwork", ndpi_struct,
+  ndpi_register_dissector("CryNetwork", ndpi_struct,
                      ndpi_search_crynet,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_CRYNET);

--- a/src/lib/protocols/dcerpc.c
+++ b/src/lib/protocols/dcerpc.c
@@ -96,7 +96,7 @@ static void ndpi_search_dcerpc(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_dcerpc_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("DCERPC", ndpi_struct,
+  ndpi_register_dissector("DCERPC", ndpi_struct,
                      ndpi_search_dcerpc,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_DCERPC);

--- a/src/lib/protocols/dhcp.c
+++ b/src/lib/protocols/dhcp.c
@@ -200,7 +200,7 @@ static void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struc
 
 
 void init_dhcp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("DHCP", ndpi_struct,
+  ndpi_register_dissector("DHCP", ndpi_struct,
                      ndpi_search_dhcp_udp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_DHCP);

--- a/src/lib/protocols/dhcpv6.c
+++ b/src/lib/protocols/dhcpv6.c
@@ -59,7 +59,7 @@ static void ndpi_search_dhcpv6_udp(struct ndpi_detection_module_struct *ndpi_str
 
 void init_dhcpv6_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("DHCPV6", ndpi_struct,
+  ndpi_register_dissector("DHCPV6", ndpi_struct,
                      ndpi_search_dhcpv6_udp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_DHCPV6);

--- a/src/lib/protocols/diameter.c
+++ b/src/lib/protocols/diameter.c
@@ -107,7 +107,7 @@ static void ndpi_search_diameter(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_diameter_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Diameter", ndpi_struct,
+  ndpi_register_dissector("Diameter", ndpi_struct,
                      ndpi_search_diameter,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_DIAMETER);

--- a/src/lib/protocols/dicom.c
+++ b/src/lib/protocols/dicom.c
@@ -59,7 +59,7 @@ static void ndpi_search_dicom(struct ndpi_detection_module_struct *ndpi_struct,
 /* ********************************* */
 
 void init_dicom_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("DICOM", ndpi_struct,
+  ndpi_register_dissector("DICOM", ndpi_struct,
                      ndpi_search_dicom,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_DICOM);

--- a/src/lib/protocols/dingtalk.c
+++ b/src/lib/protocols/dingtalk.c
@@ -53,7 +53,7 @@ static void ndpi_search_dingtalk(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_dingtalk_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("DingTalk", ndpi_struct,
+  ndpi_register_dissector("DingTalk", ndpi_struct,
                      ndpi_search_dingtalk,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_DINGTALK);

--- a/src/lib/protocols/discord.c
+++ b/src/lib/protocols/discord.c
@@ -77,7 +77,7 @@ static void ndpi_search_discord(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_discord_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Discord", ndpi_struct,
+  ndpi_register_dissector("Discord", ndpi_struct,
                      ndpi_search_discord,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_DISCORD);

--- a/src/lib/protocols/dlep.c
+++ b/src/lib/protocols/dlep.c
@@ -72,7 +72,7 @@ static void ndpi_search_dlep(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_dlep_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("DLEP", ndpi_struct,
+  ndpi_register_dissector("DLEP", ndpi_struct,
                      ndpi_search_dlep,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_DLEP);

--- a/src/lib/protocols/dnp3.c
+++ b/src/lib/protocols/dnp3.c
@@ -57,7 +57,7 @@ static void ndpi_search_dnp3_tcp(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_dnp3_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
 
-  register_dissector("DNP3", ndpi_struct,
+  ndpi_register_dissector("DNP3", ndpi_struct,
                      ndpi_search_dnp3_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_DNP3);

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -996,7 +996,7 @@ static void ndpi_search_dns(struct ndpi_detection_module_struct *ndpi_struct, st
 /* *********************************************** */
 
 void init_dns_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("DNS", ndpi_struct,
+  ndpi_register_dissector("DNS", ndpi_struct,
                      ndpi_search_dns,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_DNS);

--- a/src/lib/protocols/dnscrypt.c
+++ b/src/lib/protocols/dnscrypt.c
@@ -69,7 +69,7 @@ static void ndpi_search_dnscrypt(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_dnscrypt_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("DNScrypt", ndpi_struct,
+  ndpi_register_dissector("DNScrypt", ndpi_struct,
                      ndpi_search_dnscrypt,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_DNSCRYPT);

--- a/src/lib/protocols/dofus.c
+++ b/src/lib/protocols/dofus.c
@@ -56,7 +56,7 @@ static void ndpi_search_dofus(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_dofus_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Dofus", ndpi_struct,
+  ndpi_register_dissector("Dofus", ndpi_struct,
                      ndpi_search_dofus,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_DOFUS);

--- a/src/lib/protocols/drda.c
+++ b/src/lib/protocols/drda.c
@@ -92,7 +92,7 @@ static void ndpi_search_drda(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_drda_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("DRDA", ndpi_struct,
+  ndpi_register_dissector("DRDA", ndpi_struct,
                      ndpi_search_drda,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_DRDA);

--- a/src/lib/protocols/dropbox.c
+++ b/src/lib/protocols/dropbox.c
@@ -76,7 +76,7 @@ static void ndpi_search_dropbox(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_dropbox_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("DROPBOX", ndpi_struct,
+  ndpi_register_dissector("DROPBOX", ndpi_struct,
                      ndpi_search_dropbox,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_DROPBOX);

--- a/src/lib/protocols/eaq.c
+++ b/src/lib/protocols/eaq.c
@@ -81,7 +81,7 @@ static void ndpi_search_eaq(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_eaq_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("EAQ", ndpi_struct,
+  ndpi_register_dissector("EAQ", ndpi_struct,
                      ndpi_search_eaq,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_EAQ);

--- a/src/lib/protocols/easyweather.c
+++ b/src/lib/protocols/easyweather.c
@@ -54,7 +54,7 @@ static void ndpi_search_easyweather(struct ndpi_detection_module_struct *ndpi_st
 
 void init_easyweather_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("EasyWeather", ndpi_struct,
+  ndpi_register_dissector("EasyWeather", ndpi_struct,
                      ndpi_search_easyweather,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_EASYWEATHER);

--- a/src/lib/protocols/edonkey.c
+++ b/src/lib/protocols/edonkey.c
@@ -60,7 +60,7 @@ static void ndpi_search_edonkey(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_edonkey_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("eDonkey", ndpi_struct,
+  ndpi_register_dissector("eDonkey", ndpi_struct,
                      ndpi_search_edonkey,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_EDONKEY);

--- a/src/lib/protocols/egd.c
+++ b/src/lib/protocols/egd.c
@@ -54,7 +54,7 @@ static void ndpi_search_egd(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_egd_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("EthernetGlobalData", ndpi_struct,
+  ndpi_register_dissector("EthernetGlobalData", ndpi_struct,
                      ndpi_search_egd,
                      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_EGD);

--- a/src/lib/protocols/elastic_search.c
+++ b/src/lib/protocols/elastic_search.c
@@ -73,7 +73,7 @@ static void ndpi_search_elasticsearch(struct ndpi_detection_module_struct *ndpi_
   
 void init_elasticsearch_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Elasticsearch", ndpi_struct,
+  ndpi_register_dissector("Elasticsearch", ndpi_struct,
                      ndpi_search_elasticsearch,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ELASTICSEARCH);

--- a/src/lib/protocols/epicgames.c
+++ b/src/lib/protocols/epicgames.c
@@ -76,7 +76,7 @@ static void ndpi_search_epicgames(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_epicgames_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("EpicGames", ndpi_struct,
+  ndpi_register_dissector("EpicGames", ndpi_struct,
                      ndpi_search_epicgames,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_EPICGAMES);

--- a/src/lib/protocols/ethereum.c
+++ b/src/lib/protocols/ethereum.c
@@ -152,7 +152,7 @@ static void ndpi_search_ethereum(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_ethereum_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Ethereum", ndpi_struct,
+  ndpi_register_dissector("Ethereum", ndpi_struct,
                      ndpi_search_ethereum,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ETHEREUM);

--- a/src/lib/protocols/ethernet_ip.c
+++ b/src/lib/protocols/ethernet_ip.c
@@ -61,7 +61,7 @@ static void ndpi_search_ethernet_ip(struct ndpi_detection_module_struct *ndpi_st
   
 
 void init_ethernet_ip_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("EthernetIP", ndpi_struct,
+  ndpi_register_dissector("EthernetIP", ndpi_struct,
                      ndpi_search_ethernet_ip,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ETHERNET_IP);

--- a/src/lib/protocols/ethersbus.c
+++ b/src/lib/protocols/ethersbus.c
@@ -62,7 +62,7 @@ static void ndpi_search_ethersbus(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_ethersbus_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Ether-S-Bus", ndpi_struct,
+  ndpi_register_dissector("Ether-S-Bus", ndpi_struct,
                      ndpi_search_ethersbus,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_ETHERSBUS);

--- a/src/lib/protocols/ethersio.c
+++ b/src/lib/protocols/ethersio.c
@@ -53,7 +53,7 @@ static void ndpi_search_ethersio(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_ethersio_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("EtherSIO", ndpi_struct,
+  ndpi_register_dissector("EtherSIO", ndpi_struct,
                      ndpi_search_ethersio,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_ETHERSIO);

--- a/src/lib/protocols/fastcgi.c
+++ b/src/lib/protocols/fastcgi.c
@@ -237,7 +237,7 @@ static int ndpi_search_fastcgi_extra(struct ndpi_detection_module_struct * ndpi_
 
 void init_fastcgi_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("FastCGI", ndpi_struct,
+  ndpi_register_dissector("FastCGI", ndpi_struct,
                      ndpi_search_fastcgi,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_FASTCGI);

--- a/src/lib/protocols/fins.c
+++ b/src/lib/protocols/fins.c
@@ -111,7 +111,7 @@ not_fins:
 
 void init_fins_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("FINS", ndpi_struct,
+  ndpi_register_dissector("FINS", ndpi_struct,
                      ndpi_search_fins,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_FINS);

--- a/src/lib/protocols/fix.c
+++ b/src/lib/protocols/fix.c
@@ -65,7 +65,7 @@ static void ndpi_search_fix(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_fix_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("FIX", ndpi_struct,
+  ndpi_register_dissector("FIX", ndpi_struct,
                      ndpi_search_fix,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_FIX);

--- a/src/lib/protocols/flute.c
+++ b/src/lib/protocols/flute.c
@@ -64,7 +64,7 @@ not_flute:
 
 void init_flute_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("FLUTE", ndpi_struct,
+  ndpi_register_dissector("FLUTE", ndpi_struct,
                      ndpi_search_flute,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_FLUTE);

--- a/src/lib/protocols/ftp_control.c
+++ b/src/lib/protocols/ftp_control.c
@@ -671,7 +671,7 @@ static void ndpi_search_ftp_control(struct ndpi_detection_module_struct *ndpi_st
 /* *************************************************************** */
 
 void init_ftp_control_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("FTP_CONTROL", ndpi_struct,
+  ndpi_register_dissector("FTP_CONTROL", ndpi_struct,
                      ndpi_search_ftp_control,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_FTP_CONTROL);

--- a/src/lib/protocols/ftp_data.c
+++ b/src/lib/protocols/ftp_data.c
@@ -250,7 +250,7 @@ static void ndpi_search_ftp_data(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_ftp_data_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("FTP_DATA", ndpi_struct,
+  ndpi_register_dissector("FTP_DATA", ndpi_struct,
                      ndpi_search_ftp_data,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_FTP_DATA);

--- a/src/lib/protocols/gaijin_entertainment.c
+++ b/src/lib/protocols/gaijin_entertainment.c
@@ -68,7 +68,7 @@ static void ndpi_search_gaijin(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_gaijin_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("GaijinEntertainment", ndpi_struct,
+  ndpi_register_dissector("GaijinEntertainment", ndpi_struct,
                      ndpi_search_gaijin,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_GAIJIN);

--- a/src/lib/protocols/gearman.c
+++ b/src/lib/protocols/gearman.c
@@ -52,7 +52,7 @@ static void ndpi_search_gearman(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_gearman_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Gearman", ndpi_struct,
+  ndpi_register_dissector("Gearman", ndpi_struct,
                      ndpi_search_gearman,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_GEARMAN);

--- a/src/lib/protocols/gearup_booster.c
+++ b/src/lib/protocols/gearup_booster.c
@@ -84,7 +84,7 @@ static void ndpi_search_gearup_booster(struct ndpi_detection_module_struct *ndpi
 
 void init_gearup_booster_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("GeaUP_Booster", ndpi_struct,
+  ndpi_register_dissector("GeaUP_Booster", ndpi_struct,
                      ndpi_search_gearup_booster,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_GEARUP_BOOSTER);

--- a/src/lib/protocols/genshin_impact.c
+++ b/src/lib/protocols/genshin_impact.c
@@ -75,7 +75,7 @@ static void ndpi_search_genshin_impact(struct ndpi_detection_module_struct *ndpi
 
 void init_genshin_impact_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("GenshinImpact", ndpi_struct,
+  ndpi_register_dissector("GenshinImpact", ndpi_struct,
                      ndpi_search_genshin_impact,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_GENSHIN_IMPACT);

--- a/src/lib/protocols/git.c
+++ b/src/lib/protocols/git.c
@@ -76,7 +76,7 @@ static void ndpi_search_git(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_git_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Git", ndpi_struct,
+  ndpi_register_dissector("Git", ndpi_struct,
                      ndpi_search_git,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_GIT);

--- a/src/lib/protocols/glbp.c
+++ b/src/lib/protocols/glbp.c
@@ -74,7 +74,7 @@ exclude:
 
 void init_glbp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("GLBP", ndpi_struct,
+  ndpi_register_dissector("GLBP", ndpi_struct,
                      ndpi_search_glbp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_GLBP);

--- a/src/lib/protocols/gnutella.c
+++ b/src/lib/protocols/gnutella.c
@@ -82,7 +82,7 @@ static void ndpi_search_gnutella(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_gnutella_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Gnutella", ndpi_struct,
+  ndpi_register_dissector("Gnutella", ndpi_struct,
                      ndpi_search_gnutella,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_GNUTELLA);

--- a/src/lib/protocols/gtp.c
+++ b/src/lib/protocols/gtp.c
@@ -129,7 +129,7 @@ static void ndpi_search_gtp(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_gtp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("GTP", ndpi_struct,
+  ndpi_register_dissector("GTP", ndpi_struct,
                      ndpi_search_gtp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_GTP);

--- a/src/lib/protocols/guildwars2.c
+++ b/src/lib/protocols/guildwars2.c
@@ -55,7 +55,7 @@ static void ndpi_search_guildwars2_tcp(struct ndpi_detection_module_struct *ndpi
 
 void init_guildwars2_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("GuildWars2", ndpi_struct,
+  ndpi_register_dissector("GuildWars2", ndpi_struct,
                      ndpi_search_guildwars2_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_GUILDWARS2);

--- a/src/lib/protocols/h323.c
+++ b/src/lib/protocols/h323.c
@@ -73,7 +73,7 @@ static void ndpi_search_h323(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_h323_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("H323", ndpi_struct,
+  ndpi_register_dissector("H323", ndpi_struct,
                      ndpi_search_h323,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_H323);

--- a/src/lib/protocols/hamachi.c
+++ b/src/lib/protocols/hamachi.c
@@ -166,7 +166,7 @@ static void ndpi_search_hamachi(struct ndpi_detection_module_struct* ndpi_struct
 
 void init_hamachi_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Hamachi", ndpi_struct,
+  ndpi_register_dissector("Hamachi", ndpi_struct,
                      ndpi_search_hamachi,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_HAMACHI);

--- a/src/lib/protocols/haproxy.c
+++ b/src/lib/protocols/haproxy.c
@@ -68,7 +68,7 @@ static void ndpi_search_haproxy(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_haproxy_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("HAProxy", ndpi_struct,
+  ndpi_register_dissector("HAProxy", ndpi_struct,
                      ndpi_search_haproxy,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_HAPROXY);

--- a/src/lib/protocols/hart-ip.c
+++ b/src/lib/protocols/hart-ip.c
@@ -102,7 +102,7 @@ not_hart_ip:
 
 void init_hart_ip_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("HART-IP", ndpi_struct,
+  ndpi_register_dissector("HART-IP", ndpi_struct,
                      ndpi_search_hart_ip,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_HART_IP);

--- a/src/lib/protocols/hcl_notes.c
+++ b/src/lib/protocols/hcl_notes.c
@@ -62,7 +62,7 @@ static void ndpi_search_hcl_notes(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_hcl_notes_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("HCL_Notes", ndpi_struct,
+  ndpi_register_dissector("HCL_Notes", ndpi_struct,
                      ndpi_search_hcl_notes,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_HCL_NOTES);

--- a/src/lib/protocols/hislip.c
+++ b/src/lib/protocols/hislip.c
@@ -61,7 +61,7 @@ static void ndpi_search_hislip(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_hislip_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("HiSLIP", ndpi_struct,
+  ndpi_register_dissector("HiSLIP", ndpi_struct,
                      ndpi_search_hislip,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_HISLIP);

--- a/src/lib/protocols/hl7.c
+++ b/src/lib/protocols/hl7.c
@@ -71,7 +71,7 @@ static void ndpi_search_hl7(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_hl7_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("HL7", ndpi_struct,
+  ndpi_register_dissector("HL7", ndpi_struct,
                      ndpi_search_hl7,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_HL7);

--- a/src/lib/protocols/hots.c
+++ b/src/lib/protocols/hots.c
@@ -66,7 +66,7 @@ void ndpi_search_hots(struct ndpi_detection_module_struct *ndpi_struct, struct n
 
 void init_hots_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("HOTS", ndpi_struct,
+  ndpi_register_dissector("HOTS", ndpi_struct,
                      ndpi_search_hots,
                      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* Only IPv4 UDP traffic is expected. */
                      1, NDPI_PROTOCOL_HOTS);

--- a/src/lib/protocols/hpvirtgrp.c
+++ b/src/lib/protocols/hpvirtgrp.c
@@ -59,7 +59,7 @@ static void ndpi_search_hpvirtgrp(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_hpvirtgrp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("HP Virtual Machine Group Management", ndpi_struct,
+  ndpi_register_dissector("HP Virtual Machine Group Management", ndpi_struct,
                      ndpi_search_hpvirtgrp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_HPVIRTGRP);

--- a/src/lib/protocols/hsrp.c
+++ b/src/lib/protocols/hsrp.c
@@ -82,7 +82,7 @@ static void ndpi_search_hsrp(struct ndpi_detection_module_struct *ndpi_struct,
 
 
 void init_hsrp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("HSRP", ndpi_struct,
+  ndpi_register_dissector("HSRP", ndpi_struct,
                      ndpi_search_hsrp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_HSRP);

--- a/src/lib/protocols/http.c
+++ b/src/lib/protocols/http.c
@@ -1954,7 +1954,7 @@ static void ndpi_search_http_tcp(struct ndpi_detection_module_struct *ndpi_struc
 }
 
 void init_http_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("HTTP", ndpi_struct,
+  ndpi_register_dissector("HTTP", ndpi_struct,
                      ndpi_search_http_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_HTTP);

--- a/src/lib/protocols/http2.c
+++ b/src/lib/protocols/http2.c
@@ -57,7 +57,7 @@ void ndpi_search_http2(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_http2_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("HTTP2", ndpi_struct,
+  ndpi_register_dissector("HTTP2", ndpi_struct,
                      ndpi_search_http2,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_HTTP2);

--- a/src/lib/protocols/i3d.c
+++ b/src/lib/protocols/i3d.c
@@ -77,7 +77,7 @@ static void ndpi_search_i3d(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_i3d_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("i3D", ndpi_struct,
+  ndpi_register_dissector("i3D", ndpi_struct,
                      ndpi_search_i3d,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_I3D);

--- a/src/lib/protocols/iax.c
+++ b/src/lib/protocols/iax.c
@@ -98,7 +98,7 @@ static void ndpi_search_iax(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_iax_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("IAX", ndpi_struct,
+  ndpi_register_dissector("IAX", ndpi_struct,
                      ndpi_search_iax,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_IAX);

--- a/src/lib/protocols/icecast.c
+++ b/src/lib/protocols/icecast.c
@@ -90,7 +90,7 @@ static void ndpi_search_icecast_tcp(struct ndpi_detection_module_struct *ndpi_st
 
 void init_icecast_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("IceCast", ndpi_struct,
+  ndpi_register_dissector("IceCast", ndpi_struct,
                      ndpi_search_icecast_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ICECAST);

--- a/src/lib/protocols/iec60870-5-104.c
+++ b/src/lib/protocols/iec60870-5-104.c
@@ -73,7 +73,7 @@ static void ndpi_search_iec60870_tcp(struct ndpi_detection_module_struct *ndpi_s
 
 
 void init_104_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("IEC60870", ndpi_struct,
+  ndpi_register_dissector("IEC60870", ndpi_struct,
                      ndpi_search_iec60870_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_IEC60870);

--- a/src/lib/protocols/iec62056.c
+++ b/src/lib/protocols/iec62056.c
@@ -63,7 +63,7 @@ static void ndpi_search_iec62056(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_iec62056_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("IEC62056", ndpi_struct,
+  ndpi_register_dissector("IEC62056", ndpi_struct,
                      ndpi_search_iec62056,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_IEC62056);

--- a/src/lib/protocols/ieee-c37118.c
+++ b/src/lib/protocols/ieee-c37118.c
@@ -68,7 +68,7 @@ static void ndpi_search_ieee_c37118(struct ndpi_detection_module_struct *ndpi_st
 
 void init_ieee_c37118_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("IEEE-C37118", ndpi_struct,
+  ndpi_register_dissector("IEEE-C37118", ndpi_struct,
                      ndpi_search_ieee_c37118,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_IEEE_C37118);

--- a/src/lib/protocols/imo.c
+++ b/src/lib/protocols/imo.c
@@ -69,7 +69,7 @@ static void ndpi_search_imo(struct ndpi_detection_module_struct *ndpi_struct, st
 
 
 void init_imo_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("IMO", ndpi_struct,
+  ndpi_register_dissector("IMO", ndpi_struct,
                      ndpi_search_imo,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_IMO);

--- a/src/lib/protocols/ipp.c
+++ b/src/lib/protocols/ipp.c
@@ -58,7 +58,7 @@ static void ndpi_search_ipp(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_ipp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("IPP", ndpi_struct,
+  ndpi_register_dissector("IPP", ndpi_struct,
                      ndpi_search_ipp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_IPP);

--- a/src/lib/protocols/ipsec.c
+++ b/src/lib/protocols/ipsec.c
@@ -185,7 +185,7 @@ static void ndpi_search_ipsec(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_ipsec_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("IPSec", ndpi_struct,
+  ndpi_register_dissector("IPSec", ndpi_struct,
                      ndpi_search_ipsec,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_IPSEC);

--- a/src/lib/protocols/iqiyi.c
+++ b/src/lib/protocols/iqiyi.c
@@ -57,7 +57,7 @@ static void ndpi_search_iqiyi(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_iqiyi_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("iQIYI", ndpi_struct,
+  ndpi_register_dissector("iQIYI", ndpi_struct,
                      ndpi_search_iqiyi,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_IQIYI);

--- a/src/lib/protocols/irc.c
+++ b/src/lib/protocols/irc.c
@@ -226,7 +226,7 @@ static void ndpi_search_irc_tcp(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_irc_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("IRC", ndpi_struct,
+  ndpi_register_dissector("IRC", ndpi_struct,
                      ndpi_search_irc_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_IRC);

--- a/src/lib/protocols/iso9506-1-mms.c
+++ b/src/lib/protocols/iso9506-1-mms.c
@@ -74,7 +74,7 @@ static void ndpi_search_iso9506_1_mms(struct ndpi_detection_module_struct *ndpi_
 
 void init_iso9506_1_mms_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("ISO9506-1-MMS", ndpi_struct,
+  ndpi_register_dissector("ISO9506-1-MMS", ndpi_struct,
                      ndpi_search_iso9506_1_mms,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ISO9506_1_MMS);

--- a/src/lib/protocols/jabber.c
+++ b/src/lib/protocols/jabber.c
@@ -142,7 +142,7 @@ static void ndpi_search_jabber_tcp(struct ndpi_detection_module_struct *ndpi_str
 
 void init_jabber_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Jabber", ndpi_struct,
+  ndpi_register_dissector("Jabber", ndpi_struct,
                       ndpi_search_jabber_tcp,
                       NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_JABBER);

--- a/src/lib/protocols/jrmi.c
+++ b/src/lib/protocols/jrmi.c
@@ -54,7 +54,7 @@ static void ndpi_search_jrmi(struct ndpi_detection_module_struct *ndpi_struct, s
 
 
 void init_jrmi_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("JRMI", ndpi_struct,
+  ndpi_register_dissector("JRMI", ndpi_struct,
                      ndpi_search_jrmi,
                       NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_JRMI);

--- a/src/lib/protocols/json-rpc.c
+++ b/src/lib/protocols/json-rpc.c
@@ -63,7 +63,7 @@ static void ndpi_search_json_rpc(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_json_rpc_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("JSON-RPC", ndpi_struct,
+  ndpi_register_dissector("JSON-RPC", ndpi_struct,
                      ndpi_search_json_rpc,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_JSON_RPC);

--- a/src/lib/protocols/json.c
+++ b/src/lib/protocols/json.c
@@ -116,7 +116,7 @@ void ndpi_search_json(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_json_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("JSON", ndpi_struct,
+  ndpi_register_dissector("JSON", ndpi_struct,
                      ndpi_search_json,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_JSON);

--- a/src/lib/protocols/kafka.c
+++ b/src/lib/protocols/kafka.c
@@ -87,7 +87,7 @@ static void ndpi_search_kafka(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_kafka_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Kafka", ndpi_struct,
+  ndpi_register_dissector("Kafka", ndpi_struct,
                      ndpi_search_kafka,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_APACHE_KAFKA);

--- a/src/lib/protocols/kakaotalk_voice.c
+++ b/src/lib/protocols/kakaotalk_voice.c
@@ -67,7 +67,7 @@ static void ndpi_search_kakaotalk_voice(struct ndpi_detection_module_struct *ndp
 
 void init_kakaotalk_voice_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("KakaoTalk_Voice", ndpi_struct,
+  ndpi_register_dissector("KakaoTalk_Voice", ndpi_struct,
                      ndpi_search_kakaotalk_voice,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                       1, NDPI_PROTOCOL_KAKAOTALK_VOICE);

--- a/src/lib/protocols/kcp.c
+++ b/src/lib/protocols/kcp.c
@@ -94,7 +94,7 @@ static void ndpi_search_kcp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_kcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("KCP", ndpi_struct,
+  ndpi_register_dissector("KCP", ndpi_struct,
                      ndpi_search_kcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_KCP);

--- a/src/lib/protocols/kerberos.c
+++ b/src/lib/protocols/kerberos.c
@@ -698,7 +698,7 @@ static int ndpi_search_kerberos_extra(struct ndpi_detection_module_struct *ndpi_
 }
 
 void init_kerberos_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Kerberos", ndpi_struct,
+  ndpi_register_dissector("Kerberos", ndpi_struct,
                      ndpi_search_kerberos,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_KERBEROS);

--- a/src/lib/protocols/kismet.c
+++ b/src/lib/protocols/kismet.c
@@ -60,7 +60,7 @@ static void ndpi_search_kismet(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_kismet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("kismet", ndpi_struct,
+  ndpi_register_dissector("kismet", ndpi_struct,
                      ndpi_search_kismet,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_KISMET);

--- a/src/lib/protocols/knxnet_ip.c
+++ b/src/lib/protocols/knxnet_ip.c
@@ -120,7 +120,7 @@ not_knxnet_ip:
 
 void init_knxnet_ip_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("KNXnet_IP", ndpi_struct,
+  ndpi_register_dissector("KNXnet_IP", ndpi_struct,
                      ndpi_search_knxnet_ip,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_KNXNET_IP);

--- a/src/lib/protocols/lagofast.c
+++ b/src/lib/protocols/lagofast.c
@@ -64,7 +64,7 @@ static void ndpi_search_lagofast(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_lagofast_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("LagoFast", ndpi_struct,
+  ndpi_register_dissector("LagoFast", ndpi_struct,
                      ndpi_search_lagofast,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                       1, NDPI_PROTOCOL_LAGOFAST);

--- a/src/lib/protocols/ldap.c
+++ b/src/lib/protocols/ldap.c
@@ -72,7 +72,7 @@ static void ndpi_search_ldap(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_ldap_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("LDAP", ndpi_struct,
+  ndpi_register_dissector("LDAP", ndpi_struct,
                      ndpi_search_ldap,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_LDAP);

--- a/src/lib/protocols/ldp.c
+++ b/src/lib/protocols/ldp.c
@@ -116,7 +116,7 @@ static void ndpi_search_ldp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_ldp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("LDP", ndpi_struct,
+  ndpi_register_dissector("LDP", ndpi_struct,
                      ndpi_search_ldp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_LDP);

--- a/src/lib/protocols/line.c
+++ b/src/lib/protocols/line.c
@@ -112,7 +112,7 @@ static void ndpi_search_line(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_line_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("LineCall", ndpi_struct,
+  ndpi_register_dissector("LineCall", ndpi_struct,
                      ndpi_search_line,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                       1, NDPI_PROTOCOL_LINE_CALL);

--- a/src/lib/protocols/lisp.c
+++ b/src/lib/protocols/lisp.c
@@ -82,7 +82,7 @@ static void ndpi_search_lisp(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_lisp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("LISP", ndpi_struct,
+  ndpi_register_dissector("LISP", ndpi_struct,
                      ndpi_search_lisp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_LISP);

--- a/src/lib/protocols/lol_wild_rift.c
+++ b/src/lib/protocols/lol_wild_rift.c
@@ -74,7 +74,7 @@ static void ndpi_search_lolwildrift(struct ndpi_detection_module_struct *ndpi_st
 
 void init_lolwildrift_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("LoLWildRift", ndpi_struct,
+  ndpi_register_dissector("LoLWildRift", ndpi_struct,
                      ndpi_search_lolwildrift,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                       1, NDPI_PROTOCOL_LOLWILDRIFT);

--- a/src/lib/protocols/lustre.c
+++ b/src/lib/protocols/lustre.c
@@ -79,7 +79,7 @@ static void ndpi_search_lustre(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_lustre_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Lustre", ndpi_struct,
+  ndpi_register_dissector("Lustre", ndpi_struct,
                      ndpi_search_lustre,
                      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION, /* Ipv4 only; Lustre doesn't support IPv6 */
                       1, NDPI_PROTOCOL_LUSTRE);

--- a/src/lib/protocols/mail_imap.c
+++ b/src/lib/protocols/mail_imap.c
@@ -275,7 +275,7 @@ static void ndpi_search_mail_imap_tcp(struct ndpi_detection_module_struct *ndpi_
 
 void init_mail_imap_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MAIL_IMAP", ndpi_struct,
+  ndpi_register_dissector("MAIL_IMAP", ndpi_struct,
                      ndpi_search_mail_imap_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MAIL_IMAP);

--- a/src/lib/protocols/mail_pop.c
+++ b/src/lib/protocols/mail_pop.c
@@ -231,7 +231,7 @@ static void popInitExtraPacketProcessing(struct ndpi_flow_struct *flow) {
 /* **************************************** */
 
 void init_mail_pop_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("MAIL_POP", ndpi_struct,
+  ndpi_register_dissector("MAIL_POP", ndpi_struct,
                      ndpi_search_mail_pop_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MAIL_POP);

--- a/src/lib/protocols/mail_smtp.c
+++ b/src/lib/protocols/mail_smtp.c
@@ -426,7 +426,7 @@ static void smtpInitExtraPacketProcessing(struct ndpi_flow_struct *flow) {
 /* **************************************** */
 
 void init_mail_smtp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("MAIL_SMTP", ndpi_struct,
+  ndpi_register_dissector("MAIL_SMTP", ndpi_struct,
                      ndpi_search_mail_smtp_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MAIL_SMTP);

--- a/src/lib/protocols/matter.c
+++ b/src/lib/protocols/matter.c
@@ -80,7 +80,7 @@ static void ndpi_search_matter(struct ndpi_detection_module_struct *ndpi_struct,
 }
 
 void init_matter_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Matter", ndpi_struct,
+  ndpi_register_dissector("Matter", ndpi_struct,
                      ndpi_search_matter,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V6_UDP_WITH_PAYLOAD, /* MATTER is only over IPv6 */
                      1, NDPI_PROTOCOL_MATTER);

--- a/src/lib/protocols/megaco.c
+++ b/src/lib/protocols/megaco.c
@@ -53,7 +53,7 @@ static void ndpi_search_megaco(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_megaco_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Megaco", ndpi_struct,
+  ndpi_register_dissector("Megaco", ndpi_struct,
                      ndpi_search_megaco,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                       1, NDPI_PROTOCOL_MEGACO);

--- a/src/lib/protocols/melsec.c
+++ b/src/lib/protocols/melsec.c
@@ -56,7 +56,7 @@ static void ndpi_search_melsec(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_melsec_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MELSEC", ndpi_struct,
+  ndpi_register_dissector("MELSEC", ndpi_struct,
                      ndpi_search_melsec,
                      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MELSEC);

--- a/src/lib/protocols/memcached.c
+++ b/src/lib/protocols/memcached.c
@@ -175,7 +175,7 @@ static void ndpi_search_memcached(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_memcached_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MEMCACHED", ndpi_struct,
+  ndpi_register_dissector("MEMCACHED", ndpi_struct,
                      ndpi_search_memcached,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MEMCACHED);

--- a/src/lib/protocols/merakicloud.c
+++ b/src/lib/protocols/merakicloud.c
@@ -51,7 +51,7 @@ static void ndpi_search_merakicloud(struct ndpi_detection_module_struct *ndpi_st
 
 void init_merakicloud_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MerakiCloud", ndpi_struct,
+  ndpi_register_dissector("MerakiCloud", ndpi_struct,
                      ndpi_search_merakicloud,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                       1, NDPI_PROTOCOL_MERAKI_CLOUD);

--- a/src/lib/protocols/mgcp.c
+++ b/src/lib/protocols/mgcp.c
@@ -103,7 +103,7 @@ static void ndpi_search_mgcp(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_mgcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MGCP", ndpi_struct,
+  ndpi_register_dissector("MGCP", ndpi_struct,
                      ndpi_search_mgcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                       1, NDPI_PROTOCOL_MGCP);

--- a/src/lib/protocols/mikrotik.c
+++ b/src/lib/protocols/mikrotik.c
@@ -109,7 +109,7 @@ static void ndpi_search_mikrotik(struct ndpi_detection_module_struct *ndpi_struc
 /* ********************************* */
 
 void init_mikrotik_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("MIKROTIK", ndpi_struct,
+  ndpi_register_dissector("MIKROTIK", ndpi_struct,
                      ndpi_search_mikrotik,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                       1, NDPI_PROTOCOL_MIKROTIK);

--- a/src/lib/protocols/mining.c
+++ b/src/lib/protocols/mining.c
@@ -96,7 +96,7 @@ static void ndpi_search_mining(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_mining_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Mining", ndpi_struct,
+  ndpi_register_dissector("Mining", ndpi_struct,
                      ndpi_search_mining,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MINING);

--- a/src/lib/protocols/modbus.c
+++ b/src/lib/protocols/modbus.c
@@ -69,7 +69,7 @@ static void ndpi_search_modbus_tcp(struct ndpi_detection_module_struct *ndpi_str
 
 void init_modbus_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
 
-  register_dissector("Modbus", ndpi_struct,
+  ndpi_register_dissector("Modbus", ndpi_struct,
                      ndpi_search_modbus_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MODBUS);

--- a/src/lib/protocols/monero.c
+++ b/src/lib/protocols/monero.c
@@ -70,7 +70,7 @@ static void ndpi_search_monero(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_monero_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Monero", ndpi_struct,
+  ndpi_register_dissector("Monero", ndpi_struct,
                      ndpi_search_monero,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MONERO);

--- a/src/lib/protocols/mongodb.c
+++ b/src/lib/protocols/mongodb.c
@@ -139,7 +139,7 @@ static void ndpi_search_mongodb(struct ndpi_detection_module_struct *ndpi_struct
 
 
 void init_mongodb_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("MongoDB", ndpi_struct,
+  ndpi_register_dissector("MongoDB", ndpi_struct,
                      ndpi_search_mongodb,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MONGODB);

--- a/src/lib/protocols/mpegdash.c
+++ b/src/lib/protocols/mpegdash.c
@@ -89,7 +89,7 @@ static void ndpi_search_mpegdash_http(struct ndpi_detection_module_struct *ndpi_
 
 void init_mpegdash_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MpegDash", ndpi_struct,
+  ndpi_register_dissector("MpegDash", ndpi_struct,
                      ndpi_search_mpegdash_http,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MPEGDASH);

--- a/src/lib/protocols/mpegts.c
+++ b/src/lib/protocols/mpegts.c
@@ -54,7 +54,7 @@ static void ndpi_search_mpegts(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_mpegts_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MPEG_TS", ndpi_struct,
+  ndpi_register_dissector("MPEG_TS", ndpi_struct,
                      ndpi_search_mpegts,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                       1, NDPI_PROTOCOL_MPEGTS);

--- a/src/lib/protocols/mqtt.c
+++ b/src/lib/protocols/mqtt.c
@@ -249,7 +249,7 @@ static void ndpi_search_mqtt(struct ndpi_detection_module_struct *ndpi_struct,
  */
 void init_mqtt_dissector (struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MQTT", ndpi_struct,
+  ndpi_register_dissector("MQTT", ndpi_struct,
                      ndpi_search_mqtt,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MQTT);

--- a/src/lib/protocols/msdo.c
+++ b/src/lib/protocols/msdo.c
@@ -66,7 +66,7 @@ static void ndpi_search_msdo(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_msdo_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MSDO", ndpi_struct,
+  ndpi_register_dissector("MSDO", ndpi_struct,
                      ndpi_search_msdo,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MSDO);

--- a/src/lib/protocols/msgpack.c
+++ b/src/lib/protocols/msgpack.c
@@ -291,7 +291,7 @@ void ndpi_search_msgpack(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_msgpack_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MessagePack", ndpi_struct,
+  ndpi_register_dissector("MessagePack", ndpi_struct,
                      ndpi_search_msgpack,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_MSGPACK);

--- a/src/lib/protocols/mssql_tds.c
+++ b/src/lib/protocols/mssql_tds.c
@@ -78,7 +78,7 @@ static void ndpi_search_mssql_tds(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_mssql_tds_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MsSQL_TDS", ndpi_struct,
+  ndpi_register_dissector("MsSQL_TDS", ndpi_struct,
                      ndpi_search_mssql_tds,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MSSQL_TDS);

--- a/src/lib/protocols/mudfish.c
+++ b/src/lib/protocols/mudfish.c
@@ -90,7 +90,7 @@ static void ndpi_search_mudfish(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_mudfish_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Mudfish", ndpi_struct,
+  ndpi_register_dissector("Mudfish", ndpi_struct,
                      ndpi_search_mudfish,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_MUDFISH);

--- a/src/lib/protocols/mumble.c
+++ b/src/lib/protocols/mumble.c
@@ -63,7 +63,7 @@ not_mumble:
 
 void init_mumble_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Mumble", ndpi_struct,
+  ndpi_register_dissector("Mumble", ndpi_struct,
                      ndpi_search_mumble,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                       1, NDPI_PROTOCOL_MUMBLE);

--- a/src/lib/protocols/munin.c
+++ b/src/lib/protocols/munin.c
@@ -81,7 +81,7 @@ static void ndpi_search_munin(struct ndpi_detection_module_struct *ndpi_struct,
   
 void init_munin_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Munin", ndpi_struct,
+  ndpi_register_dissector("Munin", ndpi_struct,
                      ndpi_search_munin,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MUNIN);

--- a/src/lib/protocols/mysql.c
+++ b/src/lib/protocols/mysql.c
@@ -64,7 +64,7 @@ static void ndpi_search_mysql_tcp(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_mysql_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("MySQL", ndpi_struct,
+  ndpi_register_dissector("MySQL", ndpi_struct,
                      ndpi_search_mysql_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                       1, NDPI_PROTOCOL_MYSQL);

--- a/src/lib/protocols/nano.c
+++ b/src/lib/protocols/nano.c
@@ -81,7 +81,7 @@ static void ndpi_search_nano(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_nano_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Nano", ndpi_struct,
+  ndpi_register_dissector("Nano", ndpi_struct,
                      ndpi_search_nano,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_NANO);

--- a/src/lib/protocols/natpmp.c
+++ b/src/lib/protocols/natpmp.c
@@ -190,7 +190,7 @@ static void ndpi_search_natpmp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_natpmp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("NAT-PMP", ndpi_struct,
+  ndpi_register_dissector("NAT-PMP", ndpi_struct,
                      ndpi_search_natpmp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_NATPMP);

--- a/src/lib/protocols/nats.c
+++ b/src/lib/protocols/nats.c
@@ -74,7 +74,7 @@ static void ndpi_search_nats_tcp(struct ndpi_detection_module_struct *ndpi_struc
 
 
 void init_nats_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Nats", ndpi_struct,
+  ndpi_register_dissector("Nats", ndpi_struct,
                      ndpi_search_nats_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_NATS);

--- a/src/lib/protocols/nest_log_sink.c
+++ b/src/lib/protocols/nest_log_sink.c
@@ -65,7 +65,7 @@ static void ndpi_search_nest_log_sink(struct ndpi_detection_module_struct *ndpi_
 
 void init_nest_log_sink_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("NEST_LOG_SINK", ndpi_struct,
+  ndpi_register_dissector("NEST_LOG_SINK", ndpi_struct,
                      ndpi_search_nest_log_sink,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_NEST_LOG_SINK);

--- a/src/lib/protocols/netbios.c
+++ b/src/lib/protocols/netbios.c
@@ -417,7 +417,7 @@ static void ndpi_search_netbios(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_netbios_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("NETBIOS", ndpi_struct,
+  ndpi_register_dissector("NETBIOS", ndpi_struct,
                      ndpi_search_netbios,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_NETBIOS);

--- a/src/lib/protocols/netease_games.c
+++ b/src/lib/protocols/netease_games.c
@@ -78,7 +78,7 @@ static void ndpi_search_netease(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_netease_games_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("NetEaseGames", ndpi_struct,
+  ndpi_register_dissector("NetEaseGames", ndpi_struct,
                      ndpi_search_netease,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_NETEASE_GAMES);

--- a/src/lib/protocols/netflow.c
+++ b/src/lib/protocols/netflow.c
@@ -184,7 +184,7 @@ static void ndpi_search_netflow(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_netflow_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("NetFlow", ndpi_struct,
+  ndpi_register_dissector("NetFlow", ndpi_struct,
                      ndpi_search_netflow,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_NETFLOW);

--- a/src/lib/protocols/nexon.c
+++ b/src/lib/protocols/nexon.c
@@ -64,7 +64,7 @@ static void ndpi_search_nexon(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_nexon_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Nexon", ndpi_struct,
+  ndpi_register_dissector("Nexon", ndpi_struct,
                      ndpi_search_nexon,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_NEXON);

--- a/src/lib/protocols/nfs.c
+++ b/src/lib/protocols/nfs.c
@@ -90,7 +90,7 @@ static void ndpi_search_nfs(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_nfs_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("NFS", ndpi_struct,
+  ndpi_register_dissector("NFS", ndpi_struct,
                      ndpi_search_nfs,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_NFS);

--- a/src/lib/protocols/nintendo.c
+++ b/src/lib/protocols/nintendo.c
@@ -55,7 +55,7 @@ static void ndpi_search_nintendo(struct ndpi_detection_module_struct *ndpi_struc
 }
 
 void init_nintendo_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Nintendo", ndpi_struct,
+  ndpi_register_dissector("Nintendo", ndpi_struct,
                      ndpi_search_nintendo,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_NINTENDO);

--- a/src/lib/protocols/noe.c
+++ b/src/lib/protocols/noe.c
@@ -73,7 +73,7 @@ static void ndpi_search_noe(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_noe_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("NOE", ndpi_struct,
+  ndpi_register_dissector("NOE", ndpi_struct,
                      ndpi_search_noe,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_NOE);

--- a/src/lib/protocols/nomachine.c
+++ b/src/lib/protocols/nomachine.c
@@ -71,7 +71,7 @@ static void ndpi_search_nomachine(struct ndpi_detection_module_struct *ndpi_stru
 }
 void init_nomachine_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("NoMachine", ndpi_struct,
+  ndpi_register_dissector("NoMachine", ndpi_struct,
                      ndpi_search_nomachine,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_NOMACHINE);

--- a/src/lib/protocols/non_tcp_udp.c
+++ b/src/lib/protocols/non_tcp_udp.c
@@ -164,7 +164,7 @@ static void ndpi_search_in_non_tcp_udp(struct ndpi_detection_module_struct
 
 void init_non_tcp_udp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Non_TCP_UDP", ndpi_struct,
+  ndpi_register_dissector("Non_TCP_UDP", ndpi_struct,
                      ndpi_search_in_non_tcp_udp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_IPV4_OR_IPV6,
                      13,

--- a/src/lib/protocols/ntp.c
+++ b/src/lib/protocols/ntp.c
@@ -62,7 +62,7 @@ static void ndpi_search_ntp_udp(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_ntp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("NTP", ndpi_struct,
+  ndpi_register_dissector("NTP", ndpi_struct,
                      ndpi_search_ntp_udp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_NTP);

--- a/src/lib/protocols/oicq.c
+++ b/src/lib/protocols/oicq.c
@@ -90,7 +90,7 @@ static void ndpi_search_oicq(struct ndpi_detection_module_struct *ndpi_struct,
   
 void init_oicq_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("OICQ", ndpi_struct,
+  ndpi_register_dissector("OICQ", ndpi_struct,
                      ndpi_search_oicq,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_OICQ);

--- a/src/lib/protocols/ookla.c
+++ b/src/lib/protocols/ookla.c
@@ -119,7 +119,7 @@ void ndpi_search_ookla(struct ndpi_detection_module_struct* ndpi_struct, struct 
 /* ************************************************************* */
 
 void init_ookla_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Ookla", ndpi_struct,
+  ndpi_register_dissector("Ookla", ndpi_struct,
                      ndpi_search_ookla,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_OOKLA);

--- a/src/lib/protocols/opc-ua.c
+++ b/src/lib/protocols/opc-ua.c
@@ -71,7 +71,7 @@ static void ndpi_search_opc_ua(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_opc_ua_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("OPC-UA", ndpi_struct,
+  ndpi_register_dissector("OPC-UA", ndpi_struct,
                      ndpi_search_opc_ua,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_OPC_UA);

--- a/src/lib/protocols/openflow.c
+++ b/src/lib/protocols/openflow.c
@@ -58,7 +58,7 @@ static void ndpi_search_openflow(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_openflow_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("OpenFlow", ndpi_struct,
+  ndpi_register_dissector("OpenFlow", ndpi_struct,
                      ndpi_search_openflow,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_OPENFLOW);

--- a/src/lib/protocols/openvpn.c
+++ b/src/lib/protocols/openvpn.c
@@ -497,7 +497,7 @@ static void ndpi_search_openvpn(struct ndpi_detection_module_struct* ndpi_struct
 }
 
 void init_openvpn_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("OpenVPN", ndpi_struct,
+  ndpi_register_dissector("OpenVPN", ndpi_struct,
                      ndpi_search_openvpn,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_OPENVPN);

--- a/src/lib/protocols/openwire.c
+++ b/src/lib/protocols/openwire.c
@@ -52,7 +52,7 @@ static void ndpi_search_openwire(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_openwire_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("OpenWire", ndpi_struct,
+  ndpi_register_dissector("OpenWire", ndpi_struct,
                      ndpi_search_openwire,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_OPENWIRE);

--- a/src/lib/protocols/oracle.c
+++ b/src/lib/protocols/oracle.c
@@ -62,7 +62,7 @@ static void ndpi_search_oracle(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_oracle_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Oracle", ndpi_struct,
+  ndpi_register_dissector("Oracle", ndpi_struct,
                      ndpi_search_oracle,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ORACLE);

--- a/src/lib/protocols/paltalk.c
+++ b/src/lib/protocols/paltalk.c
@@ -62,7 +62,7 @@ static void ndpi_search_paltalk(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_paltalk_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Paltalk", ndpi_struct,
+  ndpi_register_dissector("Paltalk", ndpi_struct,
                      ndpi_search_paltalk,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_PALTALK);

--- a/src/lib/protocols/path_of_exile.c
+++ b/src/lib/protocols/path_of_exile.c
@@ -71,7 +71,7 @@ static void ndpi_search_pathofexile(struct ndpi_detection_module_struct *ndpi_st
 
 void init_pathofexile_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("PathofExile", ndpi_struct,
+  ndpi_register_dissector("PathofExile", ndpi_struct,
                      ndpi_search_pathofexile,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_PATHOFEXILE);

--- a/src/lib/protocols/pfcp.c
+++ b/src/lib/protocols/pfcp.c
@@ -60,7 +60,7 @@ static void ndpi_search_pfcp(struct ndpi_detection_module_struct *ndpi_struct,
 }
 void init_pfcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("PFCP", ndpi_struct,
+  ndpi_register_dissector("PFCP", ndpi_struct,
                      ndpi_search_pfcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_PFCP);

--- a/src/lib/protocols/postgres.c
+++ b/src/lib/protocols/postgres.c
@@ -125,7 +125,7 @@ static void ndpi_search_postgres_tcp(struct ndpi_detection_module_struct
 
 void init_postgres_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("PostgreSQL", ndpi_struct,
+  ndpi_register_dissector("PostgreSQL", ndpi_struct,
                      ndpi_search_postgres_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_POSTGRES);

--- a/src/lib/protocols/pptp.c
+++ b/src/lib/protocols/pptp.c
@@ -59,7 +59,7 @@ static void ndpi_search_pptp(struct ndpi_detection_module_struct
 
 void init_pptp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("PPTP", ndpi_struct,
+  ndpi_register_dissector("PPTP", ndpi_struct,
                      ndpi_search_pptp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_PPTP);

--- a/src/lib/protocols/profinet_io.c
+++ b/src/lib/protocols/profinet_io.c
@@ -77,7 +77,7 @@ static void ndpi_search_profinet_io(struct ndpi_detection_module_struct *ndpi_st
 
 void init_profinet_io_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("PROFINET_IO", ndpi_struct,
+  ndpi_register_dissector("PROFINET_IO", ndpi_struct,
                      ndpi_search_profinet_io,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_PROFINET_IO);

--- a/src/lib/protocols/protobuf.c
+++ b/src/lib/protocols/protobuf.c
@@ -251,7 +251,7 @@ static void ndpi_search_protobuf(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_protobuf_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Protobuf", ndpi_struct,
+  ndpi_register_dissector("Protobuf", ndpi_struct,
                      ndpi_search_protobuf,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_PROTOBUF);

--- a/src/lib/protocols/ptpv2.c
+++ b/src/lib/protocols/ptpv2.c
@@ -68,7 +68,7 @@ static void ndpi_search_ptpv2_udp(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_ptpv2_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("PTPv2", ndpi_struct,
+  ndpi_register_dissector("PTPv2", ndpi_struct,
                      ndpi_search_ptpv2_udp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_PTPV2);

--- a/src/lib/protocols/qq.c
+++ b/src/lib/protocols/qq.c
@@ -60,7 +60,7 @@ static void ndpi_search_qq(struct ndpi_detection_module_struct *ndpi_struct, str
 
 void init_qq_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("QQ", ndpi_struct,
+  ndpi_register_dissector("QQ", ndpi_struct,
                      ndpi_search_qq,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_QQ);

--- a/src/lib/protocols/quic.c
+++ b/src/lib/protocols/quic.c
@@ -2069,7 +2069,7 @@ static void ndpi_search_quic(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_quic_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("QUIC", ndpi_struct,
+  ndpi_register_dissector("QUIC", ndpi_struct,
                      ndpi_search_quic,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_QUIC);

--- a/src/lib/protocols/radius_proto.c
+++ b/src/lib/protocols/radius_proto.c
@@ -75,7 +75,7 @@ static void ndpi_search_radius(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_radius_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Radius", ndpi_struct,
+  ndpi_register_dissector("Radius", ndpi_struct,
                      ndpi_search_radius,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_RADIUS);

--- a/src/lib/protocols/radmin.c
+++ b/src/lib/protocols/radmin.c
@@ -90,7 +90,7 @@ static void ndpi_search_radmin(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_radmin_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Radmin", ndpi_struct,
+  ndpi_register_dissector("Radmin", ndpi_struct,
                      ndpi_search_radmin,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_RADMIN);

--- a/src/lib/protocols/raft.c
+++ b/src/lib/protocols/raft.c
@@ -98,7 +98,7 @@ static void ndpi_search_raft(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_raft_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Raft", ndpi_struct,
+  ndpi_register_dissector("Raft", ndpi_struct,
                      ndpi_search_raft,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_RAFT);

--- a/src/lib/protocols/raknet.c
+++ b/src/lib/protocols/raknet.c
@@ -393,7 +393,7 @@ static void ndpi_search_raknet(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_raknet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RakNet", ndpi_struct,
+  ndpi_register_dissector("RakNet", ndpi_struct,
                      ndpi_search_raknet,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_RAKNET);

--- a/src/lib/protocols/rdp.c
+++ b/src/lib/protocols/rdp.c
@@ -197,7 +197,7 @@ static void ndpi_search_rdp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_rdp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RDP", ndpi_struct,
+  ndpi_register_dissector("RDP", ndpi_struct,
                      ndpi_search_rdp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_RDP);

--- a/src/lib/protocols/resp.c
+++ b/src/lib/protocols/resp.c
@@ -71,7 +71,7 @@ exclude:
 
 void init_resp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RESP", ndpi_struct,
+  ndpi_register_dissector("RESP", ndpi_struct,
                      ndpi_search_resp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_RESP);

--- a/src/lib/protocols/riotgames.c
+++ b/src/lib/protocols/riotgames.c
@@ -69,7 +69,7 @@ static void ndpi_search_riotgames(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_riotgames_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RiotGames", ndpi_struct,
+  ndpi_register_dissector("RiotGames", ndpi_struct,
                      ndpi_search_riotgames,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_RIOTGAMES);

--- a/src/lib/protocols/ripe_atlas.c
+++ b/src/lib/protocols/ripe_atlas.c
@@ -61,7 +61,7 @@ static void ndpi_search_ripe_atlas(struct ndpi_detection_module_struct *ndpi_str
 
 void init_ripe_atlas_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RipeAtlas", ndpi_struct,
+  ndpi_register_dissector("RipeAtlas", ndpi_struct,
                      ndpi_search_ripe_atlas,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_RIPE_ATLAS);

--- a/src/lib/protocols/rmcp.c
+++ b/src/lib/protocols/rmcp.c
@@ -88,7 +88,7 @@ static void ndpi_search_rmcp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_rmcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RMCP", ndpi_struct,
+  ndpi_register_dissector("RMCP", ndpi_struct,
                      ndpi_search_rmcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_RMCP);

--- a/src/lib/protocols/roughtime.c
+++ b/src/lib/protocols/roughtime.c
@@ -126,7 +126,7 @@ static void ndpi_search_roughtime(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_roughtime_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Roughtime", ndpi_struct,
+  ndpi_register_dissector("Roughtime", ndpi_struct,
                      ndpi_search_roughtime,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ROUGHTIME);

--- a/src/lib/protocols/rsh.c
+++ b/src/lib/protocols/rsh.c
@@ -152,7 +152,7 @@ static void ndpi_search_rsh(struct ndpi_detection_module_struct * ndpi_struct,
 
 void init_rsh_dissector(struct ndpi_detection_module_struct * ndpi_struct)
 {
-  register_dissector("RSH", ndpi_struct,
+  ndpi_register_dissector("RSH", ndpi_struct,
                      ndpi_search_rsh,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_RSH);

--- a/src/lib/protocols/rsync.c
+++ b/src/lib/protocols/rsync.c
@@ -60,7 +60,7 @@ static void ndpi_search_rsync(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_rsync_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RSYNC", ndpi_struct,
+  ndpi_register_dissector("RSYNC", ndpi_struct,
                      ndpi_search_rsync,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_RSYNC);

--- a/src/lib/protocols/rtmp.c
+++ b/src/lib/protocols/rtmp.c
@@ -93,7 +93,7 @@ static void ndpi_search_rtmp(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_rtmp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RTMP", ndpi_struct,
+  ndpi_register_dissector("RTMP", ndpi_struct,
                      ndpi_search_rtmp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_RTMP);

--- a/src/lib/protocols/rtp.c
+++ b/src/lib/protocols/rtp.c
@@ -545,7 +545,7 @@ static void ndpi_search_rtp(struct ndpi_detection_module_struct *ndpi_struct, st
 /* *************************************************************** */
 
 void init_rtp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("RT(C)P", ndpi_struct,
+  ndpi_register_dissector("RT(C)P", ndpi_struct,
                      ndpi_search_rtp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      2, NDPI_PROTOCOL_RTP, NDPI_PROTOCOL_RTCP);

--- a/src/lib/protocols/rtps.c
+++ b/src/lib/protocols/rtps.c
@@ -62,7 +62,7 @@ static void ndpi_search_rtps(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_rtps_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RTPS", ndpi_struct,
+  ndpi_register_dissector("RTPS", ndpi_struct,
                      ndpi_search_rtps,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_RTPS);

--- a/src/lib/protocols/rtsp.c
+++ b/src/lib/protocols/rtsp.c
@@ -73,7 +73,7 @@ static void ndpi_search_rtsp_tcp_udp(struct ndpi_detection_module_struct *ndpi_s
 
 void init_rtsp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RTSP", ndpi_struct,
+  ndpi_register_dissector("RTSP", ndpi_struct,
                      ndpi_search_rtsp_tcp_udp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_RTSP);

--- a/src/lib/protocols/rx.c
+++ b/src/lib/protocols/rx.c
@@ -214,7 +214,7 @@ static void ndpi_search_rx(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_rx_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("RX", ndpi_struct,
+  ndpi_register_dissector("RX", ndpi_struct,
                      ndpi_search_rx,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_RX);

--- a/src/lib/protocols/s7comm.c
+++ b/src/lib/protocols/s7comm.c
@@ -234,7 +234,7 @@ static void ndpi_search_s7comm(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_s7comm_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("S7Comm", ndpi_struct,
+  ndpi_register_dissector("S7Comm", ndpi_struct,
                      ndpi_search_s7comm,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_S7COMM);

--- a/src/lib/protocols/samsung_sdp.c
+++ b/src/lib/protocols/samsung_sdp.c
@@ -57,7 +57,7 @@ static void ndpi_search_samsung_sdp(struct ndpi_detection_module_struct *ndpi_st
 
 void init_samsung_sdp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("SamsungSDP", ndpi_struct,
+  ndpi_register_dissector("SamsungSDP", ndpi_struct,
                      ndpi_search_samsung_sdp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_SAMSUNG_SDP);

--- a/src/lib/protocols/sd_rtn.c
+++ b/src/lib/protocols/sd_rtn.c
@@ -85,7 +85,7 @@ static void ndpi_search_sd_rtn(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_sd_rtn_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("SD-RTN", ndpi_struct,
+  ndpi_register_dissector("SD-RTN", ndpi_struct,
                      ndpi_search_sd_rtn,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_SD_RTN);

--- a/src/lib/protocols/sflow.c
+++ b/src/lib/protocols/sflow.c
@@ -57,7 +57,7 @@ static void ndpi_search_sflow(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_sflow_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("sFlow", ndpi_struct,
+  ndpi_register_dissector("sFlow", ndpi_struct,
                      ndpi_search_sflow,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_SFLOW);

--- a/src/lib/protocols/sip.c
+++ b/src/lib/protocols/sip.c
@@ -274,7 +274,7 @@ static void ndpi_search_sip(struct ndpi_detection_module_struct *ndpi_struct, st
 /* ********************************************************** */
 
 void init_sip_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("SIP", ndpi_struct,
+  ndpi_register_dissector("SIP", ndpi_struct,
                      ndpi_search_sip,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SIP);

--- a/src/lib/protocols/skinny.c
+++ b/src/lib/protocols/skinny.c
@@ -93,7 +93,7 @@ static void ndpi_search_skinny(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_skinny_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("CiscoSkinny", ndpi_struct,
+  ndpi_register_dissector("CiscoSkinny", ndpi_struct,
                      ndpi_search_skinny,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SKINNY);

--- a/src/lib/protocols/slp.c
+++ b/src/lib/protocols/slp.c
@@ -323,7 +323,7 @@ static void ndpi_search_slp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_slp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Service_Location_Protocol", ndpi_struct,
+  ndpi_register_dissector("Service_Location_Protocol", ndpi_struct,
                      ndpi_search_slp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SERVICE_LOCATION);

--- a/src/lib/protocols/smb.c
+++ b/src/lib/protocols/smb.c
@@ -82,7 +82,7 @@ static void ndpi_search_smb_tcp(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_smb_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("SMB", ndpi_struct,
+  ndpi_register_dissector("SMB", ndpi_struct,
                      ndpi_search_smb_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SMBV23);

--- a/src/lib/protocols/smpp.c
+++ b/src/lib/protocols/smpp.c
@@ -312,7 +312,7 @@ static void ndpi_search_smpp_tcp(struct ndpi_detection_module_struct* ndpi_struc
 
 void init_smpp_dissector(struct ndpi_detection_module_struct* ndpi_struct)
 {
-  register_dissector("SMPP", ndpi_struct,
+  ndpi_register_dissector("SMPP", ndpi_struct,
                      ndpi_search_smpp_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SMPP);

--- a/src/lib/protocols/snmp_proto.c
+++ b/src/lib/protocols/snmp_proto.c
@@ -145,7 +145,7 @@ static void ndpi_search_snmp(struct ndpi_detection_module_struct *ndpi_struct,
 }
 
 void init_snmp_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("SNMP", ndpi_struct,
+  ndpi_register_dissector("SNMP", ndpi_struct,
                      ndpi_search_snmp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_SNMP);

--- a/src/lib/protocols/soap.c
+++ b/src/lib/protocols/soap.c
@@ -82,7 +82,7 @@ static void ndpi_search_soap(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_soap_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("SOAP", ndpi_struct,
+  ndpi_register_dissector("SOAP", ndpi_struct,
                      ndpi_search_soap,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SOAP);

--- a/src/lib/protocols/socks45.c
+++ b/src/lib/protocols/socks45.c
@@ -124,7 +124,7 @@ static void ndpi_search_socks(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_socks_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("SOCKS", ndpi_struct,
+  ndpi_register_dissector("SOCKS", ndpi_struct,
                      ndpi_search_socks,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SOCKS);

--- a/src/lib/protocols/softether.c
+++ b/src/lib/protocols/softether.c
@@ -348,7 +348,7 @@ static int ndpi_search_softether_again(struct ndpi_detection_module_struct *ndpi
 /* ***************************************************** */
   
 void init_softether_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Softether", ndpi_struct,
+  ndpi_register_dissector("Softether", ndpi_struct,
                      ndpi_search_softether,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_SOFTETHER);

--- a/src/lib/protocols/someip.c
+++ b/src/lib/protocols/someip.c
@@ -193,7 +193,7 @@ static void ndpi_search_someip(struct ndpi_detection_module_struct *ndpi_struct,
  */
 void init_someip_dissector (struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("SOME/IP", ndpi_struct,
+  ndpi_register_dissector("SOME/IP", ndpi_struct,
                      ndpi_search_someip,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SOMEIP);

--- a/src/lib/protocols/sonos.c
+++ b/src/lib/protocols/sonos.c
@@ -63,7 +63,7 @@ void ndpi_search_sonos(struct ndpi_detection_module_struct *ndpi_struct, struct 
 
 void init_sonos_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Sonos", ndpi_struct,
+  ndpi_register_dissector("Sonos", ndpi_struct,
                      ndpi_search_sonos,
                      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* Only IPv4 UDP traffic is expected. */
                      1, NDPI_PROTOCOL_SONOS);

--- a/src/lib/protocols/source_engine.c
+++ b/src/lib/protocols/source_engine.c
@@ -96,7 +96,7 @@ static void ndpi_search_source_engine(struct ndpi_detection_module_struct *ndpi_
   
 void init_source_engine_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Source_Engine", ndpi_struct,
+  ndpi_register_dissector("Source_Engine", ndpi_struct,
                      ndpi_search_source_engine,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_SOURCE_ENGINE);

--- a/src/lib/protocols/spotify.c
+++ b/src/lib/protocols/spotify.c
@@ -78,7 +78,7 @@ static void ndpi_search_spotify(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_spotify_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("SPOTIFY", ndpi_struct,
+  ndpi_register_dissector("SPOTIFY", ndpi_struct,
                      ndpi_search_spotify,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SPOTIFY);

--- a/src/lib/protocols/ssdp.c
+++ b/src/lib/protocols/ssdp.c
@@ -261,7 +261,7 @@ static void ndpi_search_ssdp(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_ssdp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("SSDP", ndpi_struct,
+  ndpi_register_dissector("SSDP", ndpi_struct,
                      ndpi_search_ssdp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_SSDP);

--- a/src/lib/protocols/ssh.c
+++ b/src/lib/protocols/ssh.c
@@ -585,7 +585,7 @@ static void ndpi_search_ssh_tcp(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_ssh_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("SSH", ndpi_struct,
+  ndpi_register_dissector("SSH", ndpi_struct,
                      ndpi_search_ssh_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SSH);

--- a/src/lib/protocols/steam.c
+++ b/src/lib/protocols/steam.c
@@ -55,7 +55,7 @@ static void ndpi_search_steam(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_steam_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Steam", ndpi_struct,
+  ndpi_register_dissector("Steam", ndpi_struct,
                      ndpi_search_steam,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_STEAM);

--- a/src/lib/protocols/steam_datagram_relay.c
+++ b/src/lib/protocols/steam_datagram_relay.c
@@ -59,7 +59,7 @@ static void ndpi_search_valve_sdr(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_valve_sdr_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("SteamDatagramRelay", ndpi_struct,
+  ndpi_register_dissector("SteamDatagramRelay", ndpi_struct,
                      ndpi_search_valve_sdr,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_VALVE_SDR);

--- a/src/lib/protocols/stomp.c
+++ b/src/lib/protocols/stomp.c
@@ -67,7 +67,7 @@ static void ndpi_search_stomp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_stomp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("STOMP", ndpi_struct,
+  ndpi_register_dissector("STOMP", ndpi_struct,
                      ndpi_search_stomp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_STOMP);

--- a/src/lib/protocols/stun.c
+++ b/src/lib/protocols/stun.c
@@ -1350,7 +1350,7 @@ void signal_add_to_cache(struct ndpi_detection_module_struct *ndpi_struct,
 /* ************************************************************ */
 
 void init_stun_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("STUN", ndpi_struct,
+  ndpi_register_dissector("STUN", ndpi_struct,
                      ndpi_search_stun,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_STUN);

--- a/src/lib/protocols/syncthing.c
+++ b/src/lib/protocols/syncthing.c
@@ -62,7 +62,7 @@ static void ndpi_search_syncthing(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_syncthing_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Syncthing", ndpi_struct,
+  ndpi_register_dissector("Syncthing", ndpi_struct,
                      ndpi_search_syncthing,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_SYNCTHING);

--- a/src/lib/protocols/syslog.c
+++ b/src/lib/protocols/syslog.c
@@ -106,7 +106,7 @@ static void ndpi_search_syslog(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_syslog_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Syslog", ndpi_struct,
+  ndpi_register_dissector("Syslog", ndpi_struct,
                      ndpi_search_syslog,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_SYSLOG);

--- a/src/lib/protocols/tailscale.c
+++ b/src/lib/protocols/tailscale.c
@@ -49,7 +49,7 @@ static void ndpi_search_tailscale(struct ndpi_detection_module_struct *ndpi_stru
 }
 
 void init_tailscale_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Tailscale", ndpi_struct,
+  ndpi_register_dissector("Tailscale", ndpi_struct,
                      ndpi_search_tailscale,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_TAILSCALE);

--- a/src/lib/protocols/teamspeak.c
+++ b/src/lib/protocols/teamspeak.c
@@ -95,7 +95,7 @@ ts3_license_weblist:
 
 void init_teamspeak_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TeamSpeak", ndpi_struct,
+  ndpi_register_dissector("TeamSpeak", ndpi_struct,
                      ndpi_search_teamspeak,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_TEAMSPEAK);

--- a/src/lib/protocols/teamviewer.c
+++ b/src/lib/protocols/teamviewer.c
@@ -85,7 +85,7 @@ static void ndpi_search_teamview(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_teamviewer_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TeamViewer", ndpi_struct,
+  ndpi_register_dissector("TeamViewer", ndpi_struct,
                      ndpi_search_teamview,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_TEAMVIEWER);

--- a/src/lib/protocols/telegram.c
+++ b/src/lib/protocols/telegram.c
@@ -113,7 +113,7 @@ static void ndpi_search_telegram(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_telegram_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Telegram", ndpi_struct,
+  ndpi_register_dissector("Telegram", ndpi_struct,
                      ndpi_search_telegram,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_TELEGRAM);

--- a/src/lib/protocols/telnet.c
+++ b/src/lib/protocols/telnet.c
@@ -202,7 +202,7 @@ static void ndpi_search_telnet_tcp(struct ndpi_detection_module_struct *ndpi_str
 
 void init_telnet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Telnet", ndpi_struct,
+  ndpi_register_dissector("Telnet", ndpi_struct,
                      ndpi_search_telnet_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_TELNET);

--- a/src/lib/protocols/tencent_games.c
+++ b/src/lib/protocols/tencent_games.c
@@ -87,7 +87,7 @@ static void ndpi_search_tencent_games(struct ndpi_detection_module_struct *ndpi_
 
 void init_tencent_games_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TencentGames", ndpi_struct,
+  ndpi_register_dissector("TencentGames", ndpi_struct,
                      ndpi_search_tencent_games,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_TENCENTGAMES);

--- a/src/lib/protocols/teredo.c
+++ b/src/lib/protocols/teredo.c
@@ -46,7 +46,7 @@ static void ndpi_search_teredo(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_teredo_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TEREDO", ndpi_struct,
+  ndpi_register_dissector("TEREDO", ndpi_struct,
                      ndpi_search_teredo,
                      NDPI_SELECTION_BITMASK_PROTOCOL_UDP_WITH_PAYLOAD, /* Teredo is inherently IPV4 only */
                      1, NDPI_PROTOCOL_TEREDO);

--- a/src/lib/protocols/teso.c
+++ b/src/lib/protocols/teso.c
@@ -80,7 +80,7 @@ static void ndpi_search_teso(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_teso_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TES_Online", ndpi_struct,
+  ndpi_register_dissector("TES_Online", ndpi_struct,
                      ndpi_search_teso,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_TESO);

--- a/src/lib/protocols/tftp.c
+++ b/src/lib/protocols/tftp.c
@@ -283,7 +283,7 @@ static void ndpi_search_tftp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_tftp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TFTP", ndpi_struct,
+  ndpi_register_dissector("TFTP", ndpi_struct,
                      ndpi_search_tftp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_TFTP);

--- a/src/lib/protocols/threema.c
+++ b/src/lib/protocols/threema.c
@@ -91,7 +91,7 @@ static void ndpi_search_threema(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_threema_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Threema", ndpi_struct,
+  ndpi_register_dissector("Threema", ndpi_struct,
                      ndpi_search_threema,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_THREEMA);

--- a/src/lib/protocols/thrift.c
+++ b/src/lib/protocols/thrift.c
@@ -257,7 +257,7 @@ static void ndpi_search_thrift_tcp_udp(struct ndpi_detection_module_struct *ndpi
 
 void init_apache_thrift_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Thrift", ndpi_struct,
+  ndpi_register_dissector("Thrift", ndpi_struct,
                      ndpi_search_thrift_tcp_udp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_APACHE_THRIFT);

--- a/src/lib/protocols/tinc.c
+++ b/src/lib/protocols/tinc.c
@@ -143,7 +143,7 @@ static void ndpi_search_tinc(struct ndpi_detection_module_struct* ndpi_struct, s
 
 void init_tinc_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TINC", ndpi_struct,
+  ndpi_register_dissector("TINC", ndpi_struct,
                      ndpi_search_tinc,
                      NDPI_SELECTION_BITMASK_PROTOCOL_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION, /* TODO: IPv6? */
                      1, NDPI_PROTOCOL_TINC);

--- a/src/lib/protocols/tivoconnect.c
+++ b/src/lib/protocols/tivoconnect.c
@@ -135,7 +135,7 @@ static void ndpi_search_tivoconnect(struct ndpi_detection_module_struct *ndpi_st
 
 void init_tivoconnect_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TiVoConnect", ndpi_struct,
+  ndpi_register_dissector("TiVoConnect", ndpi_struct,
                      ndpi_search_tivoconnect,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_TIVOCONNECT);

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -3608,7 +3608,7 @@ static void ndpi_search_tls_wrapper(struct ndpi_detection_module_struct *ndpi_st
 /* **************************************** */
 
 void init_tls_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("(D)TLS", ndpi_struct,
+  ndpi_register_dissector("(D)TLS", ndpi_struct,
                      ndpi_search_tls_wrapper,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      2,

--- a/src/lib/protocols/tocaboca.c
+++ b/src/lib/protocols/tocaboca.c
@@ -78,7 +78,7 @@ static void ndpi_search_toca_boca(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_toca_boca_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TocaBoca", ndpi_struct,
+  ndpi_register_dissector("TocaBoca", ndpi_struct,
                      ndpi_search_toca_boca,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_TOCA_BOCA);

--- a/src/lib/protocols/tplink_shp.c
+++ b/src/lib/protocols/tplink_shp.c
@@ -83,7 +83,7 @@ static void ndpi_search_tplink_shp(struct ndpi_detection_module_struct *ndpi_str
   
 void init_tplink_shp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TPLINK SHP", ndpi_struct,
+  ndpi_register_dissector("TPLINK SHP", ndpi_struct,
                      ndpi_search_tplink_shp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_TPLINK_SHP);

--- a/src/lib/protocols/trdp.c
+++ b/src/lib/protocols/trdp.c
@@ -85,7 +85,7 @@ static void ndpi_search_trdp(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_trdp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TRDP", ndpi_struct,
+  ndpi_register_dissector("TRDP", ndpi_struct,
                      ndpi_search_trdp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_TRDP);

--- a/src/lib/protocols/tristation.c
+++ b/src/lib/protocols/tristation.c
@@ -73,7 +73,7 @@ static void ndpi_search_tristation(struct ndpi_detection_module_struct *ndpi_str
 
 void init_tristation_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TriStation", ndpi_struct,
+  ndpi_register_dissector("TriStation", ndpi_struct,
                      ndpi_search_tristation,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_TRISTATION);

--- a/src/lib/protocols/tuya_lp.c
+++ b/src/lib/protocols/tuya_lp.c
@@ -82,7 +82,7 @@ static void ndpi_search_tuya_lp(struct ndpi_detection_module_struct *ndpi_struct
   
 void init_tuya_lp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("TUYA LP", ndpi_struct,
+  ndpi_register_dissector("TUYA LP", ndpi_struct,
                      ndpi_search_tuya_lp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_TUYA_LP);

--- a/src/lib/protocols/ubntac2.c
+++ b/src/lib/protocols/ubntac2.c
@@ -74,7 +74,7 @@ static void ndpi_search_ubntac2(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_ubntac2_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("UBNTAC2", ndpi_struct,
+  ndpi_register_dissector("UBNTAC2", ndpi_struct,
                      ndpi_search_ubntac2,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_UBNTAC2);

--- a/src/lib/protocols/uftp.c
+++ b/src/lib/protocols/uftp.c
@@ -59,7 +59,7 @@ static void ndpi_search_uftp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_uftp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("UFTP", ndpi_struct,
+  ndpi_register_dissector("UFTP", ndpi_struct,
                      ndpi_search_uftp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_UFTP);

--- a/src/lib/protocols/ultrasurf.c
+++ b/src/lib/protocols/ultrasurf.c
@@ -60,7 +60,7 @@ static void ndpi_search_ultrasurf(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_ultrasurf_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("UltraSurf", ndpi_struct,
+  ndpi_register_dissector("UltraSurf", ndpi_struct,
                      ndpi_search_ultrasurf,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ULTRASURF);

--- a/src/lib/protocols/usenet.c
+++ b/src/lib/protocols/usenet.c
@@ -98,7 +98,7 @@ static void ndpi_search_usenet_tcp(struct ndpi_detection_module_struct *ndpi_str
 
 void init_usenet_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Usenet", ndpi_struct,
+  ndpi_register_dissector("Usenet", ndpi_struct,
                      ndpi_search_usenet_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_USENET);

--- a/src/lib/protocols/viber.c
+++ b/src/lib/protocols/viber.c
@@ -100,7 +100,7 @@ static void ndpi_search_viber(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_viber_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Viber", ndpi_struct,
+  ndpi_register_dissector("Viber", ndpi_struct,
                      ndpi_search_viber,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_VIBER);

--- a/src/lib/protocols/vmware.c
+++ b/src/lib/protocols/vmware.c
@@ -46,7 +46,7 @@ static void ndpi_search_vmware(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_vmware_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("VMWARE", ndpi_struct,
+  ndpi_register_dissector("VMWARE", ndpi_struct,
                      ndpi_search_vmware,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_VMWARE);

--- a/src/lib/protocols/vnc.c
+++ b/src/lib/protocols/vnc.c
@@ -63,7 +63,7 @@ static void ndpi_search_vnc_tcp(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_vnc_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("VNC", ndpi_struct,
+  ndpi_register_dissector("VNC", ndpi_struct,
                      ndpi_search_vnc_tcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_VNC);

--- a/src/lib/protocols/vxlan.c
+++ b/src/lib/protocols/vxlan.c
@@ -66,7 +66,7 @@ static void ndpi_search_vxlan(struct ndpi_detection_module_struct *ndpi_struct, 
 
 void init_vxlan_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("VXLAN", ndpi_struct,
+  ndpi_register_dissector("VXLAN", ndpi_struct,
                      ndpi_search_vxlan,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_VXLAN);

--- a/src/lib/protocols/websocket.c
+++ b/src/lib/protocols/websocket.c
@@ -150,7 +150,7 @@ static void ndpi_search_websocket(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_websocket_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("WEBSOCKET", ndpi_struct,
+  ndpi_register_dissector("WEBSOCKET", ndpi_struct,
                      ndpi_search_websocket,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_WEBSOCKET);

--- a/src/lib/protocols/whatsapp.c
+++ b/src/lib/protocols/whatsapp.c
@@ -122,7 +122,7 @@ static void ndpi_search_whatsapp(struct ndpi_detection_module_struct *ndpi_struc
 
 void init_whatsapp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("WhatsApp", ndpi_struct,
+  ndpi_register_dissector("WhatsApp", ndpi_struct,
                      ndpi_search_whatsapp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_WHATSAPP);

--- a/src/lib/protocols/whoisdas.c
+++ b/src/lib/protocols/whoisdas.c
@@ -60,7 +60,7 @@ static void ndpi_search_whois_das(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_whois_das_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Whois-DA", ndpi_struct,
+  ndpi_register_dissector("Whois-DA", ndpi_struct,
                      ndpi_search_whois_das,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_WHOIS_DAS);

--- a/src/lib/protocols/wireguard.c
+++ b/src/lib/protocols/wireguard.c
@@ -200,7 +200,7 @@ static void ndpi_search_wireguard(struct ndpi_detection_module_struct *ndpi_stru
 
 void init_wireguard_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("WireGuard", ndpi_struct,
+  ndpi_register_dissector("WireGuard", ndpi_struct,
                      ndpi_search_wireguard,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_WIREGUARD);

--- a/src/lib/protocols/wsd.c
+++ b/src/lib/protocols/wsd.c
@@ -54,7 +54,7 @@ static void ndpi_search_wsd(struct ndpi_detection_module_struct *ndpi_struct,
 
 
 void init_wsd_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("WSD", ndpi_struct,
+  ndpi_register_dissector("WSD", ndpi_struct,
                      ndpi_search_wsd,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_WSD);

--- a/src/lib/protocols/xbox.c
+++ b/src/lib/protocols/xbox.c
@@ -100,7 +100,7 @@ static void ndpi_search_xbox(struct ndpi_detection_module_struct *ndpi_struct, s
 
 void init_xbox_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Xbox", ndpi_struct,
+  ndpi_register_dissector("Xbox", ndpi_struct,
                      ndpi_search_xbox,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_XBOX);

--- a/src/lib/protocols/xdmcp.c
+++ b/src/lib/protocols/xdmcp.c
@@ -67,7 +67,7 @@ static void ndpi_search_xdmcp(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_xdmcp_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("XDMCP", ndpi_struct,
+  ndpi_register_dissector("XDMCP", ndpi_struct,
                      ndpi_search_xdmcp,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_XDMCP);

--- a/src/lib/protocols/xiaomi.c
+++ b/src/lib/protocols/xiaomi.c
@@ -111,7 +111,7 @@ static void ndpi_search_xiaomi(struct ndpi_detection_module_struct *ndpi_struct,
 }
 
 void init_xiaomi_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Xiaomi", ndpi_struct,
+  ndpi_register_dissector("Xiaomi", ndpi_struct,
                      ndpi_search_xiaomi,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_XIAOMI);

--- a/src/lib/protocols/yojimbo.c
+++ b/src/lib/protocols/yojimbo.c
@@ -62,7 +62,7 @@ static void ndpi_search_yojimbo(struct ndpi_detection_module_struct *ndpi_struct
 
 void init_yojimbo_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Yojimbo", ndpi_struct,
+  ndpi_register_dissector("Yojimbo", ndpi_struct,
                      ndpi_search_yojimbo,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_YOJIMBO);

--- a/src/lib/protocols/z3950.c
+++ b/src/lib/protocols/z3950.c
@@ -126,7 +126,7 @@ static void ndpi_search_z3950(struct ndpi_detection_module_struct *ndpi_struct,
 /* ***************************************************************** */
 
 void init_z3950_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Z3950", ndpi_struct,
+  ndpi_register_dissector("Z3950", ndpi_struct,
                      ndpi_search_z3950,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_Z3950);

--- a/src/lib/protocols/zabbix.c
+++ b/src/lib/protocols/zabbix.c
@@ -51,7 +51,7 @@ static void ndpi_search_zabbix(struct ndpi_detection_module_struct *ndpi_struct,
 /* *************************************************** */
 
 void init_zabbix_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Zabbix", ndpi_struct,
+  ndpi_register_dissector("Zabbix", ndpi_struct,
                      ndpi_search_zabbix,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ZABBIX);

--- a/src/lib/protocols/zattoo.c
+++ b/src/lib/protocols/zattoo.c
@@ -210,7 +210,7 @@ static void ndpi_search_zattoo(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_zattoo_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("Zattoo", ndpi_struct,
+  ndpi_register_dissector("Zattoo", ndpi_struct,
                      ndpi_search_zattoo,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_OR_UDP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ZATTOO);

--- a/src/lib/protocols/zeromq.c
+++ b/src/lib/protocols/zeromq.c
@@ -47,7 +47,7 @@ static void ndpi_search_zmq(struct ndpi_detection_module_struct *ndpi_struct, st
 
 void init_zmq_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("ZeroMQ", ndpi_struct,
+  ndpi_register_dissector("ZeroMQ", ndpi_struct,
                      ndpi_search_zmq,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_TCP_WITH_PAYLOAD_WITHOUT_RETRANSMISSION,
                      1, NDPI_PROTOCOL_ZMQ);

--- a/src/lib/protocols/zoom.c
+++ b/src/lib/protocols/zoom.c
@@ -248,7 +248,7 @@ static void ndpi_search_zoom(struct ndpi_detection_module_struct *ndpi_struct,
 /* *************************************************** */
 
 void init_zoom_dissector(struct ndpi_detection_module_struct *ndpi_struct) {
-  register_dissector("Zoom", ndpi_struct,
+  ndpi_register_dissector("Zoom", ndpi_struct,
                      ndpi_search_zoom,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_ZOOM);

--- a/src/lib/protocols/zug.c
+++ b/src/lib/protocols/zug.c
@@ -60,7 +60,7 @@ static void ndpi_search_zug(struct ndpi_detection_module_struct *ndpi_struct,
 
 void init_zug_dissector(struct ndpi_detection_module_struct *ndpi_struct)
 {
-  register_dissector("ZUG", ndpi_struct,
+  ndpi_register_dissector("ZUG", ndpi_struct,
                      ndpi_search_zug,
                      NDPI_SELECTION_BITMASK_PROTOCOL_V4_V6_UDP_WITH_PAYLOAD,
                      1, NDPI_PROTOCOL_ZUG);


### PR DESCRIPTION
Try to avoid collisions with similar Wireshark function: see #3063. Note that this function is now used by plugins, so it is somehow part of the public API anyway.

Close #3063



