### PR TITLE
Fix MinGW pcap check when using --with-only-libndpi

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -331,7 +331,7 @@ case "$host" in
       LIBS="${LIBS} -lws2_32"
       BUILD_MINGW=1
       EXE_SUFFIX=".exe"
-      AS_IF([test "${enable_npcap+set}" != set && test "${with_only_libndpi+set}" != set],,
+      AS_IF([test "${enable_npcap+set}" = set && test "${with_only_libndpi+set}" != set],
             [PKG_CHECK_MODULES([PCAP], [libpcap], [PCAP_LIB="" PCAP_INC="${pkg_cv_PCAP_CFLAGS}"])
              AC_CHECK_LIB([pcap], [pcap_open_live],, [AC_MSG_ERROR([Missing msys2/mingw libpcap library. Install it with `pacman -S mingw-w64-x86_64-libpcap' (msys2).])])])
       ;;


### PR DESCRIPTION
## Summary

On MinGW/MSYS2, `--with-only-libndpi` triggers the pcap check instead of skipping it. This is the opposite of the non-MinGW path behavior (line 355) which corretcly skips pcap when building only the library.

## Change

One-line fix in `configure.ac`: flip the `AS_IF` condition so the pcap check runs only when npcap is explicitly enabled and `--with-only-libndpi` is not set.

Before: empty then-body (`,,`) meant the check ran whenever *either* flag was set
After: check runs in the then-body, only when `enable_npcap` is set AND `with_only_libndpi` is not set

Fixes https://github.com/ntop/nDPI/issues/3114