### PR TITLE
SSH: another fix for metadata extraction

### DIFF
--- a/src/lib/protocols/ssh.c
+++ b/src/lib/protocols/ssh.c
@@ -255,6 +255,8 @@ static u_int16_t concat_hash_string(struct ndpi_detection_module_struct *ndpi_st
     goto invalid_payload;
 
   len = ntohl(*(u_int32_t*)&packet->payload[offset]);
+  if(len > len_max)
+    goto invalid_payload;
   offset += 4;
 
   /* -1 for ';' */
@@ -319,11 +321,10 @@ static u_int16_t concat_hash_string(struct ndpi_detection_module_struct *ndpi_st
   
   /* ssh.server_host_key_algorithms [None] */
   len = ntohl(*(u_int32_t*)&packet->payload[offset]);
-
   if(len > len_max)
     goto invalid_payload;
-  offset += 4;
 
+  offset += 4;
   if(ndpi_struct->cfg.ssh_hassh_data_enabled && len > 0 &&
      offset + len <= packet->payload_packet_len) {
     char *tmp = (char*)ndpi_malloc(len + 1);
@@ -351,6 +352,8 @@ static u_int16_t concat_hash_string(struct ndpi_detection_module_struct *ndpi_st
 
   /* ssh.encryption_algorithms_client_to_server [C] */
   len = ntohl(*(u_int32_t*)&packet->payload[offset]);
+  if(len > len_max)
+    goto invalid_payload;
 
   offset += 4;
   if(client_hash) {
@@ -383,8 +386,6 @@ static u_int16_t concat_hash_string(struct ndpi_detection_module_struct *ndpi_st
     }
   }
 
-  if(len > len_max)
-    goto invalid_payload;
   offset += len;
 
   if(offset >= max_payload_len)


### PR DESCRIPTION
```
==15839==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5020000fbe71 at pc 0x62f2391126c7 bp 0x7ffc06be5ad0 sp 0x7ffc06be5288
WRITE of size 4294967295 at 0x5020000fbe71 thread T0
    #0 0x62f2391126c6 in strncpy (/mnt/11a40362-265c-4ec3-8d95-2c65dbe1df34/builds/nDPI/build-fuzz/fuzz/fuzz_ndpi_reader_pl7m_simplest+0x94a6c6) (BuildId: 8aeee13364aaad1a523f774868144161a75189ed)
    #1 0x62f239613037 in concat_hash_string /home/ivan/svnrepos/nDPI/src/lib/protocols/ssh.c:377:7
    #2 0x62f23960db18 in ndpi_search_ssh_tcp /home/ivan/svnrepos/nDPI/src/lib/protocols/ssh.c:683:12
    #3 0x62f239617dd7 in search_ssh_again /home/ivan/svnrepos/nDPI/src/lib/protocols/ssh.c:219:3
    #4 0x62f239358c84 in process_extra_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:9752:9
    #5 0x62f23930872c in ndpi_internal_detection_process_packet /home/ivan/svnrepos/nDPI/src/lib/ndpi_main.c:10559:5
```
Found by oss-fuzz


