### PR TITLE
usdt probes: pass flow pointer to probes for flexible field access

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
-          sudo apt-get install systemtap-sdt-dev bpftrace pahole llvm linux-tools-common linux-tools-azure linux-cloud-tools-azure
+          sudo apt-get install systemtap-sdt-dev bpftrace pahole llvm
       - name: Download latest bpftrace
         run: |
           curl -L -O https://github.com/bpftrace/bpftrace/releases/download/v0.24.2/bpftrace
@@ -271,7 +271,7 @@ jobs:
           make -j all
       - name: Build bpftool
         run: |
-          # Temporary workaround: some 6.14 kernel don't have bpftool (and perf) in their packages
+          # Temporary workaround: some 6.14 kernels don't have bpftool (and perf) in their packages
           # See: https://bugs.launchpad.net/ubuntu/+source/linux-hwe-6.14/+bug/2117147
           # See: https://gist.github.com/karlivory/9111f906f4eb06370b2b237c62a6b00e
           curl -L -O https://gist.githubusercontent.com/karlivory/9111f906f4eb06370b2b237c62a6b00e/raw/dbd24228dda79e05815531a1db643d0709301838/build-perf.sh
@@ -309,7 +309,7 @@ jobs:
           # Verify we actually traced some flows
           grep -q '@flows:' /tmp/bpf_classified.txt
           echo "flow_classified probe (scalar args): OK"
-      - name: Test flow_classified probe with flow pointer (arg4) via BTF
+      - name: Test flow_classified probe with flow pointer (arg4) via header
         run: |
           # Embedding .BTF section and reading it from bpftrace is still a bit buggy.
           # Use explicit header, with latest bpftrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,7 +269,7 @@ jobs:
       - name: Build nDPI
         run: |
           make -j all
-      -name: Build bpftool
+      - name: Build bpftool
         run: |
           curl -L -O https://gist.githubusercontent.com/karlivory/9111f906f4eb06370b2b237c62a6b00e/raw/dbd24228dda79e05815531a1db643d0709301838/build-perf.sh
           bash build-perf.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,16 +269,12 @@ jobs:
       - name: Build nDPI
         run: |
           make -j all
-          make -C example
       - name: Generate header file for bpftrace
         run: |
-          pahole -J src/lib/libndpi.so
           pahole -J example/ndpiReader
           bpftool btf dump file example/ndpiReader format c > ndpi_types.h
       - name: Verify USDT probes are embedded (readelf)
         run: |
-          echo "=== Probes in libndpi.so ==="
-          readelf -n src/lib/libndpi.so | grep -A4 stapsdt
           echo "=== Probes in ndpiReader ==="
           readelf -n example/ndpiReader | grep -A4 stapsdt
           # Verify both probes are present

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
-          sudo apt-get install systemtap-sdt-dev bpftrace pahole llvm
+          sudo apt-get install systemtap-sdt-dev bpftrace pahole llvm linux-tools-common
       - name: Download latest bpftrace
         run: |
           curl -L -O https://github.com/bpftrace/bpftrace/releases/download/v0.24.2/bpftrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
-          sudo apt-get install systemtap-sdt-dev bpftrace pahole llvm linux-tools-common
+          sudo apt-get install systemtap-sdt-dev bpftrace pahole llvm linux-tools-common linux-tools-azure linux-cloud-tools-azure
       - name: Download latest bpftrace
         run: |
           curl -L -O https://github.com/bpftrace/bpftrace/releases/download/v0.24.2/bpftrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,26 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
-          sudo apt-get install systemtap-sdt-dev bpftrace dwarves
+          sudo apt-get install systemtap-sdt-dev bpftrace
+          sudo apt-get install cmake libdwarf-dev libelf-dev zlib1g-dev
+      - name: Build and install patched pahole
+        run: |
+          git clone --depth=1 --branch v1.31 \
+            https://git.kernel.org/pub/scm/devel/pahole/pahole.git
+          # DW_TAG_atomic_type (C11 _Atomic) is absent from the BTF encoder in
+          # all released pahole versions. Map it to BTF_KIND_VOLATILE, exactly
+          # as the DWARF loader already does (commit 6fdb0140).
+          python3 -c "
+          content = open('pahole/btf_encoder.c').read()
+          content = content.replace(
+              '\tcase DW_TAG_volatile_type:',
+              '\tcase DW_TAG_atomic_type:\n\tcase DW_TAG_volatile_type:',
+              1)
+          open('pahole/btf_encoder.c', 'w').write(content)
+          "
+          cmake -S pahole -B pahole/build -D__LIB=lib
+          make -j$(nproc) -C pahole/build
+          sudo make -C pahole/build install
       - name: Configure nDPI with USDT
         run: |
           ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --enable-usdt-probes
@@ -265,10 +284,6 @@ jobs:
           make -C example
       - name: Embed BTF into binaries (pahole)
         run: |
-          # pahole converts DWARF debug info into a .BTF ELF section.
-          # The GNU linker does not merge .BTF sections from object files,
-          # so -gbtf at compile time is ineffective for shared libraries;
-          # pahole -J is the correct post-build approach.
           pahole -J src/lib/libndpi.so
           pahole -J example/ndpiReader
           echo "BTF embedding done."
@@ -282,7 +297,7 @@ jobs:
           readelf -n example/ndpiReader | grep -q 'flow_classified'
           readelf -n example/ndpiReader | grep -q 'hostname_set'
           echo "All expected USDT probes found."
-          # Verify BTF section is present (embedded by pahole above)
+          # Verify BTF section is present
           readelf -S example/ndpiReader | grep -q '\.BTF'
           echo "BTF section found in ndpiReader."
           readelf -S src/lib/libndpi.so | grep -q '\.BTF'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
-          sudo apt-get install systemtap-sdt-dev bpftrace
+          sudo apt-get install systemtap-sdt-dev bpftrace dwarves
       - name: Configure nDPI with USDT
         run: |
           ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --enable-usdt-probes
@@ -263,6 +263,15 @@ jobs:
         run: |
           make -j all
           make -C example
+      - name: Embed BTF into binaries (pahole)
+        run: |
+          # pahole converts DWARF debug info into a .BTF ELF section.
+          # The GNU linker does not merge .BTF sections from object files,
+          # so -gbtf at compile time is ineffective for shared libraries;
+          # pahole -J is the correct post-build approach.
+          pahole -J src/lib/libndpi.so
+          pahole -J example/ndpiReader
+          echo "BTF embedding done."
       - name: Verify USDT probes are embedded (readelf)
         run: |
           echo "=== Probes in libndpi.so ==="
@@ -273,7 +282,7 @@ jobs:
           readelf -n example/ndpiReader | grep -q 'flow_classified'
           readelf -n example/ndpiReader | grep -q 'hostname_set'
           echo "All expected USDT probes found."
