### PR TITLE
Fix libpcap check when using --with-only-libndpi on MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -426,9 +426,15 @@ case "$host" in
       LIBS="${LIBS} -lws2_32"
       BUILD_MINGW=1
       EXE_SUFFIX=".exe"
-      AS_IF([test "${enable_npcap+set}" != set && test "${with_only_libndpi+set}" != set],,
-            [PKG_CHECK_MODULES([PCAP], [libpcap], [PCAP_LIB="" PCAP_INC="${pkg_cv_PCAP_CFLAGS}"])
-             AC_CHECK_LIB([pcap], [pcap_open_live],, [AC_MSG_ERROR([Missing msys2/mingw libpcap library. Install it with `pacman -S mingw-w64-x86_64-libpcap' (msys2).])])])
+      AS_IF([test "${enable_npcap+set}" != set && test "${with_only_libndpi+set}" != set], [
+            PKG_CHECK_MODULES([PCAP], [libpcap], [
+              PCAP_LIB=""
+              PCAP_INC="${pkg_cv_PCAP_CFLAGS}"
+            ])
+            AC_CHECK_LIB([pcap], [pcap_open_live], , [
+              AC_MSG_ERROR([Missing msys2/mingw libpcap library. Install it with `pacman -S mingw-w64-x86_64-libpcap' (msys2).])
+            ])
+      ])
       ;;
    *)
       if test -n "$LIBPCAP_PATH"; then :


### PR DESCRIPTION
## What?

Fix incorrect branching logic for `--with-only-libndpi` on MinGW builds.

## Why?

The libpcap check was still being executed on MinGW even when `--with-only-libndpi `was specified.
When building only the library, libpcap should not be required, as it is only needed for examples and tools.

This change corrects the conditional logic so that libpcap checks are properly skipped when `--with-only-libndpi` is set.


## Contribution Agreement

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)


