### PR TITLE
ci: bump actions/checkout v4 to v5

### DIFF
--- a/.github/workflows/build-msbuild.yml
+++ b/.github/workflows/build-msbuild.yml
@@ -19,7 +19,7 @@ jobs:
         os: ["windows-latest", "windows-11-arm"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: almalinux:8
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Alma Linux Prerequisites
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       CFLAGS: -Werror
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python 3.9
@@ -48,7 +48,7 @@ jobs:
     name: Test Utils (ubuntu-latest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Ubuntu Prerequisites
@@ -114,7 +114,7 @@ jobs:
             maxminddb: "--with-maxminddb"
             msan: ""
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install Ubuntu Prerequisites
@@ -218,7 +218,7 @@ jobs:
       matrix:
         os: ["windows-latest"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install Windows msys2 prerequisites
@@ -248,7 +248,7 @@ jobs:
     env:
       CFLAGS: -Werror -g -O2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Prerequisites

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup multiarch/qemu-user-static
         run: |
           docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Display qemu specified architecture (armhf - little endian)

--- a/.github/workflows/build_freebsd.yml
+++ b/.github/workflows/build_freebsd.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       CFLAGS: -Werror -DNDPI_EXTENDED_SANITY_CHECKS -g -O2
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Test in FreeBSD
       id: test
       uses: vmactions/freebsd-vm@1885b78bae4c4c4b331b4b0461d23cc14cc72387 #v1.2.9

--- a/.github/workflows/build_masan.yml
+++ b/.github/workflows/build_masan.yml
@@ -24,7 +24,7 @@ jobs:
       # Idea to have significant faster tests while pushing/merging: test all pcaps only on schedule runs; otherwise tests only the pcaps updated/added recently
       NDPI_TEST_ONLY_RECENTLY_UPDATED_PCAPS: ${{ (github.event_name == 'schedule') && '0' || '1' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Ubuntu Prerequisites

--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       CFLAGS: -Werror
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Ubuntu Prerequisites
@@ -42,7 +42,7 @@ jobs:
     name: Documentation (ubuntu-latest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python 3.9
@@ -75,7 +75,7 @@ jobs:
     env:
       CFLAGS: -Werror
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Ubuntu Prerequisites
@@ -114,7 +114,7 @@ jobs:
     env:
       CFLAGS: -Werror
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Ubuntu Prerequisites
@@ -141,7 +141,7 @@ jobs:
     env:
       CFLAGS: -Werror
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Ubuntu Prerequisites
@@ -175,7 +175,7 @@ jobs:
     env:
       CFLAGS: -Werror
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Ubuntu Prerequisites
@@ -208,7 +208,7 @@ jobs:
         os: ["ubuntu-22.04", "ubuntu-24.04", "macos-15-intel", "macOS-14", "macOS-15", "macOS-26", "ubuntu-22.04-arm", "ubuntu-24.04-arm"]
         gcrypt: ["", "--with-local-libgcrypt"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Ubuntu Prerequisites
@@ -245,7 +245,7 @@ jobs:
       matrix:
         os: ["windows-latest"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install Windows msys2 prerequisites
@@ -288,7 +288,7 @@ jobs:
             ar: "llvm-ar-18"
             ranlib: "llvm-ranlib-18"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install Ubuntu Prerequisites
@@ -313,7 +313,7 @@ jobs:
     env:
       CFLAGS: -Werror -DNDPI_EXTENDED_SANITY_CHECKS -g -O2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install Ubuntu Prerequisites

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
         language: [ 'cpp', 'python' ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Ubuntu Prerequisites


### PR DESCRIPTION
Avoid GitHub Actions deprecation warnings for Node 20-based actions; checkout v5 runs on the Node 24 runtime.

Please sign (check) the below before submitting the Pull Request:

- [ X ] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ X ] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [ X ] I have updated the documentation (in doc/) to reflect the changes made (if applicable)


Describe changes:

ci: bump actions/checkout v4 to v5
    Avoid GitHub Actions deprecation warnings for Node 20-based actions;
    checkout v5 runs on the Node 24 runtime.
