### PR TITLE
fix: ndpi_network_ptree6_match uses v6 maxbits for prefix fill

### DIFF
--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -3345,7 +3345,7 @@ u_int16_t ndpi_network_ptree6_match(struct ndpi_detection_module_struct *ndpi_st
 
   /* Make sure all in network byte order otherwise compares wont work */
   ndpi_fill_prefix_v6(&prefix, pin, 128,
-		      ((ndpi_patricia_tree_t *) ndpi_str->protocols->v4)->maxbits);
+		      ((ndpi_patricia_tree_t *) ndpi_str->protocols->v6)->maxbits);
   node = ndpi_patricia_search_best(ndpi_str->protocols->v6, &prefix);
 
   return(node ? node->value.u.uv16[0].user_value : NDPI_PROTOCOL_UNKNOWN);


### PR DESCRIPTION
## Summary

 passes  to  for a 128-bit IPv6 prefix. The function rejects this with  because , so the subsequent  against the v6 tree never runs against a valid prefix and the lookup always misses.

Commit 5d941ca7 ("Typo fix") already corrected the  argument to use , but missed the matching cast in the  argument right above it.

## Fix

Use  so the prefix is filled, matching the symmetry already present in  (which uses  with ).



## Reproduction

Per #3253,  reports:



because  returns  (bits=128 > maxbits=32) before the search runs.

## Checklist

- [x] I have signed the ntop Contributor License Agreement
- [x] I have read the contributing guidelines

Closes #3253
