### PR TITLE
fix(tests/unit): fix MinGW build in serializeProtoUnitTest

### DIFF
--- a/tests/unit/unit.c
+++ b/tests/unit/unit.c
@@ -362,8 +362,8 @@ int serializeProtoUnitTest(void)
         printf("%s: ERROR: expected CSV str: \"%s\"\n", __func__, expected_csv_buf_str);
         printf("%s: ERROR: got CSV str.....: \"%.*s\"\n", __func__, (int)buffer_len, buffer);
       }
-    }
 #endif
+    }
 
     ndpi_term_serializer(&serializer);
   }


### PR DESCRIPTION
The closing brace for the CSV format branch was inside #ifndef WIN32, so the preprocessor removed it on Windows and broke the brace structure, causing bogus errors around main() with -Werror.

Please sign (check) the below before submitting the Pull Request:

- [ X ] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ X ] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [ X ] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [3160](https://github.com/ntop/nDPI/issues/3160):


Describe changes:

fix(tests/unit): fix MinGW build in serializeProtoUnitTest

    The closing brace for the CSV format branch was inside #ifndef WIN32, so
    the preprocessor removed it on Windows and broke the brace structure,
    causing bogus errors around main() with -Werror.

