### PR TITLE
fingerprint: fix stack overflow building the TLS blocks string

### DIFF
--- a/src/lib/ndpi_fingerprint.c
+++ b/src/lib/ndpi_fingerprint.c
@@ -170,12 +170,30 @@ static char* ndpi_compute_tls_blocks_flow_fingerprint(struct ndpi_flow_struct *f
   fp_buf[0] = '\0'; /* Not really necessary, but just to be sure */
 
   for(i=0; i< flow->l4.tcp.tls.num_tls_blocks; i++) {
-    ret = snprintf(&fp_buf[idx], fp_buf_len-idx-1, "%s%u=%d",
+    u_int avail;
+
+    if(idx >= fp_buf_len - 1)
+      break;
+
+    avail = fp_buf_len - idx;
+
+    ret = snprintf(&fp_buf[idx], avail, "%s%u=%d",
 		   (i > 0) ? "," : "",
 		   flow->l4.tcp.tls.tls_blocks[i].block_type,
 		   flow->l4.tcp.tls.tls_blocks[i].len);
 
-    if(ret > 0) idx += ret; else break;
+    if(ret <= 0)
+      break;
+
+    if((u_int)ret >= avail) {
+      /* Truncated: snprintf() returns the would-be length, not what was
+	 written. Keep the avail-1 chars that fit and stop, or idx walks
+	 past the buffer and avail underflows on the next round. */
+      idx = fp_buf_len - 1;
+      break;
+    }
+
+    idx += ret;
   } /* for */
 
 #if 0
@@ -284,8 +302,12 @@ char* ndpi_compute_ndpi_flow_fingerprint(struct ndpi_detection_module_struct *nd
     s = snprintf((char*)fp_buf, sizeof(fp_buf)-1, "%s-%s%s-%s",
 		 l4_fp, l7_pf, l7_pf_tls_blocks, l7_pf_server);
 
-    if(ndpi_str->cfg.tls_ndpifp_ignore_sni_extension)
-      fp_buf[strlen(l4_fp)+4] = '_';
+    if(ndpi_str->cfg.tls_ndpifp_ignore_sni_extension) {
+      size_t sni_off = strlen(l4_fp) + 4;
+
+      if(sni_off < ndpi_min(s, sizeof(fp_buf)-1))
+	fp_buf[sni_off] = '_';
+    }
 
 #if 0
     fprintf(stderr, "#### [sport=%u] %s\n", ntohs(flow->c_port), fp_buf);


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):


Describe changes:
The tls-blocks loop advanced idx by the raw snprintf() return value, which on truncation is the would-be length rather than what was written. With tls.max_num_blocks_to_analyze=32 and application block tracking enabled the blocks string regularly exceeds the 256-byte buffer, idx walks past it and the unsigned fp_buf_len-idx-1 size underflows, so the next snprintf() writes far out of bounds and trips the stack protector (SIGSEGV via __stack_chk_fail in ndpi_compute_ndpi_flow_fingerprint on aarch64/musl).

Bound each round by the space actually remaining and stop at the first truncation, keeping the chars that fit so the digest input stays deterministic. Also bound the ignore_sni_extension patch byte to the formatted length instead of writing at strlen(l4_fp)+4 unconditionally.

Reproduced the overflow with an ASan harness of the old loop (32 blocks of ",23=-14600" overflow a 256-byte buffer); the fixed loop caps at idx=255.

