### PR TITLE
CI: run internal unit tests only once

### DIFF
--- a/example/ndpiReader.c
+++ b/example/ndpiReader.c
@@ -106,11 +106,7 @@ static char* fargv[MAX_FARGS];
 static int fargc = 0;
 static int dump_fpc_stats = 0;
 
-#ifdef NDPI_EXTENDED_SANITY_CHECKS
-int skip_unit_tests = 0;
-#else
 int skip_unit_tests = 1;
-#endif
 
 #ifdef CUSTOM_NDPI_PROTOCOLS
 #include "../../nDPI-custom/ndpiReader_defs.c"
@@ -1016,7 +1012,7 @@ static void help(u_int long_help) {
          "  --dump-fpc-stats           | Print FPC statistics\n"
 	 "  --protos-dump <mode>       | Dump host-based protocolId (mode=1) and categoryId (mode=2)\n"
 	 "  --plugins-dir <dir>        | Directory from which plugins are dynamically loaded\n"
-         "  --run-tests                | Run unit tests at startup\n"
+         "  --run-tests                | Run only unit tests\n"
          ,
          human_readeable_string_len,
          min_pattern_len, max_pattern_len, max_num_packets_per_flow, max_packet_payload_dissection,
@@ -1883,6 +1879,9 @@ static void parseOptions(int argc, char **argv) {
 #endif
 
   parse_parameters(argc, argv);
+
+  if(!skip_unit_tests)
+    return;
 
   if (serialization_fp == NULL && serialization_format != ndpi_serialization_format_unknown)
   {
@@ -5795,6 +5794,7 @@ int main(int argc, char **argv) {
     if(!quiet_mode)
       printf("Run internal unit tests\n");
     run_unit_tests();
+    exit(0);
   }
 
   if(dump_hosts_mode > 0) {

--- a/tests/do.sh.in
+++ b/tests/do.sh.in
@@ -79,6 +79,7 @@ PLUGINS_CFGS="plugins"
 ABS_SRCDIR="@abs_top_srcdir@"
 ABS_BUILDDIR="@abs_top_builddir@"
 READER="${CMD_PREFIX} ../../../example/ndpiReader${EXE_SUFFIX} --cfg=filename.config,../../../example/config.txt -A -p ../../..//example/protos.txt -c ../../..//example/categories.txt -r ../../../example/risky_domains.txt -j ../../../example/ja4_fingerprints.csv -S ../../..//example/sha1_fingerprints.csv -G ../../../lists -L ../../../lists/public_suffix_list.dat -q -K JSON -k /dev/null -t -v 2"
+READER_UTESTS="${CMD_PREFIX} ./example/ndpiReader${EXE_SUFFIX} --run-tests"
 #Used by plugins; different variables for Linux and macOS: no harm in setting always both of them
 LD_LIBRARY_PATH=${ABS_BUILDDIR}/src/lib/
 DYLD_LIBRARY_PATH=${ABS_BUILDDIR}/src/lib/
@@ -320,6 +321,16 @@ process_single_config() {
     return $RET
 }
 export -f process_single_config
+
+# Run (once) internal unit tests
+cd ${ABS_BUILDDIR}
+$READER_UTESTS
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "Error internl unit tests"
+    exit $RC
+fi
+cd -
 
 if [ $FUZZY_TESTING_ENABLED -eq 1 ]; then
     fuzzy_testing


### PR DESCRIPTION
Internal tests take a non-negligible duration: run them only once in CI. This way, CI is faster.

To manually run them, use `ndpiReader --run-tests`; note that this way the application runs ONLY these tests.



