### PR TITLE
configure: remove `--enable-tls-sigs` option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
           brew install libmaxminddb
       - name: Configure nDPI
         run: |
-          ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages ${{ matrix.msan }} ${{ matrix.pcre }} ${{ matrix.maxminddb }} --enable-tls-sigs 
+          ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages ${{ matrix.msan }} ${{ matrix.pcre }} ${{ matrix.maxminddb }}
       - name: Build nDPI
         run: |
           make -j all
@@ -203,7 +203,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.msan, '--with-') # Only on a few "standard" builds
         run: |
           make distclean
-          ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --enable-tls-sigs --host=x86_64-w64-mingw32
+          ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --host=x86_64-w64-mingw32
           make -j $(nproc) all
         env:
           CC:
@@ -229,7 +229,7 @@ jobs:
           install: git mingw-w64-x86_64-toolchain automake1.16 automake-wrapper autoconf libtool make mingw-w64-x86_64-json-c mingw-w64-x86_64-crt-git mingw-w64-x86_64-pcre mingw-w64-x86_64-libpcap parallel
       - name: Configure nDPI on Windows msys2
         run: |
-          msys2 -c './autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --enable-tls-sigs --disable-npcap'
+          msys2 -c './autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --disable-npcap'
       - name: Build nDPI on Windows msys2
         run: |
           msys2 -c 'make -j all'

--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install libpcre3-dev libmaxminddb-dev lcov
           sudo apt-get install wdiff colordiff
       - name: Configure
-        run: ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --enable-code-coverage --with-pcre2 --with-maxminddb --enable-tls-sigs
+        run: ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --enable-code-coverage --with-pcre2 --with-maxminddb
       - name: Build
         run: make all
       - name: Test
@@ -89,7 +89,7 @@ jobs:
           pprof -h
       - name: Configure nDPI library
         run: |
-          ./autogen.sh && ./configure --enable-gprof --enable-option-checking=fatal --with-pcre2 --with-maxminddb --enable-tls-sigs
+          ./autogen.sh && ./configure --enable-gprof --enable-option-checking=fatal --with-pcre2 --with-maxminddb
       - name: Build nDPI library
         run: |
           make -j
@@ -256,7 +256,7 @@ jobs:
           install: git mingw-w64-x86_64-toolchain automake1.16 automake-wrapper autoconf libtool make mingw-w64-x86_64-json-c mingw-w64-x86_64-crt-git mingw-w64-x86_64-pcre mingw-w64-x86_64-libpcap mingw-w64-x86_64-libgcrypt parallel
       - name: Configure nDPI on Windows msys2
         run: |
-          msys2 -c './autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --enable-tls-sigs --disable-npcap --with-local-libgcrypt'
+          msys2 -c './autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --disable-npcap --with-local-libgcrypt'
       - name: Build nDPI on Windows msys2
         run: |
           msys2 -c 'make -j all'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
           pprof -h
       - name: Configure nDPI library
         run: |
