### PR TITLE
categories: add mmap .ndb backend for custom category lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@
 /example/ndpiReader
 /example/ndpiReader.exe
 /example/ndpiSimpleIntegration
+/example/ndpi_gen_categories_bin
 /utils/Makefile
 /utils/hosts2domains
 /utils/print_rank

--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ EXTRA_DIST = README.md README.fuzzer.md CHANGELOG.md CONTRIBUTING.md \
 	autogen.sh wireshark windows utils packages dga \
 	influxdb/Makefile.in influxdb/metric_anomaly.c influxdb/README.txt \
 	rrdtool/Makefile.in rrdtool/README.txt rrdtool/rrd_anomaly.c rrdtool/rrd_similarity.c \
-	doc/requirements.txt doc/conf.py doc/flow_risks.rst doc/protocols.rst doc/guide/nDPI_QuickStartGuide.pages \
+	doc/requirements.txt doc/categories-ndb.md doc/conf.py doc/flow_risks.rst doc/protocols.rst doc/guide/nDPI_QuickStartGuide.pages \
 		doc/guide/nDPI_QuickStartGuide.pdf doc/img/logo.png doc/index.rst \
 		doc/Makefile doc/what_is_ndpi.rst \
 		doc/FAQ.rst \

--- a/configure.ac
+++ b/configure.ac
@@ -302,7 +302,11 @@ echo "Setting API version to ${NDPI_API_VERSION}"
 AC_DEFINE_UNQUOTED(NDPI_GIT_RELEASE, "${GIT_RELEASE}", [GIT Release])
 AC_DEFINE_UNQUOTED(NDPI_GIT_DATE, "${GIT_DATE}", [Last GIT change])
 
-NDPI_CFLAGS="-W -Wall -Wextra -Wno-address-of-packed-member ${NDPI_CFLAGS}"
+NDPI_CFLAGS="-W -Wall -Wextra ${NDPI_CFLAGS}"
+dnl> gcc < 5 does not support -Wno-address-of-packed-member (unknown -Wno-* is fatal with -Werror)
+AX_CHECK_COMPILE_FLAG([-Wno-address-of-packed-member], [
+  NDPI_CFLAGS="${NDPI_CFLAGS} -Wno-address-of-packed-member"
+], [], [-Werror])
 
 dnl> MacOS brew.sh
 HOMEBREW_DIR=/opt/homebrew
@@ -431,6 +435,8 @@ if test -d ${srcdir}/../nDPI-custom; then :
    AC_MSG_RESULT([Compiling with custom nDPI protocols])
 fi
 
+dnl> example/ndpi_gen_categories_bin is linked without $(LIBS); Winsock must still be linked.
+NDPI_GEN_EXTRA_LIBS=
 case "$host" in
    *-*-mingw32*|*-*-msys)
       PCAP_INC=""
@@ -450,6 +456,7 @@ case "$host" in
       esac
       NDPI_CFLAGS="-D__USE_MINGW_ANSI_STDIO -D__STDC_FORMAT_MACROS ${NDPI_CFLAGS}"
       LIBS="${LIBS} -lws2_32"
