### PR TITLE
TLS: fix dissection stop when block analysis is enabled

### DIFF
--- a/src/include/ndpi_private.h
+++ b/src/include/ndpi_private.h
@@ -370,7 +370,7 @@ struct ndpi_detection_module_config_struct {
 
 struct ndpi_detection_module_struct {
   u_int64_t current_ts;
-  u_int8_t skip_tls_blocks_until_change_cipher:1, finalized:1, _notused:6;
+  u_int8_t finalized:1, _notused:7;
   u_int8_t tls_certificate_expire_in_x_days;
 
   void *user_data;

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -885,7 +885,7 @@ struct ndpi_flow_tcp_struct {
   struct {
     /* NDPI_PROTOCOL_TLS */
     u_int8_t app_data_seen[2];
-    u_int8_t num_tls_blocks, num_processed_tls_blocks /* used internally for dissection */;
+    u_int8_t num_tls_blocks /* used internally for dissection */;
     u_int64_t last_tls_block_time_ms;
     struct ndpi_tls_block *tls_blocks; /* ndpi_struct->cfg.tls_num_blocks_analyzed */
   } tls;

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4757,9 +4757,6 @@ int ndpi_finalize_initialization(struct ndpi_detection_module_struct *ndpi_str) 
       ac_automata_finalize((AC_AUTOMATA_t *) a->ac_automa);
   }
 
-  if(ndpi_str->cfg.tls_max_num_blocks_to_analyze > 0)
-    ndpi_str->skip_tls_blocks_until_change_cipher = 1;
-
   if(ndpi_str->cfg.track_payload_enabled)
     ndpi_str->max_payload_track_len = 1024; /* track up to X payload bytes */
 

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -1230,7 +1230,7 @@ int processCertificate(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
   if((ndpi_struct->cfg.tls_max_num_blocks_to_analyze != 0)
-     && (flow->l4.tcp.tls.num_processed_tls_blocks >= ndpi_struct->cfg.tls_max_num_blocks_to_analyze)) {
+     && (flow->l4.tcp.tls.num_tls_blocks >= ndpi_struct->cfg.tls_max_num_blocks_to_analyze)) {
 #ifdef DEBUG_TLS_BLOCKS
     printf("*** [TLS Block] Enough blocks dissected\n");
 #endif
@@ -1507,14 +1507,6 @@ int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
     p_len = packet->payload_packet_len; /* Backup */
 
     if(content_type == 0x14 /* Change Cipher Spec */) {
-      if(ndpi_struct->skip_tls_blocks_until_change_cipher) {
-	/*
-	  Ignore Application Data up until change cipher
-	  so in this case we reset the number of observed
-	  TLS blocks
-	*/
-	flow->l4.tcp.tls.num_processed_tls_blocks = 0;
-      }
       if(len == 6 &&
          message->buffer[1] == 0x03 && /* TLS >= 1.0 */
          ((message->buffer[3] << 8) + (message->buffer[4])) == 1) {
@@ -1625,12 +1617,15 @@ int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
   }
 
 #ifdef DEBUG_TLS_MEMORY
-  printf("[TLS] Eval if keep going [%p]\n", flow->extra_packets_func);
+  printf("[TLS] Eval if keep going [%p][blocks:%d/%d][wrong:%d]\n",
+         flow->extra_packets_func,
+         flow->l4.tcp.tls.num_tls_blocks, ndpi_struct->cfg.tls_max_num_blocks_to_analyze,
+         something_went_wrong);
 #endif
 
   if(something_went_wrong
      || ((ndpi_struct->cfg.tls_max_num_blocks_to_analyze > 0)
-	 && (flow->l4.tcp.tls.num_processed_tls_blocks == ndpi_struct->cfg.tls_max_num_blocks_to_analyze))
+	 && (flow->l4.tcp.tls.num_tls_blocks == ndpi_struct->cfg.tls_max_num_blocks_to_analyze))
      || ((ndpi_struct->cfg.tls_max_num_blocks_to_analyze == 0)
 	 && (!keep_extra_dissection_tcp(ndpi_struct, flow)))
      ) {


### PR DESCRIPTION
Use the proper variable; remove the unused parameter `skip_tls_blocks_until_change_cipher`.