-          # Verify BTF section is embedded (requires GCC 10.1+ / Clang 10+)
+          # Verify BTF section is present (embedded by pahole above)
           readelf -S example/ndpiReader | grep -q '\.BTF'
           echo "BTF section found in ndpiReader."
           readelf -S src/lib/libndpi.so | grep -q '\.BTF'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
-          sudo apt-get install systemtap-sdt-dev bpftrace pahole libelf-dev
+          sudo apt-get install systemtap-sdt-dev bpftrace pahole libelf-dev libdwarf1 llvm
       - name: Download latest bpftrace
         run: |
           curl -L -O https://github.com/bpftrace/bpftrace/releases/download/v0.24.2/bpftrace
@@ -271,6 +271,8 @@ jobs:
           make -j all
       - name: Generate header file for bpftrace
         run: |
+          pahole --version
+          ldd $(which pahole) | grep bpf
           pahole -J example/ndpiReader
           bpftool btf dump file example/ndpiReader format c > ndpi_types.h
       - name: Verify USDT probes are embedded (readelf)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,7 +272,7 @@ jobs:
       - name: Build bpftool
         run: |
           curl -L -O https://gist.githubusercontent.com/karlivory/9111f906f4eb06370b2b237c62a6b00e/raw/dbd24228dda79e05815531a1db643d0709301838/build-perf.sh
-          bash build-perf.sh
+          sudo bash build-perf.sh
       - name: Generate header file for bpftrace
         run: |
           pahole -J src/lib/libndpi.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,6 +271,9 @@ jobs:
           make -j all
       - name: Build bpftool
         run: |
+          # Temporary workaround: some 6.14 kernel don't have bpftool (and perf) in their packages
+          # See: https://bugs.launchpad.net/ubuntu/+source/linux-hwe-6.14/+bug/2117147
+          # See: https://gist.github.com/karlivory/9111f906f4eb06370b2b237c62a6b00e
           curl -L -O https://gist.githubusercontent.com/karlivory/9111f906f4eb06370b2b237c62a6b00e/raw/dbd24228dda79e05815531a1db643d0709301838/build-perf.sh
           sudo bash build-perf.sh
       - name: Generate header file for bpftrace
@@ -315,7 +318,7 @@ jobs:
             $flow = (struct ndpi_flow_struct *)arg4;
             @flows = count();
             if ($flow->risk != 0) { @risky[arg0] = count(); }
-          }' -c './example/ndpiReader -q -i tests/pcap/http.pcapng' 2>&1 | tee /tmp/bpf_classified_ptr.txt
+          }' -c './example/ndpiReader -q -i tests/pcap/1kxun.pcap' 2>&1 | tee /tmp/bpf_classified_ptr.txt
           grep -q '@flows:' /tmp/bpf_classified_ptr.txt
           echo "flow_classified probe (struct dereference): OK"
       - name: Test hostname_set probe with ndpiReader
@@ -339,6 +342,6 @@ jobs:
           usdt:./example/ndpiReader:ndpi:flow_classified {
             @classified[arg0] = count();
           }' -c './example/ndpiReader -q -i tests/pcap/dns.pcap' 2>&1 | tee /tmp/bpf_both.txt
-          grep -q '@classified:' /tmp/bpf_both.txt
-          grep -q '@hostnames:' /tmp/bpf_both.txt
+          grep -q '@classified' /tmp/bpf_both.txt
+          grep -q '@hostnames' /tmp/bpf_both.txt
           echo "Both probes fired successfully."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,15 +255,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
-          sudo apt-get install systemtap-sdt-dev bpftrace
-          sudo apt-get install cmake libdwarf-dev libelf-dev zlib1g-dev llvm libelf-dev
+          sudo apt-get install systemtap-sdt-dev bpftrace pahole
       - name: Download latest bpftrace
         run: |
           curl -L -O https://github.com/bpftrace/bpftrace/releases/download/v0.24.2/bpftrace
           chmod +x bpftrace
       - name: Configure nDPI with USDT
         run: |
-          # Workaround: C11 '_Atomic' type is not fully supported for BPF CO-RE purposes
+          # Workaround: C11 '_Atomic' type (from croaring code) is not fully supported for BPF CO-RE purposes
           # This is needed only if you want to dereference `struct ndpi_flow_struct *`
           # in the probe actions
           ./autogen.sh && CFLAGS="-DCROARING_ATOMIC_IMPL=1" ./configure --enable-option-checking=fatal --enable-debug-messages --enable-usdt-probes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
-          sudo apt-get install systemtap-sdt-dev bpftrace pahole
+          sudo apt-get install systemtap-sdt-dev bpftrace pahole llvm
       - name: Download latest bpftrace
         run: |
           curl -L -O https://github.com/bpftrace/bpftrace/releases/download/v0.24.2/bpftrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,6 +273,11 @@ jobs:
           readelf -n example/ndpiReader | grep -q 'flow_classified'
           readelf -n example/ndpiReader | grep -q 'hostname_set'
           echo "All expected USDT probes found."
+          # Verify BTF section is embedded (requires GCC 10.1+ / Clang 10+)
+          readelf -S example/ndpiReader | grep -q '\.BTF'
+          echo "BTF section found in ndpiReader."
+          readelf -S src/lib/libndpi.so | grep -q '\.BTF'
+          echo "BTF section found in libndpi.so."
       - name: List probes via bpftrace
         run: |
           sudo bpftrace -l "usdt:./example/ndpiReader:ndpi:*" | tee /tmp/probe_list.txt
@@ -291,26 +296,28 @@ jobs:
           # Verify we actually traced some flows
           grep -q '@flows:' /tmp/bpf_classified.txt
           echo "flow_classified probe (scalar args): OK"
-      - name: Test flow_classified probe with flow pointer (arg4)
+      - name: Test flow_classified probe with flow pointer (arg4) via BTF
         run: |
-          sudo bpftrace -e '
-          usdt:./example/ndpiReader:ndpi:flow_classified {
-            $flow = (struct ndpi_flow_struct *)arg4;
-            if ($flow->risk != 0) {
-              @risky[arg0] = count();
-            }
+          # Use the full binary path so bpftrace reads struct types from the
+          # embedded .BTF section — no --include needed.
+          READER=$(realpath example/ndpiReader)
+          sudo bpftrace -e "
+          usdt:${READER}:ndpi:flow_classified {
+            \$flow = (struct ndpi_flow_struct *)arg4;
             @flows = count();
-          }' -c './example/ndpiReader -q -i tests/pcap/http.pcapng' 2>&1 | tee /tmp/bpf_classified_ptr.txt
+            if (\$flow->risk != 0) { @risky[arg0] = count(); }
+          }" -c './example/ndpiReader -q -i tests/pcap/http.pcapng' 2>&1 | tee /tmp/bpf_classified_ptr.txt
           grep -q '@flows:' /tmp/bpf_classified_ptr.txt
