### PR TITLE
Fix ndpi_network_ptree6_match using the v4 tree maxbits

### DIFF
--- a/example/utests.c
+++ b/example/utests.c
@@ -2438,6 +2438,35 @@ static void tlsBlocksUnitTest(void) {
   assert(num_blocks == 0);
 }
 
+/* *********************************************** */
+
+static void networkPtreeUnitTest() {
+  struct ndpi_detection_module_struct *ndpi_str = ndpi_init_detection_module(NULL, NDPI_LICENSE_NOT_FOR_PROFIT_LGPL);
+  /* from ndpi_content_match.c.inc */
+  const char *v4_addr = "178.248.208.1";    /* 178.248.208.0/21 -> OCS */
+  const char *v6_addr = "2606:4700:100::1"; /* 2606:4700:100::/48 -> CloudflareWarp */
+  ndpi_prefix_t prefix;
+  struct in_addr pin;
+  struct in6_addr pin6;
+
+  assert(ndpi_str);
+  assert(ndpi_finalize_initialization(ndpi_str) == 0);
+
+  assert(inet_pton(AF_INET, v4_addr, &pin) == 1);
+  assert(inet_pton(AF_INET6, v6_addr, &pin6) == 1);
+
+  /* A v6 prefix needs the maxbits of the v6 tree: 128 bits never fit in 32 */
+  assert(ndpi_fill_prefix_v6(&prefix, &pin6, 128, 32) == -1);
+  assert(ndpi_fill_prefix_v6(&prefix, &pin6, 128, 128) == 0);
+  assert(prefix.bitlen == 128);
+  assert(memcmp(&prefix.add.sin6, &pin6, sizeof(struct in6_addr)) == 0);
+
+  assert(ndpi_network_ptree_match(ndpi_str, &pin) == NDPI_PROTOCOL_OCS);
+  assert(ndpi_network_ptree6_match(ndpi_str, &pin6) == NDPI_PROTOCOL_CLOUDFLARE_WARP);
+
+  ndpi_exit_detection_module(ndpi_str);
+}
+
 void run_unit_tests() {
 
   checkRankingUnitTest(false);
@@ -2496,5 +2525,6 @@ void run_unit_tests() {
   cryptoUnitTest();
   hexDecodeUnitTest();
   tlsBlocksUnitTest();
+  networkPtreeUnitTest();
 
 }

--- a/src/lib/ndpi_main.c
+++ b/src/lib/ndpi_main.c
@@ -3345,7 +3345,7 @@ u_int16_t ndpi_network_ptree6_match(struct ndpi_detection_module_struct *ndpi_st
 
   /* Make sure all in network byte order otherwise compares wont work */
   ndpi_fill_prefix_v6(&prefix, pin, 128,
-		      ((ndpi_patricia_tree_t *) ndpi_str->protocols->v4)->maxbits);
+		      ((ndpi_patricia_tree_t *) ndpi_str->protocols->v6)->maxbits);
   node = ndpi_patricia_search_best(ndpi_str->protocols->v6, &prefix);
 
   return(node ? node->value.u.uv16[0].user_value : NDPI_PROTOCOL_UNKNOWN);


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X] I have read the contributing guidelines at https://github.com/ntop/nDPI/blob/dev/CONTRIBUTING.md
- [X] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/nDPI/issues): https://github.com/ntop/nDPI/issues/3253


Describe changes:
ndpi_network_ptree6_match was using the v4 ptree instead of the v6 ptree to get the max_bits for ndpi_fill_prefix_v6. This caused the function to always return NDPI_PROTOCOL_UNKNOWN.

Add a unit test for this to showcase the problem.

