### PR TITLE
Fix out-of-bounds read of TLS certificate dates

### DIFF
--- a/src/lib/ndpi_utils.c
+++ b/src/lib/ndpi_utils.c
@@ -1466,11 +1466,20 @@ static void ndpi_tls2json(struct ndpi_detection_module_struct *ndpi_struct, ndpi
 
     ndpi_ssl_version2str(version, sizeof(version), flow->protos.tls_quic.ssl_version, &unknown_tls_version);
 
-    if(flow->protos.tls_quic.notBefore)
-      before = ndpi_gmtime_r((const time_t *)&flow->protos.tls_quic.notBefore, &a);
+    /* notBefore/notAfter are u_int32_t, so their address cannot be passed as a
+       time_t *: on 64-bit platforms that reads 8 bytes out of a 4-byte field.
+       Convert to a real time_t instead. */
+    if(flow->protos.tls_quic.notBefore) {
+      time_t not_before = (time_t)flow->protos.tls_quic.notBefore;
 
-    if(flow->protos.tls_quic.notAfter)
-      after = ndpi_gmtime_r((const time_t *)&flow->protos.tls_quic.notAfter, &b);
+      before = ndpi_gmtime_r(&not_before, &a);
+    }
+
+    if(flow->protos.tls_quic.notAfter) {
+      time_t not_after = (time_t)flow->protos.tls_quic.notAfter;
+
+      after = ndpi_gmtime_r(&not_after, &b);
+    }
 
     if(!unknown_tls_version) {
       ndpi_serialize_start_of_block(serializer, "tls");


### PR DESCRIPTION
`ndpi_tls2json()` passes the address of a `u_int32_t` where a `time_t *` is
expected:

```c
if(flow->protos.tls_quic.notBefore)
  before = ndpi_gmtime_r((const time_t *)&flow->protos.tls_quic.notBefore, &a);

if(flow->protos.tls_quic.notAfter)
  after = ndpi_gmtime_r((const time_t *)&flow->protos.tls_quic.notAfter, &b);
```

Those fields are 32-bit in `ndpi_typedefs.h`:

```c
u_int32_t notBefore, notAfter;
```

Wherever `time_t` is 8 bytes, `gmtime_r()` reads 4 bytes past the field. The
extra bytes come from the adjacent member. On little-endian the value passed is
therefore `notBefore | (notAfter << 32)`. `gmtime_r()` fails on that value and
returns `NULL`. `before` and `after` stay `NULL`, so the `notbefore` and
`notafter` fields never reach the JSON output.

Here it is on plain x86-64, `dev` at 49ed06a, using
`tests/cfgs/default/pcap/tls_verylong_certificate.pcap`:

```
$ ./example/ndpiReader -i tls_verylong_certificate.pcap -K JSON -k out.json -q -v 2
$ grep -c notbefore out.json
0
$ grep -o '"ja3s":"[^"]*"' out.json
"ja3s":"ae53107a2e47ea20c72ac44821a728bf"
```

The `tls` block is emitted. Only the two date fields are missing. With this
patch applied, same machine and same pcap:

```
"notbefore":"2019-11-19 01:31:22"
"notafter":"2020-08-29 17:19:32"
```

Here is the mechanism on its own, in case that is useful. It needs no nDPI, and
only mirrors the struct layout and the call:

```c
#include <stdio.h>
#include <time.h>
#include <sys/types.h>

struct tls_quic { u_int32_t notBefore, notAfter; };   /* as in ndpi_typedefs.h */

int main(void) {
  struct tls_quic t = { 1704067200 /* 2024-01-01 */, 1735689600 /* 2025-01-01 */ };
  struct tm a, *r;
  char buf[64];

  printf("sizeof(time_t)=%zu sizeof(notBefore)=%zu\n", sizeof(time_t), sizeof(t.notBefore));

  r = gmtime_r((const time_t *)&t.notBefore, &a);       /* current code */
  if(r == NULL)
    printf("current : gmtime_r returned NULL\n");
  else {
    strftime(buf, sizeof(buf), "%F %T", &a);
    printf("current : %s\n", buf);
  }

  { time_t nb = (time_t)t.notBefore;                    /* fixed */
    r = gmtime_r(&nb, &a);
    strftime(buf, sizeof(buf), "%F %T", &a);
    printf("fixed   : %s  (expected 2024-01-01 00:00:00)\n", buf); }
  return 0;
}
```

```
sizeof(time_t)=8 sizeof(notBefore)=4
current : gmtime_r returned NULL
fixed   : 2024-01-01 00:00:00  (expected 2024-01-01 00:00:00)
```

On architectures that require naturally aligned access the 8-byte load traps
instead of merely being wrong. That is how I found it. On sparc64 `ndpiReader
-K JSON` dies with SIGBUS inside `gmtime_r()`, called from `ndpi_tls2json()`.

The test suite does not catch this. `tests/do.sh` runs the reader with
`-K JSON -k /dev/null`, so the flow JSON is discarded, and `notbefore` and
`notafter` appear in no `tests/cfgs/*/result/*.out`.

The patch converts to a real `time_t` instead of casting the address. The
temporaries are named `not_before` and `not_after` because `notBefore` and
`notAfter` are already `char[32]` buffers in the same function.

`./tests/do.sh` passes on x86-64 with exit 0 and no changes to expected
results. The build is clean with no new warnings in `ndpi_utils.c`.
