### PR TITLE
fuzz: fuzz_config: restore custom logic for memory allocation failure

### DIFF
--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -63,9 +63,9 @@ fuzz_quic_get_crypto_data_SOURCES = fuzz_quic_get_crypto_data.c fuzz_common_code
 fuzz_quic_get_crypto_data_CFLAGS = $(AM_CFLAGS) -DNDPI_LIB_COMPILATION
 fuzz_quic_get_crypto_data_LINK = $(FUZZ_LINK_COMMAND)
 
-fuzz_config_SOURCES = fuzz_config.cpp
-fuzz_config_CXXFLAGS = $(AM_CXXFLAGS) -I $(top_srcdir)/src/lib/third_party/src/fuzz -DNDPI_LIB_COMPILATION -DENABLE_NALLOC
-fuzz_config_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/src/lib/third_party/src/fuzz -DNDPI_LIB_COMPILATION -DENABLE_NALLOC
+fuzz_config_SOURCES = fuzz_config.cpp fuzz_common_code.c
+fuzz_config_CXXFLAGS = $(AM_CXXFLAGS) -DNDPI_LIB_COMPILATION
+fuzz_config_CFLAGS = $(AM_CFLAGS) -DNDPI_LIB_COMPILATION
 fuzz_config_LINK = $(FUZZ_LINK_COMMAND)
 
 fuzz_community_id_SOURCES = fuzz_community_id.cpp fuzz_common_code.c

--- a/fuzz/fuzz_config.cpp
+++ b/fuzz/fuzz_config.cpp
@@ -1,10 +1,7 @@
 #include "ndpi_api.h"
 #include "ndpi_private.h"
 #include "ndpi_classify.h"
-
-#ifdef ENABLE_NALLOC
-#include "nallocinc.c"
-#endif
+#include "fuzz_common_code.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -48,20 +45,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   u_int64_t cat_userdata = 0;
   u_int16_t unused1, unused2;
   ndpi_master_app_protocol proto1, proto2;
-#ifdef ENABLE_NALLOC
-  int nalloc_active = 0;
-#endif
 
-#ifdef ENABLE_NALLOC
-  /* Nalloc doesn't work with masan. That means that this fuzzers doesn't test
-     allocation failures with masan. Is taht a problem? */
-  /* Make allocation failures more unlikely */
-  if(fuzzed_data.ConsumeBool()) {
-    nalloc_init("nalloc");
-    nalloc_start(data, size);
-    nalloc_active = 1;
-  }
-#endif
+  if(fuzzed_data.ConsumeBool())
+    fuzz_set_alloc_callbacks_and_seed(size);
+  else
+    fuzz_set_alloc_callbacks_and_seed(0);
 
   if(fuzzed_data.ConsumeBool())
     g_ctx = ndpi_global_init();
@@ -446,11 +434,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   ndpi_exit_detection_module(ndpi_info_mod);
 
   ndpi_global_deinit(g_ctx);
-
-#ifdef ENABLE_NALLOC
-  if(nalloc_active)
-    nalloc_end();
-#endif
 
   return 0;
 }


### PR DESCRIPTION
It seems nalloc doesn't work with `FuzzedDataProvider.h`; see https://github.com/catenacyber/nallocfuzz/issues/4. Partial revert of f67293e9f