-          echo "flow_classified probe (flow pointer): OK"
+          echo "flow_classified probe (BTF struct dereference): OK"
       - name: Test hostname_set probe with ndpiReader
         run: |
-          sudo bpftrace -e '
-          usdt:./example/ndpiReader:ndpi:hostname_set {
-            $flow = (struct ndpi_flow_struct *)arg1;
+          READER=$(realpath example/ndpiReader)
+          sudo bpftrace -e "
+          usdt:${READER}:ndpi:hostname_set {
+            \$flow = (struct ndpi_flow_struct *)arg1;
             @hostnames = count();
-            @top[str(arg0), $flow->detected_protocol_stack[0]] = count();
-          }' -c './example/ndpiReader -q -i tests/pcap/tls_certificate_too_long.pcap' 2>&1 | tee /tmp/bpf_hostname.txt
+            @top[str(arg0), \$flow->detected_protocol_stack[0]] = count();
+          }" -c './example/ndpiReader -q -i tests/pcap/tls_certificate_too_long.pcap' 2>&1 | tee /tmp/bpf_hostname.txt
           # Verify we actually traced some hostnames
           grep -q '@hostnames:' /tmp/bpf_hostname.txt
           echo "hostname_set probe: OK"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,13 +290,26 @@ jobs:
           }' -c './example/ndpiReader -q -i tests/pcap/http.pcapng' 2>&1 | tee /tmp/bpf_classified.txt
           # Verify we actually traced some flows
           grep -q '@flows:' /tmp/bpf_classified.txt
-          echo "flow_classified probe: OK"
+          echo "flow_classified probe (scalar args): OK"
+      - name: Test flow_classified probe with flow pointer (arg4)
+        run: |
+          sudo bpftrace -e '
+          usdt:./example/ndpiReader:ndpi:flow_classified {
+            $flow = (struct ndpi_flow_struct *)arg4;
+            if ($flow->risk != 0) {
+              @risky[arg0] = count();
+            }
+            @flows = count();
+          }' -c './example/ndpiReader -q -i tests/pcap/http.pcapng' 2>&1 | tee /tmp/bpf_classified_ptr.txt
+          grep -q '@flows:' /tmp/bpf_classified_ptr.txt
+          echo "flow_classified probe (flow pointer): OK"
       - name: Test hostname_set probe with ndpiReader
         run: |
           sudo bpftrace -e '
           usdt:./example/ndpiReader:ndpi:hostname_set {
+            $flow = (struct ndpi_flow_struct *)arg1;
             @hostnames = count();
-            @top[str(arg0)] = count();
+            @top[str(arg0), $flow->detected_protocol_stack[0]] = count();
           }' -c './example/ndpiReader -q -i tests/pcap/tls_certificate_too_long.pcap' 2>&1 | tee /tmp/bpf_hostname.txt
           # Verify we actually traced some hostnames
           grep -q '@hostnames:' /tmp/bpf_hostname.txt
@@ -308,7 +321,7 @@ jobs:
             @hostnames = count();
           }
           usdt:./example/ndpiReader:ndpi:flow_classified {
-            @classified = count();
+            @classified[arg0] = count();
           }' -c './example/ndpiReader -q -i tests/pcap/dns.pcap' 2>&1 | tee /tmp/bpf_both.txt
           grep -q '@classified:' /tmp/bpf_both.txt
           grep -q '@hostnames:' /tmp/bpf_both.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
-          sudo apt-get install systemtap-sdt-dev bpftrace pahole libelf-dev libdwarf1 llvm
+          sudo apt-get install systemtap-sdt-dev bpftrace pahole
       - name: Download latest bpftrace
         run: |
           curl -L -O https://github.com/bpftrace/bpftrace/releases/download/v0.24.2/bpftrace
@@ -265,18 +265,19 @@ jobs:
           # Workaround: C11 '_Atomic' type (from croaring code) is not fully supported for BPF CO-RE purposes
           # This is needed only if you want to dereference `struct ndpi_flow_struct *`
           # in the probe actions
-          ./autogen.sh && CFLAGS="-DCROARING_ATOMIC_IMPL=1" ./configure --enable-option-checking=fatal --enable-debug-messages --enable-usdt-probes
+          ./autogen.sh && CFLAGS="-DCROARING_ATOMIC_IMPL=1" ./configure --enable-option-checking=fatal --enable-debug-build --enable-debug-messages --enable-usdt-probes
       - name: Build nDPI
         run: |
           make -j all
       - name: Generate header file for bpftrace
         run: |
-          pahole --version
-          ldd $(which pahole) | grep bpf
+          pahole -J src/lib/libndpi.so
           pahole -J example/ndpiReader
           bpftool btf dump file example/ndpiReader format c > ndpi_types.h
       - name: Verify USDT probes are embedded (readelf)
         run: |
+          echo "=== Probes in libndpi.so ==="
+          readelf -n src/lib/libndpi.so | grep -A4 stapsdt
           echo "=== Probes in ndpiReader ==="
           readelf -n example/ndpiReader | grep -A4 stapsdt
           # Verify both probes are present

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
-          sudo apt-get install systemtap-sdt-dev bpftrace pahole
+          sudo apt-get install systemtap-sdt-dev bpftrace pahole libelf-dev
       - name: Download latest bpftrace
         run: |
           curl -L -O https://github.com/bpftrace/bpftrace/releases/download/v0.24.2/bpftrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,37 +256,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev flex bison libpcap-dev
           sudo apt-get install systemtap-sdt-dev bpftrace
-          sudo apt-get install cmake libdwarf-dev libelf-dev zlib1g-dev
-      - name: Build and install patched pahole
+          sudo apt-get install cmake libdwarf-dev libelf-dev zlib1g-dev llvm libelf-dev
+      - name: Download latest bpftrace
         run: |
-          git clone --depth=1 --branch v1.31 \
-            https://git.kernel.org/pub/scm/devel/pahole/pahole.git
-          # DW_TAG_atomic_type (C11 _Atomic) is absent from the BTF encoder in
-          # all released pahole versions. Map it to BTF_KIND_VOLATILE, exactly
-          # as the DWARF loader already does (commit 6fdb0140).
-          python3 -c "
-          content = open('pahole/btf_encoder.c').read()
-          content = content.replace(
-              '\tcase DW_TAG_volatile_type:',
-              '\tcase DW_TAG_atomic_type:\n\tcase DW_TAG_volatile_type:',
-              1)
-          open('pahole/btf_encoder.c', 'w').write(content)
-          "
-          cmake -S pahole -B pahole/build -D__LIB=lib
-          make -j$(nproc) -C pahole/build
-          sudo make -C pahole/build install
+          curl -L -O https://github.com/bpftrace/bpftrace/releases/download/v0.24.2/bpftrace
+          chmod +x bpftrace
       - name: Configure nDPI with USDT
         run: |