+      NDPI_GEN_EXTRA_LIBS="-lws2_32"
       BUILD_MINGW=1
       EXE_SUFFIX=".exe"
       AS_IF([test "${enable_npcap+set}" != set && test "${with_only_libndpi+set}" != set],,
@@ -649,6 +656,7 @@ AC_SUBST(NDPI_API_VERSION)
 AC_SUBST(EXTRA_TARGETS)
 AC_SUBST(BUILD_MINGW)
 AC_SUBST(BUILD_MINGW_X64)
+AC_SUBST(NDPI_GEN_EXTRA_LIBS)
 AC_SUBST(BUILD_FUZZTARGETS)
 AC_SUBST(JSONC_CFLAGS)
 AC_SUBST(JSONC_LIBS)

--- a/doc/categories-ndb.md
+++ b/doc/categories-ndb.md
@@ -1,0 +1,356 @@
+# nDPI `.ndb` Category Backend — Manual
+
+## Overview
+
+The `.ndb`  backend provides a high-performance, memory-mapped (`mmap`) category lookup engine for:
+
+- Hostnames (FQDN)
+- IPv4 networks (CIDR)
+- IPv6 networks (CIDR)
+
+It replaces large text-based category lists with a compact binary format, improving:
+
+- Startup time
+- Memory usage
+- Lookup performance
+- Reload behavior
+
+---
+
+## Backend Modes
+
+The category backend operates in three modes (see `ndpi_category_backend_mode_t` in `ndpi_api.h`):
+
+| User-facing name | API constant |
+|------------------|--------------|
+| LEGACY | `NDPI_CATEGORY_BACKEND_LEGACY` |
+| HYBRID | `NDPI_CATEGORY_BACKEND_HYBRID` |
+| NDB_ONLY | `NDPI_CATEGORY_BACKEND_NDB_ONLY` |
+
+### LEGACY
+
+- Uses the classic in-memory backends: **Patricia** for custom IP/network categories and **Aho-Corasick** (`ndpi_domain_classify_hostname()`) for hostname lists (see `ndpi_api.h` comments on `ndpi_category_backend_mode_t`)
+- `.ndb` is not consulted; `ndpi_load_category_ndb_file()` rejects `NDPI_CATEGORY_BACKEND_LEGACY`. After `ndpi_unload_category_ndb()`, the module returns to this mode with no mmap database attached.
+
+### HYBRID
+
+- `.ndb` is consulted first
+- Falls back to legacy structures if no match
+
+### NDB_ONLY
+
+- Only `.ndb` is used
+- No fallback
+
+---
+
+## Runtime Behavior
+
+### Lookup Order
+
+**Hostname** — handled in `ndpi_match_custom_category()`.
+
+**IP (IPv4 / IPv6)** — handled in `ndpi_get_custom_category_match()`.
+
+### Behavior by mode
+
+| Mode | Order |
+|------|--------|
+| HYBRID | `.ndb` → legacy fallback |
+| NDB_ONLY | `.ndb` only |
+
+### Thread safety
+
+**Unix (POSIX), with global context support (`USE_GLOBAL_CONTEXT`)**
+
+- Uses `pthread_rwlock_t`
+- Read: shared lock
+- Reload: exclusive lock
+
+**Unix (POSIX), without global context support (`--disable-global-context-support`)**
+
+- Lock calls are no-ops; there is no `pthread` dependency for this backend in that configuration.
+- In this configuration, the `.ndb` backend should be considered single-threaded unless external synchronization is provided by the caller.
+- Post-build check (static lib): `nm -u libndpi.a` lists *unresolved* symbols; plain `nm` lists defined and undefined symbols. Expect **no unresolved nor referenced `pthread_*` symbols** in `ndpi_category_ndb.o` nor in `libndpi.a` for the `.ndb` path when built without global context support (other optional library pieces may still pull pthread elsewhere).
+
+**Windows**
+
+- Uses `SRWLOCK` with the same semantics:
+  - `AcquireSRWLockShared` for readers
+  - `AcquireSRWLockExclusive` for reload
+
+**Note:** while locking primitives are implemented on Windows (`SRWLOCK`), the `.ndb` backend relies on `mmap`-based loading and is primarily validated on Unix/POSIX environments. Full Windows support may depend on toolchain and runtime configuration.
+
+**Guarantee (when internal rwlock is enabled)**
+
+- Lookups are always protected
+- Reload is atomic (pointer swap)
+- Old `mmap` is released after unlock
+
+---
+
+## Reload behavior
+
+Reload uses a safe swap model (see `ndpi_load_category_ndb_file()` in `ndpi_category_ndb.c`):
+
+1. Load new `.ndb` (`mmap` + `ndb_validate`) **before** taking the module lock (so readers are not blocked during I/O)
+2. Acquire write lock (`pthread_rwlock` / `SRWLOCK` exclusive)
+3. Swap pointer and backend mode
+4. Release lock
+5. `munmap` the previous database (`ndb_unmap`)
+
+This guarantees:
+
+- No use-after-unmap
+- No partial reads
+
+---
+
+## DNS validation (single source of truth)
+
+Disk strings and normalized hostnames must satisfy `ndpi_category_hostname_labels_valid_ascii()` (`ndpi_category_host_norm.c` / `ndpi_category_host_norm.h`). The generator applies **`ndpi_category_normalize_host_for_ndb()`** first (lowercase, strip scheme/path, port stripping, `*.` wildcard prefix, then the label rules via `ndpi_category_hostname_labels_valid_ascii()`).
+
+### Rules
+
+- Total length: 1–253
+- Labels: 1–63 characters
+- Allowed characters: `[a-z0-9-]` (ASCII lowercase digits and hyphen)
+- Labels cannot start or end with `-`
+- No leading or trailing `.`
+
+This validation is used in:
+
+- The generator (`ndpi_gen_categories_bin` → `ndpi_category_normalize_host_for_ndb()`)
+- The loader (`ndb_validate()` in `ndpi_category_ndb.c`)
+- Runtime lookup (`ndpi_category_ndb_lookup_hostname()` → same normalization path)
+
+---
+
+## `.ndb` format
+
+The on-disk layout is defined in `ndpi_categories_bin.h`. At a high level the file contains:
+
+- Header (`ndb_header_disk_t`)
+- Category table
+- Domain hash buckets and domain entries
+- String pool
+- IPv4 entries
+- IPv6 entries
+
+### IPv4 entry (`ndb_ipv4_entry_disk_t`)
+
+| Field | Role |
+|-------|------|
+| `network_be` | IPv4 network address, **network** byte order |
+| `prefix_len` | Prefix length (0–32) |
+| `flags`, `reserved0` | Reserved / flags (packed record) |
+| `category_id` | Category identifier |
+
+### IPv6 entry (`ndb_ipv6_entry_disk_t`)
+
+| Field | Role |
+|-------|------|
+| `addr[16]` | IPv6 network address |
+| `prefix_len` | Prefix length (0–128) |
+| `flags`, `reserved0` | Reserved / flags (packed record) |
+| `category_id` | Category identifier |
+
+### Validation (`ndb_validate`)
+
+On load, the file is validated.
+
+**General**
+
+- File bounds are checked
+- Overflow-safe arithmetic is used
+
+**IPv4 / IPv6**
+
+- Offsets must lie inside the file
+- `offset + count * sizeof(entry)` is checked safely
+- `prefix_len`: IPv4 in 0–32, IPv6 in 0–128
+- `category_id` must be valid
+
+**Optional**
+
+- Ordering may be validated (future optimization)
+
+---
+
+## Lookup algorithm
+
+### IPv4 / IPv6
+
+Uses linear LPM (longest prefix match): for each entry, if the address matches the network/prefix, keep the entry with the largest `prefix_len`.
+
+Properties:
+
+- Correct even without sorting
+- Simple and robust
+- Does not depend on generator ordering
+
+### Future optimization
+
+- Binary search
+- Indexed lookup
+
+---
+
+## Generator (`ndpi_gen_categories_bin`)
+
+### Input files
+
+Categories must follow one of these filename patterns (see `is_domain_list_file()` / `is_ipv4_list_file()` / `is_ipv6_list_file()` in `ndpi_gen_categories_bin.c`):
+
+```text
+<id>_<name>.list
+<id>_<name>.ipv4.list
+<id>_<name>.ipv6.list
+```
+
+Examples:
+
+- `10_web.list`
+- `20_vpn.list`
+- `10_corp.ipv4.list` / `10_corp.ipv6.list` (IP-only lists)
+
+### Rules
+
+- `id` must satisfy: `0 < id < NDPI_PROTOCOL_NUM_CATEGORIES`
+- The generator fails early on invalid filename or invalid ID
+
+---
+
+## IP canonicalization and deduplication
+
+### IPv4
+
+- Input is masked with `ipv4_apply_mask()`
+
+### IPv6
+
+- The network is masked to the prefix (`ipv6_apply_mask()` in `ndpi_gen_categories_bin.c`) when building canonical keys and on-disk rows
+
+### Deduplication
+
+- Based on canonical key: **network + prefix**
+- Equivalent entries collapse into one
+
+Example:
+
+```text
+10.1.2.3/16
+10.1.0.0/16
+```
+
+→ same network → single entry
+
+---
+
+## Conflict handling
+
+All of this is **generator-time** (`ndpi_gen_categories_bin`, `--conflict-policy`); runtime only does LPM over the emitted rows.
+
+- **Duplicate key, same category:** collapsed (deduplication).
+- **Duplicate key, different categories:** default **`error`** (exit); optional policies `warn-ignore`, `first-wins`, `last-wins` resolve which category wins at build time.
+- **Distinct overlapping prefixes:** longest-prefix match at runtime (see [Lookup algorithm](#lookup-algorithm)).
+
+---
+
+## Integration in runtime
+
+| Concern | Entry point |
+|---------|--------------|
+| Hostname | `ndpi_match_custom_category()` |
+| IP | `ndpi_get_custom_category_match()` |
+| Backend mode | Shared across both paths (`ndpi_str->category_backend_mode`) |
+
+---
+
+## Testing
+
+### Unit (minimum)
+
+The `category_ndb_smoke_unit()` test in `tests/unit/unit.c` (non-Windows) covers:
+
+- Hostname hit (`ndpi_match_custom_category`)
+- IPv4 LPM and a `/32` row (`ndpi_get_custom_category_match`)
+- Hostname miss under `NDB_ONLY`
+- Loading **`HYBRID`** and exercising an **IPv6 miss** (no `.ndb` IPv6 rows and no Patricia entries in the test module — not a full “`.ndb` miss → list hit” integration)
+
+Example scenario:
+
+- `10.0.0.0/8` → WEB  
+- `10.1.0.0/16` → VPN  
+
+Then:
+
+- `10.1.2.3` → VPN (longer prefix)
+- `10.9.9.9` → WEB
+
+### Fuzz (optional)
+
+- Extended coverage
+- Includes IP path (`fuzz/fuzz_match_custom_category.c`)
+
+---
+
+## Build notes
+
+### Generator
+
+Built as a separate tool: `ndpi_gen_categories_bin`.
+
+Requires `ndpi_category_host_norm.h` (shared hostname normalization / validation).
+
+### Known issues
+
+- `libndpi.so` may fail linking in some custom environments (glibc / toolchain quirks)
+- `libndpi.a` is sufficient for most use cases
+
+---
+
+## Usage
+
+### Generate `.ndb`
+
+```sh
+ndpi_gen_categories_bin \
+  -i /path/categories \
+  -o /path/base.ndb
+# optional: -V "build label" (stored in the on-disk header)
+```
+
+### Run `ndpiReader`
+
+```sh
+ndpiReader --categories-bin /path/base.ndb
+```
+
+### Enable reload
+
+```sh
+ndpiReader --categories-bin /path/base.ndb \
+  --category-ndb-reload-interval <seconds>
+```
+
+---
+
+## Summary
+
+This implementation provides:
+
+- Safe hot-reload
+- Unified validation
+- Full support for hostname, IPv4, and IPv6
+- Deterministic behavior across modes
+- Clean separation between generator and runtime
+
+---
+
+## Next steps (future work)
+
+- Indexed lookup for IP (performance)
+- RCU-based lock-free reads
+- Extended validation (ordering contract)
+- Metrics (hits, misses, latency)

--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -20,7 +20,7 @@ AM_CFLAGS=-fPIC -DPIC
 else
 AM_CFLAGS=
 endif
-AM_CFLAGS+=-I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@ @PCAP_INC@ @GPROF_CFLAGS@ @CUSTOM_NDPI@
+AM_CFLAGS+=-I$(SRCHOME)/include -I$(SRCHOME)/lib -I$(top_builddir)/src/include @NDPI_CFLAGS@ @PCAP_INC@ @GPROF_CFLAGS@ @CUSTOM_NDPI@
 AM_LDFLAGS=@NDPI_LDFLAGS@
 ENABLE_STATIC        = @enable_static@
 ifeq ($(ENABLE_STATIC),yes)
@@ -62,16 +62,20 @@ endif
 
 AM_CFLAGS+=-pthread
 
-all: ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) @DPDK_TARGET@
+all: ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) ndpi_gen_categories_bin$(EXE_SUFFIX) @DPDK_TARGET@
 
 EXECUTABLE_SOURCES := ndpiReader.c ndpiSimpleIntegration.c
-COMMON_SOURCES := $(filter-out $(EXECUTABLE_SOURCES),$(notdir $(wildcard $(srcdir)/*.c)))
+NDPI_GEN_TOOL := ndpi_gen_categories_bin.c
+COMMON_SOURCES := $(filter-out $(EXECUTABLE_SOURCES) $(NDPI_GEN_TOOL),$(notdir $(wildcard $(srcdir)/*.c)))
 
 ndpiReader$(EXE_SUFFIX): $(COMMON_SOURCES:%.c=%.o) ndpiReader.o $(LIBNDPI_DEP)
 	$(CC) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) ndpiReader.o $(COMMON_SOURCES:%.c=%.o) $(LIBS) -o $@
 
 ndpiSimpleIntegration$(EXE_SUFFIX): ndpiSimpleIntegration.o
 	$(CC) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) $< $(LIBS) -o $@
+
+ndpi_gen_categories_bin$(EXE_SUFFIX): ndpi_gen_categories_bin.o $(top_builddir)/src/lib/ndpi_category_host_norm.o $(LIBNDPI_DEP)
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) ndpi_gen_categories_bin.o $(top_builddir)/src/lib/ndpi_category_host_norm.o @NDPI_GEN_EXTRA_LIBS@ -o $@
 
 %.o: %.c $(HEADERS) Makefile
 	$(CC) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c $< -o $@
@@ -96,7 +100,7 @@ cppcheck:
 	 cppcheck --template='{file}:{line}:{severity}:{message}' --quiet --enable=all --force -I$(SRCHOME)/include $(srcdir)/*.c
 
 clean:
-	$(RM) *.o *.lo ndpiReader ndpiSimpleIntegration ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) ndpiReader.dpdk
+	$(RM) *.o *.lo ndpiReader ndpiSimpleIntegration ndpi_gen_categories_bin ndpiReader$(EXE_SUFFIX) ndpiSimpleIntegration$(EXE_SUFFIX) ndpi_gen_categories_bin$(EXE_SUFFIX) ndpiReader.dpdk
 	$(RM) .*.dpdk.cmd .*.o.cmd *.dpdk.map .*.o.d
 	$(RM) _install _postbuild _postinstall _preinstall
 	$(RM) -r build .libs .deps

--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -63,6 +63,7 @@
 #endif
 #include <errno.h>
 #include "reader_util.h"
+#include "ndpiReader_category_ndb_reload.h"
 
 #define ntohl64(x) ( ( (uint64_t)(ntohl( (uint32_t)((x << 32) >> 32) )) << 32) | ntohl( ((uint32_t)(x >> 32)) ) )
 #define htonl64(x) ntohl64(x)
@@ -88,6 +89,13 @@ static char *_maliciousSHA1Path     = NULL; /**< Malicious SSL certificate SHA1 
 static char *_riskyDomainFilePath   = NULL; /**< Risky domain files */
 static char *_domain_suffixes       = NULL; /**< Domain suffixes file */
 static char *_categoriesDirPath     = NULL; /**< Directory containing domain files */
+static char *_categoryNdbPath       = NULL; /**< Compiled categories (.ndb) for hostname backend */
+static ndpi_category_backend_mode_t g_category_ndb_effective_mode = NDPI_CATEGORY_BACKEND_NDB_ONLY;
+static unsigned g_category_ndb_reload_interval_sec = 5;
+static volatile int g_category_ndb_monitor_stop;
+static pthread_t g_category_ndb_monitor_ptid;
+static ndpi_reader_category_ndb_snap_t g_category_ndb_snap;
+static struct ndpi_detection_module_struct *g_category_ndb_str_ptrs[MAX_NUM_READER_THREADS];
 static u_int8_t live_capture = 0;
 static u_int8_t undetected_flows_deleted = 0;
 static FILE *csv_fp                 = NULL; /**< for CSV export */
@@ -574,6 +582,17 @@ static void configure_ndpi(struct ndpi_detection_module_struct *ndpi_struct) {
     }
   }
 
+  if(_categoryNdbPath) {
+    g_category_ndb_effective_mode =
+      (_categoriesDirPath != NULL || _customCategoryFilePath != NULL) ? NDPI_CATEGORY_BACKEND_HYBRID :
+      NDPI_CATEGORY_BACKEND_NDB_ONLY;
+
+    if(ndpi_load_category_ndb_file(ndpi_struct, _categoryNdbPath, g_category_ndb_effective_mode) != 0) {
+      fprintf(stderr, "Failed to load category .ndb file: %s\n", _categoryNdbPath);
+      exit(-1);
+    }
+  }
+
   ndpi_set_config(ndpi_struct, NULL, "tcp_ack_payload_heuristic", "enable");
 
   for(i = 0; i < num_cfgs; i++) {
@@ -978,6 +997,11 @@ static void help(u_int long_help) {
          "  -j <path>                  | Load malicious JA4 fingeprints\n"
          "  -S <path>                  | Load malicious SSL certificate SHA1 fingerprints\n"
 	 "  -G <dir>                   | Bind domain names to categories loading files from <dir>\n"
+   "  --category-ndb <path>      | Load compiled hostname categories from .ndb (mmap).\n"
+   "                             | With only this flag: NDB_ONLY (external hostname lists use .ndb).\n"
+   "                             | With -G or -c also: HYBRID (ndb hit wins; miss falls back to lists).\n"
+   "                             | Built-in category_match[] behaviour is unchanged.\n"
+   "  --category-ndb-reload-interval <sec> | Hot-reload poll interval (default 5; >= 1).\n"
          "  -w <path>                  | Write test output on the specified file. This is useful for\n"
          "                             | testing purposes in order to compare results across runs\n"
 	 "  --protocols-list-dir <dir> | Directory containing protocols directory (e.g. ../lists/protocols)\n"
@@ -1070,6 +1094,8 @@ static void help(u_int long_help) {
 #define OPTLONG_VALUE_FPC_STATS                 3004
 #define OPTLONG_VALUE_DOMAINS_FILE              3005
 #define OPTLONG_VALUE_RUN_TESTS                 3006
+#define OPTLONG_VALUE_CATEGORY_NDB              3007
+#define OPTLONG_VALUE_CATEGORY_NDB_RELOAD_INT   3008
 
 static struct option longopts[] = {
   /* mandatory extcap options */
@@ -1126,6 +1152,8 @@ static struct option longopts[] = {
 
   { "x-file", required_argument, NULL, OPTLONG_VALUE_DOMAINS_FILE},
   { "run-tests", no_argument, NULL, OPTLONG_VALUE_RUN_TESTS},
+  { "category-ndb", required_argument, NULL, OPTLONG_VALUE_CATEGORY_NDB},
+  { "category-ndb-reload-interval", required_argument, NULL, OPTLONG_VALUE_CATEGORY_NDB_RELOAD_INT},
 
   {0, 0, 0, 0}
 };
@@ -1819,6 +1847,22 @@ static void parse_parameters(int argc, char **argv)
     case OPTLONG_VALUE_RUN_TESTS:
       skip_unit_tests = 0;
       break;
+
+    case OPTLONG_VALUE_CATEGORY_NDB:
+      _categoryNdbPath = optarg;
+      break;
+
+    case OPTLONG_VALUE_CATEGORY_NDB_RELOAD_INT:
+      {
+        int iv = atoi(optarg);
+
+        if(iv < 1) {
+          fprintf(stderr, "--category-ndb-reload-interval must be >= 1\n");
+          exit(1);
+        }
+        g_category_ndb_reload_interval_sec = (unsigned)iv;
+        break;
+      }
 
     case 'X':
       ip_port_to_check = optarg;
@@ -5568,6 +5612,34 @@ void * processing_thread(void *_thread_id) {
 
 /* ***************************************************** */
 
+/*
+ * Periodic .ndb hot-reload monitor: aims to converge all ndpi_struct instances to the
+ * latest valid on-disk file; does not guarantee an atomic swap across threads (Etapa 2).
+ */
+static void *category_ndb_monitor_thread(void *arg) {
+  unsigned i, n;
+
+  (void)arg;
+  n = (unsigned)num_threads;
+
+  while(!g_category_ndb_monitor_stop) {
+    for(i = 0; i < g_category_ndb_reload_interval_sec && !g_category_ndb_monitor_stop; i++)
+      sleep(1);
+
+    if(g_category_ndb_monitor_stop || !_categoryNdbPath)
+      break;
+
+    for(i = 0; i < n; i++)
+      g_category_ndb_str_ptrs[i] = ndpi_thread_info[i].workflow->ndpi_struct;
+
+    (void)ndpi_reader_category_ndb_poll_reload(_categoryNdbPath, g_category_ndb_effective_mode,
+        (struct ndpi_detection_module_struct *const *)g_category_ndb_str_ptrs, n,
+        &g_category_ndb_snap);
+  }
+
+  return NULL;
+}
+
 /**
  * @brief Begin, process, end detection process
  */
@@ -5607,43 +5679,58 @@ void test_lib() {
     setupDetection(thread_id, cap, g_ctx);
   }
 
-  gettimeofday(&begin, NULL);
+  {
+    int category_ndb_monitor_running = 0;
 
-  int status;
-  void * thd_res;
+    if(_categoryNdbPath && ndpi_reader_category_ndb_snap_init(_categoryNdbPath, &g_category_ndb_snap) == 0) {
+      g_category_ndb_monitor_stop = 0;
+      if(pthread_create(&g_category_ndb_monitor_ptid, NULL, category_ndb_monitor_thread, NULL) == 0)
+        category_ndb_monitor_running = 1;
+      else
+        fprintf(stderr, "[category-ndb] warning: could not start reload monitor thread\n");
+    }
 
-  /* Running processing threads */
-  for(thread_id = 0; thread_id < num_threads; thread_id++) {
-    status = pthread_create(&ndpi_thread_info[thread_id].pthread, NULL, processing_thread, (void *) thread_id);
-    /* check pthreade_create return value */
-    if(status != 0) {
+    gettimeofday(&begin, NULL);
+
+    {
+      int status;
+      void *thd_res;
+
+      for(thread_id = 0; thread_id < num_threads; thread_id++) {
+        status = pthread_create(&ndpi_thread_info[thread_id].pthread, NULL, processing_thread, (void *)thread_id);
+        if(status != 0) {
 #ifdef WIN64
-      fprintf(stderr, "error on create %lld thread\n", thread_id);
+          fprintf(stderr, "error on create %lld thread\n", thread_id);
 #else
-      fprintf(stderr, "error on create %ld thread\n", thread_id);
+          fprintf(stderr, "error on create %ld thread\n", thread_id);
 #endif
-      exit(-1);
-    }
-  }
-  /* Waiting for completion */
-  for(thread_id = 0; thread_id < num_threads; thread_id++) {
-    status = pthread_join(ndpi_thread_info[thread_id].pthread, &thd_res);
-    /* check pthreade_join return value */
-    if(status != 0) {
+          exit(-1);
+        }
+      }
+
+      for(thread_id = 0; thread_id < num_threads; thread_id++) {
+        status = pthread_join(ndpi_thread_info[thread_id].pthread, &thd_res);
+        if(status != 0) {
 #ifdef WIN64
-      fprintf(stderr, "error on join %lld thread\n", thread_id);
+          fprintf(stderr, "error on join %lld thread\n", thread_id);
 #else
-      fprintf(stderr, "error on join %ld thread\n", thread_id);
+          fprintf(stderr, "error on join %ld thread\n", thread_id);
 #endif
-      exit(-1);
-    }
-    if(thd_res != NULL) {
+          exit(-1);
+        }
+        if(thd_res != NULL) {
 #ifdef WIN64
-      fprintf(stderr, "error on returned value of %lld joined thread\n", thread_id);
+          fprintf(stderr, "error on returned value of %lld joined thread\n", thread_id);
 #else
-      fprintf(stderr, "error on returned value of %ld joined thread\n", thread_id);
+          fprintf(stderr, "error on returned value of %ld joined thread\n", thread_id);
 #endif
-      exit(-1);
+          exit(-1);
+        }
+      }
+
+      g_category_ndb_monitor_stop = 1;
+      if(category_ndb_monitor_running)
+        pthread_join(g_category_ndb_monitor_ptid, NULL);
     }
   }
 

--- a/example/ndpiReader_category_ndb_reload.c
+++ b/example/ndpiReader_category_ndb_reload.c
@@ -1,0 +1,86 @@
+/*
+ * ndpiReader_category_ndb_reload.c
+ *
+ * The monitor does not guarantee atomic reload across all ndpi_struct pointers;
+ * it attempts to converge every instance to the same newest valid file version.
+ * Partial failure after some threads succeeded is accepted; the poll
+ * returns failure and the snapshot is not advanced.
+ */
+#include "ndpiReader_category_ndb_reload.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+static void snap_copy_from_stat(ndpi_reader_category_ndb_snap_t *snap, const struct stat *st) {
+  snap->snap_dev = st->st_dev;
+  snap->snap_ino = st->st_ino;
+  snap->snap_mtime = st->st_mtime;
+  snap->snap_size = st->st_size;
+  snap->valid = 1;
+}
+
+static int snap_identity_unchanged(const struct stat *st, const ndpi_reader_category_ndb_snap_t *snap) {
+  return st->st_dev == snap->snap_dev && st->st_ino == snap->snap_ino && st->st_mtime == snap->snap_mtime &&
+    st->st_size == snap->snap_size;
+}
+
+int ndpi_reader_category_ndb_snap_init(const char *path, ndpi_reader_category_ndb_snap_t *snap) {
+  struct stat st;
+
+  if(!path || !snap)
+    return -1;
+  memset(snap, 0, sizeof(*snap));
+  if(stat(path, &st) != 0)
+    return -1;
+  snap_copy_from_stat(snap, &st);
+  return 0;
+}
+
+int ndpi_reader_category_ndb_poll_reload(const char *path,
+    ndpi_category_backend_mode_t mode,
+    struct ndpi_detection_module_struct *const *ndpi_strs,
+    unsigned num_threads,
+    ndpi_reader_category_ndb_snap_t *snap) {
+  struct stat st;
+  const char *modestr =
+    (mode == NDPI_CATEGORY_BACKEND_HYBRID) ? "HYBRID" : (mode == NDPI_CATEGORY_BACKEND_NDB_ONLY ? "NDB_ONLY" : "?");
+
+  if(!path || !snap || !snap->valid || !ndpi_strs || num_threads == 0)
+    return NDPI_READER_NDB_POLL_ERR_STAT;
+
+  if(stat(path, &st) != 0) {
+    fprintf(stderr, "[category-ndb] stat failed for %s: %s\n", path, strerror(errno));
+    return NDPI_READER_NDB_POLL_ERR_STAT;
+  }
+
+  if(snap_identity_unchanged(&st, snap))
+    return NDPI_READER_NDB_POLL_NOCHANGE;
+
+  fprintf(stderr, "[category-ndb] change detected for %s, attempting reload\n", path);
+
+  for(unsigned i = 0; i < num_threads; i++) {
+    int rc = ndpi_load_category_ndb_file(ndpi_strs[i], path, mode);
+    if(rc != 0) {
+      fprintf(stderr,
+          "[category-ndb] reload failed for %s (thread=%u mode=%s err=%d), keeping previous database active\n",
+          path, i, modestr, rc);
+      return NDPI_READER_NDB_POLL_ERR_RELOAD;
+    }
+  }
+
+  {
+    struct stat st2;
+
+    if(stat(path, &st2) == 0)
+      snap_copy_from_stat(snap, &st2);
+    else {
+      fprintf(stderr, "[category-ndb] reload succeeded but post-reload stat failed for %s: %s\n", path,
+          strerror(errno));
+      snap_copy_from_stat(snap, &st);
+    }
+  }
+
+  fprintf(stderr, "[category-ndb] reload successful for %s\n", path);
+  return NDPI_READER_NDB_POLL_RELOADED;
+}

--- a/example/ndpiReader_category_ndb_reload.h
+++ b/example/ndpiReader_category_ndb_reload.h
@@ -1,0 +1,44 @@
+/*
+ * ndpiReader_category_ndb_reload.h — periodic .ndb hot-reload helper.
+ *
+ * Goal: converge all ndpi_struct instances to the latest valid on-disk file;
+ *       does not guarantee atomic swap across threads (see comments in .c).
+ *
+ * Return convention for ndpi_reader_category_ndb_poll_reload():
+ *   0  = no change vs snapshot (does not call ndpi_load_category_ndb_file)
+ *   1  = file changed and reload succeeded on all threads
+ *   <0 = operational error (use logs or future distinct negative codes to
+ *        distinguish stat failure vs reload failure)
+ */
+#ifndef NDPI_READER_CATEGORY_NDB_RELOAD_H
+#define NDPI_READER_CATEGORY_NDB_RELOAD_H
+
+#include <sys/stat.h>
+
+#include "ndpi_api.h"
+
+struct ndpi_detection_module_struct;
+
+/* Field names avoid st_* members (e.g. st_mtime is a macro on some platforms). */
+typedef struct {
+  dev_t snap_dev;
+  ino_t snap_ino;
+  time_t snap_mtime;
+  off_t snap_size;
+  int valid;
+} ndpi_reader_category_ndb_snap_t;
+
+#define NDPI_READER_NDB_POLL_NOCHANGE   0
+#define NDPI_READER_NDB_POLL_RELOADED   1
+#define NDPI_READER_NDB_POLL_ERR_STAT   -1
+#define NDPI_READER_NDB_POLL_ERR_RELOAD -2
+
+int ndpi_reader_category_ndb_snap_init(const char *path, ndpi_reader_category_ndb_snap_t *snap);
+
+int ndpi_reader_category_ndb_poll_reload(const char *path,
+    ndpi_category_backend_mode_t mode,
+    struct ndpi_detection_module_struct *const *ndpi_strs,
+    unsigned num_threads,
+    ndpi_reader_category_ndb_snap_t *snap);
+
+#endif /* NDPI_READER_CATEGORY_NDB_RELOAD_H */

--- a/example/ndpi_gen_categories_bin.c
+++ b/example/ndpi_gen_categories_bin.c
@@ -1,0 +1,1455 @@
+/*
+ * ndpi_gen_categories_bin.c
+ *
+ * Usage:
+ *   ./ndpi_gen_categories_bin -i /usr/local/ngfw/categories -o /usr/local/ngfw/base.ndb -V "2026-04-01"
+ *
+ * Format:
+ *   [Header]
+ *   [Category records]
+ *   [Bucket table]
+ *   [Entry table]
+ *   [String pool]
+ */
+
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <time.h>
+#if defined(_WIN32)
+#include <io.h>
+#endif
+
+#include "ndpi_typedefs.h"
+#include "ndpi_categories_bin.h"
+#include "ndpi_category_host_norm.h"
+
+#define INITIAL_CAP 1024
+
+/*
+ * PATH_MAX-sized buffers are too small for "dir/file" joins and trigger
+ * -Wformat-truncation under -Werror: input_dir is PATH_MAX and readdir names
+ * add up to NAME_MAX; temp output path also needs room for ".tmp." + pid.
+ */
+#ifndef NAME_MAX
+#define NDPI_CATBIN_NAME_MAX 255u
+#else
+#define NDPI_CATBIN_NAME_MAX ((size_t)NAME_MAX)
+#endif
+#define NDPI_CATBIN_JOIN_BUFSZ ((size_t)PATH_MAX + NDPI_CATBIN_NAME_MAX + 2u)
+#define NDPI_CATBIN_TMP_OUT_BUFSZ ((size_t)PATH_MAX + 64u)
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+_Static_assert(sizeof(ndb_header_disk_t) == 200, "ndb_header_disk_t size drift");
+#endif
+
+typedef struct {
+  uint32_t id;
+  char *name;
+  uint32_t name_off;
+} category_t;
+
+typedef struct {
+  uint64_t hash;
+  char *domain;
+  uint16_t domain_len;
+  uint16_t flags;
+  uint32_t category_id;
+  uint32_t domain_off;
+} entry_t;
+
+typedef struct {
+  uint32_t network_be;
+  uint8_t  prefix_len;
+  uint8_t  flags;
+  uint32_t category_id;
+} ipv4_entry_t;
+
+typedef struct {
+  uint8_t  addr[16];
+  uint8_t  prefix_len;
+  uint8_t  flags;
+  uint32_t category_id;
+} ipv6_entry_t;
+
+typedef struct {
+  ipv4_entry_t *items;
+  size_t count;
+  size_t cap;
+} ipv4_entry_vec_t;
+
+typedef struct {
+  ipv6_entry_t *items;
+  size_t count;
+  size_t cap;
+} ipv6_entry_vec_t;
+
+typedef struct {
+  category_t *items;
+  size_t count;
+  size_t cap;
+} category_vec_t;
+
+typedef struct {
+  entry_t *items;
+  size_t count;
+  size_t cap;
+} entry_vec_t;
+
+typedef struct {
+  char *data;
+  size_t len;
+  size_t cap;
+} strpool_t;
+
+typedef enum {
+  RULE_INVALID = 0,
+  RULE_DOMAIN,
+  RULE_IPV4,
+  RULE_IPV6
+} rule_kind_t;
+
+typedef struct {
+  rule_kind_t kind;
+  char text[4096]; /* domain or canonical textual representation of IP/CIDR */
+} parsed_rule_t;
+
+/* set per input file while parsing lines (error context) */
+static const char *g_parse_src_file;
+/* if set: in mixed lists, treat bare IPv4-looking tokens without '/' as domains, not hosts */
+static int g_ip_only_cidr;
+
+typedef enum {
+  CONFLICT_POLICY_ERROR = 0,
+  CONFLICT_POLICY_WARN_IGNORE,
+  CONFLICT_POLICY_FIRST_WINS,
+  CONFLICT_POLICY_LAST_WINS
+} conflict_policy_t;
+
+static conflict_policy_t g_conflict_policy = CONFLICT_POLICY_ERROR;
+static const char *g_conflict_policy_label = "error";
+
+static void dief(const char *msg);
+
+static void set_conflict_policy_arg(const char *s) {
+  if(!s || !*s)
+    dief("invalid --conflict-policy");
+  if(strcasecmp(s, "error") == 0) {
+    g_conflict_policy = CONFLICT_POLICY_ERROR;
+    g_conflict_policy_label = "error";
+    return;
+  }
+  if(strcasecmp(s, "warn-ignore") == 0) {
+    g_conflict_policy = CONFLICT_POLICY_WARN_IGNORE;
+    g_conflict_policy_label = "warn-ignore";
+    return;
+  }
+  if(strcasecmp(s, "first-wins") == 0) {
+    g_conflict_policy = CONFLICT_POLICY_FIRST_WINS;
+    g_conflict_policy_label = "first-wins";
+    return;
+  }
+  if(strcasecmp(s, "last-wins") == 0) {
+    g_conflict_policy = CONFLICT_POLICY_LAST_WINS;
+    g_conflict_policy_label = "last-wins";
+    return;
+  }
+  dief("invalid --conflict-policy (expected error|warn-ignore|first-wins|last-wins)");
+}
+
+static void die(const char *msg) {
+  perror(msg);
+  exit(1);
+}
+
+static void dief(const char *msg) {
+  fprintf(stderr, "ERROR: %s\n", msg);
+  exit(1);
+}
+
+/* MinGW/MSVC may not declare getline(); behaviour matches POSIX for this tool. */
+static ssize_t catbin_getline(char **lineptr, size_t *n, FILE *fp) {
+  size_t pos = 0;
+
+  if(!lineptr || !n || !fp)
+    return -1;
+
+  for(;;) {
+    if(pos + 2 > *n) {
+      size_t newsz = *n ? *n * 2 : 256;
+      while(newsz < pos + 2)
+        newsz *= 2;
+      char *p = realloc(*lineptr, newsz);
+      if(!p)
+        return -1;
+      *lineptr = p;
+      *n = newsz;
+    }
+    {
+      int c = fgetc(fp);
+      if(c == EOF) {
+        if(pos == 0)
+          return -1;
+        (*lineptr)[pos] = '\0';
+        return (ssize_t)pos;
+      }
+      (*lineptr)[pos++] = (char)(unsigned char)c;
+      if(c == '\n') {
+        (*lineptr)[pos] = '\0';
+        return (ssize_t)pos;
+      }
+    }
+  }
+}
+
+static void *xmalloc(size_t n) {
+  void *p = malloc(n);
+  if(!p) die("malloc");
+  return p;
+}
+
+static void *xrealloc(void *p, size_t n) {
+  void *q = realloc(p, n);
+  if(!q) die("realloc");
+  return q;
+}
+
+static char *xstrdup(const char *s) {
+  char *p = strdup(s);
+  if(!p) die("strdup");
+  return p;
+}
+
+static uint64_t fnv1a64(const char *s, size_t len) {
+  uint64_t h = 1469598103934665603ULL;
+  for(size_t i = 0; i < len; ++i) {
+    h ^= (unsigned char)s[i];
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
+
+static int looks_like_ip_candidate(const char *s) {
+  for(const char *p = s; *p; ++p) {
+    unsigned char c = (unsigned char)*p;
+    if(isdigit(c) || c == '.' || c == ':' || c == '/' ||
+        (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+      continue;
+    }
+    return 0;
+  }
+  return 1;
+}
+
+static void category_vec_push(category_vec_t *v, category_t c) {
+  if(v->count == v->cap) {
+    v->cap = v->cap ? v->cap * 2 : INITIAL_CAP;
+    v->items = xrealloc(v->items, v->cap * sizeof(v->items[0]));
+  }
+  v->items[v->count++] = c;
+}
+
+static void entry_vec_push(entry_vec_t *v, entry_t e) {
+  if(v->count == v->cap) {
+    v->cap = v->cap ? v->cap * 2 : INITIAL_CAP;
+    v->items = xrealloc(v->items, v->cap * sizeof(v->items[0]));
+  }
+  v->items[v->count++] = e;
+}
+
+static void ipv4_entry_vec_push(ipv4_entry_vec_t *v, ipv4_entry_t e) {
+  if(v->count == v->cap) {
+    v->cap = v->cap ? v->cap * 2 : INITIAL_CAP;
+    v->items = xrealloc(v->items, v->cap * sizeof(v->items[0]));
+  }
+  v->items[v->count++] = e;
+}
+
+static void ipv6_entry_vec_push(ipv6_entry_vec_t *v, ipv6_entry_t e) {
+  if(v->count == v->cap) {
+    v->cap = v->cap ? v->cap * 2 : INITIAL_CAP;
+    v->items = xrealloc(v->items, v->cap * sizeof(v->items[0]));
+  }
+  v->items[v->count++] = e;
+}
+
+static category_t *find_category_by_id(category_vec_t *v, uint32_t id) {
+  for(size_t i = 0; i < v->count; ++i) {
+    if(v->items[i].id == id) return &v->items[i];
+  }
+  return NULL;
+}
+
+static category_t *find_or_add_category(category_vec_t *v, uint32_t id, const char *name) {
+  category_t *found = find_category_by_id(v, id);
+  if(found) {
+    if(strcmp(found->name, name) != 0) {
+      fprintf(stderr, "ERROR: category id %u reused with different names: '%s' vs '%s'\n",
+          id, found->name, name);
+      exit(1);
+    }
+    return found;
+  }
+
+  category_t cat = {0};
+  cat.id = id;
+  cat.name = xstrdup(name);
+  category_vec_push(v, cat);
+  return &v->items[v->count - 1];
+}
+
+static uint32_t strpool_add(strpool_t *p, const char *s, size_t len) {
+  if(p->len + len + 1 > p->cap) {
+    size_t new_cap = p->cap ? p->cap * 2 : 4096;
+    while(new_cap < p->len + len + 1) new_cap *= 2;
+    p->data = xrealloc(p->data, new_cap);
+    p->cap = new_cap;
+  }
+  uint32_t off = (uint32_t)p->len;
+  memcpy(p->data + p->len, s, len);
+  p->len += len;
+  p->data[p->len++] = '\0';
+  return off;
+}
+
+static size_t next_pow2(size_t v) {
+  size_t p = 1;
+  while(p < v) p <<= 1;
+  return p;
+}
+
+/* ---------- category-aware dedupe (cross-category policy) ---------- */
+
+typedef enum { DEDUPE_DOMAIN = 0, DEDUPE_IPV4, DEDUPE_IPV6 } dedupe_kind_t;
+
+typedef struct catdedupe_node {
+  char *key;
+  uint32_t cat_id;
+  size_t entry_index;
+  struct catdedupe_node *next;
+} catdedupe_node_t;
+
+typedef struct {
+  catdedupe_node_t **buckets;
+  size_t nbuckets;
+} catdedupe_t;
+
+typedef struct {
+  conflict_policy_t policy;
+  uint64_t *conflicts_total;
+  uint64_t *conflicts_ignored;
+  uint64_t *conflicts_overwritten;
+  entry_vec_t *domain_entries;
+  ipv4_entry_vec_t *ipv4_entries;
+  ipv6_entry_vec_t *ipv6_entries;
+} catdedupe_ctx_t;
+
+static void catdedupe_init(catdedupe_t *d, size_t nbuckets) {
+  d->nbuckets = nbuckets ? nbuckets : 65536;
+  d->buckets = calloc(d->nbuckets, sizeof(*d->buckets));
+  if(!d->buckets) die("calloc catdedupe");
+}
+
+static void catdedupe_free(catdedupe_t *d) {
+  if(!d || !d->buckets) return;
+  for(size_t i = 0; i < d->nbuckets; ++i) {
+    catdedupe_node_t *n = d->buckets[i];
+    while(n) {
+      catdedupe_node_t *nx = n->next;
+      free(n->key);
+      free(n);
+      n = nx;
+    }
+  }
+  free(d->buckets);
+  d->buckets = NULL;
+}
+
+/*
+ * Return 0 = new key (out_interned = stable pointer to stored key when non-NULL),
+ * 1 = duplicate (same category skip, or resolved conflict per policy).
+ */
+static int catdedupe_add(catdedupe_t *d, dedupe_kind_t kind, const char *key, uint32_t cat_id,
+    const char *src_file, size_t new_entry_index, catdedupe_ctx_t *ctx,
+    const char **out_interned) {
+  uint64_t h = fnv1a64(key, strlen(key));
+  size_t b = (size_t)(h % d->nbuckets);
+
+  for(catdedupe_node_t *n = d->buckets[b]; n; n = n->next) {
+    if(strcmp(n->key, key) == 0) {
+      if(n->cat_id == cat_id)
+        return 1;
+
+      if(ctx->policy == CONFLICT_POLICY_ERROR) {
+        fprintf(stderr,
+            "ERROR: entry '%s' appears in category %u and %u (conflict). Source file: %s\n",
+            key, n->cat_id, cat_id, src_file ? src_file : "?");
+        exit(1);
+      }
+
+      (*ctx->conflicts_total)++;
+      if(ctx->policy == CONFLICT_POLICY_WARN_IGNORE) {
+        fprintf(stderr,
+            "WARN: entry '%s' category conflict %u vs %u; keeping first (file %s ignored; policy=warn-ignore)\n",
+            key, n->cat_id, cat_id, src_file ? src_file : "?");
+        (*ctx->conflicts_ignored)++;
+        return 1;
+      }
+      if(ctx->policy == CONFLICT_POLICY_FIRST_WINS) {
+        (*ctx->conflicts_ignored)++;
+        return 1;
+      }
+      if(ctx->policy == CONFLICT_POLICY_LAST_WINS) {
+        n->cat_id = cat_id;
+        (*ctx->conflicts_overwritten)++;
+        switch(kind) {
+          case DEDUPE_DOMAIN:
+            if(n->entry_index < ctx->domain_entries->count)
+              ctx->domain_entries->items[n->entry_index].category_id = cat_id;
+            break;
+          case DEDUPE_IPV4:
+            if(n->entry_index < ctx->ipv4_entries->count)
+              ctx->ipv4_entries->items[n->entry_index].category_id = cat_id;
+            break;
+          case DEDUPE_IPV6:
+            if(n->entry_index < ctx->ipv6_entries->count)
+              ctx->ipv6_entries->items[n->entry_index].category_id = cat_id;
+            break;
+        }
+        return 1;
+      }
+      dief("internal: bad conflict policy");
+    }
+  }
+
+  catdedupe_node_t *n = (catdedupe_node_t *)malloc(sizeof(*n));
+  if(!n) die("malloc catdedupe_node");
+  n->key = xstrdup(key);
+  n->cat_id = cat_id;
+  n->entry_index = new_entry_index;
+  n->next = d->buckets[b];
+  d->buckets[b] = n;
+  if(out_interned)
+    *out_interned = n->key;
+  return 0;
+}
+
+static char *trim(char *s) {
+  while(*s && isspace((unsigned char)*s)) s++;
+  if(!*s) return s;
+
+  char *end = s + strlen(s) - 1;
+  while(end > s && isspace((unsigned char)*end)) {
+    *end = '\0';
+    end--;
+  }
+  return s;
+}
+
+static void strip_comment(char *s) {
+  for(char *p = s; *p; ++p) {
+    if(*p == '#') {
+      *p = '\0';
+      return;
+    }
+  }
+}
+
+static int normalize_raw_line(const char *input, char *out, size_t out_sz) {
+  if(strlen(input) + 1 > out_sz) return 0;
+  strcpy(out, input);
+
+  strip_comment(out);
+
+  char *s = trim(out);
+  if(s != out) memmove(out, s, strlen(s) + 1);
+
+  if(out[0] == '\0') return 0;
+  return 1;
+}
+
+static int normalize_ipv4_or_cidr_line(const char *input, char *out, size_t out_sz) {
+  if(strlen(input) + 1 > out_sz) return 0;
+  strcpy(out, input);
+
+  strip_comment(out);
+  char *s = trim(out);
+  if(s != out) memmove(out, s, strlen(s) + 1);
+  if(out[0] == '\0') return 0;
+
+  char *slash = strchr(out, '/');
+  uint32_t prefix = 32;
+
+  if(slash) {
+    *slash = '\0';
+    char *pfx = trim(slash + 1);
+    if(*pfx == '\0') return 0;
+
+    char *endp = NULL;
+    unsigned long x = strtoul(pfx, &endp, 10);
+    if(*endp != '\0' || x > 32) return 0;
+    prefix = (uint32_t)x;
+  }
+
+  struct in_addr a4;
+  if(inet_pton(AF_INET, out, &a4) != 1) return 0;
+
+  uint32_t host = ntohl(a4.s_addr);
+  uint32_t mask = (prefix == 0) ? 0u : (0xFFFFFFFFu << (32 - prefix));
+  uint32_t net = host & mask;
+
+  struct in_addr net4;
+  net4.s_addr = htonl(net);
+
+  char ipbuf[INET_ADDRSTRLEN];
+  if(!inet_ntop(AF_INET, &net4, ipbuf, sizeof(ipbuf))) return 0;
+
+  if(prefix == 32) {
+    if(strlen(ipbuf) + 1 > out_sz) return 0;
+    snprintf(out, out_sz, "%s", ipbuf);
+  } else {
+    if(strlen(ipbuf) + 4 > out_sz) return 0;
+    snprintf(out, out_sz, "%s/%u", ipbuf, prefix);
+  }
+
+  return 1;
+}
+
+static int normalize_ipv6_or_cidr_line(const char *input, char *out, size_t out_sz) {
+  if(strlen(input) + 1 > out_sz) return 0;
+  strcpy(out, input);
+
+  strip_comment(out);
+  char *s = trim(out);
+  if(s != out) memmove(out, s, strlen(s) + 1);
+  if(out[0] == '\0') return 0;
+
+  char *slash = strchr(out, '/');
+  uint32_t prefix = 128;
+
+  if(slash) {
+    *slash = '\0';
+    char *pfx = trim(slash + 1);
+    if(*pfx == '\0') return 0;
+
+    char *endp = NULL;
+    unsigned long x = strtoul(pfx, &endp, 10);
+    if(*endp != '\0' || x > 128) return 0;
+    prefix = (uint32_t)x;
+  }
+
+  uint8_t addr[16];
+  if(inet_pton(AF_INET6, out, addr) != 1) return 0;
+
+  uint8_t net[16];
+  memcpy(net, addr, 16);
+
+  uint32_t bits = prefix;
+  for(int i = 0; i < 16; ++i) {
+    if(bits >= 8) {
+      bits -= 8;
+    } else if(bits == 0) {
+      net[i] = 0;
+    } else {
+      net[i] &= (uint8_t)(0xFF << (8 - bits));
+      bits = 0;
+    }
+  }
+
+  char ipbuf[INET6_ADDRSTRLEN];
+  if(!inet_ntop(AF_INET6, net, ipbuf, sizeof(ipbuf))) return 0;
+
+  if(prefix == 128) {
+    if(strlen(ipbuf) + 1 > out_sz) return 0;
+    snprintf(out, out_sz, "%s", ipbuf);
+  } else {
+    if(strlen(ipbuf) + 6 > out_sz) return 0;
+    snprintf(out, out_sz, "%s/%u", ipbuf, prefix);
+  }
+
+  return 1;
+}
+
+static int parse_mixed_rule_line(const char *line, parsed_rule_t *out) {
+  char raw[4096];
+
+  memset(out, 0, sizeof(*out));
+
+  if(!normalize_raw_line(line, raw, sizeof(raw))) {
+    return 0;
+  }
+
+  /*
+   * Order is important:
+   * 1) IPv4/CIDR
+   * 2) IPv6/CIDR
+   * 3) domain (same normalization as the .ndb runtime)
+   */
+  {
+    int try_ip = looks_like_ip_candidate(raw);
+
+    if(try_ip && g_ip_only_cidr && strchr(raw, '/') == NULL)
+      try_ip = 0;
+
+    if(try_ip) {
+      char ip4[128];
+      if(normalize_ipv4_or_cidr_line(raw, ip4, sizeof(ip4))) {
+        out->kind = RULE_IPV4;
+        snprintf(out->text, sizeof(out->text), "%s", ip4);
+        return 1;
+      }
+
+      char ip6[256];
+      if(normalize_ipv6_or_cidr_line(raw, ip6, sizeof(ip6))) {
+        out->kind = RULE_IPV6;
+        snprintf(out->text, sizeof(out->text), "%s", ip6);
+        return 1;
+      }
+    }
+  }
+
+  {
+    char dom[4096];
+
+    if(ndpi_category_normalize_host_for_ndb(raw, dom, sizeof(dom)) != 0)
+      return 0;
+
+    if(ndpi_category_hostname_is_isolated_tld(dom)) {
+      fprintf(stderr,
+          "ERROR: isolated public-TLD label not allowed in .ndb input: '%s' (%s)\n",
+          dom, g_parse_src_file ? g_parse_src_file : "?");
+      exit(1);
+    }
+
+    if(strchr(dom, '.') == NULL) {
+      fprintf(stderr,
+          "ERROR: hostname must include a dot (FQDN), not a single label: '%s' (%s)\n",
+          dom, g_parse_src_file ? g_parse_src_file : "?");
+      exit(1);
+    }
+
+    out->kind = RULE_DOMAIN;
+    snprintf(out->text, sizeof(out->text), "%s", dom);
+    return 1;
+  }
+}
+
+static int is_regular_file(const char *path) {
+  struct stat st;
+  if(stat(path, &st) != 0) return 0;
+  return S_ISREG(st.st_mode);
+}
+
+static int cmp_strptr(const void *a, const void *b) {
+  const char * const *sa = a;
+  const char * const *sb = b;
+  return strcmp(*sa, *sb);
+}
+
+static int cmp_entry_hash_domain(const void *a, const void *b) {
+  const entry_t *ea = a;
+  const entry_t *eb = b;
+
+  if(ea->hash < eb->hash) return -1;
+  if(ea->hash > eb->hash) return 1;
+
+  int c = strcmp(ea->domain, eb->domain);
+  if(c != 0) return c;
+
+  if(ea->category_id < eb->category_id) return -1;
+  if(ea->category_id > eb->category_id) return 1;
+  return 0;
+}
+
+static int cmp_ipv4_entry(const void *a, const void *b) {
+  const ipv4_entry_t *ea = a;
+  const ipv4_entry_t *eb = b;
+
+  uint32_t na = ntohl(ea->network_be);
+  uint32_t nb = ntohl(eb->network_be);
+
+  if(na < nb) return -1;
+  if(na > nb) return 1;
+
+  if(ea->prefix_len < eb->prefix_len) return -1;
+  if(ea->prefix_len > eb->prefix_len) return 1;
+
+  if(ea->category_id < eb->category_id) return -1;
+  if(ea->category_id > eb->category_id) return 1;
+
+  return 0;
+}
+
+static int cmp_ipv6_entry(const void *a, const void *b) {
+  const ipv6_entry_t *ea = a;
+  const ipv6_entry_t *eb = b;
+
+  int c = memcmp(ea->addr, eb->addr, 16);
+  if(c != 0) return c;
+
+  if(ea->prefix_len < eb->prefix_len) return -1;
+  if(ea->prefix_len > eb->prefix_len) return 1;
+
+  if(ea->category_id < eb->category_id) return -1;
+  if(ea->category_id > eb->category_id) return 1;
+
+  return 0;
+}
+
+static int has_suffix_exact(const char *s, const char *suffix) {
+  size_t sl = strlen(s);
+  size_t xl = strlen(suffix);
+  if(sl < xl) return 0;
+  return strcmp(s + sl - xl, suffix) == 0;
+}
+
+static int is_domain_list_file(const char *filename) {
+  if(has_suffix_exact(filename, ".ipv4.list")) return 0;
+  if(has_suffix_exact(filename, ".ipv6.list")) return 0;
+  return has_suffix_exact(filename, ".list");
+}
+
+static int is_ipv4_list_file(const char *filename) {
+  return has_suffix_exact(filename, ".ipv4.list");
+}
+
+static int is_ipv6_list_file(const char *filename) {
+  return has_suffix_exact(filename, ".ipv6.list");
+}
+
+/* Canonical masked network for stable dedupe keys and on-disk rows. */
+static void ipv4_apply_mask(ipv4_entry_t *e) {
+  uint32_t a = ntohl(e->network_be);
+  uint8_t pl = e->prefix_len;
+
+  if(pl >= 32)
+    return;
+  if(pl == 0) {
+    e->network_be = 0;
+    return;
+  }
+  {
+    uint32_t m = 0xffffffffu << (32u - (uint32_t)pl);
+    e->network_be = htonl(a & m);
+  }
+}
+
+static void ipv4_canonical_key(const ipv4_entry_t *e, char *out, size_t out_sz) {
+  struct in_addr a4;
+  char ip[INET_ADDRSTRLEN];
+
+  a4.s_addr = e->network_be;
+  inet_ntop(AF_INET, &a4, ip, sizeof(ip));
+  snprintf(out, out_sz, "%s/%u", ip, (unsigned)e->prefix_len);
+}
+
+static void ipv6_apply_mask(uint8_t addr[16], uint8_t pl) {
+  unsigned full = (unsigned)pl / 8;
+  unsigned rem = (unsigned)pl % 8;
+  unsigned i;
+
+  if(pl >= 128)
+    return;
+  if(rem) {
+    uint8_t m = (uint8_t)(0xffu << (8 - rem));
+    addr[full] &= m;
+    full++;
+  }
+  for(i = full; i < 16; i++)
+    addr[i] = 0;
+}
+
+static void ipv6_canonical_key(const uint8_t addr[16], uint8_t pl, char *out, size_t out_sz) {
+  size_t pos = 0;
+  unsigned j;
+
+  for(j = 0; j < 16 && pos + 3 < out_sz; j++)
+    pos += (size_t)snprintf(out + pos, out_sz - pos, "%02x", addr[j]);
+  snprintf(out + pos, out_sz - pos, "/%u", (unsigned)pl);
+}
+
+static int parse_ipv4_canonical(const char *s, ipv4_entry_t *out, uint32_t category_id) {
+  char tmp[64];
+  snprintf(tmp, sizeof(tmp), "%s", s);
+
+  char *slash = strchr(tmp, '/');
+  uint32_t prefix = 32;
+  if(slash) {
+    *slash = '\0';
+    prefix = (uint32_t)strtoul(slash + 1, NULL, 10);
+  }
+
+  struct in_addr a4;
+  if(inet_pton(AF_INET, tmp, &a4) != 1) return 0;
+
+  out->network_be = a4.s_addr;
+  out->prefix_len = (uint8_t)prefix;
+  out->flags = 0;
+  out->category_id = category_id;
+  ipv4_apply_mask(out);
+  return 1;
+}
+
+static int parse_ipv6_canonical(const char *s, ipv6_entry_t *out, uint32_t category_id) {
+  char tmp[128];
+  snprintf(tmp, sizeof(tmp), "%s", s);
+
+  char *slash = strchr(tmp, '/');
+  uint32_t prefix = 128;
+  if(slash) {
+    *slash = '\0';
+    prefix = (uint32_t)strtoul(slash + 1, NULL, 10);
+  }
+
+  if(inet_pton(AF_INET6, tmp, out->addr) != 1) return 0;
+
+  out->prefix_len = (uint8_t)prefix;
+  out->flags = 0;
+  out->category_id = category_id;
+  ipv6_apply_mask(out->addr, out->prefix_len);
+  return 1;
+}
+
+static int parse_category_filename(const char *filename, uint32_t auto_id,
+    uint32_t *out_id, char *out_name, size_t out_name_sz) {
+  char tmp[PATH_MAX];
+
+  (void)auto_id;
+  size_t len = strlen(filename);
+
+  if(len >= sizeof(tmp)) {
+    fprintf(stderr, "ERROR: filename too long: %s\n", filename);
+    exit(EXIT_FAILURE);
+  }
+
+  memcpy(tmp, filename, len + 1);
+
+  if(has_suffix_exact(tmp, ".ipv4.list")) {
+    tmp[len - strlen(".ipv4.list")] = '\0';
+  } else if(has_suffix_exact(tmp, ".ipv6.list")) {
+    tmp[len - strlen(".ipv6.list")] = '\0';
+  } else if(has_suffix_exact(tmp, ".list")) {
+    tmp[len - strlen(".list")] = '\0';
+  } else {
+    return 0;
+  }
+
+  char *underscore = strchr(tmp, '_');
+  if(underscore) {
+    int all_digits = 1;
+    for(char *p = tmp; p < underscore; ++p) {
+      if(!isdigit((unsigned char)*p)) {
+        all_digits = 0;
+        break;
+      }
+    }
+    if(all_digits && underscore > tmp) {
+      *out_id = (uint32_t)strtoul(tmp, NULL, 10);
+
+      if(strlen(underscore + 1) >= out_name_sz) {
+        fprintf(stderr, "ERROR: category name too long: %s\n", filename);
+        exit(EXIT_FAILURE);
+      }
+      snprintf(out_name, out_name_sz, "%s", underscore + 1);
+      return 1;
+    }
+  }
+
+  fprintf(stderr, "ERROR: category file name must use '<id>_<name>.list' (numeric id prefix): %s\n", filename);
+  exit(EXIT_FAILURE);
+}
+
+static void ensure_parent_dir_exists(const char *path) {
+  char tmp[PATH_MAX];
+  snprintf(tmp, sizeof(tmp), "%s", path);
+  char *slash = strrchr(tmp, '/');
+  if(!slash) return;
+  *slash = '\0';
+  if(tmp[0] == '\0') return;
+
+  struct stat st;
+  if(stat(tmp, &st) != 0) {
+    fprintf(stderr, "ERROR: parent directory does not exist: %s\n", tmp);
+    exit(1);
+  }
+  if(!S_ISDIR(st.st_mode)) {
+    fprintf(stderr, "ERROR: parent path is not a directory: %s\n", tmp);
+    exit(1);
+  }
+}
+
+static void catbin_join_path(char *dst, size_t dstsz, const char *dir, size_t dir_cap, const char *name,
+    size_t name_max) {
+  size_t dlen = strnlen(dir, dir_cap ? dir_cap - 1 : 0);
+  size_t nlen = strnlen(name, name_max);
+
+  if(dlen + 1 + nlen >= dstsz) dief("path too long");
+  memcpy(dst, dir, dlen);
+  dst[dlen] = '/';
+  memcpy(dst + dlen + 1, name, nlen);
+  dst[dlen + 1 + nlen] = '\0';
+}
+
+static void catbin_mk_tmp_output_path(char *dst, size_t dstsz, const char *output_file, size_t out_cap) {
+  size_t olen = strnlen(output_file, out_cap ? out_cap - 1 : 0);
+  char suf[48];
+  int sl = snprintf(suf, sizeof(suf), ".tmp.%d", (int)getpid());
+
+  if(sl < 0 || (size_t)sl >= sizeof(suf)) dief("temp output path suffix");
+  if(olen + (size_t)sl + 1 > dstsz) dief("output path too long");
+
+  memcpy(dst, output_file, olen);
+  memcpy(dst + olen, suf, (size_t)sl + 1);
+}
+
+int main(int argc, char **argv) {
+  char input_dir[PATH_MAX] = {0};
+  char output_file[PATH_MAX] = {0};
+  char base_version[64] = {0};
+
+  g_ip_only_cidr = 0;
+
+  static const struct option lopts[] = {
+    { "ip-only-with-mask", no_argument, NULL, 1000 },
+    { "conflict-policy", required_argument, NULL, 2001 },
+    { "help", no_argument, NULL, 'h' },
+    { NULL, 0, NULL, 0 }
+  };
+
+  int opt;
+  while((opt = getopt_long(argc, argv, "i:o:V:h", lopts, NULL)) != -1) {
+    switch(opt) {
+      case 'i':
+        snprintf(input_dir, sizeof(input_dir), "%s", optarg);
+        break;
+      case 'o':
+        snprintf(output_file, sizeof(output_file), "%s", optarg);
+        break;
+      case 'V':
+        snprintf(base_version, sizeof(base_version), "%s", optarg);
+        break;
+      case 1000:
+        g_ip_only_cidr = 1;
+        break;
+      case 2001:
+        set_conflict_policy_arg(optarg);
+        break;
+      case 'h':
+        fprintf(stderr,
+            "Usage: %s -i <categories_dir> -o <output.ndb> -V <base_version> [options]\n",
+            argv[0]);
+        fprintf(stderr,
+            "  --ip-only-with-mask     In mixed .list files, require '/' for IPv4/IPv6 (else parse as FQDN).\n");
+        fprintf(stderr,
+            "  --conflict-policy <p>   Cross-category duplicate key: error (default), warn-ignore, first-wins,\n"
+            "                          last-wins. Processing order is deterministic (sorted input filenames,\n"
+            "                          then line order per file); first/last refer to that order.\n");
+        return 0;
+      default:
+        fprintf(stderr,
+            "Usage: %s -i <categories_dir> -o <output.ndb> -V <base_version> [options]\n",
+            argv[0]);
+        return 1;
+    }
+  }
+
+  if(input_dir[0] == '\0' || output_file[0] == '\0' || base_version[0] == '\0') {
+    fprintf(stderr,
+        "Usage: %s -i <categories_dir> -o <output.ndb> -V <base_version> [options]\n",
+        argv[0]);
+    return 1;
+  }
+
+  struct stat st;
+  if(stat(input_dir, &st) != 0 || !S_ISDIR(st.st_mode)) {
+    fprintf(stderr, "ERROR: invalid input directory: %s\n", input_dir);
+    return 1;
+  }
+
+  ensure_parent_dir_exists(output_file);
+
+  DIR *dir = opendir(input_dir);
+  if(!dir) die("opendir");
+
+  char **file_list = NULL;
+  size_t file_count = 0, file_cap = 0;
+
+  struct dirent *de;
+  while((de = readdir(dir)) != NULL) {
+    if(strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0) continue;
+
+    char path[NDPI_CATBIN_JOIN_BUFSZ];
+    catbin_join_path(path, sizeof(path), input_dir, sizeof(input_dir), de->d_name, NDPI_CATBIN_NAME_MAX + 1);
+
+    if(!is_regular_file(path)) continue;
+    if(file_count == file_cap) {
+      file_cap = file_cap ? file_cap * 2 : 128;
+      file_list = xrealloc(file_list, file_cap * sizeof(file_list[0]));
+    }
+    file_list[file_count++] = xstrdup(de->d_name);
+  }
+  closedir(dir);
+
+  if(file_count == 0) dief("no category files found");
+
+  qsort(file_list, file_count, sizeof(file_list[0]), cmp_strptr);
+
+  category_vec_t categories = {0};
+
+  entry_vec_t domain_entries = {0};
+  ipv4_entry_vec_t ipv4_entries = {0};
+  ipv6_entry_vec_t ipv6_entries = {0};
+
+  catdedupe_t domain_dedupe;
+  catdedupe_t ipv4_dedupe;
+  catdedupe_t ipv6_dedupe;
+
+  catdedupe_init(&domain_dedupe, 1u << 20);
+  catdedupe_init(&ipv4_dedupe, 65536);
+  catdedupe_init(&ipv6_dedupe, 65536);
+
+  uint64_t conflict_total = 0, conflict_ignored = 0, conflict_overwritten = 0;
+  catdedupe_ctx_t dedupe_ctx = {.policy = g_conflict_policy,
+    .conflicts_total = &conflict_total,
+    .conflicts_ignored = &conflict_ignored,
+    .conflicts_overwritten = &conflict_overwritten,
+    .domain_entries = &domain_entries,
+    .ipv4_entries = &ipv4_entries,
+    .ipv6_entries = &ipv6_entries};
+
+  for(size_t i = 0; i < file_count; ++i) {
+    char filepath[NDPI_CATBIN_JOIN_BUFSZ];
+    catbin_join_path(filepath, sizeof(filepath), input_dir, sizeof(input_dir), file_list[i],
+        NDPI_CATBIN_NAME_MAX + 1);
+
+    if(!(is_domain_list_file(file_list[i]) ||
+          is_ipv4_list_file(file_list[i]) ||
+          is_ipv6_list_file(file_list[i]))) {
+      fprintf(stderr, "Skipping unsupported file: %s\n", file_list[i]);
+      continue;
+    }
+
+    uint32_t cat_id;
+    char cat_name[256];
+    if(!parse_category_filename(file_list[i], 0, &cat_id, cat_name, sizeof(cat_name))) {
+      fprintf(stderr, "WARN: failed to parse category file name: %s\n", file_list[i]);
+      continue;
+    }
+
+    if(cat_id == 0 || cat_id >= NDPI_PROTOCOL_NUM_CATEGORIES) {
+      fprintf(stderr, "ERROR: category id %u out of range (must be 0 < id < %d): %s\n", cat_id,
+          NDPI_PROTOCOL_NUM_CATEGORIES, file_list[i]);
+      exit(EXIT_FAILURE);
+    }
+
+    (void)find_or_add_category(&categories, cat_id, cat_name);
+
+    FILE *fp = fopen(filepath, "r");
+    if(!fp) {
+      fprintf(stderr, "WARN: cannot open %s: %s\n", filepath, strerror(errno));
+      continue;
+    }
+
+    fprintf(stderr, "Processing [%zu/%zu] %s...\n", i + 1, file_count, file_list[i]);
+
+    g_parse_src_file = file_list[i];
+
+    char *line = NULL;
+    size_t linecap = 0;
+    ssize_t linelen;
+
+    uint64_t added_domains_this_file = 0;
+    uint64_t added_ipv4_this_file = 0;
+    uint64_t added_ipv6_this_file = 0;
+    uint64_t skipped_this_file = 0;
+
+    while((linelen = catbin_getline(&line, &linecap, fp)) != -1) {
+      (void)linelen;
+
+      if(is_domain_list_file(file_list[i])) {
+        parsed_rule_t rule;
+
+        if(!parse_mixed_rule_line(line, &rule)) {
+          skipped_this_file++;
+          continue;
+        }
+
+        if(rule.kind == RULE_DOMAIN) {
+          const char *interned = NULL;
+
+          if(catdedupe_add(&domain_dedupe, DEDUPE_DOMAIN, rule.text, cat_id, file_list[i], domain_entries.count,
+                &dedupe_ctx, &interned))
+            continue;
+
+          entry_t e = {0};
+          e.hash = fnv1a64(interned, strlen(interned));
+          e.domain = (char *)interned;
+          e.domain_len = (uint16_t)strlen(interned);
+          e.flags = 0;
+          e.category_id = cat_id;
+          entry_vec_push(&domain_entries, e);
+          added_domains_this_file++;
+          continue;
+        }
+
+        if(rule.kind == RULE_IPV4) {
+          ipv4_entry_t e = {0};
+
+          if(!parse_ipv4_canonical(rule.text, &e, cat_id)) {
+            skipped_this_file++;
+            continue;
+          }
+          {
+            char dedk[INET_ADDRSTRLEN + 16];
+
+            ipv4_canonical_key(&e, dedk, sizeof(dedk));
+            if(catdedupe_add(&ipv4_dedupe, DEDUPE_IPV4, dedk, cat_id, file_list[i], ipv4_entries.count,
+                  &dedupe_ctx, NULL))
+              continue;
+          }
+
+          ipv4_entry_vec_push(&ipv4_entries, e);
+          added_ipv4_this_file++;
+          continue;
+        }
+
+        if(rule.kind == RULE_IPV6) {
+          ipv6_entry_t e = {{0}, 0, 0, 0};
+
+          if(!parse_ipv6_canonical(rule.text, &e, cat_id)) {
+            skipped_this_file++;
+            continue;
+          }
+          {
+            char dedk[48];
+
+            ipv6_canonical_key(e.addr, e.prefix_len, dedk, sizeof(dedk));
+            if(catdedupe_add(&ipv6_dedupe, DEDUPE_IPV6, dedk, cat_id, file_list[i], ipv6_entries.count,
+                  &dedupe_ctx, NULL))
+              continue;
+          }
+
+          ipv6_entry_vec_push(&ipv6_entries, e);
+          added_ipv6_this_file++;
+          continue;
+        }
+
+        skipped_this_file++;
+        continue;
+      }
+
+      if(is_ipv4_list_file(file_list[i])) {
+        char normalized[128];
+        if(!normalize_ipv4_or_cidr_line(line, normalized, sizeof(normalized))) {
+          skipped_this_file++;
+          continue;
+        }
+
+        ipv4_entry_t e = {0};
+
+        if(!parse_ipv4_canonical(normalized, &e, cat_id)) {
+          skipped_this_file++;
+          continue;
+        }
+        {
+          char dedk[INET_ADDRSTRLEN + 16];
+
+          ipv4_canonical_key(&e, dedk, sizeof(dedk));
+          if(catdedupe_add(&ipv4_dedupe, DEDUPE_IPV4, dedk, cat_id, file_list[i], ipv4_entries.count,
+                &dedupe_ctx, NULL))
+            continue;
+        }
+        ipv4_entry_vec_push(&ipv4_entries, e);
+        added_ipv4_this_file++;
+        continue;
+      }
+
+      if(is_ipv6_list_file(file_list[i])) {
+        char normalized[256];
+        if(!normalize_ipv6_or_cidr_line(line, normalized, sizeof(normalized))) {
+          skipped_this_file++;
+          continue;
+        }
+
+        ipv6_entry_t e = {{0}, 0, 0, 0};
+
+        if(!parse_ipv6_canonical(normalized, &e, cat_id)) {
+          skipped_this_file++;
+          continue;
+        }
+        {
+          char dedk[48];
+
+          ipv6_canonical_key(e.addr, e.prefix_len, dedk, sizeof(dedk));
+          if(catdedupe_add(&ipv6_dedupe, DEDUPE_IPV6, dedk, cat_id, file_list[i], ipv6_entries.count,
+                &dedupe_ctx, NULL))
+            continue;
+        }
+        ipv6_entry_vec_push(&ipv6_entries, e);
+        added_ipv6_this_file++;
+        continue;
+      }
+
+      skipped_this_file++;
+    }
+
+    free(line);
+    fclose(fp);
+
+    fprintf(stderr,
+        "Category %-32s id=%u domains=%" PRIu64 " ipv4=%" PRIu64 " ipv6=%" PRIu64 " skipped=%" PRIu64 "\n",
+        file_list[i], cat_id,
+        added_domains_this_file,
+        added_ipv4_this_file,
+        added_ipv6_this_file,
+        skipped_this_file);
+  }
+
+  fprintf(stderr, "Conflict summary: total=%" PRIu64 " ignored=%" PRIu64 " overwritten=%" PRIu64 " policy=%s\n",
+      conflict_total, conflict_ignored, conflict_overwritten, g_conflict_policy_label);
+
+  fprintf(stderr, "Finished reading all category domain files. entries=%zu\n", domain_entries.count);
+  fprintf(stderr, "Finished reading all category ipv4 files. entries=%zu\n", ipv4_entries.count);
+  fprintf(stderr, "Finished reading all category ipv6 files. entries=%zu\n", ipv6_entries.count);
+
+  for(size_t i = 0; i < file_count; ++i) free(file_list[i]);
+  free(file_list);
+
+  if(domain_entries.count == 0 && ipv4_entries.count == 0 && ipv6_entries.count == 0) {
+    dief("no valid entries parsed");
+  }
+
+  if(domain_entries.count > 0) {
+    fprintf(stderr, "Starting global domain sort...\n");
+    qsort(domain_entries.items, domain_entries.count, sizeof(domain_entries.items[0]), cmp_entry_hash_domain);
+  }
+
+  if(ipv4_entries.count > 0) {
+    fprintf(stderr, "Starting IPv4 sort...\n");
+    qsort(ipv4_entries.items, ipv4_entries.count, sizeof(ipv4_entries.items[0]), cmp_ipv4_entry);
+    /* Rows are sorted for stable dumps; future optimization: binary search window + LPM. */
+  }
+
+  if(ipv6_entries.count > 0) {
+    fprintf(stderr, "Starting IPv6 sort...\n");
+    qsort(ipv6_entries.items, ipv6_entries.count, sizeof(ipv6_entries.items[0]), cmp_ipv6_entry);
+    /* Same ordering contract as IPv4; future optimization: binary search window + LPM. */
+  }
+
+  strpool_t pool = {0};
+
+  for(size_t i = 0; i < categories.count; ++i) {
+    categories.items[i].name_off = strpool_add(&pool, categories.items[i].name, strlen(categories.items[i].name));
+  }
+
+  for(size_t i = 0; i < domain_entries.count; ++i) {
+    domain_entries.items[i].domain_off =
+      strpool_add(&pool, domain_entries.items[i].domain, domain_entries.items[i].domain_len);
+  }
+
+  size_t bucket_count = next_pow2(domain_entries.count / 2 + 1);
+  if(bucket_count < 1024) bucket_count = 1024;
+
+  ndb_bucket_disk_t *buckets = calloc(bucket_count, sizeof(*buckets));
+  if(!buckets) die("calloc");
+
+  uint32_t *bucket_tmp_counts = calloc(bucket_count, sizeof(uint32_t));
+  if(!bucket_tmp_counts) die("calloc");
+
+  for(size_t i = 0; i < domain_entries.count; ++i) {
+    size_t b = (size_t)(domain_entries.items[i].hash & (bucket_count - 1));
+    bucket_tmp_counts[b]++;
+  }
+
+  if(domain_entries.count > 0) {
+    uint32_t max_fill = 0, min_fill = UINT32_MAX;
+    size_t nonempty = 0;
+    uint64_t sum_fill = 0;
+
+    for(size_t b = 0; b < bucket_count; ++b) {
+      uint32_t c = bucket_tmp_counts[b];
+
+      sum_fill += c;
+      if(c > 0) {
+        nonempty++;
+        if(c < min_fill)
+          min_fill = c;
+      }
+      if(c > max_fill)
+        max_fill = c;
+    }
+
+    fprintf(stderr,
+        "Bucket stats: buckets=%zu nonempty=%zu max=%u min_nonempty=%u avg=%.2f\n",
+        bucket_count, nonempty, max_fill, min_fill == UINT32_MAX ? 0u : min_fill,
+        (double)sum_fill / (double)bucket_count);
+  }
+
+  uint32_t running = 0;
+  for(size_t b = 0; b < bucket_count; ++b) {
+    buckets[b].first = running;
+    buckets[b].count = bucket_tmp_counts[b];
+    running += bucket_tmp_counts[b];
+  }
+
+  entry_t *bucketed = xmalloc(domain_entries.count * sizeof(*bucketed));
+  uint32_t *cursor = calloc(bucket_count, sizeof(uint32_t));
+  if(!cursor) die("calloc");
+
+  for(size_t b = 0; b < bucket_count; ++b) cursor[b] = buckets[b].first;
+
+  for(size_t i = 0; i < domain_entries.count; ++i) {
+    size_t b = (size_t)(domain_entries.items[i].hash & (bucket_count - 1));
+    bucketed[cursor[b]++] = domain_entries.items[i];
+  }
+
+  free(domain_entries.items);
+  domain_entries.items = bucketed;
+
+  ndb_header_disk_t hdr;
+  memset(&hdr, 0, sizeof(hdr));
+  memcpy(hdr.magic, NDB_MAGIC, 4);
+  hdr.format_version = NDB_FORMAT_VERSION;
+  hdr.build_unix_time = (uint64_t)time(NULL);
+  snprintf(hdr.base_version, sizeof(hdr.base_version), "%s", base_version);
+
+  hdr.category_count = categories.count;
+
+  hdr.domain_entry_count = domain_entries.count;
+  hdr.domain_bucket_count = bucket_count;
+  hdr.string_pool_size = pool.len;
+
+  hdr.ipv4_entry_count = ipv4_entries.count;
+  hdr.ipv6_entry_count = ipv6_entries.count;
+
+  uint64_t off = sizeof(hdr);
+
+  hdr.categories_off = off;
+  off += (uint64_t)categories.count * sizeof(ndb_category_disk_t);
+
+  hdr.domain_buckets_off = off;
+  off += (uint64_t)bucket_count * sizeof(ndb_bucket_disk_t);
+
+  hdr.domain_entries_off = off;
+  off += (uint64_t)domain_entries.count * sizeof(ndb_entry_disk_t);
+
+  hdr.string_pool_off = off;
+  off += pool.len;
+
+  hdr.ipv4_entries_off = off;
+  off += (uint64_t)ipv4_entries.count * sizeof(ndb_ipv4_entry_disk_t);
+
+  hdr.ipv6_entries_off = off;
+  off += (uint64_t)ipv6_entries.count * sizeof(ndb_ipv6_entry_disk_t);
+
+  hdr.file_size = off;
+
+  char tmp_output[NDPI_CATBIN_TMP_OUT_BUFSZ];
+  catbin_mk_tmp_output_path(tmp_output, sizeof(tmp_output), output_file, sizeof(output_file));
+
+  int fd = open(tmp_output, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+  if(fd < 0) die("open output");
+
+  FILE *out = fdopen(fd, "wb");
+  if(!out) die("fdopen");
+
+  if(fwrite(&hdr, 1, sizeof(hdr), out) != sizeof(hdr)) die("fwrite header");
+
+  for(size_t i = 0; i < categories.count; ++i) {
+    ndb_category_disk_t dc;
+    dc.id = categories.items[i].id;
+    dc.name_off = categories.items[i].name_off;
+    if(fwrite(&dc, 1, sizeof(dc), out) != sizeof(dc)) die("fwrite category");
+  }
+
+  if(fwrite(buckets, sizeof(*buckets), bucket_count, out) != bucket_count) die("fwrite buckets");
+
+  for(size_t i = 0; i < domain_entries.count; ++i) {
+    ndb_entry_disk_t de;
+    de.hash = domain_entries.items[i].hash;
+    de.domain_off = domain_entries.items[i].domain_off;
+    de.domain_len = domain_entries.items[i].domain_len;
+    de.flags = domain_entries.items[i].flags;
+    de.category_id = domain_entries.items[i].category_id;
+    if(fwrite(&de, 1, sizeof(de), out) != sizeof(de)) die("fwrite entry");
+  }
+
+  if(pool.len > 0) {
+    if(fwrite(pool.data, 1, pool.len, out) != pool.len) die("fwrite string pool");
+  }
+
+  for(size_t i = 0; i < ipv4_entries.count; ++i) {
+    ndb_ipv4_entry_disk_t de;
+    de.network_be = ipv4_entries.items[i].network_be;
+    de.prefix_len = ipv4_entries.items[i].prefix_len;
+    de.flags = ipv4_entries.items[i].flags;
+    de.reserved0 = 0;
+    de.category_id = ipv4_entries.items[i].category_id;
+
+    if(fwrite(&de, 1, sizeof(de), out) != sizeof(de)) die("fwrite ipv4 entry");
+  }
+
+  for(size_t i = 0; i < ipv6_entries.count; ++i) {
+    ndb_ipv6_entry_disk_t de;
+    memcpy(de.addr, ipv6_entries.items[i].addr, 16);
+    de.prefix_len = ipv6_entries.items[i].prefix_len;
+    de.flags = ipv6_entries.items[i].flags;
+    de.reserved0 = 0;
+    de.category_id = ipv6_entries.items[i].category_id;
+
+    if(fwrite(&de, 1, sizeof(de), out) != sizeof(de)) die("fwrite ipv6 entry");
+  }
+
+  if(fflush(out) != 0) die("fflush");
+#if defined(_WIN32)
+  if(_commit(fd) != 0) die("_commit");
+#else
+  if(fsync(fd) != 0) die("fsync");
+#endif
+  if(fclose(out) != 0) die("fclose");
+
+  if(rename(tmp_output, output_file) != 0) {
+    unlink(tmp_output);
+    die("rename");
+  }
+
+  fprintf(stderr, "\nBuilt %s successfully\n", output_file);
+  fprintf(stderr, "  categories   : %zu\n", categories.count);
+  fprintf(stderr, "  domain entries : %zu\n", domain_entries.count);
+  fprintf(stderr, "  ipv4 entries   : %zu\n", ipv4_entries.count);
+  fprintf(stderr, "  ipv6 entries   : %zu\n", ipv6_entries.count);
+  fprintf(stderr, "  domain buckets : %zu\n", bucket_count);
+  fprintf(stderr, "  string pool    : %zu bytes\n", pool.len);
+  fprintf(stderr, "  file size    : %" PRIu64 " bytes\n", hdr.file_size);
+  fprintf(stderr, "  base version : %s\n", hdr.base_version);
+
+  for(size_t i = 0; i < categories.count; ++i) free(categories.items[i].name);
+  free(categories.items);
+
+  free(domain_entries.items);
+  free(ipv4_entries.items);
+  free(ipv6_entries.items);
+
+  free(pool.data);
+  free(buckets);
+  free(bucket_tmp_counts);
+  free(cursor);
+
+  catdedupe_free(&domain_dedupe);
+  catdedupe_free(&ipv4_dedupe);
+  catdedupe_free(&ipv6_dedupe);
+
+  return 0;
+}

--- a/fuzz/fuzz_match_custom_category.c
+++ b/fuzz/fuzz_match_custom_category.c
@@ -24,5 +24,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   ndpi_match_custom_category(ndpi_struct, (char *)data, size,
                              &category, &breed);
+
+  if(size < 128) {
+    char buf[128];
+    memcpy(buf, data, size);
+    buf[size] = '\0';
+    (void)ndpi_get_custom_category_match(ndpi_struct, buf, (u_int)size, &category, &breed);
+  }
   return 0;
 }

--- a/src/include/ndpi_api.h
+++ b/src/include/ndpi_api.h
@@ -905,6 +905,37 @@ extern "C" {
 			       char* path);
 
   /**
+   * Category hostname backend: LEGACY (Aho-Corasick lists), NDB_ONLY (.ndb only for external lists),
+   * HYBRID (.ndb first, then AC for external lists on miss).
+   */
+  typedef enum {
+    NDPI_CATEGORY_BACKEND_LEGACY = 0,
+    NDPI_CATEGORY_BACKEND_NDB_ONLY,
+    NDPI_CATEGORY_BACKEND_HYBRID
+  } ndpi_category_backend_mode_t;
+
+  /**
+   * Load a compiled .ndb category file (mmap). mode must be NDB_ONLY or HYBRID (not LEGACY).
+   * On failure the previous module state is preserved. On success, replaces any prior .ndb cleanly.
+   *
+   * Threading: when nDPI is built without global context support (no internal pthread rwlock for this
+   * backend), the .ndb backend should be considered single-threaded unless external synchronization is
+   * provided by the caller. Concurrent reload/unload while other threads perform category lookups is unsafe;
+   * the caller must serialize those operations (e.g. one thread or an external mutex).
+   *
+   * @return 0 on success, &lt; 0 on error (e.g. -2 invalid argument).
+   */
+  int ndpi_load_category_ndb_file(struct ndpi_detection_module_struct *ndpi_str, const char *path,
+      ndpi_category_backend_mode_t mode);
+
+  /**
+   * Release .ndb state; sets backend to LEGACY.
+   * Threading: same contract as ndpi_load_category_ndb_file (single-threaded unless the caller provides
+   * external synchronization when built without global context support).
+   */
+  void ndpi_unload_category_ndb(struct ndpi_detection_module_struct *ndpi_str);
+
+  /**
    * Load files (whose name is <protocolid>_<label>.<extension>) stored
    * in a directory and binds each IP/network to the specified protocol.
    * This function is used to bind IP addresses to protocols

--- a/src/include/ndpi_categories_bin.h
+++ b/src/include/ndpi_categories_bin.h
@@ -1,0 +1,79 @@
+/*
+ * ndpi_categories_bin.h — on-disk .ndb format (single source of truth)
+ */
+#ifndef NDPI_CATEGORIES_BIN_H
+#define NDPI_CATEGORIES_BIN_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define NDB_MAGIC "NDB1"
+#define NDB_FORMAT_VERSION 1
+
+typedef struct {
+  uint32_t id;
+  uint32_t name_off;
+} ndb_category_disk_t;
+
+typedef struct {
+  uint64_t hash;
+  uint32_t domain_off;
+  uint16_t domain_len;
+  uint16_t flags;
+  uint32_t category_id;
+} ndb_entry_disk_t;
+
+typedef struct {
+  uint32_t first;
+  uint32_t count;
+} ndb_bucket_disk_t;
+
+/* Packed on-disk records: #pragma pack works with MSVC, GCC, and Clang. */
+#pragma pack(push, 1)
+typedef struct {
+  uint32_t network_be; /* IPv4 network address, network byte order */
+  uint8_t prefix_len;  /* 0..32 */
+  uint8_t flags;
+  uint16_t reserved0;
+  uint32_t category_id;
+} ndb_ipv4_entry_disk_t;
+
+typedef struct {
+  uint8_t addr[16]; /* IPv6 network address */
+  uint8_t prefix_len; /* 0..128 */
+  uint8_t flags;
+  uint16_t reserved0;
+  uint32_t category_id;
+} ndb_ipv6_entry_disk_t;
+
+typedef struct {
+  char magic[4];
+  uint32_t format_version;
+  uint32_t flags;
+  uint32_t reserved0;
+
+  uint64_t build_unix_time;
+  char base_version[64];
+
+  uint64_t category_count;
+
+  uint64_t domain_entry_count;
+  uint64_t domain_bucket_count;
+  uint64_t string_pool_size;
+
+  uint64_t ipv4_entry_count;
+  uint64_t ipv6_entry_count;
+
+  uint64_t categories_off;
+  uint64_t domain_buckets_off;
+  uint64_t domain_entries_off;
+  uint64_t string_pool_off;
+  uint64_t ipv4_entries_off;
+  uint64_t ipv6_entries_off;
+
+  uint64_t file_size;
+  uint64_t reserved1;
+} ndb_header_disk_t;
+#pragma pack(pop)
+
+#endif /* NDPI_CATEGORIES_BIN_H */

--- a/src/include/ndpi_private.h
+++ b/src/include/ndpi_private.h
@@ -36,6 +36,17 @@ extern "C" {
 #define _NDPI_CONFIG_H_
 #endif
 
+#if defined(WIN32) || defined(_MSC_VER)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#if defined(USE_GLOBAL_CONTEXT)
+#include <pthread.h>
+#endif
+#endif
+
 #include "ndpi_usdt.h"
 
 /* NDPI_NODE */
@@ -429,6 +440,16 @@ struct ndpi_detection_module_struct {
     void *ipAddresses6, *ipAddresses6_shadow; /* Patricia IPv6*/
     u_int8_t categories_loaded;
   } custom_categories;
+
+  void *category_ndb; /* struct ndpi_category_ndb * — mmap .ndb hostname backend */
+  u_int8_t category_backend_mode;
+#if defined(WIN32) || defined(_MSC_VER)
+  SRWLOCK category_ndb_lock;
+  u_int8_t category_ndb_lock_inited;
+#elif defined(USE_GLOBAL_CONTEXT)
+  pthread_rwlock_t category_ndb_lock;
+  u_int8_t category_ndb_lock_inited;
+#endif
 
   u_int8_t ip_version_limit;
 
@@ -1132,6 +1153,18 @@ struct cfg_param {
 extern const struct cfg_param cfg_params[];
 #endif
 
+struct ndpi_category_ndb;
+int ndpi_category_ndb_lookup_hostname(struct ndpi_category_ndb *db, const char *name, u_int name_len,
+    uint32_t *category_id);
+int ndpi_category_ndb_lookup_ipv4(struct ndpi_category_ndb *db, uint32_t addr_be, uint32_t *category_id);
+int ndpi_category_ndb_lookup_ipv6(struct ndpi_category_ndb *db, const uint8_t addr[16], uint32_t *category_id);
+
+void ndpi_category_ndb_rwlock_init(struct ndpi_detection_module_struct *ndpi_str);
+void ndpi_category_ndb_rwlock_destroy(struct ndpi_detection_module_struct *ndpi_str);
+void ndpi_category_ndb_lock_rd(struct ndpi_detection_module_struct *ndpi_str);
+void ndpi_category_ndb_unlock_rd(struct ndpi_detection_module_struct *ndpi_str);
+void ndpi_category_ndb_lock_wr(struct ndpi_detection_module_struct *ndpi_str);
+void ndpi_category_ndb_unlock_wr(struct ndpi_detection_module_struct *ndpi_str);
 
 #endif
 

--- a/src/lib/ndpi_category_host_norm.c
+++ b/src/lib/ndpi_category_host_norm.c
@@ -1,0 +1,166 @@
+/*
+ * Shared hostname normalization for .ndb generator and runtime.
+ */
+#include "ndpi_category_host_norm.h"
+
+#include <ctype.h>
+#include <stdint.h>
+#include <string.h>
+#if defined(_MSC_VER) && !defined(strncasecmp)
+#define strncasecmp _strnicmp
+#else
+#include <strings.h>
+#endif
+
+static int count_colons(const char *s) {
+  int n = 0;
+  for(; *s; s++)
+    if(*s == ':') n++;
+  return n;
+}
+
+static void strip_scheme(char *s) {
+  static const char *schemes[] = {"http://", "https://", NULL};
+  for(int i = 0; schemes[i]; i++) {
+    size_t len = strlen(schemes[i]);
+    if(strncasecmp(s, schemes[i], len) == 0) {
+      memmove(s, s + len, strlen(s + len) + 1);
+      return;
+    }
+  }
+}
+
+static void strip_leading_wildcard(char *s) {
+  while(strncmp(s, "*.", 2) == 0)
+    memmove(s, s + 2, strlen(s + 2) + 1);
+}
+
+int ndpi_category_hostname_is_isolated_tld(const char *h) {
+  static const char *tlds[] = {
+    "com", "net", "org", "edu", "gov", "mil", "int", "arpa",
+    "info", "biz", "name", "pro", "aero", "coop", "museum", "jobs", "mobi", "travel",
+    "asia", "cat", "tel", "xxx", "post", "geo", "onion",
+    NULL
+  };
+
+  if(!h || !*h || strchr(h, '.') != NULL)
+    return 0;
+
+  for(int i = 0; tlds[i]; i++) {
+    if(strcmp(h, tlds[i]) == 0)
+      return 1;
+  }
+  return 0;
+}
+
+int ndpi_category_hostname_labels_valid_ascii(const char *host) {
+  const char *p;
+  size_t total_len, lablen = 0;
+
+  if(!host || !*host)
+    return 0;
+
+  total_len = strlen(host);
+  if(total_len > 253)
+    return 0;
+
+  if(host[0] == '.' || host[total_len - 1] == '.')
+    return 0;
+
+  for(p = host; *p; ++p) {
+    unsigned char c = (unsigned char)*p;
+
+    if(c == '.') {
+      if(lablen == 0 || lablen > 63)
+        return 0;
+      if(*(p - 1) == '-')
+        return 0;
+      lablen = 0;
+      continue;
+    }
+
+    if(!(islower(c) || isdigit(c) || c == '-'))
+      return 0;
+    if(c == '-' && lablen == 0)
+      return 0;
+    lablen++;
+    if(lablen > 63)
+      return 0;
+  }
+
+  if(lablen == 0 || lablen > 63)
+    return 0;
+  if(host[total_len - 1] == '-')
+    return 0;
+
+  return 1;
+}
+
+int ndpi_category_normalize_host_for_ndb(const char *input, char *out, size_t out_sz) {
+  size_t i = 0;
+
+  if(!input || !out || out_sz < 2)
+    return -1;
+
+  while(*input && isspace((unsigned char)*input))
+    input++;
+
+  for(; *input && i + 1 < out_sz; ++input) {
+    char c = *input;
+
+    out[i++] = (char)tolower((unsigned char)c);
+  }
+  out[i] = '\0';
+
+  if(out[0] == '\0')
+    return -1;
+
+  strip_scheme(out);
+
+  if(out[0] == '\0')
+    return -1;
+
+  {
+    char *p = strpbrk(out, "/?#");
+
+    if(p)
+      *p = '\0';
+  }
+
+  if(out[0] == '\0')
+    return -1;
+
+  {
+    int colons = count_colons(out);
+    if(colons > 1)
+      return -1;
+    if(colons == 1) {
+      char *colon = strchr(out, ':');
+      if(!colon)
+        return -1;
+      for(char *q = colon + 1; *q; q++) {
+        if(!isdigit((unsigned char)*q))
+          return -1;
+      }
+      *colon = '\0';
+    }
+  }
+
+  {
+    size_t len = strlen(out);
+    while(len > 0 && out[len - 1] == '.') {
+      out[len - 1] = '\0';
+      len--;
+    }
+  }
+
+  strip_leading_wildcard(out);
+
+  if(out[0] == '\0')
+    return -1;
+
+  if(!ndpi_category_hostname_labels_valid_ascii(out))
+    return -1;
+
+  return 0;
+}

--- a/src/lib/ndpi_category_host_norm.h
+++ b/src/lib/ndpi_category_host_norm.h
@@ -1,0 +1,15 @@
+#ifndef __NDPI_CATEGORY_HOST_NORM_H__
+#define __NDPI_CATEGORY_HOST_NORM_H__
+
+#include <stddef.h>
+
+/* 0 = success (out is NUL-terminated normalized hostname), -1 = empty/invalid for .ndb */
+int ndpi_category_normalize_host_for_ndb(const char *input, char *out, size_t out_sz);
+
+/* 1 = reject as isolated public-TLD-style label (generator), 0 = ok */
+int ndpi_category_hostname_is_isolated_tld(const char *normalized_host);
+
+/* 1 = valid ASCII LDH labels, 0 = invalid */
+int ndpi_category_hostname_labels_valid_ascii(const char *host);
+
+#endif

--- a/src/lib/ndpi_category_ndb.c
+++ b/src/lib/ndpi_category_ndb.c
@@ -1,0 +1,618 @@
+/*
+ * ndpi_category_ndb.c — mmap .ndb category backend (hostname + IPv4/IPv6)
+ */
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/stat.h>
+#if !defined(WIN32) && !defined(_MSC_VER)
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+#include "ndpi_api.h"
+#include "ndpi_private.h"
+#include "ndpi_categories_bin.h"
+#include "ndpi_category_host_norm.h"
+
+struct ndpi_category_ndb {
+#if defined(WIN32) || defined(_MSC_VER)
+  HANDLE file_handle;
+  HANDLE mapping_handle;
+#else
+  int fd;
+#endif
+  size_t map_size;
+  void *map_base;
+  const ndb_header_disk_t *hdr;
+  const ndb_category_disk_t *categories;
+  const ndb_bucket_disk_t *buckets;
+  const ndb_entry_disk_t *entries;
+  const char *strpool;
+  const ndb_ipv4_entry_disk_t *ipv4_entries;
+  const ndb_ipv6_entry_disk_t *ipv6_entries;
+};
+
+static uint64_t fnv1a64(const char *s, size_t len) {
+  uint64_t h = 1469598103934665603ULL;
+  for(size_t i = 0; i < len; ++i) {
+    h ^= (unsigned char)s[i];
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
+
+static int is_power_of_two_u64(uint64_t n) { return n != 0 && (n & (n - 1)) == 0; }
+
+/* True if [off, off+count*elem) is not fully contained in [0,file_size) or if multiply overflows. */
+static int ndb_u64_range_invalid(uint64_t off, uint64_t count, uint64_t elem, uint64_t file_size) {
+  if(elem == 0)
+    return 1;
+  if(count == 0)
+    return off > file_size;
+  if(count > UINT64_MAX / elem)
+    return 1;
+  {
+    uint64_t nbytes = count * elem;
+    if(off > file_size || nbytes > file_size - off)
+      return 1;
+  }
+  return 0;
+}
+
+static int ndb_ipv4_prefix_matches(uint32_t addr_be, uint32_t net_be, uint8_t pl) {
+  uint32_t a, n, mask_host;
+
+  if(pl > 32)
+    return 0;
+  a = ntohl(addr_be);
+  n = ntohl(net_be);
+  if(pl == 0)
+    return 1;
+  if(pl == 32)
+    return a == n;
+  mask_host = (uint32_t)(0xFFFFFFFFu << (32u - (uint32_t)pl));
+  return (a & mask_host) == (n & mask_host);
+}
+
+static int ndb_ipv6_prefix_matches(const uint8_t *addr, const uint8_t *net, uint8_t pl) {
+  unsigned i, full_bytes, rem_bits;
+
+  if(pl > 128)
+    return 0;
+  full_bytes = (unsigned)pl / 8;
+  for(i = 0; i < full_bytes; i++) {
+    if(addr[i] != net[i])
+      return 0;
+  }
+  rem_bits = (unsigned)pl % 8;
+  if(rem_bits) {
+    uint8_t m = (uint8_t)(0xFFu << (8 - rem_bits));
+    if((addr[full_bytes] & m) != (net[full_bytes] & m))
+      return 0;
+  }
+  return 1;
+}
+
+static int ndb_validate(const ndb_header_disk_t *hdr, size_t file_size) {
+  uint64_t i;
+
+  if(memcmp(hdr->magic, NDB_MAGIC, 4) != 0)
+    return -1;
+  if(hdr->format_version != NDB_FORMAT_VERSION)
+    return -2;
+  if(hdr->file_size != (uint64_t)file_size)
+    return -3;
+  if(hdr->domain_bucket_count == 0 || !is_power_of_two_u64(hdr->domain_bucket_count))
+    return -4;
+
+  if(hdr->categories_off > file_size || hdr->domain_buckets_off > file_size ||
+      hdr->domain_entries_off > file_size || hdr->string_pool_off > file_size ||
+      hdr->ipv4_entries_off > file_size || hdr->ipv6_entries_off > file_size)
+    return -5;
+
+  if(ndb_u64_range_invalid(hdr->categories_off, hdr->category_count, sizeof(ndb_category_disk_t), file_size))
+    return -7;
+
+  if(ndb_u64_range_invalid(hdr->domain_buckets_off, hdr->domain_bucket_count, sizeof(ndb_bucket_disk_t),
+         file_size))
+    return -8;
+
+  if(ndb_u64_range_invalid(hdr->domain_entries_off, hdr->domain_entry_count, sizeof(ndb_entry_disk_t), file_size))
+    return -10;
+
+  if(hdr->string_pool_off > file_size || hdr->string_pool_size > file_size - hdr->string_pool_off)
+    return -11;
+
+  if(ndb_u64_range_invalid(hdr->ipv4_entries_off, hdr->ipv4_entry_count, sizeof(ndb_ipv4_entry_disk_t), file_size))
+    return -14;
+
+  if(ndb_u64_range_invalid(hdr->ipv6_entries_off, hdr->ipv6_entry_count, sizeof(ndb_ipv6_entry_disk_t), file_size))
+    return -17;
+
+  const ndb_category_disk_t *cats =
+    (const ndb_category_disk_t *)((const char *)hdr + hdr->categories_off);
+  const ndb_bucket_disk_t *bucks =
+    (const ndb_bucket_disk_t *)((const char *)hdr + hdr->domain_buckets_off);
+  const ndb_entry_disk_t *ents =
+    (const ndb_entry_disk_t *)((const char *)hdr + hdr->domain_entries_off);
+  const char *pool = (const char *)hdr + hdr->string_pool_off;
+  const ndb_ipv4_entry_disk_t *ipv4e =
+    (const ndb_ipv4_entry_disk_t *)((const char *)hdr + hdr->ipv4_entries_off);
+  const ndb_ipv6_entry_disk_t *ipv6e =
+    (const ndb_ipv6_entry_disk_t *)((const char *)hdr + hdr->ipv6_entries_off);
+
+  for(i = 0; i < hdr->category_count; i++) {
+    uint32_t cid = cats[i].id;
+    if(cid == 0 || cid >= NDPI_PROTOCOL_NUM_CATEGORIES)
+      return -20;
+    if((uint64_t)cats[i].name_off >= hdr->string_pool_size)
+      return -21;
+  }
+
+  uint64_t sum = 0;
+  for(i = 0; i < hdr->domain_bucket_count; i++) {
+    uint64_t f = bucks[i].first;
+    uint64_t c = bucks[i].count;
+    sum += c;
+    if(f + c > hdr->domain_entry_count)
+      return -30;
+  }
+  if(sum != hdr->domain_entry_count)
+    return -31;
+
+  for(i = 0; i < hdr->domain_entry_count; i++) {
+    uint32_t cid = ents[i].category_id;
+    if(cid == 0 || cid >= NDPI_PROTOCOL_NUM_CATEGORIES)
+      return -40;
+    if((uint64_t)ents[i].domain_off + (uint64_t)ents[i].domain_len > hdr->string_pool_size)
+      return -41;
+    if(ents[i].domain_len == 0)
+      return -42;
+    const char *ds = pool + ents[i].domain_off;
+    if(strlen(ds) != ents[i].domain_len)
+      return -43;
+    if(!ndpi_category_hostname_labels_valid_ascii(ds))
+      return -44;
+  }
+
+  for(i = 0; i < hdr->ipv4_entry_count; i++) {
+    uint32_t cid = ipv4e[i].category_id;
+    if(cid == 0 || cid >= NDPI_PROTOCOL_NUM_CATEGORIES)
+      return -50;
+    if(ipv4e[i].prefix_len > 32)
+      return -51;
+  }
+
+  for(i = 0; i < hdr->ipv6_entry_count; i++) {
+    uint32_t cid = ipv6e[i].category_id;
+    if(cid == 0 || cid >= NDPI_PROTOCOL_NUM_CATEGORIES)
+      return -60;
+    if(ipv6e[i].prefix_len > 128)
+      return -61;
+  }
+
+  return 0;
+}
+
+static void ndb_unmap(struct ndpi_category_ndb *db) {
+  if(!db)
+    return;
+#if defined(WIN32) || defined(_MSC_VER)
+  if(db->map_base)
+    UnmapViewOfFile(db->map_base);
+  if(db->mapping_handle && db->mapping_handle != INVALID_HANDLE_VALUE)
+    CloseHandle(db->mapping_handle);
+  if(db->file_handle && db->file_handle != INVALID_HANDLE_VALUE)
+    CloseHandle(db->file_handle);
+#else
+  if(db->map_base && db->map_base != MAP_FAILED)
+    munmap(db->map_base, db->map_size);
+  if(db->fd >= 0)
+    close(db->fd);
+#endif
+  ndpi_free(db);
+}
+
+#if defined(WIN32) || defined(_MSC_VER)
+static struct ndpi_category_ndb *ndb_mmap_path(const char *path, int *err_out) {
+  struct ndpi_category_ndb *db;
+  HANDLE fh = INVALID_HANDLE_VALUE;
+  HANDLE mh = INVALID_HANDLE_VALUE;
+  void *map = NULL;
+  LARGE_INTEGER sz;
+
+  fh = CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  if(fh == INVALID_HANDLE_VALUE) {
+    if(err_out) *err_out = -(int)GetLastError();
+    return NULL;
+  }
+
+  if(!GetFileSizeEx(fh, &sz)) {
+    if(err_out) *err_out = -(int)GetLastError();
+    CloseHandle(fh);
+    return NULL;
+  }
+
+  if(sz.QuadPart < (LONGLONG)sizeof(ndb_header_disk_t)) {
+    if(err_out) *err_out = -EINVAL;
+    CloseHandle(fh);
+    return NULL;
+  }
+
+  mh = CreateFileMappingA(fh, NULL, PAGE_READONLY, (DWORD)(sz.QuadPart >> 32),
+      (DWORD)(sz.QuadPart & 0xFFFFFFFFu), NULL);
+  if(mh == NULL) {
+    if(err_out) *err_out = -(int)GetLastError();
+    CloseHandle(fh);
+    return NULL;
+  }
+
+  map = MapViewOfFile(mh, FILE_MAP_READ, 0, 0, 0);
+  if(map == NULL) {
+    if(err_out) *err_out = -(int)GetLastError();
+    CloseHandle(mh);
+    CloseHandle(fh);
+    return NULL;
+  }
+
+  const ndb_header_disk_t *hdr = (const ndb_header_disk_t *)map;
+  int vr = ndb_validate(hdr, (size_t)sz.QuadPart);
+  if(vr != 0) {
+    if(err_out) *err_out = vr;
+    UnmapViewOfFile(map);
+    CloseHandle(mh);
+    CloseHandle(fh);
+    return NULL;
+  }
+
+  db = (struct ndpi_category_ndb *)ndpi_malloc(sizeof(*db));
+  if(!db) {
+    if(err_out) *err_out = -ENOMEM;
+    UnmapViewOfFile(map);
+    CloseHandle(mh);
+    CloseHandle(fh);
+    return NULL;
+  }
+
+  db->file_handle = fh;
+  db->mapping_handle = mh;
+  db->map_size = (size_t)sz.QuadPart;
+  db->map_base = map;
+  db->hdr = hdr;
+  db->categories = (const ndb_category_disk_t *)((const char *)map + hdr->categories_off);
+  db->buckets = (const ndb_bucket_disk_t *)((const char *)map + hdr->domain_buckets_off);
+  db->entries = (const ndb_entry_disk_t *)((const char *)map + hdr->domain_entries_off);
+  db->strpool = (const char *)map + hdr->string_pool_off;
+  db->ipv4_entries = (const ndb_ipv4_entry_disk_t *)((const char *)map + hdr->ipv4_entries_off);
+  db->ipv6_entries = (const ndb_ipv6_entry_disk_t *)((const char *)map + hdr->ipv6_entries_off);
+
+  if(err_out) *err_out = 0;
+  return db;
+}
+#else
+static struct ndpi_category_ndb *ndb_mmap_path(const char *path, int *err_out) {
+  struct ndpi_category_ndb *db;
+  struct stat st;
+  void *map = MAP_FAILED;
+  int fd = -1;
+
+  fd = open(path, O_RDONLY);
+  if(fd < 0) {
+    if(err_out) *err_out = -errno;
+    return NULL;
+  }
+
+  if(fstat(fd, &st) != 0) {
+    if(err_out) *err_out = -errno;
+    close(fd);
+    return NULL;
+  }
+
+  if(st.st_size < (off_t)sizeof(ndb_header_disk_t)) {
+    if(err_out) *err_out = -EINVAL;
+    close(fd);
+    return NULL;
+  }
+
+  map = mmap(NULL, (size_t)st.st_size, PROT_READ, MAP_SHARED, fd, 0);
+  if(map == MAP_FAILED) {
+    if(err_out) *err_out = -errno;
+    close(fd);
+    return NULL;
+  }
+
+  const ndb_header_disk_t *hdr = (const ndb_header_disk_t *)map;
+  int vr = ndb_validate(hdr, (size_t)st.st_size);
+  if(vr != 0) {
+    if(err_out) *err_out = vr;
+    munmap(map, (size_t)st.st_size);
+    close(fd);
+    return NULL;
+  }
+
+  db = (struct ndpi_category_ndb *)ndpi_malloc(sizeof(*db));
+  if(!db) {
+    if(err_out) *err_out = -ENOMEM;
+    munmap(map, (size_t)st.st_size);
+    close(fd);
+    return NULL;
+  }
+
+  db->fd = fd;
+  db->map_size = (size_t)st.st_size;
+  db->map_base = map;
+  db->hdr = hdr;
+  db->categories = (const ndb_category_disk_t *)((const char *)map + hdr->categories_off);
+  db->buckets = (const ndb_bucket_disk_t *)((const char *)map + hdr->domain_buckets_off);
+  db->entries = (const ndb_entry_disk_t *)((const char *)map + hdr->domain_entries_off);
+  db->strpool = (const char *)map + hdr->string_pool_off;
+  db->ipv4_entries = (const ndb_ipv4_entry_disk_t *)((const char *)map + hdr->ipv4_entries_off);
+  db->ipv6_entries = (const ndb_ipv6_entry_disk_t *)((const char *)map + hdr->ipv6_entries_off);
+
+  if(err_out) *err_out = 0;
+  return db;
+}
+#endif
+
+static int ndb_lookup_exact(const struct ndpi_category_ndb *db, const char *host, uint32_t *category_id) {
+  size_t len = strlen(host);
+  uint64_t h = fnv1a64(host, len);
+  size_t bucket = (size_t)(h & (db->hdr->domain_bucket_count - 1));
+
+  uint32_t first = db->buckets[bucket].first;
+  uint32_t count = db->buckets[bucket].count;
+
+  for(uint32_t j = 0; j < count; j++) {
+    const ndb_entry_disk_t *e = &db->entries[first + j];
+    if(e->hash != h)
+      continue;
+    if(e->domain_len != len)
+      continue;
+
+    const char *s = db->strpool + e->domain_off;
+    if(memcmp(s, host, len) == 0) {
+      *category_id = e->category_id;
+      return 0;
+    }
+  }
+  return -1;
+}
+
+int ndpi_category_ndb_lookup_hostname(struct ndpi_category_ndb *db, const char *name, u_int name_len,
+    uint32_t *category_id) {
+  char buf[512];
+  char *candidate;
+  int first = 1;
+
+  if(!db || !name || !category_id || name_len == 0)
+    return -1;
+
+  if(name_len >= sizeof(buf))
+    name_len = sizeof(buf) - 1;
+  memcpy(buf, name, name_len);
+  buf[name_len] = '\0';
+
+  if(ndpi_category_normalize_host_for_ndb(buf, buf, sizeof(buf)) != 0)
+    return -1;
+
+  candidate = buf;
+  while(candidate && *candidate) {
+    if(first || strchr(candidate, '.') != NULL) {
+      if(ndb_lookup_exact(db, candidate, category_id) == 0)
+        return 0;
+    }
+    first = 0;
+    char *dot = strchr(candidate, '.');
+    if(!dot)
+      break;
+    candidate = dot + 1;
+  }
+  return -1;
+}
+
+int ndpi_category_ndb_lookup_ipv4(struct ndpi_category_ndb *db, uint32_t addr_be, uint32_t *category_id) {
+  uint64_t i;
+  uint8_t best_pl = 0;
+  int found = 0;
+  uint32_t best_cat = 0;
+
+  if(!db || !category_id)
+    return -1;
+
+  /*
+   * Linear scan for longest-prefix match. The generator emits sorted IPv4 rows; future optimization:
+   * binary search window + LPM when profiling shows this path is hot on large IP tables.
+   */
+  for(i = 0; i < db->hdr->ipv4_entry_count; i++) {
+    const ndb_ipv4_entry_disk_t *e = &db->ipv4_entries[i];
+    if(!ndb_ipv4_prefix_matches(addr_be, e->network_be, e->prefix_len))
+      continue;
+    if(!found || e->prefix_len > best_pl) {
+      best_pl = e->prefix_len;
+      best_cat = e->category_id;
+      found = 1;
+    }
+  }
+
+  if(!found)
+    return -1;
+  *category_id = best_cat;
+  return 0;
+}
+
+int ndpi_category_ndb_lookup_ipv6(struct ndpi_category_ndb *db, const uint8_t addr[16], uint32_t *category_id) {
+  uint64_t i;
+  uint8_t best_pl = 0;
+  int found = 0;
+  uint32_t best_cat = 0;
+
+  if(!db || !addr || !category_id)
+    return -1;
+
+  /* Same strategy as IPv4; sorted on-disk rows from the generator — see IPv4 comment. */
+  for(i = 0; i < db->hdr->ipv6_entry_count; i++) {
+    const ndb_ipv6_entry_disk_t *e = &db->ipv6_entries[i];
+    if(!ndb_ipv6_prefix_matches(addr, e->addr, e->prefix_len))
+      continue;
+    if(!found || e->prefix_len > best_pl) {
+      best_pl = e->prefix_len;
+      best_cat = e->category_id;
+      found = 1;
+    }
+  }
+
+  if(!found)
+    return -1;
+  *category_id = best_cat;
+  return 0;
+}
+
+void ndpi_category_ndb_rwlock_init(struct ndpi_detection_module_struct *ndpi_str) {
+  if(!ndpi_str)
+    return;
+#if defined(WIN32) || defined(_MSC_VER)
+  /* SRWLOCK (Vista+): shared for lookups, exclusive for load/unload; same contract as pthread_rwlock. */
+  InitializeSRWLock(&ndpi_str->category_ndb_lock);
+  ndpi_str->category_ndb_lock_inited = 1;
+#elif defined(USE_GLOBAL_CONTEXT)
+  if(pthread_rwlock_init(&ndpi_str->category_ndb_lock, NULL) == 0)
+    ndpi_str->category_ndb_lock_inited = 1;
+  else
+    ndpi_str->category_ndb_lock_inited = 0;
+#else
+  (void)ndpi_str;
+#endif
+}
+
+void ndpi_category_ndb_rwlock_destroy(struct ndpi_detection_module_struct *ndpi_str) {
+  if(!ndpi_str)
+    return;
+#if defined(WIN32) || defined(_MSC_VER)
+  ndpi_str->category_ndb_lock_inited = 0;
+#elif defined(USE_GLOBAL_CONTEXT)
+  if(ndpi_str->category_ndb_lock_inited) {
+    pthread_rwlock_destroy(&ndpi_str->category_ndb_lock);
+    ndpi_str->category_ndb_lock_inited = 0;
+  }
+#else
+  (void)ndpi_str;
+#endif
+}
+
+void ndpi_category_ndb_lock_rd(struct ndpi_detection_module_struct *ndpi_str) {
+  if(!ndpi_str)
+    return;
+#if defined(WIN32) || defined(_MSC_VER)
+  if(!ndpi_str->category_ndb_lock_inited)
+    return;
+  AcquireSRWLockShared(&ndpi_str->category_ndb_lock);
+#elif defined(USE_GLOBAL_CONTEXT)
+  if(!ndpi_str->category_ndb_lock_inited)
+    return;
+  pthread_rwlock_rdlock(&ndpi_str->category_ndb_lock);
+#else
+  (void)ndpi_str;
+#endif
+}
+
+void ndpi_category_ndb_unlock_rd(struct ndpi_detection_module_struct *ndpi_str) {
+  if(!ndpi_str)
+    return;
+#if defined(WIN32) || defined(_MSC_VER)
+  if(!ndpi_str->category_ndb_lock_inited)
+    return;
+  ReleaseSRWLockShared(&ndpi_str->category_ndb_lock);
+#elif defined(USE_GLOBAL_CONTEXT)
+  if(!ndpi_str->category_ndb_lock_inited)
+    return;
+  pthread_rwlock_unlock(&ndpi_str->category_ndb_lock);
+#else
+  (void)ndpi_str;
+#endif
+}
+
+void ndpi_category_ndb_lock_wr(struct ndpi_detection_module_struct *ndpi_str) {
+  if(!ndpi_str)
+    return;
+#if defined(WIN32) || defined(_MSC_VER)
+  if(!ndpi_str->category_ndb_lock_inited)
+    return;
+  AcquireSRWLockExclusive(&ndpi_str->category_ndb_lock);
+#elif defined(USE_GLOBAL_CONTEXT)
+  if(!ndpi_str->category_ndb_lock_inited)
+    return;
+  pthread_rwlock_wrlock(&ndpi_str->category_ndb_lock);
+#else
+  (void)ndpi_str;
+#endif
+}
+
+void ndpi_category_ndb_unlock_wr(struct ndpi_detection_module_struct *ndpi_str) {
+  if(!ndpi_str)
+    return;
+#if defined(WIN32) || defined(_MSC_VER)
+  if(!ndpi_str->category_ndb_lock_inited)
+    return;
+  ReleaseSRWLockExclusive(&ndpi_str->category_ndb_lock);
+#elif defined(USE_GLOBAL_CONTEXT)
+  if(!ndpi_str->category_ndb_lock_inited)
+    return;
+  pthread_rwlock_unlock(&ndpi_str->category_ndb_lock);
+#else
+  (void)ndpi_str;
+#endif
+}
+
+int ndpi_load_category_ndb_file(struct ndpi_detection_module_struct *ndpi_str, const char *path,
+    ndpi_category_backend_mode_t mode) {
+  struct ndpi_category_ndb *newdb, *olddb;
+  int err = 0;
+
+  if(!ndpi_str)
+    return -2;
+  if(!path || path[0] == '\0')
+    return -2;
+  if(mode == NDPI_CATEGORY_BACKEND_LEGACY)
+    return -2;
+  if(mode != NDPI_CATEGORY_BACKEND_NDB_ONLY && mode != NDPI_CATEGORY_BACKEND_HYBRID)
+    return -2;
+
+  newdb = ndb_mmap_path(path, &err);
+  if(!newdb)
+    return err ? err : -1;
+
+  ndpi_category_ndb_lock_wr(ndpi_str);
+
+  olddb = (struct ndpi_category_ndb *)ndpi_str->category_ndb;
+  ndpi_str->category_ndb = (void *)newdb;
+  ndpi_str->category_backend_mode = (u_int8_t)mode;
+
+  ndpi_category_ndb_unlock_wr(ndpi_str);
+
+  if(olddb)
+    ndb_unmap(olddb);
+
+  return 0;
+}
+
+void ndpi_unload_category_ndb(struct ndpi_detection_module_struct *ndpi_str) {
+  struct ndpi_category_ndb *olddb;
+
+  if(!ndpi_str)
+    return;
+
+  ndpi_category_ndb_lock_wr(ndpi_str);
+
+  olddb = (struct ndpi_category_ndb *)ndpi_str->category_ndb;
+  ndpi_str->category_ndb = NULL;
+  /* Always LEGACY once the mmap backend is detached (no NDB_* mode without a live db). */
+  ndpi_str->category_backend_mode = NDPI_CATEGORY_BACKEND_LEGACY;
+
+  ndpi_category_ndb_unlock_wr(ndpi_str);
+
+  if(olddb)
+    ndb_unmap(olddb);
+}

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -4362,6 +4362,8 @@ struct ndpi_detection_module_struct *ndpi_init_detection_module(struct ndpi_glob
     return(NULL);
   }
 
+  ndpi_category_ndb_rwlock_init(ndpi_str);
+
   return(ndpi_str);
 }
 
@@ -5099,6 +5101,25 @@ int ndpi_match_custom_category(struct ndpi_detection_module_struct *ndpi_str,
   memcpy(buf, name, name_len);
   buf[name_len] = '\0';
 
+  if(ndpi_str->category_ndb &&
+      (ndpi_str->category_backend_mode == NDPI_CATEGORY_BACKEND_NDB_ONLY ||
+       ndpi_str->category_backend_mode == NDPI_CATEGORY_BACKEND_HYBRID)) {
+    uint32_t cat_id;
+    int ndb_rc;
+
+    ndpi_category_ndb_lock_rd(ndpi_str);
+    ndb_rc = ndpi_category_ndb_lookup_hostname((struct ndpi_category_ndb *)ndpi_str->category_ndb, name, name_len,
+          &cat_id);
+    ndpi_category_ndb_unlock_rd(ndpi_str);
+    if(ndb_rc == 0) {
+      *category = (ndpi_protocol_category_t)cat_id;
+      *breed = NDPI_PROTOCOL_ACCEPTABLE;
+      return(0);
+    }
+    if(ndpi_str->category_backend_mode == NDPI_CATEGORY_BACKEND_NDB_ONLY)
+      return(-1);
+  }
+
   if(ndpi_domain_classify_hostname(ndpi_str, ndpi_str->custom_categories.sc_hostnames,
 				   &class_id, buf)) {
     *category = (ndpi_protocol_category_t)(class_id & 0xFFFF);
@@ -5140,7 +5161,24 @@ int ndpi_get_custom_category_match(struct ndpi_detection_module_struct *ndpi_str
     ptr[0] = '\0';
 
   if(inet_pton(AF_INET, ipbuf, &pin) == 1) {
-    /* Search IPv4 */
+    /* Search IPv4: .ndb first when enabled, then Patricia in HYBRID */
+    if(ndpi_str->category_ndb &&
+       (ndpi_str->category_backend_mode == NDPI_CATEGORY_BACKEND_NDB_ONLY ||
+        ndpi_str->category_backend_mode == NDPI_CATEGORY_BACKEND_HYBRID)) {
+      uint32_t cat_u32;
+      int ndb_rc;
+
+      ndpi_category_ndb_lock_rd(ndpi_str);
+      ndb_rc = ndpi_category_ndb_lookup_ipv4((struct ndpi_category_ndb *)ndpi_str->category_ndb, pin.s_addr,
+          &cat_u32);
+      ndpi_category_ndb_unlock_rd(ndpi_str);
+      if(ndb_rc == 0) {
+        *category = (ndpi_protocol_category_t)cat_u32;
+        return(0);
+      }
+      if(ndpi_str->category_backend_mode == NDPI_CATEGORY_BACKEND_NDB_ONLY)
+        return(-1);
+    }
 
     /* Make sure all in network byte order otherwise compares wont work */
     ndpi_fill_prefix_v4(&prefix, &pin, 32,
@@ -5154,7 +5192,25 @@ int ndpi_get_custom_category_match(struct ndpi_detection_module_struct *ndpi_str
     }
     return(-1);
   } else if(inet_pton(AF_INET6, ipbuf, &pin6) == 1) {
-    /* Search IPv6 */
+    /* Search IPv6: .ndb first when enabled, then Patricia in HYBRID */
+    if(ndpi_str->category_ndb &&
+       (ndpi_str->category_backend_mode == NDPI_CATEGORY_BACKEND_NDB_ONLY ||
+        ndpi_str->category_backend_mode == NDPI_CATEGORY_BACKEND_HYBRID)) {
+      uint32_t cat_u32;
+      int ndb_rc;
+
+      ndpi_category_ndb_lock_rd(ndpi_str);
+      ndb_rc = ndpi_category_ndb_lookup_ipv6((struct ndpi_category_ndb *)ndpi_str->category_ndb, pin6.s6_addr,
+          &cat_u32);
+      ndpi_category_ndb_unlock_rd(ndpi_str);
+      if(ndb_rc == 0) {
+        *category = (ndpi_protocol_category_t)cat_u32;
+        return(0);
+      }
+      if(ndpi_str->category_backend_mode == NDPI_CATEGORY_BACKEND_NDB_ONLY)
+        return(-1);
+    }
+
     ndpi_fill_prefix_v6(&prefix, &pin6, 128,
 			((ndpi_patricia_tree_t *) ndpi_str->custom_categories.ipAddresses6)->maxbits);
     node = ndpi_patricia_search_best(ndpi_str->custom_categories.ipAddresses6, &prefix);
@@ -5179,6 +5235,9 @@ void ndpi_exit_detection_module(struct ndpi_detection_module_struct *ndpi_str) {
 
     /* Unload plugins (if any) */
     ndpi_unload_protocol_plugins(ndpi_str);
+
+    ndpi_unload_category_ndb(ndpi_str);
+    ndpi_category_ndb_rwlock_destroy(ndpi_str);
 
     ndpi_bitmask_free(&ndpi_str->cfg.detection_bitmask);
     ndpi_bitmask_free(&ndpi_str->cfg.debug_bitmask);

--- a/tests/performance/Makefile.in
+++ b/tests/performance/Makefile.in
@@ -11,7 +11,7 @@ INC=-I $(top_srcdir)/src/include/ -I $(top_builddir)/src/include/ -I $(top_srcdi
 LIB=$(top_builddir)/src/lib/libndpi.a @ADDITIONAL_LIBS@ @LIBS@
 GEN_HEADERS=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 
-TOOLS=substringsearch patriciasearch gcrypt-int gcrypt-gnu strnstr
+TOOLS=substringsearch patriciasearch gcrypt-int gcrypt-gnu strnstr category_ndb_bench
 TESTS=substring_test patricia_test strnstr_test geo_test
 
 
@@ -47,6 +47,9 @@ geo_test: geo
 
 patriciasearch: $(srcdir)/patriciasearch.c Makefile $(GEN_HEADERS)
 	$(CC) $(INC) $(AM_CFLAGS) $(CFLAGS) $(srcdir)/patriciasearch.c -o patriciasearch $(LIB)
+
+category_ndb_bench: $(srcdir)/category_ndb_bench.c Makefile $(GEN_HEADERS)
+	$(CC) $(INC) $(AM_CFLAGS) $(CFLAGS) $(srcdir)/category_ndb_bench.c -o category_ndb_bench $(LIB)
 
 patricia_test: patriciasearch blacklist-ip.txt
 	./patriciasearch

--- a/tests/performance/category_ndb_bench.c
+++ b/tests/performance/category_ndb_bench.c
@@ -1,0 +1,1624 @@
+/*
+ * category_ndb_bench.c — category lookup benchmark (.ndb vs legacy), hot path only.
+ *
+ * Default: micro profile (1 host, 3 IPv4 rules, 2 buckets) + temp .ndb, same cases as legacy mirror.
+ * Positional: ./category_ndb_bench [iters] [rounds] when argv contains no "--" (backward compatible).
+ * Flags: see --help (--mode, --profile, --backend, --ndb-file, --out-file, --only-*, RSS, block percentiles).
+ *
+ * Pipeline: generate (unless --ndb-file / --skip-build) -> load .ndb -> optional legacy mirror ->
+ *           optional --only-load exit -> timed lookups. .ndb IPv4 path is O(N) over ipv4_entry_count.
+ */
+
+#if defined(_WIN32) || defined(WIN32)
+#include <stdio.h>
+int main(void) {
+  puts("category_ndb_bench: not run on Windows (uses POSIX temp file / mmap bench)");
+  return 0;
+}
+#else
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#ifdef __APPLE__
+#include <mach/mach.h>
+#endif
+
+#include "ndpi_api.h"
+#include "ndpi_categories_bin.h"
+#include "ndpi_config.h"
+#include "ndpi_define.h"
+
+#ifdef USE_GLOBAL_CONTEXT
+#define GC_LABEL "USE_GLOBAL_CONTEXT=1"
+#else
+#define GC_LABEL "USE_GLOBAL_CONTEXT=0"
+#endif
+
+#define LEGACY_MAX_HOSTS_DEFAULT 500000u
+#define LEGACY_MAX_IPV4_RULES_DEFAULT 200000u
+#define QUERY_POOL_CAP 4096u
+/* Max synthetic IPv4 rows (exact + prefix). Stress profile uses 200k+200k; keep headroom. */
+#define IPV4_RULE_CAP (512u * 1024u)
+#define DEFAULT_BLOCKS_PER_ROUND 64
+
+enum bench_backend { BACKEND_NDB = 1, BACKEND_LEGACY = 2, BACKEND_BOTH = 3 };
+enum bench_mode { MODE_FIXED = 0, MODE_MIXED_BY_CASE = 1, MODE_MIXED_GLOBAL = 2 };
+
+typedef struct {
+  size_t iters;
+  int rounds;
+  size_t warm;
+  unsigned seed;
+  enum bench_backend backend;
+  int backend_explicit; /* 1 if user passed --backend */
+  enum bench_mode mode;
+  int profile_set; /* 1 if --profile */
+  int iters_explicit; /* 1 if --iters or positional iters */
+  char profile[32]; /* micro|scale|stress|scale_lookup_light|stress_lookup_light */
+  char ndb_file[4096];
+  char out_file[4096];
+  int skip_build;
+  int only_generate;
+  int only_load;
+  int only_lookup;
+  int force_legacy;
+  int lpm_realistic; /* 0=clean, 1=realistic overlapping (subset) */
+  size_t hosts;
+  size_t ipv4_exact;
+  size_t ipv4_prefix;
+  size_t domain_buckets;
+  int blocks_per_round;
+  /* runtime warnings */
+  int warn_ipv4_linear;
+  int warn_unfair_compare;
+  int warn_legacy_fallback;
+  char unfair_reason[256];
+} bench_opts_t;
+
+/* Must match fnv1a64 in src/lib/ndpi_category_ndb.c */
+static uint64_t bench_fnv1a64(const char *s, size_t len) {
+  uint64_t h = 1469598103934665603ULL;
+  size_t i;
+  for(i = 0; i < len; ++i) {
+    h ^= (unsigned char)s[i];
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
+
+static int is_power_of_two_u64(uint64_t n) {
+  return n != 0 && (n & (n - 1)) == 0;
+}
+
+static int rss_bytes_self(size_t *out_bytes) {
+#ifdef __APPLE__
+  struct task_basic_info tbi;
+  mach_msg_type_number_t cnt = TASK_BASIC_INFO_COUNT;
+  kern_return_t kr = task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&tbi, &cnt);
+  if(kr != KERN_SUCCESS)
+    return -1;
+  *out_bytes = (size_t)tbi.resident_size;
+  return 0;
+#else
+  FILE *f;
+  char line[256];
+  unsigned long kb = 0;
+
+  f = fopen("/proc/self/status", "r");
+  if(!f)
+    return -1;
+  while(fgets(line, sizeof(line), f)) {
+    if(strncmp(line, "VmRSS:", 6) == 0) {
+      if(sscanf(line + 6, "%lu", &kb) == 1) {
+        *out_bytes = (size_t)kb * 1024ul;
+        fclose(f);
+        return 0;
+      }
+    }
+  }
+  fclose(f);
+  return -1;
+#endif
+}
+
+static void print_usage(const char *prog) {
+  printf(
+      "Usage: %s [options]\n"
+      "       %s [iterations] [rounds]   (legacy, if argv has no '--')\n"
+      "\n"
+      "Options:\n"
+      "  --help                 This help\n"
+      "  --iters N              Lookups per timed round (default 2000000).\n"
+      "                         --profile scale|stress: default 100000 when neither --iters nor legacy\n"
+      "                         positional [iterations] is given (both count as explicit --iters).\n"
+      "  --rounds N             Timed rounds for median (default 5, min 3)\n"
+      "  --warm N               Warm-up iterations per round (default derived)\n"
+      "  --backend ndb|legacy|both   (default both)\n"
+      "  --mode fixed|mixed_by_case|mixed_global   (default fixed; mixed_by_case varies per lookup case)\n"
+      "                         mixed_global: same per-case string pools as mixed_by_case, not a true\n"
+      "                         cross-API mix; noisier, not a CI baseline.\n"
+      "  --profile micro|scale|stress|scale_lookup_light|stress_lookup_light\n"
+      "                         scale|stress: same synthetic DB shape (hosts/IPv4/buckets), fewer default\n"
+      "                         timed lookups unless --iters or positional [iterations] is provided.\n"
+      "                         *_lookup_light: same DB shape as scale|stress, lighter preset lookups\n"
+      "                         (iters 50000, rounds 3; does not use the scale/stress default-iters rule).\n"
+      "  --ndb-file PATH        Load this .ndb (no synthetic build; precedence over generator)\n"
+      "                         External `.ndb` files are best suited for load-only measurements (`--only-load`).\n"
+      "                         For lookup benchmarks, results are only meaningful if the file matches the\n"
+      "                         synthetic generator conventions used by this benchmark (fixed strings/pools).\n"
+      "  --out-file PATH        Persist synthetic .ndb here; without it, temp file + unlink at exit\n"
+      "  --skip-build           No synthetic generation (requires --ndb-file)\n"
+      "  --only-generate        Write synthetic .ndb to --out-file and exit (requires --out-file)\n"
+      "  --only-load            Print load metrics and exit (no lookup timing)\n"
+      "  --only-lookup          After load, only report lookup timings\n"
+      "  --hosts N              Synthetic hostname rows\n"
+      "  --ipv4-exact N         Synthetic /32 rows\n"
+      "  --ipv4-prefix N        Synthetic prefix rows\n"
+      "  --domain-buckets N     Hash buckets (power of two, >=2)\n"
+      "  --seed U               RNG seed (reserved / reproducibility hooks)\n"
+      "  --lpm clean|realistic  IPv4 table style for synthetic generator\n"
+      "  --force-legacy         Override default %u-host / %u-IPv4-rule cap; build the legacy mirror\n"
+      "                         anyway (may OOM).\n"
+      "  --blocks-per-round K   Block samples per round for percentiles (default %d)\n"
+      "\n"
+      "Default iters: with --profile scale|stress, timed lookups default to 100000 unless you pass\n"
+      "  --iters or positional [iterations] (both count as explicit; see --iters above).\n"
+      "\n"
+      "Recommended (from repo root after build; adjust if out-of-tree):\n"
+      "  ./tests/performance/category_ndb_bench --profile micro --backend both --mode fixed\n"
+      "  ./tests/performance/category_ndb_bench --profile micro --backend both --mode mixed_by_case\n"
+      "  ./tests/performance/category_ndb_bench --profile scale --backend both --only-load\n"
+      "  ./tests/performance/category_ndb_bench --profile scale --backend both --mode mixed_by_case\n"
+      "  ./tests/performance/category_ndb_bench --profile stress --backend ndb --only-load\n"
+      "\n"
+      "Pipeline: generate (unless --ndb-file or --skip-build) -> load_ndb -> optional legacy build ->\n"
+      "          optional --only-load exit -> lookup benchmarks.\n"
+      "\n"
+      "Note: .ndb IPv4 lookup is O(N) over ipv4_entry_count; large N stresses current implementation.\n",
+      prog, prog, (unsigned)LEGACY_MAX_HOSTS_DEFAULT, (unsigned)LEGACY_MAX_IPV4_RULES_DEFAULT, DEFAULT_BLOCKS_PER_ROUND);
+}
+
+static void opts_defaults(bench_opts_t *o) {
+  memset(o, 0, sizeof(*o));
+  o->iters = 2000000;
+  o->rounds = 5;
+  o->warm = 0; /* computed later */
+  o->seed = 1;
+  o->backend = BACKEND_BOTH;
+  o->backend_explicit = 0;
+  o->mode = MODE_FIXED;
+  strcpy(o->profile, "micro");
+  o->domain_buckets = 2;
+  o->hosts = 1;
+  o->ipv4_exact = 1; /* will align with micro 3 ipv4 total */
+  o->ipv4_prefix = 2;
+  o->blocks_per_round = DEFAULT_BLOCKS_PER_ROUND;
+  o->iters_explicit = 0;
+}
+
+static void profile_apply(bench_opts_t *o) {
+  if(strcmp(o->profile, "micro") == 0) {
+    o->hosts = 1;
+    o->ipv4_exact = 1;
+    o->ipv4_prefix = 2;
+    o->domain_buckets = 2;
+  } else if(strcmp(o->profile, "scale") == 0) {
+    o->hosts = 200000;
+    o->ipv4_exact = 50000;
+    o->ipv4_prefix = 50000;
+    o->domain_buckets = 1u << 18;
+  } else if(strcmp(o->profile, "stress") == 0) {
+    o->hosts = 2000000;
+    o->ipv4_exact = 200000;
+    o->ipv4_prefix = 200000;
+    o->domain_buckets = 1u << 20;
+    if(o->backend == BACKEND_BOTH && !o->backend_explicit)
+      o->backend = BACKEND_NDB; /* stress defaults to ndb-only unless --backend was passed */
+  } else if(strcmp(o->profile, "scale_lookup_light") == 0) {
+    o->hosts = 200000;
+    o->ipv4_exact = 50000;
+    o->ipv4_prefix = 50000;
+    o->domain_buckets = 1u << 18;
+    o->iters = 50000;
+    o->rounds = 3;
+    o->iters_explicit = 1;
+  } else if(strcmp(o->profile, "stress_lookup_light") == 0) {
+    o->hosts = 2000000;
+    o->ipv4_exact = 200000;
+    o->ipv4_prefix = 200000;
+    o->domain_buckets = 1u << 20;
+    if(o->backend == BACKEND_BOTH && !o->backend_explicit)
+      o->backend = BACKEND_NDB;
+    o->iters = 50000;
+    o->rounds = 3;
+    o->iters_explicit = 1;
+  }
+}
+
+static int parse_u64(const char *s, uint64_t *out) {
+  char *end = NULL;
+  unsigned long long v;
+  errno = 0;
+  v = strtoull(s, &end, 10);
+  if(errno || end == s || (end && *end))
+    return -1;
+  *out = (uint64_t)v;
+  return 0;
+}
+
+static int parse_args(int argc, char **argv, bench_opts_t *o) {
+  int i;
+  int any_flag = 0;
+
+  for(i = 1; i < argc; i++) {
+    if(argv[i][0] == '-' && argv[i][1] == '-')
+      any_flag = 1;
+  }
+  if(!any_flag && argc >= 2) {
+    uint64_t v;
+    if(parse_u64(argv[1], &v) == 0) {
+      o->iters = (size_t)v;
+      o->iters_explicit = 1; /* so end-of-parse scale/stress default-iters cap does not override */
+      if(o->iters < 1000)
+        o->iters = 1000;
+    }
+    if(argc >= 3 && parse_u64(argv[2], &v) == 0) {
+      o->rounds = (int)v;
+      if(o->rounds < 3)
+        o->rounds = 3;
+    }
+    return 0;
+  }
+
+  for(i = 1; i < argc; i++) {
+    const char *a = argv[i];
+#define NEED_ARG()                                                                               \
+  do {                                                                                           \
+    if(i + 1 >= argc) {                                                                          \
+      fprintf(stderr, "missing value after %s\n", a);                                            \
+      return -1;                                                                                 \
+    }                                                                                            \
+  } while(0)
+    if(strcmp(a, "--help") == 0) {
+      print_usage(argv[0]);
+      exit(0);
+    } else if(strcmp(a, "--iters") == 0) {
+      uint64_t v;
+      NEED_ARG();
+      if(parse_u64(argv[++i], &v) || v < 1000) {
+        fprintf(stderr, "bad --iters\n");
+        return -1;
+      }
+      o->iters = (size_t)v;
+      o->iters_explicit = 1;
+    } else if(strcmp(a, "--rounds") == 0) {
+      uint64_t v;
+      NEED_ARG();
+      if(parse_u64(argv[++i], &v) || v < 3) {
+        fprintf(stderr, "bad --rounds\n");
+        return -1;
+      }
+      o->rounds = (int)v;
+    } else if(strcmp(a, "--warm") == 0) {
+      uint64_t v;
+      NEED_ARG();
+      if(parse_u64(argv[++i], &v)) {
+        fprintf(stderr, "bad --warm\n");
+        return -1;
+      }
+      o->warm = (size_t)v;
+    } else if(strcmp(a, "--seed") == 0) {
+      uint64_t v;
+      NEED_ARG();
+      if(parse_u64(argv[++i], &v)) {
+        fprintf(stderr, "bad --seed\n");
+        return -1;
+      }
+      o->seed = (unsigned)v;
+    } else if(strcmp(a, "--backend") == 0) {
+      NEED_ARG();
+      a = argv[++i];
+      o->backend_explicit = 1;
+      if(strcmp(a, "ndb") == 0)
+        o->backend = BACKEND_NDB;
+      else if(strcmp(a, "legacy") == 0)
+        o->backend = BACKEND_LEGACY;
+      else if(strcmp(a, "both") == 0)
+        o->backend = BACKEND_BOTH;
+      else {
+        fprintf(stderr, "bad --backend\n");
+        return -1;
+      }
+    } else if(strcmp(a, "--mode") == 0) {
+      NEED_ARG();
+      a = argv[++i];
+      if(strcmp(a, "fixed") == 0)
+        o->mode = MODE_FIXED;
+      else if(strcmp(a, "mixed_by_case") == 0)
+        o->mode = MODE_MIXED_BY_CASE;
+      else if(strcmp(a, "mixed_global") == 0)
+        o->mode = MODE_MIXED_GLOBAL;
+      else {
+        fprintf(stderr, "bad --mode\n");
+        return -1;
+      }
+    } else if(strcmp(a, "--profile") == 0) {
+      NEED_ARG();
+      a = argv[++i];
+      if(strcmp(a, "micro") != 0 && strcmp(a, "scale") != 0 && strcmp(a, "stress") != 0 &&
+          strcmp(a, "scale_lookup_light") != 0 && strcmp(a, "stress_lookup_light") != 0) {
+        fprintf(stderr, "bad --profile\n");
+        return -1;
+      }
+      strncpy(o->profile, a, sizeof(o->profile) - 1);
+      o->profile[sizeof(o->profile) - 1] = '\0';
+      o->profile_set = 1;
+      profile_apply(o);
+    } else if(strcmp(a, "--ndb-file") == 0) {
+      NEED_ARG();
+      strncpy(o->ndb_file, argv[++i], sizeof(o->ndb_file) - 1);
+      o->ndb_file[sizeof(o->ndb_file) - 1] = '\0';
+    } else if(strcmp(a, "--out-file") == 0) {
+      NEED_ARG();
+      strncpy(o->out_file, argv[++i], sizeof(o->out_file) - 1);
+      o->out_file[sizeof(o->out_file) - 1] = '\0';
+    } else if(strcmp(a, "--skip-build") == 0) {
+      o->skip_build = 1;
+    } else if(strcmp(a, "--only-generate") == 0) {
+      o->only_generate = 1;
+    } else if(strcmp(a, "--only-load") == 0) {
+      o->only_load = 1;
+    } else if(strcmp(a, "--only-lookup") == 0) {
+      o->only_lookup = 1;
+    } else if(strcmp(a, "--force-legacy") == 0) {
+      o->force_legacy = 1;
+    } else if(strcmp(a, "--lpm") == 0) {
+      NEED_ARG();
+      a = argv[++i];
+      if(strcmp(a, "realistic") == 0)
+        o->lpm_realistic = 1;
+      else if(strcmp(a, "clean") == 0)
+        o->lpm_realistic = 0;
+      else {
+        fprintf(stderr, "bad --lpm\n");
+        return -1;
+      }
+    } else if(strcmp(a, "--hosts") == 0) {
+      uint64_t v;
+      NEED_ARG();
+      if(parse_u64(argv[++i], &v)) {
+        fprintf(stderr, "bad --hosts\n");
+        return -1;
+      }
+      o->hosts = (size_t)v;
+    } else if(strcmp(a, "--ipv4-exact") == 0) {
+      uint64_t v;
+      NEED_ARG();
+      if(parse_u64(argv[++i], &v)) {
+        fprintf(stderr, "bad --ipv4-exact\n");
+        return -1;
+      }
+      o->ipv4_exact = (size_t)v;
+    } else if(strcmp(a, "--ipv4-prefix") == 0) {
+      uint64_t v;
+      NEED_ARG();
+      if(parse_u64(argv[++i], &v)) {
+        fprintf(stderr, "bad --ipv4-prefix\n");
+        return -1;
+      }
+      o->ipv4_prefix = (size_t)v;
+    } else if(strcmp(a, "--domain-buckets") == 0) {
+      uint64_t v;
+      NEED_ARG();
+      if(parse_u64(argv[++i], &v) || v < 2) {
+        fprintf(stderr, "bad --domain-buckets\n");
+        return -1;
+      }
+      o->domain_buckets = (size_t)v;
+    } else if(strcmp(a, "--blocks-per-round") == 0) {
+      uint64_t v;
+      NEED_ARG();
+      if(parse_u64(argv[++i], &v) || v < 2) {
+        fprintf(stderr, "bad --blocks-per-round\n");
+        return -1;
+      }
+      o->blocks_per_round = (int)v;
+    } else {
+      fprintf(stderr, "unknown option: %s\n", a);
+      return -1;
+    }
+#undef NEED_ARG
+  }
+
+  if(o->skip_build && o->ndb_file[0] == '\0') {
+    fprintf(stderr, "error: --skip-build requires --ndb-file\n");
+    return -1;
+  }
+  if(o->only_generate && o->out_file[0] == '\0') {
+    fprintf(stderr, "error: --only-generate requires --out-file\n");
+    return -1;
+  }
+  if(o->only_generate && (o->ndb_file[0] || o->skip_build)) {
+    fprintf(stderr, "error: --only-generate conflicts with --ndb-file / --skip-build\n");
+    return -1;
+  }
+  if(o->ndb_file[0] && o->backend == BACKEND_LEGACY) {
+    fprintf(stderr, "error: --ndb-file requires --backend ndb or both\n");
+    return -1;
+  }
+  if((o->only_load || o->only_lookup) && o->skip_build && o->ndb_file[0] == '\0') {
+    fprintf(stderr, "error: --only-load / --only-lookup with --skip-build requires --ndb-file\n");
+    return -1;
+  }
+  if(!is_power_of_two_u64((uint64_t)o->domain_buckets)) {
+    fprintf(stderr, "error: --domain-buckets must be a power of two >= 2\n");
+    return -1;
+  }
+  if(o->hosts == 0 && o->ipv4_exact == 0 && o->ipv4_prefix == 0 && o->ndb_file[0] == '\0' && !o->only_generate) {
+    /* micro profile still sets hosts>=1; this catches empty synthetic with no external file */
+    fprintf(stderr, "error: need --ndb-file or non-zero synthetic counts\n");
+    return -1;
+  }
+  /* Large DB profiles: keep full synthetic tables but avoid multi-hour lookup loops by default.
+   * For lighter preset lookup runs (same DB shape), see scale_lookup_light / stress_lookup_light. */
+  if(o->profile_set && !o->iters_explicit) {
+    if(strcmp(o->profile, "scale") == 0 || strcmp(o->profile, "stress") == 0)
+      o->iters = 100000;
+  }
+  return 0;
+}
+
+/* ---- micro .ndb (historical minimal file) ---- */
+static int write_micro_ndb(const char *path) {
+  FILE *fp;
+  ndb_header_disk_t hdr;
+  ndb_category_disk_t cat;
+  ndb_bucket_disk_t bucks[2];
+  ndb_entry_disk_t ent;
+  const char *dom = "example.com";
+  size_t dom_len = strlen(dom);
+  const char pool[] = "x\0example.com\0";
+  const size_t pool_len = sizeof(pool) - 1;
+  ndb_ipv4_entry_disk_t v4[3];
+  uint64_t off;
+  uint32_t addr_8888 = htonl(0x08080808);
+  uint32_t addr_10_8 = htonl(0x0a000000);
+  uint32_t addr_10_1_16 = htonl(0x0a010000);
+
+  fp = fopen(path, "wb");
+  if(!fp)
+    return -1;
+
+  memset(&hdr, 0, sizeof(hdr));
+  memcpy(hdr.magic, NDB_MAGIC, 4);
+  hdr.format_version = NDB_FORMAT_VERSION;
+  hdr.category_count = 1;
+  hdr.domain_entry_count = 1;
+  hdr.domain_bucket_count = 2;
+  hdr.string_pool_size = pool_len;
+  hdr.ipv4_entry_count = 3;
+  hdr.ipv6_entry_count = 0;
+
+  off = sizeof(hdr);
+  hdr.categories_off = off;
+  off += sizeof(cat);
+  hdr.domain_buckets_off = off;
+  off += sizeof(bucks);
+  hdr.domain_entries_off = off;
+  off += sizeof(ent);
+  hdr.string_pool_off = off;
+  off += pool_len;
+  hdr.ipv4_entries_off = off;
+  off += sizeof(v4);
+  hdr.ipv6_entries_off = off;
+  hdr.file_size = off;
+
+  cat.id = NDPI_PROTOCOL_CATEGORY_WEB;
+  cat.name_off = 0;
+
+  bucks[0].first = 0;
+  bucks[0].count = 1;
+  bucks[1].first = 0;
+  bucks[1].count = 0;
+
+  ent.hash = bench_fnv1a64(dom, dom_len);
+  ent.domain_off = 2;
+  ent.domain_len = (uint16_t)dom_len;
+  ent.flags = 0;
+  ent.category_id = NDPI_PROTOCOL_CATEGORY_WEB;
+
+  v4[0].network_be = addr_10_8;
+  v4[0].prefix_len = 8;
+  v4[0].flags = 0;
+  v4[0].reserved0 = 0;
+  v4[0].category_id = NDPI_PROTOCOL_CATEGORY_WEB;
+
+  v4[1].network_be = addr_10_1_16;
+  v4[1].prefix_len = 16;
+  v4[1].flags = 0;
+  v4[1].reserved0 = 0;
+  v4[1].category_id = NDPI_PROTOCOL_CATEGORY_VPN;
+
+  v4[2].network_be = addr_8888;
+  v4[2].prefix_len = 32;
+  v4[2].flags = 0;
+  v4[2].reserved0 = 0;
+  v4[2].category_id = NDPI_PROTOCOL_CATEGORY_VPN;
+
+  if(fwrite(&hdr, 1, sizeof(hdr), fp) != sizeof(hdr) || fwrite(&cat, 1, sizeof(cat), fp) != sizeof(cat) ||
+      fwrite(bucks, 1, sizeof(bucks), fp) != sizeof(bucks) || fwrite(&ent, 1, sizeof(ent), fp) != sizeof(ent) ||
+      fwrite(pool, 1, pool_len, fp) != pool_len || fwrite(v4, 1, sizeof(v4), fp) != sizeof(v4)) {
+    fclose(fp);
+    return -1;
+  }
+  fclose(fp);
+  return 0;
+}
+
+/* ---- synthetic .ndb ---- */
+static int write_synthetic_ndb(const char *path, const bench_opts_t *opt, size_t *out_pool_used) {
+  FILE *fp = NULL;
+  ndb_header_disk_t hdr;
+  ndb_category_disk_t cat;
+  ndb_bucket_disk_t *bucks = NULL;
+  ndb_entry_disk_t *ents = NULL;
+  uint32_t *bc = NULL;
+  uint32_t *bwr = NULL;
+  char *pool = NULL;
+  ndb_ipv4_entry_disk_t *v4 = NULL;
+  uint64_t off;
+  size_t nb = opt->domain_buckets;
+  size_t N = opt->hosts;
+  size_t nex = opt->ipv4_exact;
+  size_t npr = opt->ipv4_prefix;
+  size_t ipv4_total;
+  size_t pool_cap;
+  size_t pool_used = 0;
+  size_t bi, idx;
+  int rc = -1;
+
+  *out_pool_used = 0;
+  ipv4_total = nex + npr;
+  if(ipv4_total > IPV4_RULE_CAP) {
+    fprintf(stderr, "ipv4 rules too large (cap %u)\n", (unsigned)IPV4_RULE_CAP);
+    return -1;
+  }
+  if(nb > (1ull << 31)) {
+    fprintf(stderr, "domain_buckets too large\n");
+    return -1;
+  }
+
+  fp = fopen(path, "wb");
+  if(!fp)
+    return -1;
+
+  memset(&hdr, 0, sizeof(hdr));
+  memcpy(hdr.magic, NDB_MAGIC, 4);
+  hdr.format_version = NDB_FORMAT_VERSION;
+  hdr.category_count = 1;
+  hdr.domain_entry_count = (uint64_t)N;
+  hdr.domain_bucket_count = (uint64_t)nb;
+  hdr.ipv4_entry_count = (uint64_t)ipv4_total;
+  hdr.ipv6_entry_count = 0;
+
+  bucks = (ndb_bucket_disk_t *)calloc(nb, sizeof(ndb_bucket_disk_t));
+  if(N > 0 && !bucks)
+    goto fail;
+
+  bc = (uint32_t *)calloc(nb, sizeof(uint32_t));
+  if(N > 0 && !bc)
+    goto fail;
+
+  /* pass 1: bucket counts */
+  if(N > 0) {
+    char hbuf[256];
+    size_t i;
+    for(i = 1; i <= N; i++) {
+      uint64_t h;
+      size_t b;
+      int nch = snprintf(hbuf, sizeof(hbuf), "d%07zu.example.test", i);
+      if(nch <= 0 || (size_t)nch >= sizeof(hbuf))
+        goto fail;
+      h = bench_fnv1a64(hbuf, (size_t)nch);
+      b = (size_t)(h & (uint64_t)(nb - 1));
+      if(bc[b] == UINT32_MAX)
+        goto fail;
+      bc[b]++;
+    }
+  }
+
+  bwr = (uint32_t *)calloc(nb, sizeof(uint32_t));
+  ents = (ndb_entry_disk_t *)calloc(N > 0 ? N : 1, sizeof(ndb_entry_disk_t));
+  if((N > 0 && !ents) || (N > 0 && !bwr))
+    goto fail;
+
+  if(N > 0) {
+    uint32_t run = 0;
+    for(bi = 0; bi < nb; bi++) {
+      bucks[bi].first = run;
+      bucks[bi].count = bc[bi];
+      run += bc[bi];
+      bwr[bi] = bucks[bi].first;
+    }
+  } else {
+    for(bi = 0; bi < nb; bi++) {
+      bucks[bi].first = 0;
+      bucks[bi].count = 0;
+    }
+  }
+
+  pool_cap = N * 48 + 16;
+  if(N > 0) {
+    pool = (char *)malloc(pool_cap);
+    if(!pool)
+      goto fail;
+    pool[0] = '\0';
+    pool_used = 1; /* cat name empty at off 0 */
+  } else {
+    pool = (char *)malloc(1);
+    if(!pool)
+      goto fail;
+    pool[0] = '\0';
+    pool_used = 1;
+  }
+
+  /* pass 2: entries + pool */
+  if(N > 0) {
+    char hbuf[256];
+    size_t i;
+    for(i = 1; i <= N; i++) {
+      uint64_t hv;
+      size_t b;
+      uint32_t pos;
+      size_t len;
+      int nch = snprintf(hbuf, sizeof(hbuf), "d%07zu.example.test", i);
+      if(nch <= 0 || (size_t)nch >= sizeof(hbuf))
+        goto fail;
+      len = (size_t)nch;
+      hv = bench_fnv1a64(hbuf, len);
+      b = (size_t)(hv & (uint64_t)(nb - 1));
+      pos = bwr[b]++;
+      if(pool_used + len + 1 > pool_cap) {
+        size_t ncap = pool_cap * 2 + len + 64;
+        char *np = (char *)realloc(pool, ncap);
+        if(!np)
+          goto fail;
+        pool = np;
+        pool_cap = ncap;
+      }
+      ents[pos].hash = hv;
+      ents[pos].domain_off = (uint32_t)pool_used;
+      ents[pos].domain_len = (uint16_t)len;
+      ents[pos].flags = 0;
+      ents[pos].category_id =
+          ((i & 1) ? NDPI_PROTOCOL_CATEGORY_VPN : NDPI_PROTOCOL_CATEGORY_WEB);
+      memcpy(pool + pool_used, hbuf, len);
+      pool_used += len;
+      pool[pool_used++] = '\0';
+    }
+  }
+
+  cat.id = NDPI_PROTOCOL_CATEGORY_WEB;
+  cat.name_off = 0;
+  hdr.string_pool_size = (uint64_t)pool_used;
+
+  v4 = (ndb_ipv4_entry_disk_t *)calloc(ipv4_total > 0 ? ipv4_total : 1, sizeof(ndb_ipv4_entry_disk_t));
+  if(ipv4_total > 0 && !v4)
+    goto fail;
+
+  /* IPv4: exact rows then prefix rows */
+  idx = 0;
+  for(; idx < nex; idx++) {
+    uint32_t a = htonl(0x0b000000u | (uint32_t)(idx & 0x00ffffffu));
+    v4[idx].network_be = a;
+    v4[idx].prefix_len = 32;
+    v4[idx].flags = 0;
+    v4[idx].reserved0 = 0;
+    v4[idx].category_id = NDPI_PROTOCOL_CATEGORY_VPN;
+  }
+  for(; idx < ipv4_total; idx++) {
+    size_t j = idx - nex;
+    uint32_t oct = (uint32_t)((j % 200) + 1);
+    uint32_t a = htonl(0x0a000000u | (oct << 16));
+    v4[idx].network_be = a;
+    v4[idx].prefix_len = 16;
+    v4[idx].flags = 0;
+    v4[idx].reserved0 = 0;
+    v4[idx].category_id = NDPI_PROTOCOL_CATEGORY_WEB;
+  }
+
+  if(opt->lpm_realistic && ipv4_total >= 4) {
+    /* overlap stack for first anchor (documentation / stress) */
+    size_t base = 0;
+    v4[base + 0].network_be = htonl(0x0a141e28u); /* 10.20.30.40 */
+    v4[base + 0].prefix_len = 8;
+    v4[base + 0].category_id = NDPI_PROTOCOL_CATEGORY_WEB;
+    v4[base + 1].network_be = htonl(0x0a141e28u);
+    v4[base + 1].prefix_len = 16;
+    v4[base + 1].category_id = NDPI_PROTOCOL_CATEGORY_VPN;
+    v4[base + 2].network_be = htonl(0x0a141e28u);
+    v4[base + 2].prefix_len = 24;
+    v4[base + 2].category_id = NDPI_PROTOCOL_CATEGORY_WEB;
+    v4[base + 3].network_be = htonl(0x0a141e28u);
+    v4[base + 3].prefix_len = 32;
+    v4[base + 3].category_id = NDPI_PROTOCOL_CATEGORY_VPN;
+  }
+
+  off = sizeof(hdr);
+  hdr.categories_off = off;
+  off += sizeof(cat);
+  hdr.domain_buckets_off = off;
+  off += (uint64_t)nb * sizeof(ndb_bucket_disk_t);
+  hdr.domain_entries_off = off;
+  off += (uint64_t)N * sizeof(ndb_entry_disk_t);
+  hdr.string_pool_off = off;
+  off += (uint64_t)pool_used;
+  hdr.ipv4_entries_off = off;
+  off += (uint64_t)ipv4_total * sizeof(ndb_ipv4_entry_disk_t);
+  hdr.ipv6_entries_off = off;
+  hdr.file_size = off;
+
+  if(fwrite(&hdr, 1, sizeof(hdr), fp) != sizeof(hdr) || fwrite(&cat, 1, sizeof(cat), fp) != sizeof(cat))
+    goto fail;
+  if(nb > 0 && fwrite(bucks, sizeof(ndb_bucket_disk_t), nb, fp) != nb)
+    goto fail;
+  if(N > 0 && fwrite(ents, sizeof(ndb_entry_disk_t), N, fp) != N)
+    goto fail;
+  if(fwrite(pool, 1, pool_used, fp) != pool_used)
+    goto fail;
+  if(ipv4_total > 0 && fwrite(v4, sizeof(ndb_ipv4_entry_disk_t), ipv4_total, fp) != ipv4_total)
+    goto fail;
+
+  *out_pool_used = pool_used;
+  rc = 0;
+fail:
+  free(v4);
+  free(pool);
+  free(ents);
+  free(bwr);
+  free(bc);
+  free(bucks);
+  if(fp)
+    fclose(fp);
+  if(rc && path)
+    unlink(path);
+  return rc;
+}
+
+static int cmp_double_asc(const void *a, const void *b) {
+  double x = *(const double *)a;
+  double y = *(const double *)b;
+  if(x < y)
+    return -1;
+  if(x > y)
+    return 1;
+  return 0;
+}
+
+typedef void (*bench_body_fn)(struct ndpi_detection_module_struct *m, void *ctx);
+
+typedef struct {
+  enum bench_mode mode;
+  char fixed_hit[256];
+  char fixed_miss[256];
+  char fixed_ip_hit[32];
+  char fixed_ip_lpm[32];
+  char fixed_ip_miss[32];
+  /* pools for mixed */
+  char **pool_host_hit;
+  char **pool_host_miss;
+  char **pool_ip_hit;
+  char **pool_ip_lpm;
+  char **pool_ip_miss;
+  size_t n_hit, n_miss, n_ip_hit, n_ip_lpm, n_ip_miss;
+  size_t ix_hit, ix_miss, ix_ip_hit, ix_ip_lpm, ix_ip_miss;
+  size_t glob_ix;
+} bench_ctx_t;
+
+static void body_host_hit(struct ndpi_detection_module_struct *m, void *ctx) {
+  bench_ctx_t *c = (bench_ctx_t *)ctx;
+  const char *s;
+  size_t len;
+  ndpi_protocol_category_t cat;
+  ndpi_protocol_breed_t breed;
+  if(c->mode == MODE_FIXED) {
+    s = c->fixed_hit;
+    len = strlen(s);
+  } else if(c->mode == MODE_MIXED_GLOBAL) {
+    /* Same pools as mixed_by_case per body; true global interleave would mix APIs in one loop (future). */
+    if(!c->n_hit)
+      return;
+    s = c->pool_host_hit[c->ix_hit++ % c->n_hit];
+    len = strlen(s);
+  } else {
+    if(!c->n_hit)
+      return;
+    s = c->pool_host_hit[c->ix_hit++ % c->n_hit];
+    len = strlen(s);
+  }
+  (void)ndpi_match_custom_category(m, (char *)s, len, &cat, &breed);
+}
+
+static void body_host_miss(struct ndpi_detection_module_struct *m, void *ctx) {
+  bench_ctx_t *c = (bench_ctx_t *)ctx;
+  const char *s;
+  size_t len;
+  ndpi_protocol_category_t cat;
+  ndpi_protocol_breed_t breed;
+  if(c->mode == MODE_FIXED) {
+    s = c->fixed_miss;
+    len = strlen(s);
+  } else if(c->mode == MODE_MIXED_GLOBAL) {
+    if(!c->n_miss)
+      return;
+    s = c->pool_host_miss[c->ix_miss++ % c->n_miss];
+    len = strlen(s);
+  } else {
+    if(!c->n_miss)
+      return;
+    s = c->pool_host_miss[c->ix_miss++ % c->n_miss];
+    len = strlen(s);
+  }
+  (void)ndpi_match_custom_category(m, (char *)s, len, &cat, &breed);
+}
+
+static void body_ip_hit(struct ndpi_detection_module_struct *m, void *ctx) {
+  bench_ctx_t *c = (bench_ctx_t *)ctx;
+  const char *s;
+  size_t len;
+  ndpi_protocol_category_t cat;
+  ndpi_protocol_breed_t breed;
+  if(c->mode == MODE_FIXED) {
+    s = c->fixed_ip_hit;
+    len = strlen(s);
+  } else if(c->mode == MODE_MIXED_GLOBAL) {
+    if(!c->n_ip_hit)
+      return;
+    s = c->pool_ip_hit[c->ix_ip_hit++ % c->n_ip_hit];
+    len = strlen(s);
+  } else {
+    if(!c->n_ip_hit)
+      return;
+    s = c->pool_ip_hit[c->ix_ip_hit++ % c->n_ip_hit];
+    len = strlen(s);
+  }
+  (void)ndpi_get_custom_category_match(m, (char *)s, len, &cat, &breed);
+}
+
+static void body_ip_lpm(struct ndpi_detection_module_struct *m, void *ctx) {
+  bench_ctx_t *c = (bench_ctx_t *)ctx;
+  const char *s;
+  size_t len;
+  ndpi_protocol_category_t cat;
+  ndpi_protocol_breed_t breed;
+  if(c->mode == MODE_FIXED) {
+    s = c->fixed_ip_lpm;
+    len = strlen(s);
+  } else if(c->mode == MODE_MIXED_GLOBAL) {
+    if(!c->n_ip_lpm)
+      return;
+    s = c->pool_ip_lpm[c->ix_ip_lpm++ % c->n_ip_lpm];
+    len = strlen(s);
+  } else {
+    if(!c->n_ip_lpm)
+      return;
+    s = c->pool_ip_lpm[c->ix_ip_lpm++ % c->n_ip_lpm];
+    len = strlen(s);
+  }
+  (void)ndpi_get_custom_category_match(m, (char *)s, len, &cat, &breed);
+}
+
+static void body_ip_miss(struct ndpi_detection_module_struct *m, void *ctx) {
+  bench_ctx_t *c = (bench_ctx_t *)ctx;
+  const char *s;
+  size_t len;
+  ndpi_protocol_category_t cat;
+  ndpi_protocol_breed_t breed;
+  if(c->mode == MODE_FIXED) {
+    s = c->fixed_ip_miss;
+    len = strlen(s);
+  } else if(c->mode == MODE_MIXED_GLOBAL) {
+    if(!c->n_ip_miss)
+      return;
+    s = c->pool_ip_miss[c->ix_ip_miss++ % c->n_ip_miss];
+    len = strlen(s);
+  } else {
+    if(!c->n_ip_miss)
+      return;
+    s = c->pool_ip_miss[c->ix_ip_miss++ % c->n_ip_miss];
+    len = strlen(s);
+  }
+  (void)ndpi_get_custom_category_match(m, (char *)s, len, &cat, &breed);
+}
+
+static double timespec_diff_sec(const struct timespec *a, const struct timespec *b) {
+  return (double)(b->tv_sec - a->tv_sec) + (double)(b->tv_nsec - a->tv_nsec) / 1e9;
+}
+
+/* Median ns/op + block percentiles; prints block_size_ops / blocks_per_round via out-params */
+static int median_ns_per_op_blocks(bench_body_fn body, void *ctx, struct ndpi_detection_module_struct *mod, size_t warm,
+    size_t iters, int rounds, int blocks_per_round, double *out_median, double *out_p50, double *out_p95, double *out_p99,
+    size_t *out_block_ops) {
+  double *round_medians;
+  double *block_samples;
+  int r, b;
+  size_t ops_per_block;
+  size_t total_block_samples;
+  size_t si;
+
+  if(iters == 0 || rounds < 1 || blocks_per_round < 2)
+    return -1;
+  ops_per_block = iters / (size_t)blocks_per_round;
+  if(ops_per_block == 0)
+    return -1;
+  *out_block_ops = ops_per_block;
+
+  round_medians = (double *)malloc((size_t)rounds * sizeof(double));
+  total_block_samples = (size_t)rounds * (size_t)blocks_per_round;
+  block_samples = (double *)malloc(total_block_samples * sizeof(double));
+  if(!round_medians || !block_samples) {
+    free(round_medians);
+    free(block_samples);
+    return -1;
+  }
+
+  si = 0;
+  for(r = 0; r < rounds + 1; r++) {
+    size_t i, base;
+    double sec_round = 0;
+
+    for(i = 0; i < warm; i++)
+      body(mod, ctx);
+
+    for(b = 0; b < blocks_per_round; b++) {
+      struct timespec t0, t1;
+      size_t k;
+      double sec, ns_per_op;
+      clock_gettime(CLOCK_MONOTONIC, &t0);
+      for(k = 0; k < ops_per_block; k++)
+        body(mod, ctx);
+      clock_gettime(CLOCK_MONOTONIC, &t1);
+      sec = timespec_diff_sec(&t0, &t1);
+      ns_per_op = (sec / (double)ops_per_block) * 1e9;
+      if(r > 0)
+        block_samples[si++] = ns_per_op;
+      sec_round += sec;
+    }
+    /* remainder ops to reach iters */
+    base = (size_t)blocks_per_round * ops_per_block;
+    for(i = base; i < iters; i++)
+      body(mod, ctx);
+
+    if(r > 0) {
+      double ns_round_op = (sec_round / (double)iters) * 1e9;
+      round_medians[r - 1] = ns_round_op;
+    }
+  }
+
+  qsort(round_medians, (size_t)rounds, sizeof(double), cmp_double_asc);
+  *out_median = round_medians[rounds / 2];
+
+  qsort(block_samples, total_block_samples, sizeof(double), cmp_double_asc);
+  *out_p50 = block_samples[(size_t)((total_block_samples - 1) * 50 / 100)];
+  *out_p95 = block_samples[(size_t)((total_block_samples - 1) * 95 / 100)];
+  *out_p99 = block_samples[(size_t)((total_block_samples - 1) * 99 / 100)];
+
+  free(block_samples);
+  free(round_medians);
+  return 0;
+}
+
+static void fill_fixed_strings(bench_ctx_t *c, const bench_opts_t *o) {
+  /* External .ndb: assume same synthetic naming as this bench's generator (d0000001…, 11.0.0.0, …). */
+  if(o->ndb_file[0]) {
+    snprintf(c->fixed_hit, sizeof(c->fixed_hit), "d%07zu.example.test", (size_t)1);
+    strcpy(c->fixed_miss, "nomatch.example.invalid");
+    strcpy(c->fixed_ip_hit, "11.0.0.0");
+    strcpy(c->fixed_ip_lpm, "10.1.1.2");
+    strcpy(c->fixed_ip_miss, "192.0.2.1");
+    return;
+  }
+  if(o->hosts >= 1 && strcmp(o->profile, "micro") != 0) {
+    snprintf(c->fixed_hit, sizeof(c->fixed_hit), "d%07zu.example.test", (size_t)1);
+  } else {
+    strcpy(c->fixed_hit, "example.com");
+  }
+  strcpy(c->fixed_miss, "nomatch.example.invalid");
+  strcpy(c->fixed_ip_hit, "8.8.8.8");
+  strcpy(c->fixed_ip_lpm, "10.1.2.3");
+  strcpy(c->fixed_ip_miss, "192.0.2.1");
+  if(strcmp(o->profile, "micro") == 0) {
+    strcpy(c->fixed_hit, "example.com");
+    strcpy(c->fixed_ip_hit, "8.8.8.8");
+    strcpy(c->fixed_ip_lpm, "10.1.2.3");
+  }
+}
+
+static void free_pools(bench_ctx_t *c) {
+  size_t i;
+  if(c->pool_host_hit) {
+    for(i = 0; i < c->n_hit; i++)
+      free(c->pool_host_hit[i]);
+    free(c->pool_host_hit);
+  }
+  if(c->pool_host_miss) {
+    for(i = 0; i < c->n_miss; i++)
+      free(c->pool_host_miss[i]);
+    free(c->pool_host_miss);
+  }
+  if(c->pool_ip_hit) {
+    for(i = 0; i < c->n_ip_hit; i++)
+      free(c->pool_ip_hit[i]);
+    free(c->pool_ip_hit);
+  }
+  if(c->pool_ip_lpm) {
+    for(i = 0; i < c->n_ip_lpm; i++)
+      free(c->pool_ip_lpm[i]);
+    free(c->pool_ip_lpm);
+  }
+  if(c->pool_ip_miss) {
+    for(i = 0; i < c->n_ip_miss; i++)
+      free(c->pool_ip_miss[i]);
+    free(c->pool_ip_miss);
+  }
+  memset(c, 0, sizeof(*c));
+}
+
+static int build_pools(bench_ctx_t *c, const bench_opts_t *o) {
+  size_t cap = QUERY_POOL_CAP;
+  size_t step, i;
+  char buf[256];
+  struct in_addr ia;
+
+  c->mode = o->mode;
+  fill_fixed_strings(c, o);
+
+  if(o->mode == MODE_FIXED)
+    return 0;
+
+  if(o->hosts == 0) {
+    c->n_hit = c->n_miss = 0;
+  } else {
+    c->n_hit = c->n_miss = (o->hosts < cap ? o->hosts : cap);
+    c->pool_host_hit = (char **)calloc(c->n_hit, sizeof(char *));
+    c->pool_host_miss = (char **)calloc(c->n_miss, sizeof(char *));
+    if(!c->pool_host_hit || !c->pool_host_miss)
+      return -1;
+    step = o->hosts / (c->n_hit ? c->n_hit : 1);
+    if(step == 0)
+      step = 1;
+    for(i = 0; i < c->n_hit; i++) {
+      size_t id = 1 + i * step;
+      if(id > o->hosts)
+        id = o->hosts;
+      snprintf(buf, sizeof(buf), "d%07zu.example.test", id);
+      c->pool_host_hit[i] = strdup(buf);
+      if(!c->pool_host_hit[i])
+        return -1;
+    }
+    for(i = 0; i < c->n_miss; i++) {
+      snprintf(buf, sizeof(buf), "zzzmiss%04zu.invalid.test", i);
+      c->pool_host_miss[i] = strdup(buf);
+      if(!c->pool_host_miss[i])
+        return -1;
+    }
+  }
+
+  if(o->ipv4_exact == 0)
+    c->n_ip_hit = 0;
+  else {
+    c->n_ip_hit = (o->ipv4_exact < cap ? o->ipv4_exact : cap);
+    c->pool_ip_hit = (char **)calloc(c->n_ip_hit, sizeof(char *));
+    if(!c->pool_ip_hit)
+      return -1;
+    step = o->ipv4_exact / (c->n_ip_hit ? c->n_ip_hit : 1);
+    if(step == 0)
+      step = 1;
+    for(i = 0; i < c->n_ip_hit; i++) {
+      uint32_t a = htonl(0x0b000000u | (uint32_t)((i * step) & 0x00ffffffu));
+      ia.s_addr = a;
+      if(!inet_ntop(AF_INET, &ia, buf, sizeof(buf)))
+        return -1;
+      c->pool_ip_hit[i] = strdup(buf);
+      if(!c->pool_ip_hit[i])
+        return -1;
+    }
+  }
+
+  if(o->ipv4_prefix == 0)
+    c->n_ip_lpm = 0;
+  else {
+    c->n_ip_lpm = (o->ipv4_prefix < cap ? o->ipv4_prefix : cap);
+    c->pool_ip_lpm = (char **)calloc(c->n_ip_lpm, sizeof(char *));
+    if(!c->pool_ip_lpm)
+      return -1;
+    for(i = 0; i < c->n_ip_lpm; i++) {
+      uint32_t oct = (uint32_t)((i % 200) + 1);
+      snprintf(buf, sizeof(buf), "10.%u.1.2", oct);
+      c->pool_ip_lpm[i] = strdup(buf);
+      if(!c->pool_ip_lpm[i])
+        return -1;
+    }
+  }
+
+  c->n_ip_miss = (cap < 256 ? cap : 256);
+  c->pool_ip_miss = (char **)calloc(c->n_ip_miss, sizeof(char *));
+  if(!c->pool_ip_miss)
+    return -1;
+  for(i = 0; i < c->n_ip_miss; i++) {
+    snprintf(buf, sizeof(buf), "192.0.2.%zu", (i % 200) + 1);
+    c->pool_ip_miss[i] = strdup(buf);
+    if(!c->pool_ip_miss[i])
+      return -1;
+  }
+  return 0;
+}
+
+static struct ndpi_detection_module_struct *bench_ndb_load(const char *ndb_path, double *load_ms) {
+  struct ndpi_detection_module_struct *m = ndpi_init_detection_module(NULL);
+  struct timespec t0, t1;
+  if(!m || ndpi_finalize_initialization(m) != 0) {
+    if(m)
+      ndpi_exit_detection_module(m);
+    return NULL;
+  }
+  clock_gettime(CLOCK_MONOTONIC, &t0);
+  if(ndpi_load_category_ndb_file(m, ndb_path, NDPI_CATEGORY_BACKEND_NDB_ONLY) != 0) {
+    ndpi_exit_detection_module(m);
+    return NULL;
+  }
+  clock_gettime(CLOCK_MONOTONIC, &t1);
+  if(load_ms)
+    *load_ms = timespec_diff_sec(&t0, &t1) * 1000.0;
+  return m;
+}
+
+static int legacy_load_mirrored(struct ndpi_detection_module_struct *m, const bench_opts_t *o, double *load_ms) {
+  struct timespec t0, t1;
+  size_t i;
+  char buf[256];
+  struct in_addr ia;
+
+  clock_gettime(CLOCK_MONOTONIC, &t0);
+  /* Historical micro .ndb: same four rules as write_micro_ndb (not dNNNNNNN hostnames). */
+  if(strcmp(o->profile, "micro") == 0 && o->ndb_file[0] == '\0') {
+    if(ndpi_load_hostname_category(m, "example.com", NDPI_PROTOCOL_CATEGORY_WEB, NDPI_PROTOCOL_ACCEPTABLE) != 0)
+      return -1;
+    if(ndpi_load_ip_category(m, "8.8.8.8/32", NDPI_PROTOCOL_CATEGORY_VPN, NULL) != 0)
+      return -1;
+    if(ndpi_load_ip_category(m, "10.0.0.0/8", NDPI_PROTOCOL_CATEGORY_WEB, NULL) != 0)
+      return -1;
+    if(ndpi_load_ip_category(m, "10.1.0.0/16", NDPI_PROTOCOL_CATEGORY_VPN, NULL) != 0)
+      return -1;
+  } else {
+    for(i = 1; i <= o->hosts; i++) {
+      snprintf(buf, sizeof(buf), "d%07zu.example.test", i);
+      if(ndpi_load_hostname_category(m, buf,
+             ((i & 1) ? NDPI_PROTOCOL_CATEGORY_VPN : NDPI_PROTOCOL_CATEGORY_WEB), NDPI_PROTOCOL_ACCEPTABLE) != 0)
+        return -1;
+    }
+    for(i = 0; i < o->ipv4_exact; i++) {
+      uint32_t a = htonl(0x0b000000u | (uint32_t)(i & 0x00ffffffu));
+      ia.s_addr = a;
+      if(!inet_ntop(AF_INET, &ia, buf, sizeof(buf)))
+        return -1;
+      {
+        char line[64];
+        snprintf(line, sizeof(line), "%s/32", buf);
+        if(ndpi_load_ip_category(m, line, NDPI_PROTOCOL_CATEGORY_VPN, NULL) != 0)
+          return -1;
+      }
+    }
+    for(i = 0; i < o->ipv4_prefix; i++) {
+      uint32_t oct = (uint32_t)((i % 200) + 1);
+      snprintf(buf, sizeof(buf), "10.%u.0.0/16", oct);
+      if(ndpi_load_ip_category(m, buf, NDPI_PROTOCOL_CATEGORY_WEB, NULL) != 0)
+        return -1;
+    }
+  }
+  if(ndpi_finalize_initialization(m) != 0)
+    return -1;
+  clock_gettime(CLOCK_MONOTONIC, &t1);
+  if(load_ms)
+    *load_ms = timespec_diff_sec(&t0, &t1) * 1000.0;
+  return 0;
+}
+
+static const char *mode_str(enum bench_mode m) {
+  switch(m) {
+    case MODE_FIXED:
+      return "fixed";
+    case MODE_MIXED_BY_CASE:
+      return "mixed_by_case";
+    case MODE_MIXED_GLOBAL:
+      return "mixed_global";
+  }
+  return "?";
+}
+
+static const char *backend_str(enum bench_backend b) {
+  switch(b) {
+    case BACKEND_NDB:
+      return "ndb";
+    case BACKEND_LEGACY:
+      return "legacy";
+    case BACKEND_BOTH:
+      return "both";
+  }
+  return "?";
+}
+
+static void print_scenario_header(bench_opts_t *o, const char *ndb_path, uint64_t file_bytes, double load_ndb_ms,
+    double load_legacy_ms, size_t rss_before, size_t rss_after_ndb, size_t rss_after_legacy, int legacy_ran) {
+  double fmb = (double)file_bytes / (1024.0 * 1024.0);
+  printf("=== scenario ===\n");
+  printf("os_platform=%s  build=%s\n",
+#ifdef __APPLE__
+         "Darwin",
+#else
+         "Linux",
+#endif
+         GC_LABEL);
+  printf("backend=%s  profile=%s  mode=%s  seed=%u\n", backend_str(o->backend), o->profile, mode_str(o->mode), o->seed);
+  if(o->mode == MODE_MIXED_GLOBAL)
+    printf("NOTE: mixed_global currently reuses per-case pools and is not yet a true cross-API mixed loop.\n");
+  printf("hosts=%zu  ipv4_exact=%zu  ipv4_prefix=%zu  domain_buckets=%zu  lpm=%s\n", o->hosts, o->ipv4_exact,
+      o->ipv4_prefix, o->domain_buckets, o->lpm_realistic ? "realistic" : "clean");
+  if(o->ndb_file[0] && strcmp(ndb_path, o->ndb_file) == 0)
+    printf("NOTE: host/ipv4 counts are CLI metadata only; external .ndb is not introspected.\n");
+  printf("ndb_path=%s\n", ndb_path);
+  printf("ndb_file_size_bytes=%llu  ndb_file_size_mb=%.3f\n", (unsigned long long)file_bytes, fmb);
+  if(o->hosts + o->ipv4_exact + o->ipv4_prefix > 0 && file_bytes > 0) {
+    double bh = o->hosts ? (double)file_bytes / (double)o->hosts : 0.0;
+    double br = (o->ipv4_exact + o->ipv4_prefix) ? (double)file_bytes / (double)(o->ipv4_exact + o->ipv4_prefix) : 0.0;
+    printf("bytes_per_host=%.3f  bytes_per_ipv4_rule=%.3f (file_size ratio; informational)\n", bh, br);
+  }
+  printf("load_ndb_ms=%.3f\n", load_ndb_ms);
+  if(legacy_ran)
+    printf("load_legacy_ms=%.3f\n", load_legacy_ms);
+  printf("rss_before_bytes=%zu  rss_after_ndb_bytes=%zu", rss_before, rss_after_ndb);
+  if(legacy_ran)
+    printf("  rss_after_legacy_bytes=%zu", rss_after_legacy);
+  printf("\n");
+  if(o->warn_ipv4_linear)
+    printf("WARNING: large ipv4_entry_count: .ndb IPv4 lookup is O(N) linear scan — interpret timings accordingly.\n");
+  if(o->warn_unfair_compare && o->unfair_reason[0])
+    printf("WARNING: comparison may be unfair: %s\n", o->unfair_reason);
+  if(o->warn_legacy_fallback)
+    printf("WARNING: legacy build failed or skipped; fell back to ndb-only with warning.\n");
+  printf("================\n\n");
+}
+
+static void run_case(const char *tag, const char *case_name, struct ndpi_detection_module_struct *m, bench_body_fn body,
+    bench_ctx_t *ctx, const bench_opts_t *o, size_t block_ops, int blocks_per_round) {
+  double med, p50, p95, p99;
+  size_t bo;
+  double sec_total;
+  double ops_per_sec;
+  if(median_ns_per_op_blocks(body, ctx, m, o->warm, o->iters, o->rounds, blocks_per_round, &med, &p50, &p95, &p99, &bo) !=
+      0) {
+    printf("%-12s %-28s error\n", tag, case_name);
+    return;
+  }
+  (void)bo;
+  sec_total = (double)o->iters * (med / 1e9); /* approx using median ns/op */
+  ops_per_sec = sec_total > 0 ? (double)o->iters / sec_total : 0;
+  printf("%-12s %-28s med_ns/op=%.2f  block_ops=%zu  blocks_per_round=%d  block_p50=%.2f p95=%.2f p99=%.2f  "
+         "~ops_per_sec=%.0f\n",
+      tag, case_name, med, block_ops, blocks_per_round, p50, p95, p99, ops_per_sec);
+}
+
+int main(int argc, char **argv) {
+  bench_opts_t opt;
+  char tmpl[] = "/tmp/ndpi_bench_ndbXXXXXX";
+  int fd = -1;
+  char ndb_work[4096];
+  uint64_t file_bytes = 0;
+  struct stat st;
+  double load_ndb_ms = 0, load_legacy_ms = 0;
+  size_t rss_b = 0, rss_ndb = 0, rss_leg = 0, rss_after_gen = 0;
+  int rss_ok;
+  int legacy_ran = 0;
+  int use_temp_file = 1;
+  struct ndpi_detection_module_struct *ndb_m = NULL, *leg_m = NULL;
+  bench_ctx_t ctx;
+  int blocks_pr;
+  size_t pool_used = 0;
+  size_t lookup_ops_total;
+
+  opts_defaults(&opt);
+  if(parse_args(argc, argv, &opt) != 0)
+    return 1;
+  /* profile_apply runs from parse_args only when --profile is set; defaults already in opts_defaults */
+
+  if(opt.warm == 0) {
+    opt.warm = opt.iters / 50;
+    if(opt.warm < 5000)
+      opt.warm = 5000;
+  }
+  blocks_pr = opt.blocks_per_round;
+  if((size_t)blocks_pr > opt.iters / 2)
+    blocks_pr = (int)(opt.iters / 2);
+  if(blocks_pr < 2)
+    blocks_pr = 2;
+
+  rss_ok = rss_bytes_self(&rss_b) == 0;
+
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.mode = opt.mode;
+  fill_fixed_strings(&ctx, &opt);
+  if(opt.mode != MODE_FIXED) {
+    if(build_pools(&ctx, &opt) != 0) {
+      fprintf(stderr, "pool build failed\n");
+      return 1;
+    }
+  }
+
+  ndb_work[0] = '\0';
+
+  if(opt.backend == BACKEND_LEGACY) {
+    use_temp_file = 0;
+    file_bytes = 0;
+    goto after_generate;
+  }
+
+  if(opt.only_generate) {
+    int wr;
+    int is_default_micro = (strcmp(opt.profile, "micro") == 0 && opt.hosts == 1 && opt.ipv4_exact == 1 && opt.ipv4_prefix == 2 &&
+                            opt.domain_buckets == 2);
+    if(is_default_micro)
+      wr = write_micro_ndb(opt.out_file);
+    else
+      wr = write_synthetic_ndb(opt.out_file, &opt, &pool_used);
+    if(wr != 0) {
+      fprintf(stderr, "generation failed\n");
+      free_pools(&ctx);
+      return 1;
+    }
+    printf("generated: %s\n", opt.out_file);
+    free_pools(&ctx);
+    return 0;
+  }
+
+  /* ---- resolve path + generate (precedence: --ndb-file) ---- */
+  if(opt.ndb_file[0]) {
+    strncpy(ndb_work, opt.ndb_file, sizeof(ndb_work) - 1);
+    ndb_work[sizeof(ndb_work) - 1] = '\0';
+    use_temp_file = 0;
+  } else if(opt.skip_build) {
+    fprintf(stderr, "error: --skip-build requires --ndb-file\n");
+    free_pools(&ctx);
+    return 1;
+  } else {
+    if(opt.out_file[0]) {
+      strncpy(ndb_work, opt.out_file, sizeof(ndb_work) - 1);
+      ndb_work[sizeof(ndb_work) - 1] = '\0';
+      use_temp_file = 0;
+    } else {
+      fd = mkstemp(tmpl);
+      if(fd < 0) {
+        perror("mkstemp");
+        free_pools(&ctx);
+        return 1;
+      }
+      close(fd);
+      strncpy(ndb_work, tmpl, sizeof(ndb_work) - 1);
+      ndb_work[sizeof(ndb_work) - 1] = '\0';
+      use_temp_file = 1;
+    }
+    {
+      int is_default_micro = (strcmp(opt.profile, "micro") == 0 && opt.hosts == 1 && opt.ipv4_exact == 1 && opt.ipv4_prefix == 2 &&
+                              opt.domain_buckets == 2);
+      if(is_default_micro) {
+        if(write_micro_ndb(ndb_work) != 0) {
+          fprintf(stderr, "write_micro_ndb failed\n");
+          if(use_temp_file)
+            unlink(ndb_work);
+          free_pools(&ctx);
+          return 1;
+        }
+      } else {
+        if(write_synthetic_ndb(ndb_work, &opt, &pool_used) != 0) {
+          fprintf(stderr, "write_synthetic_ndb failed\n");
+          if(use_temp_file)
+            unlink(ndb_work);
+          free_pools(&ctx);
+          return 1;
+        }
+      }
+    }
+  }
+
+  if(stat(ndb_work, &st) != 0) {
+    perror("stat ndb");
+    free_pools(&ctx);
+    return 1;
+  }
+  file_bytes = (uint64_t)st.st_size;
+  (void)rss_bytes_self(&rss_after_gen);
+
+after_generate:
+
+  if(opt.ipv4_exact + opt.ipv4_prefix > 100000u)
+    opt.warn_ipv4_linear = 1;
+
+  if(opt.ndb_file[0] && (opt.backend == BACKEND_BOTH || opt.backend == BACKEND_LEGACY)) {
+    opt.warn_unfair_compare = 1;
+    snprintf(opt.unfair_reason, sizeof(opt.unfair_reason), "legacy not mirrored for external --ndb-file");
+    opt.backend = BACKEND_NDB;
+  }
+
+  /* ---- load .ndb (skipped for legacy-only) ---- */
+  if(opt.backend != BACKEND_LEGACY) {
+    ndb_m = bench_ndb_load(ndb_work, &load_ndb_ms);
+    if(!ndb_m) {
+      fprintf(stderr, "ndpi_load_category_ndb_file failed\n");
+      if(use_temp_file)
+        unlink(ndb_work);
+      free_pools(&ctx);
+      return 1;
+    }
+    (void)rss_bytes_self(&rss_ndb);
+  } else {
+    load_ndb_ms = 0.0;
+    rss_ndb = rss_b;
+  }
+
+  /* ---- legacy mirror ---- */
+  {
+    int skip_legacy = 0;
+    size_t ipv4_rules = opt.ipv4_exact + opt.ipv4_prefix;
+    if(opt.backend == BACKEND_LEGACY || opt.backend == BACKEND_BOTH) {
+      if(!opt.force_legacy) {
+        int over_hosts = opt.hosts > (size_t)LEGACY_MAX_HOSTS_DEFAULT;
+        int over_v4 = ipv4_rules > (size_t)LEGACY_MAX_IPV4_RULES_DEFAULT;
+        if(over_hosts || over_v4) {
+          skip_legacy = 1;
+          if(opt.backend == BACKEND_LEGACY) {
+            if(over_hosts && over_v4) {
+              fprintf(stderr,
+                  "error: --backend legacy: default safety limits exceeded (max %u hosts, max %u total IPv4 "
+                  "rules). Use --force-legacy, or --backend ndb|both, or lower --hosts / --ipv4-* counts.\n",
+                  (unsigned)LEGACY_MAX_HOSTS_DEFAULT, (unsigned)LEGACY_MAX_IPV4_RULES_DEFAULT);
+            } else if(over_hosts) {
+              fprintf(stderr,
+                  "error: --backend legacy: default safety limit exceeded (max %u hosts). Use --force-legacy, "
+                  "or --backend ndb|both, or lower --hosts.\n",
+                  (unsigned)LEGACY_MAX_HOSTS_DEFAULT);
+            } else {
+              fprintf(stderr,
+                  "error: --backend legacy: default safety limit exceeded (max %u total IPv4 rules=exact+"
+                  "prefix). Use --force-legacy, or --backend ndb|both, or lower --ipv4-*.\n",
+                  (unsigned)LEGACY_MAX_IPV4_RULES_DEFAULT);
+            }
+            if(ndb_m) {
+              ndpi_unload_category_ndb(ndb_m);
+              ndpi_exit_detection_module(ndb_m);
+            }
+            if(use_temp_file && ndb_work[0])
+              unlink(ndb_work);
+            free_pools(&ctx);
+            return 1;
+          }
+          opt.warn_unfair_compare = 1;
+          if(over_hosts && over_v4) {
+            snprintf(
+                opt.unfair_reason, sizeof(opt.unfair_reason),
+                "legacy skipped (exceeds default limits): hosts %zu > %u and ipv4 rules %zu > %u (use `--force-legacy`)",
+                opt.hosts, (unsigned)LEGACY_MAX_HOSTS_DEFAULT, ipv4_rules, (unsigned)LEGACY_MAX_IPV4_RULES_DEFAULT);
+          } else if(over_hosts) {
+            snprintf(opt.unfair_reason, sizeof(opt.unfair_reason),
+                "legacy skipped (exceeds default limits): hosts %zu > %u (use `--force-legacy`)", opt.hosts,
+                (unsigned)LEGACY_MAX_HOSTS_DEFAULT);
+          } else {
+            snprintf(opt.unfair_reason, sizeof(opt.unfair_reason),
+                "legacy skipped (exceeds default limits): ipv4 rules %zu > %u (use `--force-legacy`)", ipv4_rules,
+                (unsigned)LEGACY_MAX_IPV4_RULES_DEFAULT);
+          }
+        }
+      }
+      if(!skip_legacy) {
+        leg_m = ndpi_init_detection_module(NULL);
+        if(!leg_m) {
+          opt.warn_legacy_fallback = 1;
+        } else {
+          if(legacy_load_mirrored(leg_m, &opt, &load_legacy_ms) != 0) {
+            opt.warn_legacy_fallback = 1;
+	    if(leg_m)
+              ndpi_exit_detection_module(leg_m);
+            leg_m = NULL;
+          } else {
+            legacy_ran = 1;
+            (void)rss_bytes_self(&rss_leg);
+          }
+        }
+      }
+    }
+  }
+
+  print_scenario_header(&opt, ndb_work, file_bytes, load_ndb_ms, load_legacy_ms, rss_ok ? rss_b : 0, rss_ok ? rss_ndb : 0,
+      rss_ok ? rss_leg : 0, legacy_ran);
+  printf("generator_rss_sample_after_file_bytes=%zu (best-effort RSS after .ndb on disk)\n", rss_after_gen);
+
+  if(opt.only_load) {
+    if(ndb_m) {
+      ndpi_unload_category_ndb(ndb_m);
+      ndpi_exit_detection_module(ndb_m);
+    }
+    if(leg_m)
+      ndpi_exit_detection_module(leg_m);
+    if(use_temp_file && ndb_work[0])
+      unlink(ndb_work);
+    free_pools(&ctx);
+    return 0;
+  }
+
+  printf("%-12s %-28s (median ns/op + block percentiles; see --help)\n", "backend", "case");
+  printf("%-12s %-28s %s\n", "-------", "----", "----------------------------------------");
+
+#define RESET_CTX_INDICES()                                                                                            \
+  do {                                                                                                                 \
+    ctx.ix_hit = ctx.ix_miss = ctx.ix_ip_hit = ctx.ix_ip_lpm = ctx.ix_ip_miss = ctx.glob_ix = 0;                       \
+  } while(0)
+
+  lookup_ops_total = 0;
+  if(ndb_m) {
+    RESET_CTX_INDICES();
+    run_case(".ndb", "hostname_hit", ndb_m, body_host_hit, &ctx, &opt, (size_t)(opt.iters / (size_t)blocks_pr), blocks_pr);
+    lookup_ops_total += opt.iters;
+    RESET_CTX_INDICES();
+    run_case(".ndb", "hostname_miss", ndb_m, body_host_miss, &ctx, &opt, (size_t)(opt.iters / (size_t)blocks_pr), blocks_pr);
+    lookup_ops_total += opt.iters;
+    RESET_CTX_INDICES();
+    run_case(".ndb", "ipv4_hit", ndb_m, body_ip_hit, &ctx, &opt, (size_t)(opt.iters / (size_t)blocks_pr), blocks_pr);
+    lookup_ops_total += opt.iters;
+    RESET_CTX_INDICES();
+    run_case(".ndb", "ipv4_lpm", ndb_m, body_ip_lpm, &ctx, &opt, (size_t)(opt.iters / (size_t)blocks_pr), blocks_pr);
+    lookup_ops_total += opt.iters;
+    RESET_CTX_INDICES();
+    run_case(".ndb", "ipv4_miss", ndb_m, body_ip_miss, &ctx, &opt, (size_t)(opt.iters / (size_t)blocks_pr), blocks_pr);
+    lookup_ops_total += opt.iters;
+  }
+  if(leg_m) {
+    RESET_CTX_INDICES();
+    run_case("legacy", "hostname_hit", leg_m, body_host_hit, &ctx, &opt, (size_t)(opt.iters / (size_t)blocks_pr), blocks_pr);
+    lookup_ops_total += opt.iters;
+    RESET_CTX_INDICES();
+    run_case("legacy", "hostname_miss", leg_m, body_host_miss, &ctx, &opt, (size_t)(opt.iters / (size_t)blocks_pr), blocks_pr);
+    lookup_ops_total += opt.iters;
+    RESET_CTX_INDICES();
+    run_case("legacy", "ipv4_hit", leg_m, body_ip_hit, &ctx, &opt, (size_t)(opt.iters / (size_t)blocks_pr), blocks_pr);
+    lookup_ops_total += opt.iters;
+    RESET_CTX_INDICES();
+    run_case("legacy", "ipv4_lpm", leg_m, body_ip_lpm, &ctx, &opt, (size_t)(opt.iters / (size_t)blocks_pr), blocks_pr);
+    lookup_ops_total += opt.iters;
+    RESET_CTX_INDICES();
+    run_case("legacy", "ipv4_miss", leg_m, body_ip_miss, &ctx, &opt, (size_t)(opt.iters / (size_t)blocks_pr), blocks_pr);
+    lookup_ops_total += opt.iters;
+  }
+
+#undef RESET_CTX_INDICES
+
+  printf("\nlookup_ops_total=%zu  (5 cases × iters per backend row; see per-row ~ops_per_sec)\n", lookup_ops_total);
+  printf("\nNote: IPv6 legacy vs .ndb not compared in this bench.\n");
+
+  if(ndb_m) {
+    ndpi_unload_category_ndb(ndb_m);
+    ndpi_exit_detection_module(ndb_m);
+  }
+  if(leg_m)
+    ndpi_exit_detection_module(leg_m);
+  if(use_temp_file && ndb_work[0])
+    unlink(ndb_work);
+  free_pools(&ctx);
+  return 0;
+}
+
+#endif

--- a/tests/unit/Makefile.in
+++ b/tests/unit/Makefile.in
@@ -18,7 +18,7 @@ AM_CFLAGS=-fPIC -DPIC
 else
 AM_CFLAGS=
 endif
-AM_CFLAGS+=-I$(SRCHOME)/include -I$(top_builddir)/src/include @NDPI_CFLAGS@ @JSONC_CFLAGS@ @PCAP_INC@ @ADDITIONAL_INCS@
+AM_CFLAGS+=-I$(SRCHOME)/include -I$(SRCHOME)/lib -I$(top_builddir)/src/include @NDPI_CFLAGS@ @JSONC_CFLAGS@ @PCAP_INC@ @ADDITIONAL_INCS@
 AM_LDFLAGS=@NDPI_LDFLAGS@
 ENABLE_STATIC        = @enable_static@
 ifeq ($(ENABLE_STATIC),yes)

--- a/tests/unit/unit.c
+++ b/tests/unit/unit.c
@@ -41,7 +41,6 @@
 #include <search.h>
 #include <pcap.h>
 #include <signal.h>
-#include <pthread.h>
 #include <assert.h>
 #include <math.h>
 #include <sys/stat.h>
@@ -51,6 +50,8 @@
 #include "ndpi_config.h"
 #include "ndpi_api.h"
 #include "ndpi_define.h"
+#include "ndpi_categories_bin.h"
+#include "ndpi_category_host_norm.h"
 
 #include "json.h" /* JSON-C */
 
@@ -375,6 +376,198 @@ int serializeProtoUnitTest(void)
 
 /* *********************************************** */
 
+#ifndef WIN32
+static uint64_t ut_fnv1a64(const char *s, size_t len) {
+  uint64_t h = 1469598103934665603ULL;
+  size_t i;
+
+  for(i = 0; i < len; ++i) {
+    h ^= (unsigned char)s[i];
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
+
+static int category_ndb_smoke_unit(void) {
+  char path[] = "/tmp/ndpi_ut_ndbXXXXXX";
+  int fd;
+  FILE *fp;
+  ndb_header_disk_t hdr;
+  ndb_category_disk_t cat;
+  ndb_bucket_disk_t bucks[2];
+  ndb_entry_disk_t ent;
+  const char *dom = "example.com";
+  size_t dom_len = strlen(dom);
+  const char pool[] = "x\0example.com\0";
+  const size_t pool_len = sizeof(pool) - 1;
+  ndb_ipv4_entry_disk_t v4[3];
+  ndpi_protocol_category_t cat_out;
+  ndpi_protocol_breed_t breed;
+  uint64_t off;
+  uint32_t addr_8888 = htonl(0x08080808);
+  uint32_t addr_10_8 = htonl(0x0a000000);
+  uint32_t addr_10_1_16 = htonl(0x0a010000);
+
+  if(!ndpi_category_hostname_labels_valid_ascii(dom))
+    return -1;
+  if(ndpi_category_hostname_labels_valid_ascii("a..b"))
+    return -1;
+
+  fd = mkstemp(path);
+  if(fd < 0) {
+    perror("mkstemp");
+    return -1;
+  }
+  fp = fdopen(fd, "wb");
+  if(!fp) {
+    close(fd);
+    return -1;
+  }
+
+  memset(&hdr, 0, sizeof(hdr));
+  memcpy(hdr.magic, NDB_MAGIC, 4);
+  hdr.format_version = NDB_FORMAT_VERSION;
+  hdr.category_count = 1;
+  hdr.domain_entry_count = 1;
+  hdr.domain_bucket_count = 2;
+  hdr.string_pool_size = pool_len;
+  hdr.ipv4_entry_count = 3;
+  hdr.ipv6_entry_count = 0;
+
+  off = sizeof(hdr);
+  hdr.categories_off = off;
+  off += sizeof(cat);
+  hdr.domain_buckets_off = off;
+  off += sizeof(bucks);
+  hdr.domain_entries_off = off;
+  off += sizeof(ent);
+  hdr.string_pool_off = off;
+  off += pool_len;
+  hdr.ipv4_entries_off = off;
+  off += sizeof(v4);
+  hdr.ipv6_entries_off = off;
+  hdr.file_size = off;
+
+  cat.id = NDPI_PROTOCOL_CATEGORY_WEB;
+  cat.name_off = 0;
+
+  bucks[0].first = 0;
+  bucks[0].count = 1;
+  bucks[1].first = 0;
+  bucks[1].count = 0;
+
+  ent.hash = ut_fnv1a64(dom, dom_len);
+  ent.domain_off = 2;
+  ent.domain_len = (uint16_t)dom_len;
+  ent.flags = 0;
+  ent.category_id = NDPI_PROTOCOL_CATEGORY_WEB;
+
+  v4[0].network_be = addr_10_8;
+  v4[0].prefix_len = 8;
+  v4[0].flags = 0;
+  v4[0].reserved0 = 0;
+  v4[0].category_id = NDPI_PROTOCOL_CATEGORY_WEB;
+
+  v4[1].network_be = addr_10_1_16;
+  v4[1].prefix_len = 16;
+  v4[1].flags = 0;
+  v4[1].reserved0 = 0;
+  v4[1].category_id = NDPI_PROTOCOL_CATEGORY_VPN;
+
+  v4[2].network_be = addr_8888;
+  v4[2].prefix_len = 32;
+  v4[2].flags = 0;
+  v4[2].reserved0 = 0;
+  v4[2].category_id = NDPI_PROTOCOL_CATEGORY_VPN;
+
+  if(fwrite(&hdr, 1, sizeof(hdr), fp) != sizeof(hdr) ||
+      fwrite(&cat, 1, sizeof(cat), fp) != sizeof(cat) ||
+      fwrite(bucks, 1, sizeof(bucks), fp) != sizeof(bucks) ||
+      fwrite(&ent, 1, sizeof(ent), fp) != sizeof(ent) ||
+      fwrite(pool, 1, pool_len, fp) != pool_len ||
+      fwrite(v4, 1, sizeof(v4), fp) != sizeof(v4)) {
+    fclose(fp);
+    unlink(path);
+    return -1;
+  }
+  fclose(fp);
+
+  if(ndpi_load_category_ndb_file(ndpi_info_mod, path, NDPI_CATEGORY_BACKEND_NDB_ONLY) != 0) {
+    unlink(path);
+    return -1;
+  }
+
+  {
+    char hostbuf[] = "example.com";
+    if(ndpi_match_custom_category(ndpi_info_mod, hostbuf, (u_int)strlen(hostbuf), &cat_out, &breed) != 0 ||
+       cat_out != NDPI_PROTOCOL_CATEGORY_WEB) {
+      ndpi_unload_category_ndb(ndpi_info_mod);
+      unlink(path);
+      return -1;
+    }
+  }
+
+  {
+    char ipbuf[] = "8.8.8.8";
+    if(ndpi_get_custom_category_match(ndpi_info_mod, ipbuf, (u_int)strlen(ipbuf), &cat_out, &breed) != 0 ||
+       cat_out != NDPI_PROTOCOL_CATEGORY_VPN) {
+      ndpi_unload_category_ndb(ndpi_info_mod);
+      unlink(path);
+      return -1;
+    }
+  }
+
+  /* Longest-prefix: 10.0.0.0/8 (WEB) vs 10.1.0.0/16 (VPN); more specific row must win. */
+  {
+    char ipbuf[] = "10.1.2.3";
+    if(ndpi_get_custom_category_match(ndpi_info_mod, ipbuf, (u_int)strlen(ipbuf), &cat_out, &breed) != 0 ||
+       cat_out != NDPI_PROTOCOL_CATEGORY_VPN) {
+      ndpi_unload_category_ndb(ndpi_info_mod);
+      unlink(path);
+      return -1;
+    }
+  }
+  {
+    char ipbuf[] = "10.9.9.9";
+    if(ndpi_get_custom_category_match(ndpi_info_mod, ipbuf, (u_int)strlen(ipbuf), &cat_out, &breed) != 0 ||
+       cat_out != NDPI_PROTOCOL_CATEGORY_WEB) {
+      ndpi_unload_category_ndb(ndpi_info_mod);
+      unlink(path);
+      return -1;
+    }
+  }
+
+  {
+    char miss[] = "nomatch.example";
+    if(ndpi_match_custom_category(ndpi_info_mod, miss, (u_int)strlen(miss), &cat_out, &breed) != -1) {
+      ndpi_unload_category_ndb(ndpi_info_mod);
+      unlink(path);
+      return -1;
+    }
+  }
+
+  ndpi_unload_category_ndb(ndpi_info_mod);
+
+  if(ndpi_load_category_ndb_file(ndpi_info_mod, path, NDPI_CATEGORY_BACKEND_HYBRID) != 0) {
+    unlink(path);
+    return -1;
+  }
+  {
+    char miss6[] = "2001:db8::1";
+    if(ndpi_get_custom_category_match(ndpi_info_mod, miss6, (u_int)strlen(miss6), &cat_out, &breed) != -1) {
+      ndpi_unload_category_ndb(ndpi_info_mod);
+      unlink(path);
+      return -1;
+    }
+  }
+  ndpi_unload_category_ndb(ndpi_info_mod);
+  unlink(path);
+  return 0;
+}
+#endif /* !WIN32 */
+
+/* *********************************************** */
+
 int main(int argc, char **argv) {
 #ifndef WIN32
   int c;
@@ -418,6 +611,14 @@ int main(int argc, char **argv) {
   /* Tests */
   if (serializerUnitTest() != 0) return -1;
   if (serializeProtoUnitTest() != 0) return -1;
+#ifndef WIN32
+  if (category_ndb_smoke_unit() != 0) {
+    printf("category_ndb_smoke_unit: FAILED\n");
+    return -1;
+  }
+  if (verbose)
+    printf("%30s                      OK\n", "category_ndb_smoke_unit");
+#endif
 
   return 0;
 }

--- a/windows/nDPI.vcxproj
+++ b/windows/nDPI.vcxproj
@@ -126,6 +126,9 @@
     <ClCompile Include="..\example\utests.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\example\ndpiReader_category_ndb_reload.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\src\lib\ndpi_analyze.c" />
     <ClCompile Include="..\src\lib\ndpi_bitmap.c" />
     <ClCompile Include="..\src\lib\ndpi_classify.c" />
@@ -133,6 +136,8 @@
     <ClCompile Include="..\src\lib\ndpi_geoip.c" />
     <ClCompile Include="..\src\lib\ndpi_main.c" />
     <ClCompile Include="..\src\lib\ndpi_cache.c" />
+    <ClCompile Include="..\src\lib\ndpi_category_host_norm.c" />
+    <ClCompile Include="..\src\lib\ndpi_category_ndb.c" />
     <ClCompile Include="..\src\lib\ndpi_config.c" />
     <ClCompile Include="..\src\lib\ndpi_filter.c" />
     <ClCompile Include="..\src\lib\ndpi_memory.c" />
@@ -431,6 +436,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\example\reader_util.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\example\ndpiReader_category_ndb_reload.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </ClInclude>
     <ClInclude Include="..\src\include\ndpi_encryption.h" />

--- a/windows/nDPI.vcxproj.filters
+++ b/windows/nDPI.vcxproj.filters
@@ -166,6 +166,8 @@
     <ClCompile Include="..\src\lib\ndpi_community_id.c" />
     <ClCompile Include="..\src\lib\ndpi_geoip.c" />
     <ClCompile Include="..\src\lib\ndpi_main.c" />
+    <ClCompile Include="..\src\lib\ndpi_category_host_norm.c" />
+    <ClCompile Include="..\src\lib\ndpi_category_ndb.c" />
     <ClCompile Include="..\src\lib\ndpi_filter.c" />
     <ClCompile Include="..\src\lib\ndpi_memory.c" />
     <ClCompile Include="..\src\lib\ndpi_serializer.c" />
@@ -285,6 +287,7 @@
     <ClCompile Include="..\example\ndpiReader.c" />
     <ClCompile Include="..\example\reader_util.c" />
     <ClCompile Include="..\example\utests.c" />
+    <ClCompile Include="..\example\ndpiReader_category_ndb_reload.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\include\ndpi_includes.h" />
@@ -342,6 +345,7 @@
     <ClInclude Include="src\ndpi_config.h" />
     <ClInclude Include="src\ndpi_define.h" />
     <ClInclude Include="..\example\reader_util.h" />
+    <ClInclude Include="..\example\ndpiReader_category_ndb_reload.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\src\lib\ndpi_content_match.c.inc" />


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [ X ] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ X ] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [ X ] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [3151](https://github.com/ntop/nDPI/issues/3151):


Describe changes:

Introduce a compiled .ndb backend (mmap) for external custom category matching, with LEGACY / NDB_ONLY / HYBRID modes, while keeping the existing -G / Aho-Corasick list path unchanged.

Adds ndpi_load_category_ndb_file() / ndpi_unload_category_ndb(), ndpiReader --category-ndb and --category-ndb-reload-interval, a polling-based hot-reload helper, offline builder ndpi_gen_categories_bin, shared hostname normalization (generator + runtime), and on-disk layout in ndpi_categories_bin.h (domains plus IPv4/IPv6 prefix entries).

The generator writes the database atomically (temporary file + fsync + rename) so ndpiReader can reload a new valid file without restart.
