### PR TITLE
classifier: add bounded random forest inference core

### DIFF
--- a/src/include/ndpi_random_forest.h
+++ b/src/include/ndpi_random_forest.h
@@ -1,0 +1,63 @@
+/*
+ * ndpi_random_forest.h
+ *
+ * Copyright (C) 2011-26 - ntop.org
+ *
+ * This file is part of nDPI, an open source deep packet inspection library.
+ */
+#ifndef __NDPI_RANDOM_FOREST_H__
+#define __NDPI_RANDOM_FOREST_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* A node with this feature index is a leaf. */
+#define NDPI_RF_LEAF_NODE UINT16_MAX
+
+struct ndpi_random_forest_node {
+  uint16_t feature_index;
+  float threshold;
+  int32_t left;
+  int32_t right;
+  uint16_t class_id;
+};
+
+struct ndpi_random_forest_model {
+  const struct ndpi_random_forest_node *nodes;
+  uint32_t node_count;
+  const int32_t *roots;
+  uint32_t tree_count;
+  uint16_t class_count;
+};
+
+/**
+ * Evaluate a caller-owned, immutable Random Forest model.
+ *
+ * Models are deliberately supplied by the caller: nDPI does not ship a
+ * trained classifier or make an accuracy claim without a versioned dataset
+ * and feature schema.  Child indexes are zero-based node indexes.  A child
+ * index must be in [0, node_count); leaf nodes use class_id and ignore their
+ * child indexes.
+ *
+ * @param model       Validated, immutable forest model.
+ * @param features    Feature vector used by the model.
+ * @param feature_count Number of values in features.
+ * @param scores      Output vote score for each class; may be NULL.
+ * @param score_count Number of entries available in scores.
+ * @return 0 on success, -1 on invalid input or malformed model.
+ */
+int ndpi_random_forest_predict(const struct ndpi_random_forest_model *model,
+                               const float *features,
+                               uint32_t feature_count,
+                               float *scores,
+                               uint16_t score_count);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __NDPI_RANDOM_FOREST_H__ */
+
+/* vim: set ts=2 sw=2 et: */

--- a/src/lib/ndpi_random_forest.c
+++ b/src/lib/ndpi_random_forest.c
@@ -1,0 +1,79 @@
+/*
+ * ndpi_random_forest.c
+ *
+ * Copyright (C) 2011-26 - ntop.org
+ *
+ * This file is part of nDPI, an open source deep packet inspection library.
+ */
+#include <math.h>
+#include <stddef.h>
+#include "ndpi_random_forest.h"
+
+static int ndpi_random_forest_node_is_leaf(const struct ndpi_random_forest_node *node)
+{
+  return node->feature_index == NDPI_RF_LEAF_NODE;
+}
+
+int ndpi_random_forest_predict(const struct ndpi_random_forest_model *model,
+                               const float *features,
+                               uint32_t feature_count,
+                               float *scores,
+                               uint16_t score_count)
+{
+  uint32_t tree;
+
+  if(model == NULL || features == NULL || model->nodes == NULL ||
+     model->roots == NULL || model->node_count == 0 ||
+     model->tree_count == 0 || model->class_count == 0 ||
+     feature_count == 0 || (scores != NULL && score_count < model->class_count))
+    return -1;
+
+  for(tree = 0; tree < feature_count; tree++) {
+    if(!isfinite(features[tree]))
+      return -1;
+  }
+
+  if(scores != NULL) {
+    for(tree = 0; tree < model->class_count; tree++)
+      scores[tree] = 0.0f;
+  }
+
+  for(tree = 0; tree < model->tree_count; tree++) {
+    int32_t node_index = model->roots[tree];
+    uint32_t steps = 0;
+    uint16_t class_id;
+
+    if(node_index < 0 || (uint32_t)node_index >= model->node_count)
+      return -1;
+
+    /* A valid tree cannot visit more nodes than the model contains. */
+    while(steps++ < model->node_count) {
+      const struct ndpi_random_forest_node *node = &model->nodes[node_index];
+
+      if(ndpi_random_forest_node_is_leaf(node)) {
+        class_id = node->class_id;
+        if(class_id >= model->class_count)
+          return -1;
+        if(scores != NULL)
+          scores[class_id] += 1.0f / (float)model->tree_count;
+        break;
+      }
+
+      if(node->feature_index >= feature_count ||
+         !isfinite(node->threshold))
+        return -1;
+
+      node_index = features[node->feature_index] <= node->threshold ?
+                   node->left : node->right;
+      if(node_index < 0 || (uint32_t)node_index >= model->node_count)
+        return -1;
+    }
+
+    if(steps > model->node_count)
+      return -1;
+  }
+
+  return 0;
+}
+
+/* vim: set ts=2 sw=2 et: */