-          ./autogen.sh && ./configure --enable-gprof --enable-option-checking=fatal --with-pcre2 --with-maxminddb --enable-tls-sigs --enable-debug-messages
+          ./autogen.sh && ./configure --enable-gprof --enable-option-checking=fatal --with-pcre2 --with-maxminddb --enable-debug-messages
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,6 @@ AC_ARG_ENABLE(fuzztargets, AS_HELP_STRING([--enable-fuzztargets], [Enable fuzz t
 AC_ARG_ENABLE(gprof, AS_HELP_STRING([--enable-gprof], [Enable CPU/HEAP profiling with gperftools]),[enable_gprof=$enableval],[enable_gprof=no])
 AC_ARG_ENABLE(code-coverage, AS_HELP_STRING([--enable-code-coverage], [Generate Code Coverage report]))
 AC_ARG_WITH(local-libgcrypt, AS_HELP_STRING([--with-local-libgcrypt], [Build with libgcrypt (if present) instead of the enclosed gcrypt light]))
-AC_ARG_ENABLE(tls-sigs, AS_HELP_STRING([--enable-tls-sigs], [Enable TLS Client signature algorithm dissection. Rarely used, but requires significantly more memory.]))
 AC_ARG_ENABLE(npcap, AS_HELP_STRING([--disable-npcap], [msys2 only: Disable linkage against the wpcap/npcap import library in windows/WpdPack/Lib.]))
 AC_ARG_WITH(nbpf-path, AS_HELP_STRING([--with-nbpf-path], [nBPF library custom path; default: ${srcdir}/../PF_RING/userland/nbpf]),[NBPF_HOME=$withval],[NBPF_HOME="`cd ${srcdir}/../PF_RING/userland/nbpf 2>/dev/null && pwd || echo ${srcdir}/../PF_RING/userland/nbpf`"])
 AC_ARG_WITH(libpcap, AS_HELP_STRING([--with-libpcap=PATH], [Linux only: Custom path to libpcap installation]),[LIBPCAP_PATH=$withval],[LIBPCAP_PATH=""])
@@ -331,11 +330,6 @@ if ! test "${with_only_libndpi+set}" = set; then :
 fi
 AM_CONDITIONAL([BUILD_UNITTESTS], [test "x$build_unittests" = "xyes"])
 
-HANDLE_TLS_SIGS="//"
-AS_IF([test "x${enable_tls_sigs}" = "xyes"],[
-  HANDLE_TLS_SIGS=""
-])
-
 AS_IF([test "${with_lto_and_gold_linker+set}" = set], [
        NDPI_CFLAGS="${NDPI_CFLAGS} -flto -fuse-ld=gold -Wno-unused-command-line-argument"
        NDPI_LDFLAGS="${NDPI_LDFLAGS} ${NDPI_CFLAGS}"
@@ -627,7 +621,6 @@ AC_SUBST(PCRE2_ENABLED)
 AC_SUBST(NBPF_ENABLED)
 AC_SUBST(GLOBAL_CONTEXT_ENABLED)
 AC_SUBST(PLUGINS_ENABLED)
-AC_SUBST(HANDLE_TLS_SIGS)
 AC_SUBST(DISABLE_NPCAP)
 AC_SUBST(EXE_SUFFIX)
 AC_SUBST(NDPI_CFLAGS)
@@ -753,12 +746,6 @@ AS_IF([test "x${PLUGINS_ENABLED}" = "x1"],
   Plugins:                 enabled"],
   [SUMMARY="${SUMMARY}
   Plugins:                 disabled"])
-
-AS_IF([test "x${enable_tls_sigs}" = "xyes"],
-  [SUMMARY="${SUMMARY}
-  TLS signatures:          enabled"],
-  [SUMMARY="${SUMMARY}
-  TLS signatures:          disabled"])
 
 AS_IF([test "x${enable_oldcroaring}" = "xyes"],
   [SUMMARY="${SUMMARY}

--- a/src/include/ndpi_define.h.in
+++ b/src/include/ndpi_define.h.in
@@ -192,8 +192,6 @@ static inline uint64_t get_u_int64_t(const uint8_t* X, int O)
 
 #define NDPI_OPTIMAL_HLL_NUM_BUCKETS           16
 
-@HANDLE_TLS_SIGS@#define TLS_HANDLE_SIGNATURE_ALGORITMS 1
-
 #ifdef __APPLE__
 
 #include <libkern/OSByteOrder.h>

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1753,12 +1753,6 @@ struct ndpi_flow_struct {
       u_int8_t client_hello_processed:1, ch_direction:1, subprotocol_detected:1,
 	server_hello_processed:1, fingerprint_set:1, webrtc:1;
 
-#ifdef TLS_HANDLE_SIGNATURE_ALGORITMS
-      /* Under #ifdef to save memory for those who do not need them */
-      u_int8_t num_tls_signature_algorithms;
-      u_int16_t client_signature_algorithms[MAX_NUM_TLS_SIGNATURE_ALGORITHMS];
-#endif
-
       struct tls_heuristics browser_heuristics;
       u_int16_t ssl_version, server_names_len;
 

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -3117,16 +3117,6 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
 		s_offset += 2;
 		tot_signature_algorithms_len = ndpi_min((sizeof(ja.client.signature_algorithms_str) / 2) - 1, tot_signature_algorithms_len);
 
-#ifdef TLS_HANDLE_SIGNATURE_ALGORITMS
-		size_t sa_size = ndpi_min(tot_signature_algorithms_len / 2, MAX_NUM_TLS_SIGNATURE_ALGORITHMS);
-
-		if (s_offset + 2 * sa_size <= packet->payload_packet_len) {
-		  flow->protos.tls_quic.num_tls_signature_algorithms = sa_size;
-		  memcpy(flow->protos.tls_quic.client_signature_algorithms,
-			 &packet->payload[s_offset], 2 /* 16 bit */ * sa_size);
-		}
-#endif
-
 		for(i=0, id=0; i<tot_signature_algorithms_len && s_offset+i+1<total_len; i += 2)
 		  ja.client.signature_algorithm[id++] = ntohs(*(u_int16_t*)&packet->payload[s_offset+i]);
 

--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -45,7 +45,7 @@ cd ndpi
 #There are two workarounds:
 # * pcap stuff + --with-only-libndpi: for introspector builds. As reported in #8939, configure is not able to detect external libraries in introspector builds
 # * ADDITIONAL_* stuff: to be able run tests/unit/unit (via chronos/check_tests.sh) even with the previous workaround
-./autogen.sh && AR=llvm-ar RANLIB=llvm-ranlib LDFLAGS="-L/usr/local/lib -lpcap" ADDITIONAL_INCS="-I/usr/local/include/json-c/" ADDITIONAL_LIBS="-L/usr/local/lib -ljson-c" ./configure --disable-shared --enable-fuzztargets --enable-tls-sigs --with-only-libndpi
+./autogen.sh && AR=llvm-ar RANLIB=llvm-ranlib LDFLAGS="-L/usr/local/lib -lpcap" ADDITIONAL_INCS="-I/usr/local/include/json-c/" ADDITIONAL_LIBS="-L/usr/local/lib -ljson-c" ./configure --disable-shared --enable-fuzztargets --with-only-libndpi
 make -j$(nproc)
 # Copy fuzzers
 ls fuzz/fuzz* | grep -v "\." | while read -r i; do cp "$i" "$OUT"/; done

--- a/windows/src/ndpi_define.h
+++ b/windows/src/ndpi_define.h
@@ -194,8 +194,6 @@ static inline u_int64_t get_u_int64_t(const u_int8_t* X, int O)
 
 #define NDPI_MAX_NUM_TLS_APPL_BLOCKS            8
 
-//#define TLS_HANDLE_SIGNATURE_ALGORITMS 1
-
 #ifdef __APPLE__
 
 #include <libkern/OSByteOrder.h>


### PR DESCRIPTION
The same information is available via
`flow->protos.tls_quic.ja_client->signature_algorithm`


