### PR TITLE
Fix install and pkg-config for out-of-tree builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@
 /influxdb/Makefile
 /install-sh
 /libndpi.pc
+/libndpi-uninstalled.pc
 /libtool
 /ltmain.sh
 /m4/libtool.m4

--- a/configure.ac
+++ b/configure.ac
@@ -596,7 +596,7 @@ dnl> Add base system libraries last (lowest-level dependencies)
 dnl> This ensures proper linking order: high-level libs -> low-level libs
 ADDITIONAL_LIBS="${ADDITIONAL_LIBS} $LIBM $LIBDL"
 
-AC_CONFIG_FILES([Makefile example/Makefile example/Makefile.dpdk tests/Makefile tests/unit/Makefile tests/performance/Makefile tests/dga/Makefile rrdtool/Makefile influxdb/Makefile libndpi.pc src/include/ndpi_define.h src/lib/Makefile src/lib/plugins/Makefile fuzz/Makefile doc/Doxyfile.cfg utils/Makefile])
+AC_CONFIG_FILES([Makefile example/Makefile example/Makefile.dpdk tests/Makefile tests/unit/Makefile tests/performance/Makefile tests/dga/Makefile rrdtool/Makefile influxdb/Makefile libndpi.pc libndpi-uninstalled.pc src/include/ndpi_define.h src/lib/Makefile src/lib/plugins/Makefile fuzz/Makefile doc/Doxyfile.cfg utils/Makefile])
 AC_CONFIG_FILES([tests/do.sh], [chmod +x tests/do.sh])
 AC_CONFIG_FILES([tests/do-dga.sh], [chmod +x tests/do-dga.sh])
 AC_CONFIG_FILES([tests/do-unit.sh], [chmod +x tests/do-unit.sh])

--- a/libndpi-uninstalled.pc.in
+++ b/libndpi-uninstalled.pc.in
@@ -1,0 +1,8 @@
+abs_top_srcdir=@abs_top_srcdir@
+abs_top_builddir=@abs_top_builddir@
+
+Name: libndpi
+Description: deep packet inspection library (uninstalled)
+Version: @VERSION@
+Libs: -L${abs_top_builddir}/src/lib -lndpi @ADDITIONAL_LIBS@
+Cflags: -I${abs_top_srcdir}/src/include -I${abs_top_builddir}/src/include

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -143,3 +143,5 @@ endif
 	#Avoid installing private header
 	# Installing header files to $(DESTDIR)@includedir@/ndpi
 	find $(top_srcdir)/src/include/*.h ! -name ndpi_private.h -exec cp "{}" $(DESTDIR)@includedir@/ndpi \;
+	cp $(top_builddir)/src/include/ndpi_config.h $(DESTDIR)@includedir@/ndpi/
+	cp $(top_builddir)/src/include/ndpi_define.h $(DESTDIR)@includedir@/ndpi/


### PR DESCRIPTION
The install target only copied headers from `$(top_srcdir)`, so `ndpi_config.h` and `ndpi_define.h` (generated into `$(top_builddir)`) were silently skipped in out-of-tree builds, breaking any consumer that included `ndpi_typedefs.h`.

Add explicit copies of the two generated headers in the install target, and add `libndpi-uninstalled.pc.in` so consumers can use pkg-config against the build tree without running make install.