-          ./autogen.sh && ./configure --enable-option-checking=fatal --enable-debug-messages --enable-usdt-probes
+          # Workaround: C11 '_Atomic' type is not fully supported for BPF CO-RE purposes
+          # This is needed only if you want to dereference `struct ndpi_flow_struct *`
+          # in the probe actions
+          ./autogen.sh && CFLAGS="-DCROARING_ATOMIC_IMPL=1" ./configure --enable-option-checking=fatal --enable-debug-messages --enable-usdt-probes
       - name: Build nDPI
         run: |
           make -j all
           make -C example
-      - name: Embed BTF into binaries (pahole)
+      - name: Generate header file for bpftrace
         run: |
           pahole -J src/lib/libndpi.so
           pahole -J example/ndpiReader
-          echo "BTF embedding done."
+          bpftool btf dump file example/ndpiReader format c > ndpi_types.h
       - name: Verify USDT probes are embedded (readelf)
         run: |
           echo "=== Probes in libndpi.so ==="
@@ -297,11 +286,6 @@ jobs:
           readelf -n example/ndpiReader | grep -q 'flow_classified'
           readelf -n example/ndpiReader | grep -q 'hostname_set'
           echo "All expected USDT probes found."
-          # Verify BTF section is present
-          readelf -S example/ndpiReader | grep -q '\.BTF'
-          echo "BTF section found in ndpiReader."
-          readelf -S src/lib/libndpi.so | grep -q '\.BTF'
-          echo "BTF section found in libndpi.so."
       - name: List probes via bpftrace
         run: |
           sudo bpftrace -l "usdt:./example/ndpiReader:ndpi:*" | tee /tmp/probe_list.txt
@@ -322,20 +306,21 @@ jobs:
           echo "flow_classified probe (scalar args): OK"
       - name: Test flow_classified probe with flow pointer (arg4) via BTF
         run: |
-          # Use the full binary path so bpftrace reads struct types from the
-          # embedded .BTF section — no --include needed.
-          READER=$(realpath example/ndpiReader)
-          sudo bpftrace -e 'usdt:'"${READER}"':ndpi:flow_classified {
+          # Embedding .BTF section and reading it from bpftrace is still a bit buggy.
+          # Use explicit header, with latest bpftrace
+          sudo ./bpftrace -I . --include ndpi_types.h \
+          -e 'usdt:./example/ndpiReader:ndpi:flow_classified {
             $flow = (struct ndpi_flow_struct *)arg4;
             @flows = count();
             if ($flow->risk != 0) { @risky[arg0] = count(); }
           }' -c './example/ndpiReader -q -i tests/pcap/http.pcapng' 2>&1 | tee /tmp/bpf_classified_ptr.txt
           grep -q '@flows:' /tmp/bpf_classified_ptr.txt
-          echo "flow_classified probe (BTF struct dereference): OK"
+          echo "flow_classified probe (struct dereference): OK"
       - name: Test hostname_set probe with ndpiReader
         run: |
           READER=$(realpath example/ndpiReader)
-          sudo bpftrace -e 'usdt:'"${READER}"':ndpi:hostname_set {
+          sudo ./bpftrace -I . --include ndpi_types.h \
+          -e 'usdt:./example/ndpiReader:ndpi:hostname_set {
             $flow = (struct ndpi_flow_struct *)arg1;
             @hostnames = count();
             @top[str(arg0), $flow->detected_protocol_stack[0]] = count();

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,6 +269,10 @@ jobs:
       - name: Build nDPI
         run: |
           make -j all
+      -name: Build bpftool
+        run: |
+          curl -L -O https://gist.githubusercontent.com/karlivory/9111f906f4eb06370b2b237c62a6b00e/raw/dbd24228dda79e05815531a1db643d0709301838/build-perf.sh
+          bash build-perf.sh
       - name: Generate header file for bpftrace
         run: |
           pahole -J src/lib/libndpi.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,23 +301,21 @@ jobs:
           # Use the full binary path so bpftrace reads struct types from the
           # embedded .BTF section — no --include needed.
           READER=$(realpath example/ndpiReader)
-          sudo bpftrace -e "
-          usdt:${READER}:ndpi:flow_classified {
-            \$flow = (struct ndpi_flow_struct *)arg4;
+          sudo bpftrace -e 'usdt:'"${READER}"':ndpi:flow_classified {
+            $flow = (struct ndpi_flow_struct *)arg4;
             @flows = count();
-            if (\$flow->risk != 0) { @risky[arg0] = count(); }
-          }" -c './example/ndpiReader -q -i tests/pcap/http.pcapng' 2>&1 | tee /tmp/bpf_classified_ptr.txt
+            if ($flow->risk != 0) { @risky[arg0] = count(); }
+          }' -c './example/ndpiReader -q -i tests/pcap/http.pcapng' 2>&1 | tee /tmp/bpf_classified_ptr.txt
           grep -q '@flows:' /tmp/bpf_classified_ptr.txt
           echo "flow_classified probe (BTF struct dereference): OK"
       - name: Test hostname_set probe with ndpiReader
         run: |
           READER=$(realpath example/ndpiReader)
