### PR TITLE
IPSec: fix infinite loop in metadata extraction

### DIFF
--- a/src/lib/protocols/ipsec.c
+++ b/src/lib/protocols/ipsec.c
@@ -80,7 +80,7 @@ static void ikev2_parse_transforms(const u_int8_t *payload, u_int16_t xform_star
 
     /* Scan attributes inside this transform (key length, etc.) */
     u_int16_t key_bits = 0;
-    u_int16_t attr_off = off + 8;
+    u_int32_t attr_off = off + 8;
     u_int16_t attr_end = off + xform_len;
 
     while (attr_off + 4 <= attr_end) {


### PR DESCRIPTION
```
/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_ndpi_8ec636d63c380d6e8784fdc4e3a5a5ea467b122e/revisions/fuzz_ndpi_reader_pl7m_simplest: Running 1 inputs 100 time(s) each.
Running: /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/timeout-bdc73040de594626d68f86ad706399c15afb5e89
ALARM: working on the last Unit for 61 seconds
       and the timeout value is 60 (use -timeout=N to change)
==249== ERROR: libFuzzer: timeout after 61 seconds
    #0 0x5732e0833364 in __sanitizer_print_stack_trace /src/llvm-project/compiler-rt/lib/ubsan/ubsan_diag_standalone.cpp:31:3
    #1 0x5732e07a78e8 in fuzzer::PrintStackTrace() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerUtil.cpp:210:5
    #2 0x5732e078a3bd in fuzzer::Fuzzer::AlarmCallback() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:304:5
    #3 0x7f16d999b32f in libc.so.6
    #4 0x5732e091c173 in ikev2_parse_transforms ndpi/src/lib/protocols/ipsec.c:86:5
    #5 0x5732e091c173 in ndpi_dissect_ikev2_sa_init ndpi/src/lib/protocols/ipsec.c:237:11
    #6 0x5732e091bafc in ndpi_search_ipsec ndpi/src/lib/protocols/ipsec.c:428:7
    #7 0x5732e08b99be in check_ndpi_detection_func ndpi/src/lib/ndpi_main.c:8840:5
```
Found by oss-fuzz
See: https://issues.oss-fuzz.com/issues/504814687