--- a/tests/performance/Makefile.in
+++ b/tests/performance/Makefile.in
@@ -11,7 +11,7 @@ INC=-I $(top_srcdir)/src/include/ -I $(top_builddir)/src/include/ -I $(top_srcdi
 LIB=$(top_builddir)/src/lib/libndpi.a @ADDITIONAL_LIBS@ @LIBS@
 GEN_HEADERS=$(top_builddir)/src/include/ndpi_config.h $(top_builddir)/src/include/ndpi_define.h
 
-TOOLS=substringsearch patriciasearch gcrypt-int gcrypt-gnu strnstr
+TOOLS=substringsearch patriciasearch gcrypt-int gcrypt-gnu strnstr random_forest
 TESTS=substring_test patricia_test strnstr_test geo_test
 
 
@@ -30,6 +30,9 @@ substringsearch: $(srcdir)/substringsearch.c Makefile $(GEN_HEADERS)
 
 strnstr: $(srcdir)/strnstr.cpp Makefile $(GEN_HEADERS)
 	$(CXX) $(INC) $(AM_CFLAGS) $(CFLAGS) $(srcdir)/strnstr.cpp -o strnstr
+
+random_forest: $(srcdir)/random_forest.c Makefile $(GEN_HEADERS)
+	$(CC) $(INC) $(AM_CFLAGS) $(CFLAGS) $(srcdir)/random_forest.c -o random_forest $(LIB)
 
 geo: $(srcdir)/geo.c Makefile $(GEN_HEADERS)
 	$(CC) $(INC) $(AM_CFLAGS) $(CFLAGS) $(srcdir)/geo.c -o geo $(LIB)
@@ -70,4 +73,3 @@ distclean: clean
 
 check:
 	true # nothing to do here, tests run via make all
-

--- a/tests/performance/random_forest.c
+++ b/tests/performance/random_forest.c
@@ -1,0 +1,43 @@
+/*
+ * Measure the bounded inference cost of the nDPI Random Forest core.
+ * This is a throughput benchmark only; it does not claim model accuracy.
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <time.h>
+#include "ndpi_random_forest.h"
+
+int main(void)
+{
+  static const struct ndpi_random_forest_node nodes[] = {
+    { 0, 0.5f, 1, 2, 0 },
+    { NDPI_RF_LEAF_NODE, 0.0f, -1, -1, 0 },
+    { 1, 1.5f, 3, 4, 0 },
+    { NDPI_RF_LEAF_NODE, 0.0f, -1, -1, 1 },
+    { NDPI_RF_LEAF_NODE, 0.0f, -1, -1, 0 },
+  };
+  static const int32_t roots[] = { 0, 2, 4 };
+  static const struct ndpi_random_forest_model model = {
+    nodes, sizeof(nodes) / sizeof(nodes[0]), roots, 3, 2
+  };
+  const float features[] = { 0.75f, 2.0f };
+  float scores[2];
+  volatile float sink = 0.0f;
+  struct timespec start, end;
+  uint32_t i;
+  const uint32_t iterations = 1000000;
+
+  clock_gettime(CLOCK_MONOTONIC, &start);
+  for(i = 0; i < iterations; i++) {
+    if(ndpi_random_forest_predict(&model, features, 2, scores, 2) != 0)
+      return 1;
+    sink += scores[0] + scores[1];
+  }
+  clock_gettime(CLOCK_MONOTONIC, &end);
+
+  double seconds = (double)(end.tv_sec - start.tv_sec) +
+                   (double)(end.tv_nsec - start.tv_nsec) / 1000000000.0;
+  printf("iterations=%u seconds=%.6f predictions_per_second=%.0f checksum=%.1f\n",
+         iterations, seconds, iterations / seconds, sink);
+  return 0;
+}

--- a/tests/unit/unit.c
+++ b/tests/unit/unit.c
@@ -51,6 +51,7 @@
 #include "ndpi_config.h"
 #include "ndpi_api.h"
 #include "ndpi_define.h"
+#include "ndpi_random_forest.h"
 
 #include "json.h" /* JSON-C */
 
@@ -60,6 +61,42 @@ static int verbose = 0;
 /* *********************************************** */
 
 #define FLT_MAX 3.402823466e+38F
+
+int randomForestUnitTest(void)
+{
+  static const struct ndpi_random_forest_node nodes[] = {
+    { 0, 0.5f, 1, 2, 0 },
+    { NDPI_RF_LEAF_NODE, 0.0f, -1, -1, 0 },
+    { 1, 1.5f, 3, 4, 0 },
+    { NDPI_RF_LEAF_NODE, 0.0f, -1, -1, 1 },
+    { NDPI_RF_LEAF_NODE, 0.0f, -1, -1, 0 },
+    { NDPI_RF_LEAF_NODE, 0.0f, -1, -1, 1 },
+  };
+  static const int32_t roots[] = { 0, 2, 5 };
+  static const struct ndpi_random_forest_model model = {
+    nodes, sizeof(nodes) / sizeof(nodes[0]), roots, 3, 2
+  };
+  float scores[2];
+  const float left[] = { 0.25f, 0.0f };
+  const float right[] = { 0.75f, 2.0f };
+  const float invalid[] = { NAN, 0.0f };
+  const int32_t invalid_roots[] = { 99, 2, 5 };
+  struct ndpi_random_forest_model invalid_model = model;
+
+  assert(ndpi_random_forest_predict(&model, left, 2, scores, 2) == 0);
+  assert(scores[0] > 0.33f && scores[0] < 0.34f);
+  assert(scores[1] > 0.66f && scores[1] < 0.67f);
+  assert(ndpi_random_forest_predict(&model, right, 2, scores, 2) == 0);
+  assert(scores[0] > 0.66f && scores[0] < 0.67f);
+  assert(scores[1] > 0.33f && scores[1] < 0.34f);
+  assert(ndpi_random_forest_predict(&model, left, 2, NULL, 0) == 0);
+  assert(ndpi_random_forest_predict(&model, invalid, 2, scores, 2) == -1);
+  assert(ndpi_random_forest_predict(&model, left, 1, scores, 2) == -1);
+  invalid_model.roots = invalid_roots;
+  assert(ndpi_random_forest_predict(&invalid_model, left, 2, scores, 2) == -1);
+  printf("%30s                      OK\n", __func__);
+  return 0;
+}
 
 int serializerUnitTest() {
   ndpi_serializer serializer, serializer_cloned, deserializer;
@@ -416,6 +453,7 @@ int main(int argc, char **argv) {
 #endif
     
   /* Tests */
+  if (randomForestUnitTest() != 0) return -1;
   if (serializerUnitTest() != 0) return -1;
   if (serializeProtoUnitTest() != 0) return -1;
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

# Random Forest Inference Core

## Related Issue

Related to #2788.

## Summary

This contribution adds a small, dependency-free Random Forest inference core to nDPI.

The implementation provides a safe and bounded execution engine for evaluating caller-owned Random Forest models against a feature vector. It does not ship a trained encrypted-traffic classifier because issue #2788 currently does not define a reproducible training dataset, feature schema, class taxonomy, model artifact, or evaluation protocol.

The purpose of this contribution is to provide the reusable inference foundation required before integrating a production encrypted-traffic model.

## Motivation

Encrypted traffic classification cannot depend on payload inspection alone because application payloads are unavailable or intentionally opaque in protocols such as TLS and QUIC. Research commonly uses flow-level statistical and protocol metadata features, including:

- Packet lengths
- Packet timing and inter-arrival times
- Directional packet and byte counts
- TLS handshake metadata
- Flow duration
- Payload-size distributions
- Protocol and transport metadata
- Session-level behavioral features

Random Forest models are attractive for this use case because they:

- Perform well on tabular statistical features.
- Do not require floating-point matrix libraries or a deep-learning runtime.
- Can handle nonlinear feature interactions.
- Are suitable for relatively small or imbalanced datasets.
- Can be exported into a compact tree representation.
- Have deterministic and relatively inexpensive inference.
- Are easier to validate and bound than a general-purpose model runtime.

However, the model accuracy reported in external research cannot be transferred directly to nDPI without using the same dataset, labels, feature definitions, preprocessing, and train/test split.

## Research Basis

The issue references the following research:

1. **Binary VPN Traffic Detection Using Wavelet Features and Machine Learning**

   [https://arxiv.org/abs/2502.13804](https://arxiv.org/abs/2502.13804)

   This work evaluates Random Forest and other machine-learning algorithms for binary VPN traffic detection. It reports strong results for its own dataset and feature-extraction pipeline, including wavelet-based features and different decomposition levels.

2. **Deep Forest-Based Detection of Encrypted Malicious Traffic**

   [https://www.mdpi.com/2079-9292/11/7/977](https://www.mdpi.com/2079-9292/11/7/977)

   This work investigates deep-forest methods for encrypted malicious traffic, especially with small and imbalanced datasets. It discusses the importance of statistical, byte-related, timing, TLS, DNS, and protocol-related features.

These papers support the choice of Random Forest as a possible classifier family, but they do not provide an nDPI-compatible production model. Their reported accuracy and F1 scores are therefore not claimed by this patch.

## Scope of This Patch

This patch intentionally implements only the inference substrate:

```text
src/include/ndpi_random_forest.h
src/lib/ndpi_random_forest.c