-          sudo bpftrace -e "
-          usdt:${READER}:ndpi:hostname_set {
-            \$flow = (struct ndpi_flow_struct *)arg1;
+          sudo bpftrace -e 'usdt:'"${READER}"':ndpi:hostname_set {
+            $flow = (struct ndpi_flow_struct *)arg1;
             @hostnames = count();
-            @top[str(arg0), \$flow->detected_protocol_stack[0]] = count();
-          }" -c './example/ndpiReader -q -i tests/pcap/tls_certificate_too_long.pcap' 2>&1 | tee /tmp/bpf_hostname.txt
+            @top[str(arg0), $flow->detected_protocol_stack[0]] = count();
+          }' -c './example/ndpiReader -q -i tests/pcap/tls_certificate_too_long.pcap' 2>&1 | tee /tmp/bpf_hostname.txt
           # Verify we actually traced some hostnames
           grep -q '@hostnames:' /tmp/bpf_hostname.txt
           echo "hostname_set probe: OK"

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,12 @@ AC_ARG_ENABLE(usdt-probes, AS_HELP_STRING([--enable-usdt-probes], [Enable USDT/D
 AS_IF([test "x$enable_usdt_probes" = "xyes"], [
   AC_CHECK_HEADER([sys/sdt.h], [
     AC_DEFINE([HAVE_USDT], [1], [Define if USDT probes are enabled])
+    dnl Embed BTF type info so bpftrace can resolve struct fields without --include.
+    dnl Requires GCC 10.1+ or Clang 10+; silently skipped on older compilers.
+    AX_CHECK_COMPILE_FLAG([-gbtf], [
+      NDPI_CFLAGS="${NDPI_CFLAGS} -gbtf"
+      AC_DEFINE([HAVE_USDT_BTF], [1], [Define if BTF type info is embedded alongside USDT probes])
+    ])
   ], [
     AC_MSG_ERROR([--enable-usdt-probes requires sys/sdt.h (install systemtap-sdt-dev)])
   ])
@@ -772,8 +778,11 @@ AS_IF([test "x${CUSTOM_NDPI}" = "x-DCUSTOM_NDPI_PROTOCOLS"],
   Custom protocols:        no"])
 
 AS_IF([test "x${enable_usdt_probes}" = "xyes"],
-  [SUMMARY="${SUMMARY}
-  USDT probes:             enabled"],
+  [AS_IF([test "x${ac_cv_compile_flag__gbtf}" = "xyes"],
+    [SUMMARY="${SUMMARY}
+  USDT probes:             enabled (with BTF)"],
+    [SUMMARY="${SUMMARY}
+  USDT probes:             enabled (no BTF: upgrade to GCC 10.1+/Clang 10+)"])],
   [SUMMARY="${SUMMARY}
   USDT probes:             disabled"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,12 +36,6 @@ AC_ARG_ENABLE(usdt-probes, AS_HELP_STRING([--enable-usdt-probes], [Enable USDT/D
 AS_IF([test "x$enable_usdt_probes" = "xyes"], [
   AC_CHECK_HEADER([sys/sdt.h], [
     AC_DEFINE([HAVE_USDT], [1], [Define if USDT probes are enabled])
-    dnl Embed BTF type info so bpftrace can resolve struct fields without --include.
-    dnl Requires GCC 10.1+ or Clang 10+; silently skipped on older compilers.
-    AX_CHECK_COMPILE_FLAG([-gbtf], [
-      NDPI_CFLAGS="${NDPI_CFLAGS} -gbtf"
-      AC_DEFINE([HAVE_USDT_BTF], [1], [Define if BTF type info is embedded alongside USDT probes])
-    ])
   ], [
     AC_MSG_ERROR([--enable-usdt-probes requires sys/sdt.h (install systemtap-sdt-dev)])
   ])
@@ -778,11 +772,8 @@ AS_IF([test "x${CUSTOM_NDPI}" = "x-DCUSTOM_NDPI_PROTOCOLS"],
   Custom protocols:        no"])
 
 AS_IF([test "x${enable_usdt_probes}" = "xyes"],
-  [AS_IF([test "x${ac_cv_compile_flag__gbtf}" = "xyes"],
-    [SUMMARY="${SUMMARY}
-  USDT probes:             enabled (with BTF)"],
-    [SUMMARY="${SUMMARY}
-  USDT probes:             enabled (no BTF: upgrade to GCC 10.1+/Clang 10+)"])],
+  [SUMMARY="${SUMMARY}
+  USDT probes:             enabled"],
   [SUMMARY="${SUMMARY}
   USDT probes:             disabled"])
 

--- a/doc/usdt.rst
+++ b/doc/usdt.rst
@@ -10,15 +10,15 @@ the application.
 Building with USDT Support
 --------------------------
 
-Install the required header (Linux):
+Install the required headers (Linux):
 
 .. code-block:: bash
 
    # Debian/Ubuntu
-   sudo apt-get install systemtap-sdt-dev
+   sudo apt-get install systemtap-sdt-dev dwarves
 
    # RHEL/CentOS/Fedora
-   sudo dnf install systemtap-sdt-devel
+   sudo dnf install systemtap-sdt-devel dwarves
 
 Then configure nDPI with USDT enabled:
 
@@ -35,12 +35,10 @@ Then configure nDPI with USDT enabled:
 
 .. note::
 
-   When ``--enable-usdt-probes`` is configured, nDPI automatically tries to embed
-   a ``.BTF`` ELF section (requires GCC 10.1+ or Clang 10+). This lets bpftrace
-   resolve ``struct ndpi_flow_struct`` fields by name without any ``--include`` flags,
-   provided the binary path is used explicitly in the probe specification (see
-   `Struct field access via BTF`_ below). On older compilers the section is simply
-   absent and the scalar arguments (``arg0``–``arg3``) remain fully usable.
+   To allow bpftrace to resolve ``struct ndpi_flow_struct`` fields by name without
+   any ``--include`` flags, embed BTF into the binaries after building using
+   ``pahole -J`` (from the ``dwarves`` package). See `Struct field access via BTF`_
+   below. Without BTF the scalar arguments (``arg0``–``arg3``) remain fully usable.
 
 Available Probes
 ----------------
@@ -78,21 +76,38 @@ bpftrace Notes
 Struct field access via BTF
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When nDPI is built with a compiler that supports ``-gbtf`` (GCC 10.1+, Clang 10+),
-the binary contains a ``.BTF`` ELF section with full type information. bpftrace can
-use this to resolve ``struct ndpi_flow_struct`` fields by name — **without any**
-``--include`` **flags** — as long as the full binary path is given in the probe
-specification:
+The GNU linker does not merge ``.BTF`` sections from object files, so compiler
+flags like ``-gbtf`` are not sufficient to embed BTF into a shared library or
+executable. The correct approach is to use ``pahole -J`` (from the ``dwarves``
+package) as a post-build step: it reads the DWARF debug info already present in
+the binary and inserts a ``.BTF`` section with full type information.
 
 .. code-block:: bash
 
-   # Use the full path (not :: shorthand) so bpftrace reads BTF from the binary
+   # Debian/Ubuntu
+   sudo apt-get install dwarves
+
+   # RHEL/CentOS/Fedora
+   sudo dnf install dwarves
+
+   ./configure --enable-usdt-probes --enable-debug-build
+   make
+   pahole -J src/lib/libndpi.so
+   pahole -J example/ndpiReader
+
+Once the ``.BTF`` section is present, bpftrace can resolve
+``struct ndpi_flow_struct`` fields by name — **without any** ``--include``
+**flags** — as long as the full binary path is used in the probe specification
+(the ``::`` shorthand does not trigger BTF lookup):
+
+.. code-block:: bash
+
    bpftrace -e 'usdt:./example/ndpiReader:ndpi:flow_classified {
      $flow = (struct ndpi_flow_struct *)arg4;
      if ($flow->risk != 0) { @risky[arg0] = count(); }
    }'
 
-You can verify whether the ``.BTF`` section is present:
+Verify the section is present with:
 
 .. code-block:: bash
 

--- a/doc/usdt.rst
+++ b/doc/usdt.rst
@@ -37,8 +37,8 @@ Then configure nDPI with USDT enabled:
 
    To allow bpftrace to resolve ``struct ndpi_flow_struct`` fields by name without
    any ``--include`` flags, embed BTF into the binaries after building using
-   ``pahole -J`` (from the ``dwarves`` package). See `Struct field access via BTF`_
-   below. Without BTF the scalar arguments (``arg0``–``arg3``) remain fully usable.
+   ``pahole -J`` (from the ``dwarves`` package). See `Struct field access`_
+   below. Without BTF the scalar arguments remain fully usable.
 
 Available Probes
 ----------------
@@ -73,14 +73,15 @@ Available Probes
 bpftrace Notes
 --------------
 
-Struct field access via BTF
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Struct field access
+^^^^^^^^^^^^^^^^^^^^
 
-The GNU linker does not merge ``.BTF`` sections from object files, so compiler
-flags like ``-gbtf`` are not sufficient to embed BTF into a shared library or
-executable. The correct approach is to use ``pahole -J`` (from the ``dwarves``
-package) as a post-build step: it reads the DWARF debug info already present in
-the binary and inserts a ``.BTF`` section with full type information.
+To be able to dereference userspace pointers (for example,
+``struct ndpi_flow_struct`` as ``arg1`` in ``hostname_set`` probe) you need to
+embed BTF information into a shared library or executable. The correct approach
+is to use ``pahole -J`` (from the ``dwarves`` package) as a post-build step:
+it reads the DWARF debug info already present in the binary and inserts a
+``.BTF`` section with full type information.
 
 .. code-block:: bash
 
@@ -102,7 +103,7 @@ Once the ``.BTF`` section is present, bpftrace can resolve
 
 .. code-block:: bash
 
-   bpftrace -e 'usdt:./example/ndpiReader:ndpi:flow_classified {
+   bpftrace -e 'usdt:/path/to/ndpiReader:ndpi:flow_classified {
      $flow = (struct ndpi_flow_struct *)arg4;
      if ($flow->risk != 0) { @risky[arg0] = count(); }
    }'
@@ -113,10 +114,83 @@ Verify the section is present with:
 
    readelf -S example/ndpiReader | grep '\.BTF'
 
-See the `bpftrace USDT documentation
-<https://github.com/bpftrace/bpftrace/blob/master/docs/reference_guide.md#usdt>`_
-and the `BTF specification <https://docs.kernel.org/bpf/btf.html>`_ for further
-details.
+
+.. _btf-pitfalls:
+
+BTF Generation — Known Issues and Workarounds
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**C11 ``_Atomic`` types break pahole BTF encoding**
+
+nDPI's bundled CRoaring library uses ``_Atomic`` qualifiers, which the
+compiler emits as ``DW_TAG_atomic_type`` entries in DWARF.  All released
+versions of ``pahole`` (including 1.31) abort BTF encoding when they
+encounter this tag, even when ``--btf_encode_force`` is passed::
+
+   Unsupported DW_TAG_atomic_type(0x47): type: 0x153c6
+   Encountered error while encoding BTF.
+
+The workaround used in nDPI's CI is to rebuild with
+``CROARING_ATOMIC_IMPL=1``, which selects a non-atomic code path and
+eliminates the offending DWARF entries:
+
+.. code-block:: bash
+
+   CFLAGS="-DCROARING_ATOMIC_IMPL=1" ./configure \
+       --enable-usdt-probes --enable-debug-build
+   make
+
+**Fallback: generate a C header with bpftool**
+
+Even with BTF info correctly embedded, pointer dereferences might fail::
+
+    stdin:1:65-93: ERROR: Cannot resolve unknown type "struct ndpi_flow_struct"
+
+In thi case, generate a C header from the BTF info and pass it to bpftrace
+with ``--include``:
+
+.. code-block:: bash
+
+   # Generate a C header with the full layout of the userspace structures
+   bpftool btf dump file /path/to/ndpiReader format c > ndpi_types.h
+
+   # Use the header in bpfttrace
+   sudo bpftrace -I .--include ndpi_types.h \
+     -e 'usdt:/path/to/ndpiReader:ndpi:flow_classified {
+       $flow = (struct ndpi_flow_struct *)arg4;
+       if ($flow->risk != 0) { @risky[arg0] = count(); }
+     }'
+
+bpftrace Map Size Limits
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When tracing long or high-throughput captures, bpftrace maps can fill
+up and emit a kernel-level ``E2BIG`` warning::
+
+   WARNING: Map full; can't update element.
+   Additional Info - helper: map_update_elem, retcode: -7
+
+Increase map key limit via the environment variable (works with all
+recent bpftrace versions):
+
+.. code-block:: bash
+
+   sudo BPFTRACE_MAX_MAP_KEYS=100000 bpftrace --include ndpi_types.h \
+     -e 'usdt:/path/to/ndpiReader:ndpi:hostname_set {
+       @top[str(arg0)] = count();
+     }'
+
+Some bpftrace builds also accept a ``config`` block at the top of the
+script:
+
+.. code-block:: bash
+
+   sudo bpftrace --include ndpi_types.h \
+     -e 'config = { max_map_keys = 100000 }
+   usdt:/path/to/ndpiReader:ndpi:hostname_set {
+     @top[str(arg0)] = count();
+   }'
+
 
 Predicates vs. action blocks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,10 +203,7 @@ bpftrace predicates (``/condition/``) work well for filtering on scalar argument
    bpftrace -e 'usdt::ndpi:flow_classified /arg0 == 91/ { ... }'
 
 Filtering on struct fields via a pointer (e.g. ``arg4`` or ``arg1`` in
-``hostname_set``) is **not supported in predicates**. User-space pointer
-dereferences require ``bpf_probe_read_user()`` internally, which bpftrace only
-generates inside action blocks — not in the predicate expression. Attempting it
-will either fail to compile or silently misbehave.
+``hostname_set``) is **not supported in predicates**.
 
 Use an ``if`` statement inside the action block instead:
 
@@ -145,12 +216,21 @@ Use an ``if`` statement inside the action block instead:
      }
    }'
 
-See the `bpftrace reference guide
-<https://github.com/bpftrace/bpftrace/blob/master/docs/reference_guide.md>`_
-for full details on predicate and action block semantics.
-
 bpftrace Examples
 -----------------
+
+.. note::
+
+   Examples that dereference a userspace pointer (``arg4`` in ``flow_classified``,
+   ``arg1`` in ``hostname_set``) require either a ``.BTF`` section embedded
+   in the binary via ``pahole -J`` **or** an explicit ``--include ndpi_types.h``
+   header (generated via ``bpftool btf dump ... format c``).  See
+   `BTF Generation — Known Issues and Workarounds`_ above.
+
+   Scalar-only examples (those using only ``arg0``–``arg3`` in ``flow_classified``,
+   ``arg0`` in ``hostname_set``, without struct dereference) work without BTF or
+   headers and can use the ``::`` shorthand.
+
 
 List available probes:
 

--- a/doc/usdt.rst
+++ b/doc/usdt.rst
@@ -25,13 +25,20 @@ Then configure nDPI with USDT enabled:
 .. code-block:: bash
 
    ./autogen.sh
-   ./configure --enable-usdt-probes
+   ./configure --enable-usdt-probes --enable-debug-build
    make
 
 .. note::
 
    On macOS, ``sys/sdt.h`` is provided by the system. On platforms where it is
    unavailable, the probes compile to no-ops and have zero impact.
+
+.. note::
+
+   To dereference the ``ndpi_flow_struct *`` pointer in bpftrace scripts, build nDPI
+   with debug symbols (``--enable-debug-build``). bpftrace then resolves field offsets
+   automatically from DWARF info. Without debug symbols you can still use the scalar
+   arguments directly.
 
 Available Probes
 ----------------
@@ -48,16 +55,54 @@ Available Probes
        | ``arg1``: application protocol ID (``u16``)
        | ``arg2``: confidence level (``enum``)
        | ``arg3``: category (``enum``)
+       | ``arg4``: flow pointer (``struct ndpi_flow_struct *``)
      - Fires exactly once per flow when classification is finalized.
        Covers all exit paths: successful detection, giveup, max-packets,
        nBPF match, and extra-dissector completion.
+       The scalar arguments allow fast filtering in bpftrace predicates;
+       ``arg4`` provides access to all other flow fields when needed.
    * - ``hostname_set``
      - | ``arg0``: hostname string (``char *``)
-       | ``arg1``: master protocol ID (``u16``)
-       | ``arg2``: application protocol ID (``u16``)
+       | ``arg1``: flow pointer (``struct ndpi_flow_struct *``)
      - Fires when a hostname/SNI is extracted from a flow.
        Covers all protocols that resolve hostnames: TLS (SNI), DNS,
        HTTP (Host header), QUIC, NetBIOS, DHCP, STUN, and others.
+       The hostname is provided directly as a string for convenience;
+       the flow pointer gives access to all other flow fields.
+
+bpftrace Notes
+--------------
+
+Predicates vs. action blocks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+bpftrace predicates (``/condition/``) work well for filtering on scalar arguments
+(``arg0``–``arg3`` in ``flow_classified``):
+
+.. code-block:: bash
+
+   bpftrace -e 'usdt::ndpi:flow_classified /arg0 == 91/ { ... }'
+
+Filtering on struct fields via a pointer (e.g. ``arg4`` or ``arg1`` in
+``hostname_set``) is **not supported in predicates**. User-space pointer
+dereferences require ``bpf_probe_read_user()`` internally, which bpftrace only
+generates inside action blocks — not in the predicate expression. Attempting it
+will either fail to compile or silently misbehave.
+
+Use an ``if`` statement inside the action block instead:
+
+.. code-block:: bash
+
+   bpftrace -e 'usdt::ndpi:hostname_set {
+     $flow = (struct ndpi_flow_struct *)arg1;
+     if ($flow->detected_protocol_stack[0] == 5) {
+       @dns[str(arg0)] = count();
+     }
+   }'
+
+See the `bpftrace reference guide
+<https://github.com/bpftrace/bpftrace/blob/master/docs/reference_guide.md>`_
+for full details on predicate and action block semantics.
 
 bpftrace Examples
 -----------------
@@ -136,6 +181,17 @@ Flows classified as SocialNetwork (category 6):
      @social[arg0, arg1] = count();
    }'
 
+Flows with non-zero risk bitmap (requires ``arg4`` / debug symbols):
+
+.. code-block:: bash
+
+   bpftrace -e 'usdt::ndpi:flow_classified {
+     $flow = (struct ndpi_flow_struct *)arg4;
+     if ($flow->risk != 0) {
+       @risky[arg0] = count();
+     }
+   }'
+
 hostname_set Examples
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -144,7 +200,11 @@ Real-time hostname log:
 .. code-block:: bash
 
    bpftrace -e 'usdt::ndpi:hostname_set {
-     printf("%s (master=%d app=%d)\n", str(arg0), arg1, arg2);
+     $flow = (struct ndpi_flow_struct *)arg1;
+     printf("%s (master=%d app=%d)\n",
+            str(arg0),
+            $flow->detected_protocol_stack[0],
+            $flow->detected_protocol_stack[1]);
    }'
 
 Top hostnames by flow count:
@@ -167,16 +227,22 @@ Hostnames resolved via DNS only (DNS = 5):
 
 .. code-block:: bash
 
-   bpftrace -e 'usdt::ndpi:hostname_set /arg1 == 5/ {
-     @dns[str(arg0)] = count();
+   bpftrace -e 'usdt::ndpi:hostname_set {
+     $flow = (struct ndpi_flow_struct *)arg1;
+     if ($flow->detected_protocol_stack[0] == 5) {
+       @dns[str(arg0)] = count();
+     }
    }'
 
 TLS SNI extraction in real time (TLS = 91):
 
 .. code-block:: bash
 
-   bpftrace -e 'usdt::ndpi:hostname_set /arg1 == 91/ {
-     printf("TLS SNI: %s\n", str(arg0));
+   bpftrace -e 'usdt::ndpi:hostname_set {
+     $flow = (struct ndpi_flow_struct *)arg1;
+     if ($flow->detected_protocol_stack[0] == 91) {
+       printf("TLS SNI: %s\n", str(arg0));
+     }
    }'
 
 Hostnames with their application protocol breakdown:
@@ -184,7 +250,8 @@ Hostnames with their application protocol breakdown:
 .. code-block:: bash
 
    bpftrace -e 'usdt::ndpi:hostname_set {
-     @host_app[str(arg0), arg2] = count();
+     $flow = (struct ndpi_flow_struct *)arg1;
+     @host_app[str(arg0), $flow->detected_protocol_stack[1]] = count();
    }'
 
 Hostname resolution rate (hostnames/sec):
@@ -199,8 +266,11 @@ Detect potential DGA activity (short hostnames with many unique values):
 
 .. code-block:: bash
 
-   bpftrace -e 'usdt::ndpi:hostname_set /arg1 == 5/ {
-     @unique_dns = count();
+   bpftrace -e 'usdt::ndpi:hostname_set {
+     $flow = (struct ndpi_flow_struct *)arg1;
+     if ($flow->detected_protocol_stack[0] == 5) {
+       @unique_dns = count();
+     }
    } interval:s:10 {
      printf("Unique DNS hostnames in last 10s: %d\n", @unique_dns);
      clear(@unique_dns);

--- a/doc/usdt.rst
+++ b/doc/usdt.rst
@@ -35,10 +35,12 @@ Then configure nDPI with USDT enabled:
 
 .. note::
 
-   To dereference the ``ndpi_flow_struct *`` pointer in bpftrace scripts, build nDPI
-   with debug symbols (``--enable-debug-build``). bpftrace then resolves field offsets
-   automatically from DWARF info. Without debug symbols you can still use the scalar
-   arguments directly.
+   When ``--enable-usdt-probes`` is configured, nDPI automatically tries to embed
+   a ``.BTF`` ELF section (requires GCC 10.1+ or Clang 10+). This lets bpftrace
+   resolve ``struct ndpi_flow_struct`` fields by name without any ``--include`` flags,
+   provided the binary path is used explicitly in the probe specification (see
+   `Struct field access via BTF`_ below). On older compilers the section is simply
+   absent and the scalar arguments (``arg0``–``arg3``) remain fully usable.
 
 Available Probes
 ----------------
@@ -73,6 +75,34 @@ Available Probes
 bpftrace Notes
 --------------
 
+Struct field access via BTF
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When nDPI is built with a compiler that supports ``-gbtf`` (GCC 10.1+, Clang 10+),
+the binary contains a ``.BTF`` ELF section with full type information. bpftrace can
+use this to resolve ``struct ndpi_flow_struct`` fields by name — **without any**
+``--include`` **flags** — as long as the full binary path is given in the probe
+specification:
+
+.. code-block:: bash
+
+   # Use the full path (not :: shorthand) so bpftrace reads BTF from the binary
+   bpftrace -e 'usdt:./example/ndpiReader:ndpi:flow_classified {
+     $flow = (struct ndpi_flow_struct *)arg4;
+     if ($flow->risk != 0) { @risky[arg0] = count(); }
+   }'
+
+You can verify whether the ``.BTF`` section is present:
+
+.. code-block:: bash
+
+   readelf -S example/ndpiReader | grep '\.BTF'
+
+See the `bpftrace USDT documentation
+<https://github.com/bpftrace/bpftrace/blob/master/docs/reference_guide.md#usdt>`_
+and the `BTF specification <https://docs.kernel.org/bpf/btf.html>`_ for further
+details.
+
 Predicates vs. action blocks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -93,7 +123,7 @@ Use an ``if`` statement inside the action block instead:
 
 .. code-block:: bash
 
-   bpftrace -e 'usdt::ndpi:hostname_set {
+   bpftrace -e 'usdt:/path/to/ndpiReader:ndpi:hostname_set {
      $flow = (struct ndpi_flow_struct *)arg1;
      if ($flow->detected_protocol_stack[0] == 5) {
        @dns[str(arg0)] = count();

--- a/src/include/ndpi_usdt.h
+++ b/src/include/ndpi_usdt.h
@@ -26,13 +26,15 @@
   #define NDPI_DTRACE1(name, a)           DTRACE_PROBE1(ndpi, name, a)
   #define NDPI_DTRACE2(name, a, b)        DTRACE_PROBE2(ndpi, name, a, b)
   #define NDPI_DTRACE3(name, a, b, c)     DTRACE_PROBE3(ndpi, name, a, b, c)
-  #define NDPI_DTRACE4(name, a, b, c, d)  DTRACE_PROBE4(ndpi, name, a, b, c, d)
+  #define NDPI_DTRACE4(name, a, b, c, d)     DTRACE_PROBE4(ndpi, name, a, b, c, d)
+  #define NDPI_DTRACE5(name, a, b, c, d, e)  DTRACE_PROBE5(ndpi, name, a, b, c, d, e)
 #else
-  #define NDPI_DTRACE0(name)              ((void)0)
-  #define NDPI_DTRACE1(name, a)           ((void)0)
-  #define NDPI_DTRACE2(name, a, b)        ((void)0)
-  #define NDPI_DTRACE3(name, a, b, c)     ((void)0)
-  #define NDPI_DTRACE4(name, a, b, c, d)  ((void)0)
+  #define NDPI_DTRACE0(name)                 ((void)0)
+  #define NDPI_DTRACE1(name, a)              ((void)0)
+  #define NDPI_DTRACE2(name, a, b)           ((void)0)
+  #define NDPI_DTRACE3(name, a, b, c)        ((void)0)
+  #define NDPI_DTRACE4(name, a, b, c, d)     ((void)0)
+  #define NDPI_DTRACE5(name, a, b, c, d, e)  ((void)0)
 #endif
 
 #endif /* __NDPI_USDT_H__ */

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -9547,11 +9547,12 @@ static void internal_giveup(struct ndpi_detection_module_struct *ndpi_struct,
 		    "nDPI protocol does not match the server IP address");
   }
 
-  NDPI_DTRACE4(flow_classified,
+  NDPI_DTRACE5(flow_classified,
                flow->detected_protocol_stack[0],  /* proto_master */
                flow->detected_protocol_stack[1],  /* proto_app */
                flow->confidence,
-               flow->category);
+               flow->category,
+               flow);
 
   if(flow->state == NDPI_STATE_CLASSIFIED) {
     NDPI_LOG_ERR(ndpi_struct, "Already classified!\n"); /* We shoudn't be here ...*/
@@ -13133,10 +13134,7 @@ char *ndpi_hostname_sni_set(struct ndpi_flow_struct *flow,
     }
   }
 
-  NDPI_DTRACE3(hostname_set,
-               dst,                                /* hostname string */
-               flow->detected_protocol_stack[0],   /* proto_master */
-               flow->detected_protocol_stack[1]);   /* proto_app */
+  NDPI_DTRACE2(hostname_set, dst, flow);
 
   return dst;
 }


### PR DESCRIPTION
`flow_classified` gains a 5th argument (`arg4 = ndpi_flow_struct *`) so scripts can access any flow field (risk, num_processed_pkts, etc.) while still using the fast scalar args (arg0-arg3) in predicates.

`hostname_set` is redesigned from three scalars to two args: arg0 keeps the hostname string for zero-friction str() access, arg1 is the flow pointer replacing the two separate protocol IDs.

Add NDPI_DTRACE5 macro to ndpi_usdt.h to support the 5-argument probe.

Documentation is updated.


