### PR TITLE
activision: classify Warzone game session flows

### DIFF
--- a/src/lib/protocols/activision.c
+++ b/src/lib/protocols/activision.c
@@ -49,43 +49,47 @@ static void ndpi_search_activision(struct ndpi_detection_module_struct *ndpi_str
     return;
   }
 
+  u_int16_t magic = ntohs(get_u_int16_t(packet->payload, 0));
+
+  /*
+   * 0x46/0x47 variant: payload direction markers are protocol-level and
+   * unrelated to nDPI's flow direction assignment, so handle them before
+   * any direction-dependent checks.
+   */
+  if (magic == 0x4600 || magic == 0x4700)
+  {
+    if (flow->packet_counter > 4)
+      ndpi_int_activision_add_connection(ndpi_struct, flow);
+
+    return;
+  }
+
+  /* original 0x0c02/0x0d02 variant: direction-dependent */
   if (flow->packet_direction_counter[packet->packet_direction] == 1)
   {
     if (packet->packet_direction == 0)
     {
-      if (ntohs(get_u_int16_t(packet->payload, 0)) != 0x0c02)
+      if (magic != 0x0c02)
       {
         NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
       }
     } else {
-      if (ntohs(get_u_int16_t(packet->payload, 0)) != 0x0d02)
+      if (magic != 0x0d02)
       {
         NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
         return;
       }
     }
 
-    if (packet->payload_packet_len < 29)
-    {
-      NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
-      return;
-    }
-
-    if (ntohs(get_u_int16_t(packet->payload, 17)) == 0xc0a8 &&
-        ntohl(get_u_int32_t(packet->payload, 19)) == 0x0015020c)
-    {
-      ndpi_int_activision_add_connection(ndpi_struct, flow);
-      return;
-    }
   } else if (packet->packet_direction == 0) {
-    if (packet->payload[0] != 0x29)
+    if (packet->payload[0] != 0x29 && magic != 0x0c02)
     {
       NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;
     }
   } else if (packet->packet_direction == 1) {
-    if (packet->payload[0] != 0x28)
+    if (packet->payload[0] != 0x28 && magic != 0x0d02)
     {
       NDPI_EXCLUDE_DISSECTOR(ndpi_struct, flow);
       return;

--- a/tests/cfgs/default/result/activision.pcap.out
+++ b/tests/cfgs/default/result/activision.pcap.out
@@ -1,13 +1,13 @@
-DPI Packets (UDP):	4	(1.00 pkts/flow)
+DPI Packets (UDP):	20	(5.00 pkts/flow)
 Confidence DPI              : 4 (flows)
-Num dissector calls: 344 (86.00 diss/flow)
+Num dissector calls: 784 (196.00 diss/flow)
 LRU cache ookla:      0/0/0 (insert/search/found)
-LRU cache bittorrent: 0/0/0 (insert/search/found)
+LRU cache bittorrent: 0/12/0 (insert/search/found)
 LRU cache stun:       0/0/0 (insert/search/found)
 LRU cache tls_cert:   0/0/0 (insert/search/found)
 LRU cache mining:     0/0/0 (insert/search/found)
 LRU cache msteams:    0/0/0 (insert/search/found)
-LRU cache fpc_dns:    0/0/0 (insert/search/found)
+LRU cache fpc_dns:    0/4/0 (insert/search/found)
 Automa host:          0/0 (search/found)
 Automa domain:        0/0 (search/found)
 Automa tls cert:      0/0 (search/found)
@@ -33,7 +33,7 @@ Fun                             60 3904          4
 
 Game                            60 3904          4            
 
-	1	UDP 192.168.2.100:3074 <-> 45.63.112.54:34741 [proto: 258/Activision][Stack: Activision][IP: 0/Unknown][ClearText][Confidence: DPI][FPC: 258/Activision, Confidence: DPI][DPI packets: 1][cat: Game/8][Breed: Fun][8 pkts/491 bytes <-> 7 pkts/485 bytes][Goodput ratio: 32/39][0.88 sec][bytes ratio: 0.006 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 79/66 130/134 202/202 51/56][Pkt Len c2s/s2c min/avg/max/stddev: 60/69 61/69 71/71 4/1][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-	2	UDP 192.168.2.100:3074 <-> 108.61.235.31:33441 [proto: 258/Activision][Stack: Activision][IP: 0/Unknown][ClearText][Confidence: DPI][FPC: 258/Activision, Confidence: DPI][DPI packets: 1][cat: Game/8][Breed: Fun][8 pkts/491 bytes <-> 7 pkts/485 bytes][Goodput ratio: 32/39][1.58 sec][bytes ratio: 0.006 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 198/198 212/214 274/269 28/28][Pkt Len c2s/s2c min/avg/max/stddev: 60/69 61/69 71/71 4/1][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-	3	UDP 192.168.2.100:3074 <-> 148.72.173.162:34311 [proto: 258/Activision][Stack: Activision][IP: 0/Unknown][ClearText][Confidence: DPI][FPC: 258/Activision, Confidence: DPI][DPI packets: 1][cat: Game/8][Breed: Fun][8 pkts/491 bytes <-> 7 pkts/485 bytes][Goodput ratio: 32/39][1.42 sec][bytes ratio: 0.006 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 200/198 203/200 213/202 5/1][Pkt Len c2s/s2c min/avg/max/stddev: 60/69 61/69 71/71 4/1][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-	4	UDP 192.168.2.100:3074 <-> 173.199.67.5:37081 [proto: 258/Activision][Stack: Activision][IP: 0/Unknown][ClearText][Confidence: DPI][FPC: 258/Activision, Confidence: DPI][DPI packets: 1][cat: Game/8][Breed: Fun][8 pkts/491 bytes <-> 7 pkts/485 bytes][Goodput ratio: 32/39][0.74 sec][bytes ratio: 0.006 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 99/99 106/106 139/132 15/13][Pkt Len c2s/s2c min/avg/max/stddev: 60/69 61/69 71/71 4/1][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	1	UDP 192.168.2.100:3074 <-> 45.63.112.54:34741 [proto: 258/Activision][Stack: Activision][IP: 0/Unknown][ClearText][Confidence: DPI][FPC: 0/Unknown, Confidence: Unknown][DPI packets: 5][cat: Game/8][Breed: Fun][8 pkts/491 bytes <-> 7 pkts/485 bytes][Goodput ratio: 32/39][0.88 sec][bytes ratio: 0.006 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 79/66 130/134 202/202 51/56][Pkt Len c2s/s2c min/avg/max/stddev: 60/69 61/69 71/71 4/1][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	2	UDP 192.168.2.100:3074 <-> 108.61.235.31:33441 [proto: 258/Activision][Stack: Activision][IP: 0/Unknown][ClearText][Confidence: DPI][FPC: 0/Unknown, Confidence: Unknown][DPI packets: 5][cat: Game/8][Breed: Fun][8 pkts/491 bytes <-> 7 pkts/485 bytes][Goodput ratio: 32/39][1.58 sec][bytes ratio: 0.006 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 198/198 212/214 274/269 28/28][Pkt Len c2s/s2c min/avg/max/stddev: 60/69 61/69 71/71 4/1][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	3	UDP 192.168.2.100:3074 <-> 148.72.173.162:34311 [proto: 258/Activision][Stack: Activision][IP: 0/Unknown][ClearText][Confidence: DPI][FPC: 0/Unknown, Confidence: Unknown][DPI packets: 5][cat: Game/8][Breed: Fun][8 pkts/491 bytes <-> 7 pkts/485 bytes][Goodput ratio: 32/39][1.42 sec][bytes ratio: 0.006 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 200/198 203/200 213/202 5/1][Pkt Len c2s/s2c min/avg/max/stddev: 60/69 61/69 71/71 4/1][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+	4	UDP 192.168.2.100:3074 <-> 173.199.67.5:37081 [proto: 258/Activision][Stack: Activision][IP: 0/Unknown][ClearText][Confidence: DPI][FPC: 0/Unknown, Confidence: Unknown][DPI packets: 5][cat: Game/8][Breed: Fun][8 pkts/491 bytes <-> 7 pkts/485 bytes][Goodput ratio: 32/39][0.74 sec][bytes ratio: 0.006 (Mixed)][IAT c2s/s2c min/avg/max/stddev: 99/99 106/106 139/132 15/13][Pkt Len c2s/s2c min/avg/max/stddev: 60/69 61/69 71/71 4/1][Plen Bins: 100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):


Describe changes:
Warzone game sessions use 0x46/0x47 direction markers that are protocol-level and unrelated to nDPI's IP-based flow canonicalization, so they must be checked independently of packet_direction.

Also removes a hardcoded client IP check (192.168.0.21) that only matched one specific capture, and accepts retransmitted 0x0c02/0x0d02 initial packets in subsequent-packet checks to prevent false exclusion from server-side application-level retransmission.

Update the activision.pcap golden accordingly: the flows are still classified as Activision by DPI, but detection now happens on packet 5 via the packet_counter check rather than on the first packet, so DPI packets goes 1 -> 5 and FPC reports Unknown. The first-packet match it replaces only ever fired for the one capture whose client was 192.168.0.21.

