### PR TITLE
geoip: support flat MMDB key schemas

### DIFF
--- a/src/lib/ndpi_geoip.c
+++ b/src/lib/ndpi_geoip.c
@@ -102,13 +102,32 @@ int ndpi_get_geoip_asn(struct ndpi_detection_module_struct *ndpi_str, char *ip, 
       *asn = 0;
     else
     {
-      /* Get the ASN */
-      if ((status = MMDB_get_value(&result.entry, &entry_data, "autonomous_system_number", NULL)) == MMDB_SUCCESS)
-      {
-        if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UINT32)
-          *asn = entry_data.uint32;
-        else
-          *asn = 0;
+      *asn = 0;
+
+      status = MMDB_get_value(&result.entry, &entry_data, "autonomous_system_number", NULL);
+      if (status == MMDB_SUCCESS && entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UINT32)
+        *asn = entry_data.uint32;
+
+      /* Flat schema fallback (e.g. IPLocate): asn stored as string */
+      if (*asn == 0) {
+        status = MMDB_get_value(&result.entry, &entry_data, "asn", NULL);
+        if (status == MMDB_SUCCESS && entry_data.has_data &&
+            entry_data.type == MMDB_DATA_TYPE_UTF8_STRING)
+        {
+          /* MMDB strings are length-counted, not NUL-terminated; copy
+             before converting. Skip an optional "AS" prefix. */
+          char asn_str[16];
+          const char *p = asn_str;
+          u_int32_t str_len = ndpi_min(entry_data.data_size, sizeof(asn_str) - 1);
+
+          memcpy(asn_str, entry_data.utf8_string, str_len);
+          asn_str[str_len] = '\0';
+
+          if ((p[0] == 'A' || p[0] == 'a') && (p[1] == 'S' || p[1] == 's'))
+            p += 2;
+
+          *asn = (u_int32_t)atol(p);
+        }
       }
     }
 
@@ -142,6 +161,11 @@ int ndpi_get_geoip_aso(struct ndpi_detection_module_struct *ndpi_str, char *ip, 
       if (aso_len > 0)
       {
         status = MMDB_get_value(&result.entry, &entry_data, "autonomous_system_organization", NULL);
+
+        /* Flat schema fallback (e.g. IPLocate): org */
+        if (status != MMDB_SUCCESS || !entry_data.has_data)
+          status = MMDB_get_value(&result.entry, &entry_data, "org", NULL);
+
         if (status != MMDB_SUCCESS || !entry_data.has_data)
           aso[0] = '\0';
         else
@@ -189,7 +213,12 @@ int ndpi_get_geoip_country_continent(struct ndpi_detection_module_struct *ndpi_s
     {
       if (country_code_len > 0)
       {
+        /* MaxMind: country -> iso_code */
         status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
+
+        /* Flat schema fallback (e.g. IPLocate): country_code */
+        if (status != MMDB_SUCCESS || !entry_data.has_data)
+          status = MMDB_get_value(&result.entry, &entry_data, "country_code", NULL);
 
         if ((status != MMDB_SUCCESS) || (!entry_data.has_data))
           country_code[0] = '\0';
@@ -204,7 +233,12 @@ int ndpi_get_geoip_country_continent(struct ndpi_detection_module_struct *ndpi_s
 
       if (continent_len > 0)
       {
+        /* MaxMind: continent -> names -> en */
         status = MMDB_get_value(&result.entry, &entry_data, "continent", "names", "en", NULL);
+
+        /* Flat schema fallback: continent_code */
+        if (status != MMDB_SUCCESS || !entry_data.has_data)
+          status = MMDB_get_value(&result.entry, &entry_data, "continent_code", NULL);
 
         if ((status != MMDB_SUCCESS) || (!entry_data.has_data))
           continent[0] = '\0';

--- a/src/lib/ndpi_geoip.c
+++ b/src/lib/ndpi_geoip.c
@@ -170,7 +170,7 @@ int ndpi_get_geoip_aso(struct ndpi_detection_module_struct *ndpi_str, char *ip, 
           aso[0] = '\0';
         else
         {
-          int str_len = ndpi_min(entry_data.data_size, aso_len);
+          int str_len = ndpi_min(entry_data.data_size, (u_int32_t)aso_len - 1);
 
           memcpy(aso, entry_data.utf8_string, str_len);
           aso[str_len] = '\0';
@@ -224,7 +224,7 @@ int ndpi_get_geoip_country_continent(struct ndpi_detection_module_struct *ndpi_s
           country_code[0] = '\0';
         else
         {
-          int str_len = ndpi_min(entry_data.data_size, country_code_len);
+          int str_len = ndpi_min(entry_data.data_size, (u_int32_t)country_code_len - 1);
 
           memcpy(country_code, entry_data.utf8_string, str_len);
           country_code[str_len] = '\0';
@@ -244,7 +244,7 @@ int ndpi_get_geoip_country_continent(struct ndpi_detection_module_struct *ndpi_s
           continent[0] = '\0';
         else
         {
-          int str_len = ndpi_min(entry_data.data_size, continent_len);
+          int str_len = ndpi_min(entry_data.data_size, (u_int32_t)continent_len - 1);
 
           memcpy(continent, entry_data.utf8_string, str_len);
           continent[str_len] = '\0';
@@ -294,7 +294,7 @@ int ndpi_get_geoip_country_continent_city(struct ndpi_detection_module_struct *n
           country_code[0] = '\0';
         else
         {
-          int str_len = ndpi_min(entry_data.data_size, country_code_len);
+          int str_len = ndpi_min(entry_data.data_size, (u_int32_t)country_code_len - 1);
 
           memcpy(country_code, entry_data.utf8_string, str_len);
           country_code[str_len] = '\0';
@@ -309,7 +309,7 @@ int ndpi_get_geoip_country_continent_city(struct ndpi_detection_module_struct *n
           continent[0] = '\0';
         else
         {
-          int str_len = ndpi_min(entry_data.data_size, continent_len);
+          int str_len = ndpi_min(entry_data.data_size, (u_int32_t)continent_len - 1);
 
           memcpy(continent, entry_data.utf8_string, str_len);
           continent[str_len] = '\0';
@@ -324,7 +324,7 @@ int ndpi_get_geoip_country_continent_city(struct ndpi_detection_module_struct *n
           city[0] = '\0';
         else
         {
-          int len = ndpi_min(entry_data.data_size, city_len);
+          int len = ndpi_min(entry_data.data_size, (u_int32_t)city_len - 1);
 
           memcpy(city, entry_data.utf8_string, len);
           city[len] = 0;


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues):


Describe changes:
MaxMind GeoIP databases use a nested key schema (e.g.
country -> iso_code, continent -> names -> en) while other
providers like IPLocate use flat keys (country_code,
continent_code, asn as string, org). Add fallback lookups
so nDPI works with either schema transparently.

Also include a small fix discovered when testing GeoIP.

